### PR TITLE
ci: add workflow dispatch to stress workflow

### DIFF
--- a/.github/workflows/cron-stress.yml
+++ b/.github/workflows/cron-stress.yml
@@ -3,6 +3,7 @@ name: stress
 on:
   schedule: 
     - cron: '0 13,1 * * *'
+  workflow_dispatch:
 
 jobs:
   build-lint-test-benchmark:


### PR DESCRIPTION
Adds a workflow_dispatch to the stress workflow for manual triggering