### PR TITLE
ci: split off lint into a standalone job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,10 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: Swatinem/rust-cache@v1
-    - name: clippy
-      run: cargo clippy --all
-    - name: fmt
-      run: cargo fmt --all -- --check
     - name: Setup dependencies (ubuntu)
       if: startsWith(matrix.os, 'ubuntu')
       run:
@@ -33,16 +29,6 @@ jobs:
       env:
         CI: true
       run: make tests
-    - name: doc
-      run: cargo doc
-    - name: Check crate package size (feat. 'cargo diet')
-      run: |
-        curl -LSfs https://raw.githubusercontent.com/the-lean-crate/cargo-diet/master/ci/install.sh | \
-         sh -s -- --git the-lean-crate/cargo-diet --target x86_64-unknown-linux-musl
-
-        # Let's not fail CI for this, it will fail locally often enough, and a crate a little bigger
-        # than allows is no problem either if it comes to that.
-        make check-size || true
 
   build-and-test-on-windows:
     name: Windows
@@ -70,6 +56,28 @@ jobs:
         with:
           command: install
           args: gitoxide
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: default
+          toolchain: stable
+          override: true
+      - name: Run cargo clippy
+        run: cargo clippy --all
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+      - name: Run cargo diet
+        run: |
+          curl -LSfs https://raw.githubusercontent.com/the-lean-crate/cargo-diet/master/ci/install.sh | \
+           sh -s -- --git the-lean-crate/cargo-diet --target x86_64-unknown-linux-musl
+
+          # Let's not fail CI for this, it will fail locally often enough, and a crate a little bigger
+          # than allows is no problem either if it comes to that.
+          make check-size || true
 
   cargo-deny:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Splits lint into a ubuntu only standalone job (as ubuntu is the fastest runner).