### PR TITLE
Connect new gitoxide.credentials subsection into section tree

### DIFF
--- a/gix/src/config/tree/sections/gitoxide.rs
+++ b/gix/src/config/tree/sections/gitoxide.rs
@@ -54,6 +54,7 @@ impl Section for Gitoxide {
             &Self::CORE,
             &Self::COMMIT,
             &Self::COMMITTER,
+            &Self::CREDENTIALS,
             &Self::HTTP,
             &Self::HTTPS,
             &Self::OBJECTS,


### PR DESCRIPTION
I believe #1127 forgot to include the new `gitoxide.credentials` subsection into the section tree?