### PR TITLE
Implement object checkout in PrepareCheckout

### DIFF
--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -60,6 +60,20 @@ pub mod main_worktree {
 
     /// Modification
     impl PrepareCheckout {
+        /// Set the `name` of the reference to check out, instead of the remote `HEAD`.
+        /// If `None`, the `HEAD` will be used, which is the default.
+        ///
+        /// Note that `name` should be a partial name like `main` or `feat/one`, but can be a full ref name.
+        /// If a branch on the remote matches, it will automatically be retrieved even without a refspec.
+        /// It can also be a commit id.
+        pub fn with_ref_name<'a, Name, E>(mut self, ref_name: Option<Name>) -> Result<PrepareCheckout, E>
+        where
+            Name: TryInto<&'a gix_ref::PartialNameRef, Error = E>,
+        {
+            self.ref_name = ref_name.map(TryInto::try_into).transpose()?.map(ToOwned::to_owned);
+            Ok(self)
+        }
+
         /// Checkout the main worktree, determining how many threads to use by looking at `checkout.workers`, defaulting to using
         /// on thread per logical core.
         ///

--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -61,49 +61,8 @@ pub mod main_worktree {
 
     /// Modification
     impl PrepareCheckout {
-        /// Set the `name` of the reference to check out, instead of the remote `HEAD`.
-        /// If `None`, the `HEAD` will be used, which is the default.
-        ///
-        /// Note that `name` should be a partial name like `main` or `feat/one`, but can be a full ref name.
-        /// If a branch on the remote matches, it will automatically be retrieved even without a refspec.
-        pub fn with_ref_name<'a, Name, E>(self, ref_name: Option<Name>) -> Result<PrepareCheckout, Error>
-        where
-            Name: TryInto<&'a gix_ref::PartialNameRef, Error = E>,
-            gix_ref::file::find::Error: std::convert::From<E>,
-        {
-            let repo = self
-                .repo
-                .as_ref()
-                .expect("BUG: this method may only be called until it is successful");
-
-            let reference = ref_name
-                .map(|ref_name| repo.try_find_reference(ref_name))
-                .transpose()
-                .map_err(|e| Error::FindHead(crate::reference::find::existing::Error::Find(e)))?
-                .flatten()
-                .map(|r| r.detach());
-
-            self.with_ref(reference)
-        }
-
         /// Set the reference to checkout from the tree.
-        pub fn with_ref<'a>(mut self, ref_val: Option<gix_ref::Reference>) -> Result<PrepareCheckout, Error> {
-            let repo = self
-                .repo
-                .as_ref()
-                .expect("BUG: this method may only be called until it is successful");
-
-            self.checkout_object = ref_val
-                .map(|r| r.attach(repo))
-                .map(|r| r.into_fully_peeled_id())
-                .transpose()?
-                .map(|r| r.inner);
-
-            Ok(self)
-        }
-
-        /// Set the reference to checkout from the tree.
-        pub fn with_object_id(mut self, object_id: Option<crate::ObjectId>) -> PrepareCheckout {
+        pub fn with_rev_single(mut self, object_id: Option<gix_hash::ObjectId>) -> PrepareCheckout {
             self.checkout_object = object_id;
 
             self

--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -5,6 +5,7 @@ use crate::{clone::PrepareCheckout, Repository};
 pub mod main_worktree {
     use std::{path::PathBuf, sync::atomic::AtomicBool};
 
+    use crate::ext::ReferenceExt;
     use crate::{clone::PrepareCheckout, Progress, Repository};
 
     /// The error returned by [`PrepareCheckout::main_worktree()`].
@@ -65,12 +66,31 @@ pub mod main_worktree {
         ///
         /// Note that `name` should be a partial name like `main` or `feat/one`, but can be a full ref name.
         /// If a branch on the remote matches, it will automatically be retrieved even without a refspec.
-        /// It can also be a commit id.
-        pub fn with_ref_name<'a, Name, E>(mut self, ref_name: Option<Name>) -> Result<PrepareCheckout, E>
+        pub fn with_ref_name<'a, Name, E>(mut self, ref_name: Option<Name>) -> Result<PrepareCheckout, Error>
         where
             Name: TryInto<&'a gix_ref::PartialNameRef, Error = E>,
+            gix_ref::file::find::Error: std::convert::From<E>
         {
-            self.ref_name = ref_name.map(TryInto::try_into).transpose()?.map(ToOwned::to_owned);
+            let repo = self
+                .repo
+                .as_ref()
+                .expect("BUG: this method may only be called until it is successful");
+
+            self.ref_val = ref_name
+                .map(|ref_name| repo.try_find_reference(ref_name))
+                .transpose()
+                .map_err(|e| Error::FindHead(crate::reference::find::existing::Error::Find(e)))?
+                .flatten()
+                .map(|r| r.detach());
+
+            Ok(self)
+        }
+        
+        /// Set the reference to checkout from the tree.
+        pub fn with_ref<'a, Name, E>(mut self, ref_val: Option<gix_ref::Reference>) -> Result<PrepareCheckout, Error>
+        {
+            self.ref_val = ref_val;
+
             Ok(self)
         }
 
@@ -111,8 +131,8 @@ pub mod main_worktree {
                 git_dir: repo.git_dir().to_owned(),
             })?;
 
-            let root_tree_id = match &self.ref_name {
-                Some(reference_val) => Some(repo.find_reference(reference_val)?.peel_to_id_in_place()?),
+            let root_tree_id = match self.ref_val.clone() {
+                Some(reference_val) => Some(reference_val.attach(repo).peel_to_id_in_place()?), //Some(repo.find_reference(reference_val)?.peel_to_id_in_place()?),
                 None => repo.head()?.try_peel_to_id_in_place()?,
             };
 

--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -5,7 +5,7 @@ use crate::{clone::PrepareCheckout, Repository};
 pub mod main_worktree {
     use std::{path::PathBuf, sync::atomic::AtomicBool};
 
-    use crate::ext::{ObjectIdExt, ReferenceExt};
+    use crate::ext::ObjectIdExt;
     use crate::{clone::PrepareCheckout, Progress, Repository};
 
     /// The error returned by [`PrepareCheckout::main_worktree()`].

--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -37,6 +37,8 @@ pub enum Error {
     },
     #[error("Failed to update HEAD with values from remote")]
     HeadUpdate(#[from] crate::reference::edit::Error),
+    #[error("Failed to parse revision")]
+    RefParseError(#[from] crate::revision::spec::parse::single::Error),
     #[error("The remote didn't have any ref that matched '{}'", wanted.as_ref().as_bstr())]
     RefNameMissing { wanted: gix_ref::PartialName },
     #[error("The remote has {} refs for '{}', try to use a specific name: {}", candidates.len(), wanted.as_ref().as_bstr(), candidates.iter().filter_map(|n| n.to_str().ok()).collect::<Vec<_>>().join(", "))]
@@ -228,14 +230,21 @@ impl PrepareFetch {
         P: crate::NestedProgress,
         P::SubProgress: 'static,
     {
+
         let (repo, fetch_outcome) = self.fetch_only(progress, should_interrupt)?;
-        Ok((
-            crate::clone::PrepareCheckout {
-                repo: repo.into(),
-                checkout_object: None,
-            }.with_ref_name(self.ref_name.as_ref()).expect("BUG: Ref not found in repo after fetching!"),
-            fetch_outcome,
-        ))
+
+        let mut checkout = crate::clone::PrepareCheckout {
+            repo: repo.into(),
+            checkout_object: None,
+        };
+
+        if let Some(ref_name) = self.ref_name.as_ref() {
+            let bstring: &gix_ref::PartialNameRef = ref_name.as_ref();
+            let rev = checkout.repo().rev_parse_single(bstring.as_bstr())?.detach();
+            checkout = checkout.with_rev_single(Some(rev));
+        }
+
+        Ok((checkout, fetch_outcome))
     }
 }
 

--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -37,6 +37,7 @@ pub enum Error {
     },
     #[error("Failed to update HEAD with values from remote")]
     HeadUpdate(#[from] crate::reference::edit::Error),
+    #[cfg(feature = "revision")]
     #[error("Failed to parse revision")]
     RefParseError(#[from] crate::revision::spec::parse::single::Error),
     #[error("The remote didn't have any ref that matched '{}'", wanted.as_ref().as_bstr())]
@@ -230,7 +231,6 @@ impl PrepareFetch {
         P: crate::NestedProgress,
         P::SubProgress: 'static,
     {
-
         let (repo, fetch_outcome) = self.fetch_only(progress, should_interrupt)?;
 
         let mut checkout = crate::clone::PrepareCheckout {

--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -232,8 +232,8 @@ impl PrepareFetch {
         Ok((
             crate::clone::PrepareCheckout {
                 repo: repo.into(),
-                ref_name: self.ref_name.clone(),
-            },
+                checkout_object: None,
+            }.with_ref_name(self.ref_name.as_ref()).expect("BUG: Ref not found in repo after fetching!"),
             fetch_outcome,
         ))
     }

--- a/gix/src/clone/mod.rs
+++ b/gix/src/clone/mod.rs
@@ -138,8 +138,8 @@ impl PrepareFetch {
 pub struct PrepareCheckout {
     /// A freshly initialized repository which is owned by us, or `None` if it was successfully checked out.
     pub(self) repo: Option<crate::Repository>,
-    /// The name of the reference to check out. If `None`, the reference pointed to by `HEAD` will be checked out.
-    pub(self) ref_val: Option<gix_ref::Reference>,
+    /// The object that will be checked out, or `None` if checking out HEAD.
+    pub(self) checkout_object: Option<gix_hash::ObjectId>,
 }
 
 // This module encapsulates functionality that works with both feature toggles. Can be combined with `fetch`

--- a/gix/src/clone/mod.rs
+++ b/gix/src/clone/mod.rs
@@ -139,7 +139,7 @@ pub struct PrepareCheckout {
     /// A freshly initialized repository which is owned by us, or `None` if it was successfully checked out.
     pub(self) repo: Option<crate::Repository>,
     /// The name of the reference to check out. If `None`, the reference pointed to by `HEAD` will be checked out.
-    pub(self) ref_name: Option<gix_ref::PartialName>,
+    pub(self) ref_val: Option<gix_ref::Reference>,
 }
 
 // This module encapsulates functionality that works with both feature toggles. Can be combined with `fetch`


### PR DESCRIPTION
In continuation of #1403, I implemented `with_object_id` to allow checking out specific commits such as is the case in submodules. 

This currently does not include any test cases as of writing this. [However, I did make sure this worked from a high level in my project](https://github.com/QuestPackageManager/QPM.CLI/blob/acf6561f16fd700d012295e2bdf735221dfc8399/src/utils/git.rs#L258-L260)

Though this does not properly update the `HEAD` and may not clone properly. Hoping I can fix it by using `util::update_head` and refactoring it to use `oid`, though I leave that decision up to you if you have a better idea.

Apologies for the lack of tests as well.

Tasks:
- [x]  Checkout tree associated with the `oid` of the revision used.
- [ ] Update the `HEAD` with `util::update_head` to use the correct detached state.
- [ ] Add tests ensuring this works as intended
-   [ ] Shallow clone with specific revision, then checkout.
-   [ ] Standard clone while checking out specific revision  