### PR TITLE
fix: remove workspace lints from Cargo manifests of fuzz-projects.

### DIFF
--- a/gix-attributes/fuzz/Cargo.toml
+++ b/gix-attributes/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-lints.workspace = true
-
 [package]
 name = "gix-attributes-fuzz"
 version = "0.0.0"

--- a/gix-commitgraph/fuzz/Cargo.toml
+++ b/gix-commitgraph/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-lints.workspace = true
-
 [package]
 name = "gix-commitgraph-fuzz"
 version = "0.0.0"

--- a/gix-config-value/fuzz/Cargo.toml
+++ b/gix-config-value/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-lints.workspace = true
-
 [package]
 name = "gix-config-value-fuzz"
 version = "0.0.0"

--- a/gix-config/fuzz/Cargo.toml
+++ b/gix-config/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-lints.workspace = true
-
 [package]
 name = "gix-config-fuzz"
 version = "0.0.0"

--- a/gix-date/fuzz/Cargo.toml
+++ b/gix-date/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-lints.workspace = true
-
 [package]
 name = "gix-date-fuzz"
 version = "0.0.0"

--- a/gix-object/fuzz/Cargo.toml
+++ b/gix-object/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-lints.workspace = true
-
 [package]
 name = "gix-object-fuzz"
 version = "0.0.0"

--- a/gix-pathspec/fuzz/Cargo.toml
+++ b/gix-pathspec/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-lints.workspace = true
-
 [package]
 name = "gix-pathspec-fuzz"
 version = "0.0.0"

--- a/gix-ref/fuzz/Cargo.toml
+++ b/gix-ref/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-lints.workspace = true
-
 [package]
 name = "gix-ref-fuzz"
 version = "0.0.0"

--- a/gix-refspec/fuzz/Cargo.toml
+++ b/gix-refspec/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-lints.workspace = true
-
 [package]
 name = "gix-refspec-fuzz"
 version = "0.0.0"

--- a/gix-revision/fuzz/Cargo.toml
+++ b/gix-revision/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-lints.workspace = true
-
 [package]
 name = "gix-revision-fuzz"
 version = "0.0.0"

--- a/gix-url/fuzz/Cargo.toml
+++ b/gix-url/fuzz/Cargo.toml
@@ -1,5 +1,3 @@
-lints.workspace = true
-
 [package]
 name = "gix-url-fuzz"
 version = "0.0.0"


### PR DESCRIPTION
They are not part of the parent workspace.
