### PR TITLE
Install `liblzma-dev` in CI `test` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Setup dependencies
         run:
-          sudo apt-get install tree
+          sudo apt-get install -y --no-install-recommends liblzma-dev tree
       - uses: extractions/setup-just@v2
       - uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
Per https://github.com/actions/runner-images/issues/10636, the `ubuntu-latest` GitHub Actions hosted runner is being migrated from `ubuntu-22.04` to `ubuntu-24.04`. The `ci.yml` workflow, including the full `test` job, uses `ubuntu-latest`, and recently has switched over to using the Ubuntu 24.04 runner.

It makes sense to use this newer version, but that runner apparently does not preinstall the headers required to build with `-llzma`. That causes `just ci-test` to fail at:

```sh
cargo nextest run -p gix-testtools --features xz
```

The error message is:

```text
/usr/bin/ld: cannot find -llzma: No such file or directory
```

This PR installs the `liblzma-dev` package that provides the required headers, so we can use Ubuntu 24.04 LTS while continuing to test the `xz` feature of `gix-testtools`.

The failure this addresses was first observed in #1618 at 64e0f78: https://github.com/GitoxideLabs/gitoxide/actions/runs/11304216949/job/31442302018?pr=1618

But it is not caused by any of the changes there, and it now occurs whenever the `test` job is run, including if it is re-run at the tip of the main branch (or any other branch), such as in: https://github.com/EliahKagan/gitoxide/actions/runs/11317510844/job/31471040361

In both cases, expanding *Set up job* > *Operating system* shows Ubuntu 24.04.1 LTS.

(The failure this addresses is also not related to #1622, which documents an unrelated failure that is possible to observe locally and that, if no change is made related to it, can be expected to occur on CI in the `test` job starting sometime soon, but that is not yet seen on CI.)

