### PR TITLE
Update and improve another few URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ base_url = https://github.com/GitoxideLabs/gitoxide.git
 update-curl-fixtures: ## use curl to fetch raw fixtures for use in unit test. Changes there might break them
 	curl -D - -L "$(base_url)/info/refs?service=git-upload-pack"  > $(transport_fixtures)/v1/http-handshake.response
 	curl -D - -H 'Git-Protocol: version=2' -L "$(base_url)/info/refs?service=git-upload-pack"  > $(transport_fixtures)/v2/http-handshake.response
-	curl -H 'User-Agent: git/oxide-0.1.0' -D - -H 'Git-Protocol: version=1' -L "https://github.com/GitoxideLabs/foo/info/refs?service=git-upload-pack"  > $(transport_fixtures)/http-401.response
+	curl -H 'User-Agent: git/oxide-0.1.0' -D - -H 'Git-Protocol: version=1' -L "https://github.com/GitoxideLabs/nonexistent/info/refs?service=git-upload-pack"  > $(transport_fixtures)/http-401.response
 	curl -D - -H 'Git-Protocol: version=1' -L "https://github.com/GitoxideLabs/gitoxide/info/refs?service=git-upload-pack"  > $(transport_fixtures)/http-404.response
 
 update-assets: $(baseline_asset_fixture) ## refresh assets compiled into the binaries from their source

--- a/gix-diff/src/tree/function.rs
+++ b/gix-diff/src/tree/function.rs
@@ -23,8 +23,8 @@ use crate::tree::{visit::Change, Error, State, TreeInfoTuple, Visit};
 /// * cycle checking is not performed, but can be performed in the delegate which can return
 ///   [`tree::visit::Action::Cancel`](crate::tree::visit::Action::Cancel) to stop the traversal.
 ///
-/// [git_cmp_c]: https://github.com/git/git/blob/311531c9de557d25ac087c1637818bd2aad6eb3a/tree-diff.c#L49:L65
-/// [git_cmp_rs]: https://github.com/GitoxideLabs/gitoxide/blob/a4d5f99c8dc99bf814790928a3bf9649cd99486b/gix-object/src/mutable/tree.rs#L52-L55
+/// [git_cmp_c]: https://github.com/git/git/blob/ef8ce8f3d4344fd3af049c17eeba5cd20d98b69f/tree-diff.c#L72-L88
+/// [git_cmp_rs]: https://github.com/GitoxideLabs/gitoxide/blob/795962b107d86f58b1f7c75006da256d19cc80ad/gix-object/src/tree/mod.rs#L263-L273
 #[doc(alias = "diff_tree_to_tree", alias = "git2")]
 pub fn diff<StateMut>(
     lhs: TreeRefIter<'_>,


### PR DESCRIPTION
This builds on 65f69f7 (#1624, see also https://github.com/GitoxideLabs/gitoxide/pull/1624#issuecomment-2410324422), completing the third task in #1627 (`gix-diff/src/tree/function.rs:27`), fixing a broken link and updating another. See 991c939 for details.

This does not do the first or second task of #1627 because I have not (yet?) figured out how. I think those improvements could go in another PR, once the best solution is figured out.

I've also improved on 1ea08bf (#1624) by giving the nonexistent repo used for a 401 response the more self-documenting name `nonexistent`. See baa6f23 for the rationale and a few details.