### PR TITLE
doc: Remove a couple obsolete planned items

### DIFF
--- a/crate-status.md
+++ b/crate-status.md
@@ -229,7 +229,6 @@ The top-level crate that acts as hub to all functionality provided by the `gix-*
         * [x] decode (zero copy)
         * [x] verify checksum
     * [x] simple and fast pack traversal
-        * [ ] [fast pack traversal works with ref-deltas](https://github.com/GitoxideLabs/gitoxide/blob/8f9a55bb31af32b266d7c53426bc925361a627b2/gix-pack/src/cache/delta/from_offsets.rs#L101-L105)
     * [x] decode
         * [x] full objects
         * [x] deltified objects

--- a/general-tasks.md
+++ b/general-tasks.md
@@ -1,5 +1,7 @@
 ## General
 
+*Note: Some of these items may be out of date.*
+
 ### Get rid of unsafe pointer magic [WithSidebands] _(cost: high)_
 
 What needs to be done is to transform the &mut StreamingPeekableIter into a child future, and when exhausted, it must be transformed back
@@ -11,12 +13,6 @@ That would be quite some work though.
 [WithSidebands]: https://github.com/GitoxideLabs/gitoxide/blob/64872690e60efdd9267d517f4d9971eecd3b875c/gix-packetline/src/read/sidebands/async_io.rs#L270
 
 ## Potential for improving performance
-
-### gix-odb
-
-* Finding an object in a loose object store [costs an extra disk IO operation][extra-iop] to pacify the borrow checker. This wouldn't be an issue with polonius.
-
-[extra-iop]: https://github.com/GitoxideLabs/gitoxide/blob/2958145a0ae1ef582bbf88352f5567d5c2b5eaf0/gix-odb/src/store/linked/find.rs#L33
 
 ### gix-object
 


### PR DESCRIPTION
Fixes #1627

This removes two items that are obsolete or effectively completed due to subsequent design changes, and whose links were broken, in `crate-status.md` and `general-tasks.md`. It also adds a note to `general-tasks.md` that it may be outdated.

These changes are based on the discussion in #1627 and specifically https://github.com/GitoxideLabs/gitoxide/issues/1627#issuecomment-2412933522.

