### PR TITLE
Reword security contact description for clarity

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,6 @@
 Please feel free to [draft a GitHub advisory](https://github.com/GitoxideLabs/gitoxide/security/advisories/new), and I will work with you to disclose and or resolve the issue
 responsibly.
 
-If this doesn't seem like the right approach or there are questions, please feel free to reach out to the @icloud.com email used in my commits.
+If this doesn't seem like the right approach or there are questions, please feel free to reach out to the email used in Sebastian Thiel's commits.
 
 Thank you.


### PR DESCRIPTION
Closes #1632

This doesn't change the contact, just rewords it to avoid possible future ambiguity, now that the repository is in an org.

This is one of several possible wording changes that I think could be done in accordance with https://github.com/GitoxideLabs/gitoxide/issues/1632#issuecomment-2415818357. Another possibility could be to keep all the previous wording and just replace "my". I'd be pleased to make adjustments to this PR and also I of course do not mind if you make them.

It's just occurred to me that I don't know if changes apply only to `SECURITY.md` should have a `doc:` prefix in the commit message title. I think they don't need one but I'm not sure.