### PR TITLE
improve find-reference error messages

### DIFF
--- a/gix-pack/src/bundle/write/mod.rs
+++ b/gix-pack/src/bundle/write/mod.rs
@@ -366,6 +366,7 @@ fn resolve_entry(range: data::EntryRange, mapped_file: &memmap2::Mmap) -> Option
     mapped_file.get(range.start as usize..range.end as usize)
 }
 
+#[allow(clippy::type_complexity)] // cannot typedef impl Fn
 fn new_pack_file_resolver(
     data_file: SharedTempFile,
 ) -> io::Result<(

--- a/gix/src/reference/errors.rs
+++ b/gix/src/reference/errors.rs
@@ -110,14 +110,16 @@ pub mod head_tree_id {
 pub mod find {
     ///
     pub mod existing {
+        use gix_ref::PartialName;
+
         /// The error returned by [`find_reference(…)`][crate::Repository::find_reference()], and others.
         #[derive(Debug, thiserror::Error)]
         #[allow(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             Find(#[from] crate::reference::find::Error),
-            #[error("The reference did not exist")]
-            NotFound,
+            #[error("The reference '{}' did not exist", name.as_ref().as_bstr())]
+            NotFound { name: PartialName },
         }
     }
 
@@ -127,7 +129,5 @@ pub mod find {
     pub enum Error {
         #[error(transparent)]
         Find(#[from] gix_ref::file::find::Error),
-        #[error(transparent)]
-        PackedRefsOpen(#[from] gix_ref::packed::buffer::open::Error),
     }
 }


### PR DESCRIPTION
Now it's possible to see the reference that wasn't found.

This comes at a cost of pre-emptively cloning something
that could be more than a reference, but without that it seems
impossible to make it compile.
