### PR TITLE
Allow construct CustomFormat outside the crate

### DIFF
--- a/gix-date/src/time/mod.rs
+++ b/gix-date/src/time/mod.rs
@@ -33,6 +33,13 @@ pub enum Format {
 #[derive(Clone, Copy, Debug)]
 pub struct CustomFormat(pub(crate) &'static str);
 
+impl CustomFormat {
+    /// Create a new custom format.
+    pub const fn new(format: &'static str) -> Self {
+        Self(format)
+    }
+}
+
 impl From<CustomFormat> for Format {
     fn from(custom_format: CustomFormat) -> Format {
         Format::Custom(custom_format)

--- a/gix-date/src/time/mod.rs
+++ b/gix-date/src/time/mod.rs
@@ -20,8 +20,7 @@ pub enum Sign {
 /// Various ways to describe a time format.
 #[derive(Debug, Clone, Copy)]
 pub enum Format {
-    /// A custom format limited to what's in the
-    /// [`format`](mod@crate::time::format) submodule.
+    /// A custom format limited to what's in the [`format`](mod@format) submodule.
     Custom(CustomFormat),
     /// The seconds since 1970, also known as unix epoch, like `1660874655`.
     Unix,
@@ -34,7 +33,7 @@ pub enum Format {
 pub struct CustomFormat(pub(crate) &'static str);
 
 impl CustomFormat {
-    /// Create a new custom format.
+    /// Create a new custom `format` suitable for use with the [`jiff`] crate.
     pub const fn new(format: &'static str) -> Self {
         Self(format)
     }


### PR DESCRIPTION
@Byron One question is that shall we use `Cow<'static, str>` instead to allow define a non-static format?

It breaks the `Copy` trait somehow so I don't make this change. And a static format is sufficient for my use cases.