### PR TITLE
Respect env variables when running gix

### DIFF
--- a/gix-config/fuzz/fuzz_targets/fuzz_file.rs
+++ b/gix-config/fuzz/fuzz_targets/fuzz_file.rs
@@ -79,7 +79,7 @@ fn fuzz_mutable_section(
         subsection_name,
         Cow::Owned(renamed_section_name.clone()),
         renamed_subsection_name.clone(),
-        &mut |_| false,
+        |_| false,
     ));
 
     Ok(())

--- a/gix-config/src/file/access/comfort.rs
+++ b/gix-config/src/file/access/comfort.rs
@@ -2,13 +2,14 @@ use std::borrow::Cow;
 
 use bstr::BStr;
 
-use crate::{file::MetadataFilter, value, AsKey, File};
+use crate::file::Metadata;
+use crate::{value, AsKey, File};
 
 /// Comfortable API for accessing values
 impl File<'_> {
     /// Like [`string_by()`](File::string_by()), but suitable for statically known `key`s like `remote.origin.url`.
     pub fn string(&self, key: impl AsKey) -> Option<Cow<'_, BStr>> {
-        self.string_filter(key, &mut |_| true)
+        self.string_filter(key, |_| true)
     }
 
     /// Like [`value()`](File::value()), but returning `None` if the string wasn't found.
@@ -20,13 +21,11 @@ impl File<'_> {
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
     ) -> Option<Cow<'_, BStr>> {
-        self.string_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), &mut |_| {
-            true
-        })
+        self.string_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), |_| true)
     }
 
     /// Like [`string_filter_by()`](File::string_filter_by()), but suitable for statically known `key`s like `remote.origin.url`.
-    pub fn string_filter(&self, key: impl AsKey, filter: &mut MetadataFilter) -> Option<Cow<'_, BStr>> {
+    pub fn string_filter(&self, key: impl AsKey, filter: impl FnMut(&Metadata) -> bool) -> Option<Cow<'_, BStr>> {
         let key = key.try_as_key()?;
         self.raw_value_filter_by(key.section_name, key.subsection_name, key.value_name, filter)
             .ok()
@@ -38,7 +37,7 @@ impl File<'_> {
         section_name: impl AsRef<str>,
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Option<Cow<'_, BStr>> {
         self.raw_value_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), filter)
             .ok()
@@ -46,7 +45,7 @@ impl File<'_> {
 
     /// Like [`path_by()`](File::path_by()), but suitable for statically known `key`s like `remote.origin.url`.
     pub fn path(&self, key: impl AsKey) -> Option<crate::Path<'_>> {
-        self.path_filter(key, &mut |_| true)
+        self.path_filter(key, |_| true)
     }
 
     /// Like [`value()`](File::value()), but returning `None` if the path wasn't found.
@@ -61,13 +60,11 @@ impl File<'_> {
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
     ) -> Option<crate::Path<'_>> {
-        self.path_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), &mut |_| {
-            true
-        })
+        self.path_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), |_| true)
     }
 
     /// Like [`path_filter_by()`](File::path_filter_by()), but suitable for statically known `key`s like `remote.origin.url`.
-    pub fn path_filter(&self, key: impl AsKey, filter: &mut MetadataFilter) -> Option<crate::Path<'_>> {
+    pub fn path_filter(&self, key: impl AsKey, filter: impl FnMut(&Metadata) -> bool) -> Option<crate::Path<'_>> {
         let key = key.try_as_key()?;
         self.path_filter_by(key.section_name, key.subsection_name, key.value_name, filter)
     }
@@ -83,7 +80,7 @@ impl File<'_> {
         section_name: impl AsRef<str>,
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Option<crate::Path<'_>> {
         self.raw_value_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), filter)
             .ok()
@@ -92,7 +89,7 @@ impl File<'_> {
 
     /// Like [`boolean_by()`](File::boolean_by()), but suitable for statically known `key`s like `remote.origin.url`.
     pub fn boolean(&self, key: impl AsKey) -> Option<Result<bool, value::Error>> {
-        self.boolean_filter(key, &mut |_| true)
+        self.boolean_filter(key, |_| true)
     }
 
     /// Like [`value()`](File::value()), but returning `None` if the boolean value wasn't found.
@@ -102,13 +99,15 @@ impl File<'_> {
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
     ) -> Option<Result<bool, value::Error>> {
-        self.boolean_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), &mut |_| {
-            true
-        })
+        self.boolean_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), |_| true)
     }
 
     /// Like [`boolean_filter_by()`](File::boolean_filter_by()), but suitable for statically known `key`s like `remote.origin.url`.
-    pub fn boolean_filter(&self, key: impl AsKey, filter: &mut MetadataFilter) -> Option<Result<bool, value::Error>> {
+    pub fn boolean_filter(
+        &self,
+        key: impl AsKey,
+        filter: impl FnMut(&Metadata) -> bool,
+    ) -> Option<Result<bool, value::Error>> {
         let key = key.try_as_key()?;
         self.boolean_filter_by(key.section_name, key.subsection_name, key.value_name, filter)
     }
@@ -119,7 +118,7 @@ impl File<'_> {
         section_name: impl AsRef<str>,
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
-        filter: &mut MetadataFilter,
+        mut filter: impl FnMut(&Metadata) -> bool,
     ) -> Option<Result<bool, value::Error>> {
         let section_name = section_name.as_ref();
         let section_ids = self
@@ -142,7 +141,7 @@ impl File<'_> {
 
     /// Like [`integer_by()`](File::integer_by()), but suitable for statically known `key`s like `remote.origin.url`.
     pub fn integer(&self, key: impl AsKey) -> Option<Result<i64, value::Error>> {
-        self.integer_filter(key, &mut |_| true)
+        self.integer_filter(key, |_| true)
     }
 
     /// Like [`value()`](File::value()), but returning an `Option` if the integer wasn't found.
@@ -152,11 +151,15 @@ impl File<'_> {
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
     ) -> Option<Result<i64, value::Error>> {
-        self.integer_filter_by(section_name, subsection_name, value_name, &mut |_| true)
+        self.integer_filter_by(section_name, subsection_name, value_name, |_| true)
     }
 
     /// Like [`integer_filter_by()`](File::integer_filter_by()), but suitable for statically known `key`s like `remote.origin.url`.
-    pub fn integer_filter(&self, key: impl AsKey, filter: &mut MetadataFilter) -> Option<Result<i64, value::Error>> {
+    pub fn integer_filter(
+        &self,
+        key: impl AsKey,
+        filter: impl FnMut(&Metadata) -> bool,
+    ) -> Option<Result<i64, value::Error>> {
         let key = key.try_as_key()?;
         self.integer_filter_by(key.section_name, key.subsection_name, key.value_name, filter)
     }
@@ -167,7 +170,7 @@ impl File<'_> {
         section_name: impl AsRef<str>,
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Option<Result<i64, value::Error>> {
         let int = self
             .raw_value_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), filter)
@@ -196,7 +199,7 @@ impl File<'_> {
     }
 
     /// Like [`strings_filter_by()`](File::strings_filter_by()), but suitable for statically known `key`s like `remote.origin.url`.
-    pub fn strings_filter(&self, key: impl AsKey, filter: &mut MetadataFilter) -> Option<Vec<Cow<'_, BStr>>> {
+    pub fn strings_filter(&self, key: impl AsKey, filter: impl FnMut(&Metadata) -> bool) -> Option<Vec<Cow<'_, BStr>>> {
         let key = key.try_as_key()?;
         self.strings_filter_by(key.section_name, key.subsection_name, key.value_name, filter)
     }
@@ -207,7 +210,7 @@ impl File<'_> {
         section_name: impl AsRef<str>,
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Option<Vec<Cow<'_, BStr>>> {
         self.raw_values_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), filter)
             .ok()
@@ -215,7 +218,7 @@ impl File<'_> {
 
     /// Like [`integers()`](File::integers()), but suitable for statically known `key`s like `remote.origin.url`.
     pub fn integers(&self, key: impl AsKey) -> Option<Result<Vec<i64>, value::Error>> {
-        self.integers_filter(key, &mut |_| true)
+        self.integers_filter(key, |_| true)
     }
 
     /// Similar to [`values_by(…)`](File::values_by()) but returning integers if at least one of them was found
@@ -226,16 +229,14 @@ impl File<'_> {
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
     ) -> Option<Result<Vec<i64>, value::Error>> {
-        self.integers_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), &mut |_| {
-            true
-        })
+        self.integers_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), |_| true)
     }
 
     /// Like [`integers_filter_by()`](File::integers_filter_by()), but suitable for statically known `key`s like `remote.origin.url`.
     pub fn integers_filter(
         &self,
         key: impl AsKey,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Option<Result<Vec<i64>, value::Error>> {
         let key = key.try_as_key()?;
         self.integers_filter_by(key.section_name, key.subsection_name, key.value_name, filter)
@@ -248,7 +249,7 @@ impl File<'_> {
         section_name: impl AsRef<str>,
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Option<Result<Vec<i64>, value::Error>> {
         self.raw_values_filter_by(section_name.as_ref(), subsection_name, value_name.as_ref(), filter)
             .ok()

--- a/gix-config/src/file/access/mutate.rs
+++ b/gix-config/src/file/access/mutate.rs
@@ -3,8 +3,9 @@ use std::borrow::Cow;
 use bstr::BStr;
 use gix_features::threading::OwnShared;
 
+use crate::file::Metadata;
 use crate::{
-    file::{self, rename_section, write::ends_with_newline, MetadataFilter, SectionBodyIdsLut, SectionId, SectionMut},
+    file::{self, rename_section, write::ends_with_newline, SectionBodyIdsLut, SectionId, SectionMut},
     lookup,
     parse::{section, Event, FrontMatterEvents},
     File,
@@ -61,7 +62,7 @@ impl<'event> File<'event> {
         name: impl AsRef<str>,
         subsection_name: Option<&BStr>,
     ) -> Result<SectionMut<'a, 'event>, section::header::Error> {
-        self.section_mut_or_create_new_filter(name, subsection_name, &mut |_| true)
+        self.section_mut_or_create_new_filter(name, subsection_name, |_| true)
     }
 
     /// Returns an mutable section with a given `name` and optional `subsection_name`, _if it exists_ **and** passes `filter`, or create
@@ -70,7 +71,7 @@ impl<'event> File<'event> {
         &'a mut self,
         name: impl AsRef<str>,
         subsection_name: Option<&BStr>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<SectionMut<'a, 'event>, section::header::Error> {
         self.section_mut_or_create_new_filter_inner(name.as_ref(), subsection_name, filter)
     }
@@ -79,7 +80,7 @@ impl<'event> File<'event> {
         &'a mut self,
         name: &str,
         subsection_name: Option<&BStr>,
-        filter: &mut MetadataFilter,
+        mut filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<SectionMut<'a, 'event>, section::header::Error> {
         match self
             .section_ids_by_name_and_subname(name.as_ref(), subsection_name)
@@ -110,7 +111,7 @@ impl<'event> File<'event> {
         &'a mut self,
         name: impl AsRef<str>,
         subsection_name: Option<&BStr>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<Option<file::SectionMut<'a, 'event>>, lookup::existing::Error> {
         self.section_mut_filter_inner(name.as_ref(), subsection_name, filter)
     }
@@ -119,7 +120,7 @@ impl<'event> File<'event> {
         &'a mut self,
         name: &str,
         subsection_name: Option<&BStr>,
-        filter: &mut MetadataFilter,
+        mut filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<Option<file::SectionMut<'a, 'event>>, lookup::existing::Error> {
         let id = self
             .section_ids_by_name_and_subname(name, subsection_name)?
@@ -137,7 +138,7 @@ impl<'event> File<'event> {
     pub fn section_mut_filter_by_key<'a, 'b>(
         &'a mut self,
         key: impl Into<&'b BStr>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<Option<file::SectionMut<'a, 'event>>, lookup::existing::Error> {
         let key = section::unvalidated::Key::parse(key).ok_or(lookup::existing::Error::KeyMissing)?;
         self.section_mut_filter(key.section_name, key.subsection_name, filter)
@@ -289,7 +290,7 @@ impl<'event> File<'event> {
         &mut self,
         name: impl AsRef<str>,
         subsection_name: impl Into<Option<&'a BStr>>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Option<file::Section<'event>> {
         self.remove_section_filter_inner(name.as_ref(), subsection_name.into(), filter)
     }
@@ -298,7 +299,7 @@ impl<'event> File<'event> {
         &mut self,
         name: &str,
         subsection_name: Option<&BStr>,
-        filter: &mut MetadataFilter,
+        mut filter: impl FnMut(&Metadata) -> bool,
     ) -> Option<file::Section<'event>> {
         let id = self
             .section_ids_by_name_and_subname(name, subsection_name)
@@ -352,7 +353,7 @@ impl<'event> File<'event> {
         subsection_name: impl Into<Option<&'a BStr>>,
         new_name: impl Into<Cow<'event, str>>,
         new_subsection_name: impl Into<Option<Cow<'event, BStr>>>,
-        filter: &mut MetadataFilter,
+        mut filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<(), rename_section::Error> {
         let id = self
             .section_ids_by_name_and_subname(name.as_ref(), subsection_name.into())?

--- a/gix-config/src/file/access/raw.rs
+++ b/gix-config/src/file/access/raw.rs
@@ -3,8 +3,9 @@ use std::{borrow::Cow, collections::HashMap};
 use bstr::BStr;
 use smallvec::ToSmallVec;
 
+use crate::file::Metadata;
 use crate::{
-    file::{mutable::multi_value::EntryData, Index, MetadataFilter, MultiValueMut, Size, ValueMut},
+    file::{mutable::multi_value::EntryData, Index, MultiValueMut, Size, ValueMut},
     lookup,
     parse::{section, Event},
     AsKey, File,
@@ -20,7 +21,7 @@ impl<'event> File<'event> {
     /// a multivar instead.
     pub fn raw_value(&self, key: impl AsKey) -> Result<Cow<'_, BStr>, lookup::existing::Error> {
         let key = key.as_key();
-        self.raw_value_filter_by(key.section_name, key.subsection_name, key.value_name, &mut |_| true)
+        self.raw_value_filter_by(key.section_name, key.subsection_name, key.value_name, |_| true)
     }
 
     /// Returns an uninterpreted value given a section, an optional subsection
@@ -34,7 +35,7 @@ impl<'event> File<'event> {
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
     ) -> Result<Cow<'_, BStr>, lookup::existing::Error> {
-        self.raw_value_filter_by(section_name, subsection_name, value_name, &mut |_| true)
+        self.raw_value_filter_by(section_name, subsection_name, value_name, |_| true)
     }
 
     /// Returns an uninterpreted value given a `key`, if it passes the `filter`.
@@ -44,7 +45,7 @@ impl<'event> File<'event> {
     pub fn raw_value_filter(
         &self,
         key: impl AsKey,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<Cow<'_, BStr>, lookup::existing::Error> {
         let key = key.as_key();
         self.raw_value_filter_by(key.section_name, key.subsection_name, key.value_name, filter)
@@ -60,7 +61,7 @@ impl<'event> File<'event> {
         section_name: impl AsRef<str>,
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<Cow<'_, BStr>, lookup::existing::Error> {
         self.raw_value_filter_inner(section_name.as_ref(), subsection_name, value_name.as_ref(), filter)
     }
@@ -70,7 +71,7 @@ impl<'event> File<'event> {
         section_name: &str,
         subsection_name: Option<&BStr>,
         value_name: &str,
-        filter: &mut MetadataFilter,
+        mut filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<Cow<'_, BStr>, lookup::existing::Error> {
         let section_ids = self.section_ids_by_name_and_subname(section_name, subsection_name)?;
         for section_id in section_ids.rev() {
@@ -110,7 +111,7 @@ impl<'event> File<'event> {
         subsection_name: Option<&'lookup BStr>,
         value_name: &'lookup str,
     ) -> Result<ValueMut<'_, 'lookup, 'event>, lookup::existing::Error> {
-        self.raw_value_mut_filter(section_name, subsection_name, value_name, &mut |_| true)
+        self.raw_value_mut_filter(section_name, subsection_name, value_name, |_| true)
     }
 
     /// Returns a mutable reference to an uninterpreted value given a section,
@@ -123,7 +124,7 @@ impl<'event> File<'event> {
         section_name: impl AsRef<str>,
         subsection_name: Option<&'lookup BStr>,
         value_name: &'lookup str,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<ValueMut<'_, 'lookup, 'event>, lookup::existing::Error> {
         self.raw_value_mut_filter_inner(section_name.as_ref(), subsection_name, value_name, filter)
     }
@@ -133,7 +134,7 @@ impl<'event> File<'event> {
         section_name: &str,
         subsection_name: Option<&'lookup BStr>,
         value_name: &'lookup str,
-        filter: &mut MetadataFilter,
+        mut filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<ValueMut<'_, 'lookup, 'event>, lookup::existing::Error> {
         let mut section_ids = self
             .section_ids_by_name_and_subname(section_name, subsection_name)?
@@ -272,7 +273,7 @@ impl<'event> File<'event> {
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
     ) -> Result<Vec<Cow<'_, BStr>>, lookup::existing::Error> {
-        self.raw_values_filter_by(section_name, subsection_name, value_name, &mut |_| true)
+        self.raw_values_filter_by(section_name, subsection_name, value_name, |_| true)
     }
 
     /// Returns all uninterpreted values given a `key`, if the value passes `filter`, in order of occurrence.
@@ -282,7 +283,7 @@ impl<'event> File<'event> {
     pub fn raw_values_filter(
         &self,
         key: impl AsKey,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<Vec<Cow<'_, BStr>>, lookup::existing::Error> {
         let key = key.as_key();
         self.raw_values_filter_by(key.section_name, key.subsection_name, key.value_name, filter)
@@ -298,7 +299,7 @@ impl<'event> File<'event> {
         section_name: impl AsRef<str>,
         subsection_name: Option<&BStr>,
         value_name: impl AsRef<str>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<Vec<Cow<'_, BStr>>, lookup::existing::Error> {
         self.raw_values_filter_inner(section_name.as_ref(), subsection_name, value_name.as_ref(), filter)
     }
@@ -308,7 +309,7 @@ impl<'event> File<'event> {
         section_name: &str,
         subsection_name: Option<&BStr>,
         value_name: &str,
-        filter: &mut MetadataFilter,
+        mut filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<Vec<Cow<'_, BStr>>, lookup::existing::Error> {
         let mut values = Vec::new();
         let section_ids = self.section_ids_by_name_and_subname(section_name, subsection_name)?;
@@ -440,7 +441,7 @@ impl<'event> File<'event> {
         subsection_name: Option<&'lookup BStr>,
         value_name: &'lookup str,
     ) -> Result<MultiValueMut<'_, 'lookup, 'event>, lookup::existing::Error> {
-        self.raw_values_mut_filter_by(section_name, subsection_name, value_name, &mut |_| true)
+        self.raw_values_mut_filter_by(section_name, subsection_name, value_name, |_| true)
     }
 
     /// Returns mutable references to all uninterpreted values given a `key`,
@@ -448,7 +449,7 @@ impl<'event> File<'event> {
     pub fn raw_values_mut_filter<'lookup>(
         &mut self,
         key: &'lookup impl AsKey,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<MultiValueMut<'_, 'lookup, 'event>, lookup::existing::Error> {
         let key = key.as_key();
         self.raw_values_mut_filter_by(key.section_name, key.subsection_name, key.value_name, filter)
@@ -461,7 +462,7 @@ impl<'event> File<'event> {
         section_name: impl AsRef<str>,
         subsection_name: Option<&'lookup BStr>,
         value_name: &'lookup str,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<MultiValueMut<'_, 'lookup, 'event>, lookup::existing::Error> {
         self.raw_values_mut_filter_inner(section_name.as_ref(), subsection_name, value_name, filter)
     }
@@ -471,7 +472,7 @@ impl<'event> File<'event> {
         section_name: &str,
         subsection_name: Option<&'lookup BStr>,
         value_name: &'lookup str,
-        filter: &mut MetadataFilter,
+        mut filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<MultiValueMut<'_, 'lookup, 'event>, lookup::existing::Error> {
         let section_ids = self.section_ids_by_name_and_subname(section_name, subsection_name)?;
         let key = section::ValueName(Cow::<BStr>::Borrowed(value_name.into()));
@@ -692,7 +693,7 @@ impl<'event> File<'event> {
         Key: TryInto<section::ValueName<'event>, Error = E>,
         section::value_name::Error: From<E>,
     {
-        self.set_raw_value_filter_by(section_name, subsection_name, value_name, new_value, &mut |_| true)
+        self.set_raw_value_filter_by(section_name, subsection_name, value_name, new_value, |_| true)
     }
 
     /// Similar to [`set_raw_value()`](Self::set_raw_value()), but only sets existing values in sections matching
@@ -701,7 +702,7 @@ impl<'event> File<'event> {
         &mut self,
         key: &'event impl AsKey,
         new_value: impl Into<&'b BStr>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<Option<Cow<'event, BStr>>, crate::file::set_raw_value::Error> {
         let key = key.as_key();
         self.set_raw_value_filter_by(key.section_name, key.subsection_name, key.value_name, new_value, filter)
@@ -715,7 +716,7 @@ impl<'event> File<'event> {
         subsection_name: Option<&BStr>,
         key: Key,
         new_value: impl Into<&'b BStr>,
-        filter: &mut MetadataFilter,
+        filter: impl FnMut(&Metadata) -> bool,
     ) -> Result<Option<Cow<'event, BStr>>, crate::file::set_raw_value::Error>
     where
         Key: TryInto<section::ValueName<'event>, Error = E>,

--- a/gix-config/src/file/mod.rs
+++ b/gix-config/src/file/mod.rs
@@ -75,9 +75,6 @@ pub struct Section<'a> {
     id: SectionId,
 }
 
-/// A function to filter metadata, returning `true` if the corresponding but omitted value can be used.
-pub type MetadataFilter = dyn FnMut(&'_ Metadata) -> bool;
-
 /// A strongly typed index into some range.
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Clone, Copy)]
 pub(crate) struct Index(pub(crate) usize);

--- a/gix-config/src/file/write.rs
+++ b/gix-config/src/file/write.rs
@@ -18,7 +18,7 @@ impl File<'_> {
     pub fn write_to_filter(
         &self,
         mut out: &mut dyn std::io::Write,
-        filter: &mut dyn FnMut(&Section<'_>) -> bool,
+        mut filter: impl FnMut(&Section<'_>) -> bool,
     ) -> std::io::Result<()> {
         let nl = self.detect_newline_style();
 
@@ -27,8 +27,7 @@ impl File<'_> {
                 event.write_to(&mut out)?;
             }
 
-            if !ends_with_newline(self.frontmatter_events.as_ref(), nl, true)
-                && self.sections.values().any(&mut *filter)
+            if !ends_with_newline(self.frontmatter_events.as_ref(), nl, true) && self.sections.values().any(&mut filter)
             {
                 out.write_all(nl)?;
             }
@@ -67,7 +66,7 @@ impl File<'_> {
     /// Stream ourselves to the given `out`, in order to reproduce this file mostly losslessly
     /// as it was parsed.
     pub fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
-        self.write_to_filter(out, &mut |_| true)
+        self.write_to_filter(out, |_| true)
     }
 }
 

--- a/gix-config/tests/file/init/from_paths/mod.rs
+++ b/gix-config/tests/file/init/from_paths/mod.rs
@@ -165,21 +165,21 @@ fn multiple_paths_multi_value_and_filter() -> crate::Result {
     );
 
     assert_eq!(
-        config.string_filter("core.key", &mut |m| m.source == Source::System),
+        config.string_filter("core.key", |m| m.source == Source::System),
         Some(cow_str("a")),
         "the filter discards all values with higher priority"
     );
     assert_eq!(
-        config.string_filter("core.key", &mut |m| m.source == Source::System),
+        config.string_filter("core.key", |m| m.source == Source::System),
         Some(cow_str("a")),
     );
 
     assert_eq!(
-        config.strings_filter("core.key", &mut |m| m.source == Source::Git || m.source == Source::User),
+        config.strings_filter("core.key", |m| m.source == Source::Git || m.source == Source::User),
         Some(vec![cow_str("b"), cow_str("c")])
     );
     assert_eq!(
-        config.strings_filter("core.key", &mut |m| m.source == Source::Git || m.source == Source::User),
+        config.strings_filter("core.key", |m| m.source == Source::Git || m.source == Source::User),
         Some(vec![cow_str("b"), cow_str("c")])
     );
 

--- a/gix-config/tests/file/mutable/section.rs
+++ b/gix-config/tests/file/mutable/section.rs
@@ -16,7 +16,7 @@ fn section_mut_or_create_new_is_infallible() -> crate::Result {
 #[test]
 fn section_mut_or_create_new_filter_may_reject_existing_sections() -> crate::Result {
     let mut config = multi_value_section();
-    let section = config.section_mut_or_create_new_filter("a", None, &mut |_| false)?;
+    let section = config.section_mut_or_create_new_filter("a", None, |_| false)?;
     assert_eq!(section.header().name(), "a");
     assert_eq!(section.header().subsection_name(), None);
     assert_eq!(section.to_bstring(), "[a]\n");

--- a/gix-config/tests/file/write.rs
+++ b/gix-config/tests/file/write.rs
@@ -135,7 +135,7 @@ mod to_filter {
             .push("c".try_into()?, Some("d".into()));
 
         let mut buf = Vec::<u8>::new();
-        config.write_to_filter(&mut buf, &mut |s| s.meta().source == gix_config::Source::Local)?;
+        config.write_to_filter(&mut buf, |s| s.meta().source == gix_config::Source::Local)?;
         let nl = config.detect_newline_style();
         assert_eq!(buf.to_str_lossy(), format!("[a \"local\"]{nl}\tb = c{nl}\tc = d{nl}"));
 

--- a/gix/src/clone/fetch/util.rs
+++ b/gix/src/clone/fetch/util.rs
@@ -50,7 +50,7 @@ fn write_to_local_config(config: &gix_config::File<'static>, mode: WriteMode) ->
         .append(matches!(mode, WriteMode::Append))
         .open(config.meta().path.as_deref().expect("local config with path set"))?;
     local_config.write_all(config.detect_newline_style())?;
-    config.write_to_filter(&mut local_config, &mut |s| s.meta().source == gix_config::Source::Local)
+    config.write_to_filter(&mut local_config, |s| s.meta().source == gix_config::Source::Local)
 }
 
 pub fn append_config_to_repo_config(repo: &mut Repository, config: gix_config::File<'static>) {

--- a/gix/src/config/cache/access.rs
+++ b/gix/src/config/cache/access.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::result_large_err)]
-use std::{borrow::Cow, path::PathBuf, time::Duration};
-
+use gix_config::file::Metadata;
 use gix_lock::acquire::Fail;
+use std::{borrow::Cow, path::PathBuf, time::Duration};
 
 use crate::{
     config,
@@ -510,7 +510,7 @@ impl Cache {
 pub(crate) fn trusted_file_path<'config>(
     config: &'config gix_config::File<'_>,
     key: impl gix_config::AsKey,
-    filter: &mut gix_config::file::MetadataFilter,
+    filter: impl FnMut(&Metadata) -> bool,
     lenient_config: bool,
     environment: crate::open::permissions::Environment,
 ) -> Option<Result<Cow<'config, std::path::Path>, gix_config::path::interpolate::Error>> {

--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -327,6 +327,15 @@ fn apply_environment_overrides(
     let mut env_override = gix_config::File::new(gix_config::file::Metadata::from(gix_config::Source::EnvOverride));
     for (section_name, subsection_name, permission, data) in [
         (
+            "core",
+            None,
+            git_prefix,
+            &[{
+                let key = &Core::WORKTREE;
+                (env(key), key.name)
+            }][..],
+        ),
+        (
             "http",
             None,
             http_transport,

--- a/gix/src/config/snapshot/credential_helpers.rs
+++ b/gix/src/config/snapshot/credential_helpers.rs
@@ -90,7 +90,7 @@ pub(super) mod function {
         mut url: gix_url::Url,
         config: &gix_config::File<'_>,
         is_lenient_config: bool,
-        filter: &mut gix_config::file::MetadataFilter,
+        mut filter: impl FnMut(&gix_config::file::Metadata) -> bool,
         environment: crate::open::permissions::Environment,
         mut use_http_path: bool,
     ) -> Result<
@@ -105,7 +105,7 @@ pub(super) mod function {
         let url_had_user_initially = url.user().is_some();
         normalize(&mut url);
 
-        if let Some(credential_sections) = config.sections_by_name_and_filter("credential", filter) {
+        if let Some(credential_sections) = config.sections_by_name_and_filter("credential", &mut filter) {
             for section in credential_sections {
                 let section = match section.header().subsection_name() {
                     Some(pattern) => gix_url::parse(pattern).ok().and_then(|mut pattern| {
@@ -181,7 +181,7 @@ pub(super) mod function {
             askpass: crate::config::cache::access::trusted_file_path(
                 config,
                 &Core::ASKPASS,
-                filter,
+                &mut filter,
                 is_lenient_config,
                 environment,
             )

--- a/gix/src/config/tree/sections/core.rs
+++ b/gix/src/config/tree/sections/core.rs
@@ -58,7 +58,7 @@ impl Core {
     /// The `core.worktree` key.
     pub const WORKTREE: keys::Any = keys::Any::new("worktree", &config::Tree::CORE)
         .with_environment_override("GIT_WORK_TREE")
-        .with_deviation("Overriding the worktree with environment variables is supported using `ThreadSafeRepository::open_with_environment_overrides()");
+        .with_deviation("Command-line overrides also work, and they act lie an environment override. If set in the git configuration file, relative paths are relative to it.");
     /// The `core.askPass` key.
     pub const ASKPASS: keys::Executable = keys::Executable::new_executable("askPass", &config::Tree::CORE)
         .with_environment_override("GIT_ASKPASS")

--- a/gix/tests/gix/repository/worktree.rs
+++ b/gix/tests/gix/repository/worktree.rs
@@ -44,7 +44,7 @@ mod with_core_worktree_config {
                 assert_eq!(
                     repo.work_dir().unwrap(),
                     repo.git_dir().parent().unwrap().parent().unwrap().join("worktree"),
-                    "work_dir is set to core.worktree config value, relative paths are appended to `git_dir() and made absolute`"
+                    "{name}|{is_relative}: work_dir is set to core.worktree config value, relative paths are appended to `git_dir() and made absolute`"
                 );
             } else {
                 assert_eq!(

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -106,8 +106,12 @@ pub fn main() -> Result<()> {
             };
             mapping.full.modify(to_match_settings);
             mapping.reduced.modify(to_match_settings);
-            let mut repo = gix::ThreadSafeRepository::discover_opts(repository, Default::default(), mapping)
-                .map(gix::Repository::from)?;
+            let mut repo = gix::ThreadSafeRepository::discover_with_environment_overrides_opts(
+                repository,
+                Default::default(),
+                mapping,
+            )
+            .map(gix::Repository::from)?;
             if !config.is_empty() {
                 repo.config_snapshot_mut()
                     .append_config(config.iter(), gix::config::Source::Cli)


### PR DESCRIPTION
While working on `gix blame` I found that, for testing purposes, I wanted to run `env GIT_WORK_TREE=… gix blame` which did not work as expected. This PR changes that. I don’t know whether it was intentional not to take env variables into account. If it was, feel free to just close this PR!
