### PR TITLE
Only run expectrl gix-prompt tests where supported

### DIFF
--- a/gix-prompt/Cargo.toml
+++ b/gix-prompt/Cargo.toml
@@ -27,4 +27,6 @@ parking_lot = "0.12.1"
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }
 serial_test = { version = "3.1.0", default-features = false }
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))'.dev-dependencies]
 expectrl = "0.7.0"

--- a/gix-prompt/tests/prompt.rs
+++ b/gix-prompt/tests/prompt.rs
@@ -34,7 +34,7 @@ mod ask {
     }
 
     #[test]
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
     fn askpass_only() {
         let mut cmd = std::process::Command::new(env!("CARGO"));
         cmd.args(["build", "--example", "use-askpass", "--example", "askpass"]);
@@ -48,7 +48,7 @@ mod ask {
     }
 
     #[test]
-    #[cfg(unix)]
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
     fn username_password() {
         let mut cmd = std::process::Command::new(env!("CARGO"));
         cmd.args(["build", "--example", "credentials"]);
@@ -65,7 +65,7 @@ mod ask {
     }
 
     #[test]
-    #[cfg(not(unix))]
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
     #[ignore]
     fn username_password_not_available() {}
 }


### PR DESCRIPTION
Two important `gix-prompt` tests simulate interactivity using [`expectrl`](https://crates.io/crates/expectrl), which (non-optionally) [depends](https://crates.io/crates/expectrl/0.7.1/dependencies) on [`ptyprocess`](https://crates.io/crates/ptyprocess). But the only (families of) Unix-like operating systems that `ptyprocess` [currently](https://github.com/zhiburt/ptyprocess/commit/70bd0ab4d97c0bdc4ae66e085e14fb3c8d414383) supports are [Linux](https://github.com/zhiburt/ptyprocess/blob/70bd0ab4d97c0bdc4ae66e085e14fb3c8d414383/src/lib.rs#L470-L473), [FreeBSD](https://github.com/zhiburt/ptyprocess/blob/70bd0ab4d97c0bdc4ae66e085e14fb3c8d414383/src/lib.rs#L475-L499), and [macOS](https://github.com/zhiburt/ptyprocess/blob/70bd0ab4d97c0bdc4ae66e085e14fb3c8d414383/src/lib.rs#L540-L567).

In `ptyprocess` on other Unix-like systems, [the call](https://github.com/zhiburt/ptyprocess/blob/70bd0ab4d97c0bdc4ae66e085e14fb3c8d414383/src/lib.rs#L431) in [`Master::get_slave_name`](https://github.com/zhiburt/ptyprocess/blob/main/src/lib.rs#L430-L432) to the free-standing `get_slave_name` function fails to compile, because the latter function is not defined. This is not specific to any particular way of using `ptyprocess`; it occurs both when building `gitoxide`'s tests and when building `ptyprocess`'s tests.

```text
error[E0425]: cannot find function `get_slave_name` in this scope
   --> /home/ek/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ptyprocess-0.4.1/src/lib.rs:431:9
    |
431 |         get_slave_name(&self.fd)
    |         ^^^^^^^^^^^^^^ not found in this scope
    |
help: consider using the method on `Self`
    |
431 |         self.get_slave_name(&self.fd)
    |         +++++

For more information about this error, try `rustc --explain E0425`.
error: could not compile `ptyprocess` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: command `/home/ek/.rustup/toolchains/stable-x86_64-unknown-illumos/bin/cargo test --no-run --message-format json-render-diagnostics` exited with code 101
```

That is from a `cargo nextest run --no-fail-fast` run in `gix-prompt` on [OmniOS](https://omnios.org/), which is an [illumos](https://www.illumos.org/) system. The error message shown above is from that system, as are the full details in [this gist](https://gist.github.com/EliahKagan/ce36bffbcfcd4d10001e5221ddc20c3e), which shows the problem on the main branch and how the build succeeds and other `gix-prompt` tests are able to run and pass after the fix here.

Please note that the problem isn't illumos-specific. Any Unix-like system that is not Linux, FreeBSD, or macOS should be expected to be affected.

The problem does not prevent `gix-prompt` from building other than for tests, because it is a dev dependency. Specifically, `ptyprocess` is a transitive dependency through `expectrl`, which is a dev dependency of `gix-prompt`.

The `gix-prompt` tests that used `expectrl` were, prior to this PR, targeted to all "unix" systems. **This narrows them** to systems where `target_os` is `linux`, `freebsd`, or `macos`, and conditions the `expectrl` dev dependency on those targets. This way, running the test suite no longer fails to build on other Unix-like systems.