### PR TITLE
Drop `-v` from `rm` and `cp` commands in fixtures for portability

### DIFF
--- a/gix-dir/tests/fixtures/many.sh
+++ b/gix-dir/tests/fixtures/many.sh
@@ -280,7 +280,7 @@ git init expendable-and-precious-nested-in-ignored-dir
   echo 'ignored/' > .gitignore
   git add .gitignore && git commit -m "init"
   mkdir -p ignored/other
-  cp -Rv ../expendable-and-precious ignored/d
+  cp -R ../expendable-and-precious ignored/d
   rm -Rf ignored/d/*-by-filematch ignored/d/some-*
   mkdir -p other/ignored && >other/ignored/a
 )

--- a/gix-discover/tests/fixtures/make_basic_repo.sh
+++ b/gix-discover/tests/fixtures/make_basic_repo.sh
@@ -35,7 +35,7 @@ rm -R worktrees/c-worktree-deleted
 (cd bare.git
   git worktree add ../worktrees/from-bare/c
   git worktree add ../worktrees/from-bare/d-private-dir-deleted
-  rm -R -v ./worktrees/d-private-dir-deleted
+  rm -R ./worktrees/d-private-dir-deleted
 )
 
 git clone --bare --shared . bare-no-config.git


### PR DESCRIPTION
In the fixture scripts, there is one invocation of `rm` with the `-v` option, which is only very recently standardized, and one invocation of `cp` with the `-v` option, which is nonstandard. The intent appears to be to make it easier to understand what a fixture has done if it fails, or if it is run manually to investigate it. This PR drops `-v` from those commands without replacing it with anything.

The two affected fixture scripts are heavily used, and the archives they generate are `.gitignore`d. So this change causes 106 formerly failing tests to pass on my OmniOS test system (decreasing the number of failing tests from 108 to 2). I expect most illiumos and various other significant but less common Unix-like systems to have the same benefit.

The tradeoff of not showing verbose output appears to be reasonable to me in context here, but it may not be the best approach. Alternative approaches, and other details about the change--including the conditions under which it makes a difference and its relationship to POSIX--are given in the commit messages.