### PR TITLE
Remove inactive `username_password_not_available` test

### DIFF
--- a/gix-prompt/tests/prompt.rs
+++ b/gix-prompt/tests/prompt.rs
@@ -63,9 +63,4 @@ mod ask {
         p.expect("\" password with space \"").unwrap();
         p.expect(expectrl::Eof).unwrap();
     }
-
-    #[test]
-    #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
-    #[ignore]
-    fn username_password_not_available() {}
 }


### PR DESCRIPTION
This is cleanup related to #1644, which further complicated the attributes on the `#[ignore]`d `username_password_not_available` test with an empty that was build (but never run) whenever the `expectrl` tests of `gix-prompt` were not built. Instead of keeping its attributes more complicated and maintaining an expectation that they continue to be updated along with the `target_os` support for `expectrl`'s `ptyprocess` dependency, this removes that empty test.

The purpose of the test case that this removes is unclear, and it may not have value anymore. It is unclear in part because actual interaction to provide a username and password is likely to work on some systems for which the related tests that use `expectrl` are not being built. But this empty test case might be read to say otherwise.

See also the related discussion at https://github.com/GitoxideLabs/gitoxide/pull/1644#pullrequestreview-2390931773.

