### PR TITLE
Run doctests across the workspace on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,14 @@ jobs:
           brew install tree openssl gnu-sed
       - name: "cargo check default features"
         if: startsWith(matrix.os, 'windows')
-        run: cargo check --all --bins --examples
+        run: cargo check --workspace --bins --examples
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest
       - name: "Test (nextest)"
         env:
           GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI: 1
-        run: cargo nextest run --all --no-fail-fast
+        run: cargo nextest run --workspace --no-fail-fast
       - name: Doctest
         run: cargo test --doc
       - name: Check that tracked archives are up to date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI: 1
         run: cargo nextest run --workspace --no-fail-fast
       - name: Doctest
-        run: cargo test --workspace --doc
+        run: cargo test --workspace --doc --no-fail-fast
       - name: Check that tracked archives are up to date
         run: git diff --exit-code  # If this fails, the fix is usually to commit a regenerated archive.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI: 1
         run: cargo nextest run --workspace --no-fail-fast
       - name: Doctest
-        run: cargo test --doc
+        run: cargo test --workspace --doc
       - name: Check that tracked archives are up to date
         run: git diff --exit-code  # If this fails, the fix is usually to commit a regenerated archive.
 

--- a/gix-merge/src/blob/builtin_driver/text/mod.rs
+++ b/gix-merge/src/blob/builtin_driver/text/mod.rs
@@ -8,20 +8,21 @@ pub enum ConflictStyle {
     /// Only show the zealously minified conflicting lines of the local changes and the incoming (other) changes,
     /// hiding the base version entirely.
     ///
-    /// ```
+    /// ```text
     /// line1-changed-by-both
     /// <<<<<<< local
     /// line2-to-be-changed-in-incoming
     /// =======
     /// line2-changed
     /// >>>>>>> incoming
-    ///```
+    /// ```
     #[default]
     Merge,
     /// Show non-minimized hunks of local changes, the base, and the incoming (other) changes.
     ///
     /// This mode does not hide any information.
-    /// ```
+    ///
+    /// ```text
     /// <<<<<<< local
     /// line1-changed-by-both
     /// line2-to-be-changed-in-incoming
@@ -32,12 +33,12 @@ pub enum ConflictStyle {
     /// line1-changed-by-both
     /// line2-changed
     /// >>>>>>> incoming
-    ///```
+    /// ```
     Diff3,
     /// Like [`Diff3](Self::Diff3), but will show *minimized* hunks of local change and the incoming (other) changes,
     /// as well as non-minimized hunks of the base.
     ///
-    /// ```
+    /// ```text
     /// line1-changed-by-both
     /// <<<<<<< local
     /// line2-to-be-changed-in-incoming

--- a/gix-merge/src/blob/mod.rs
+++ b/gix-merge/src/blob/mod.rs
@@ -96,7 +96,7 @@ pub struct Driver {
     ///
     /// A typical invocation with all arguments substituted could then look like this:
     ///
-    /// ```
+    /// ```sh
     /// <driver-program> .merge_file_nR2Qs1 .merge_file_WYXCJe .merge_file_UWbzrm 7 file e2a2970 HEAD feature
     /// ```
     ///

--- a/gix-pack/src/index/mod.rs
+++ b/gix-pack/src/index/mod.rs
@@ -1,5 +1,5 @@
 //! an index into the pack file
-//!
+
 /// From itertools
 /// Create an iterator running multiple iterators in lockstep.
 ///
@@ -21,7 +21,7 @@
 ///
 /// [`multizip`]: fn.multizip.html
 ///
-/// ```
+/// ```ignore
 /// # use itertools::izip;
 /// #
 /// # fn main() {
@@ -37,6 +37,9 @@
 /// assert_eq!(results, [0 + 3, 10 + 7, 29, 36]);
 /// # }
 /// ```
+///
+/// (The above is vendored from [itertools](https://github.com/rust-itertools/itertools),
+/// including the original doctest, though it has been marked `ignore` here.)
 macro_rules! izip {
     // @closure creates a tuple-flattening closure for .map() call. usage:
     // @closure partial_pattern => partial_tuple , rest , of , iterators

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ clippy-fix:
 
 # Build all code in suitable configurations
 check:
-    cargo check --all
+    cargo check --workspace
     cargo check --no-default-features --features small
     # assure compile error occurs
     if cargo check --features lean-async 2>/dev/null; then false; else true; fi
@@ -146,8 +146,8 @@ check:
 
 # Run cargo doc on all crates
 doc $RUSTDOCFLAGS="-D warnings":
-    cargo doc --all --no-deps --features need-more-recent-msrv
-    cargo doc --features=max,lean,small --all --no-deps --features need-more-recent-msrv
+    cargo doc --workspace --no-deps --features need-more-recent-msrv
+    cargo doc --features=max,lean,small --workspace --no-deps --features need-more-recent-msrv
 
 # run all unit tests
 unit-tests:


### PR DESCRIPTION
The attempt to run doctests, added to the CI `test-fast` jobs in 89a0567 (#1556), actually [runs zero doctests](https://github.com/GitoxideLabs/gitoxide/actions/runs/11690609999/job/32555922512#step:9:70), because there are none in the top-level project and neither `--workspace` nor its deprecated `--all` alias is passed.

```text
   Finished `test` profile [unoptimized + debuginfo] target(s) in 28.55s
   Doc-tests gitoxide

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

This was the case both before and after #1559 (which revised #1556 in other ways). I am actually not sure doctests across all creates had ever been run automatically. The doctest command in the `justfile`, which can be run manually but is also in the CI `test` job, is the same as the the command added to `test-fast` in 89a0567. Furthermore, there are two situations with failing doctests, one of which is long-standing:

- Recently, in [#1585](https://github.com/GitoxideLabs/gitoxide/pull/1585), some code fences were added that were not intended as doctests, holding text with conflict markers (present intentionally to document `gix-merge`), or in one case a suggested shell command. Since the opening ```` ``` ```` was not followed by text to indicate the language, however, they were taken to be Rust doctests.
- Years ago, `zip!` was vendored from `itertools`, including the original `zip!` macro's doctest. This fails because it tries to `use` it from `itertools`, and the failure is not--as far as I can tell--straightforwardly repairable by making the doctest use the vendored macro, due to the rules about macro visibility, the way scoping interacts with doctests, and the status of the vendored `zip!` as something that should not be part of the interface of `gix-pack`. That doctest could of course be converted into a regular unit test with `#[test]`. But the goal doesn't seem to be to actually test that, so much as to keep its origin in `itertools` clear.

This PR adds `--workspace` to the command to run doctests in all projects/crates, as well as `--no-fail-fast` so the status of all doctests will be seen in any fail. After observing those failures, I fixed them, though for `zip!` the "fix" was to `ignore` the doctest. It also replaces `--all` with `--workspace` for `cargo` subcommands where it is a deprecated alias of `--workspace`, which is not specifically related to doctests. There is a bit more detailed information in the commit messages.