### PR TITLE
Run CI on Windows with `GIX_TEST_IGNORE_ARCHIVES=1`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.with-xml.junit]
+path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,37 @@ jobs:
       - name: Check that tracked archives are up to date
         run: git diff --exit-code  # If this fails, the fix is usually to commit a regenerated archive.
 
+  test-fixtures-windows:
+    runs-on: windows-latest
+    env:
+      # FIXME: Change to 15 after verifying that the last step can fail.
+      # See https://github.com/GitoxideLabs/gitoxide/issues/1358.
+      EXPECTED_FAILURE_COUNT: 13
+    defaults:
+      run:
+        shell: bash  # Includes `-o pipefail`.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - name: "Test (nextest)"
+        env:
+          GIX_TEST_IGNORE_ARCHIVES: 1
+        run: |
+          cargo nextest --color=always run --workspace --no-fail-fast |& tee nextest.log
+        continue-on-error: true
+      - name: Allow up to ${{ env.EXPECTED_FAILURE_COUNT }} failures
+        if: failure()
+        run: |
+          set -x
+          sed -Ei 's/\x1B\[[[:digit:];]*m//g' nextest.log  # Remove ANSI color codes.
+          pattern='\n-{10,}\r?\n[ \t]+Summary\b[^\n]+[ \t]\K\d+(?= failed\b)'
+          count="$(grep -zoP "$pattern" nextest.log)"
+          ((count <= EXPECTED_FAILURE_COUNT))
+
   test-32bit:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Check how many tests failed
         if: steps.nextest.outcome == 'failure'
         env:
-          LC_ALL: C
+          LC_ALL: C.utf8
           # FIXME: Change to 15 after verifying that the last step can fail.
           # See https://github.com/GitoxideLabs/gitoxide/issues/1358.
           EXPECTED_FAILURE_COUNT: 13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,8 @@ jobs:
       - name: Check how many tests failed
         if: steps.nextest.outcome == 'failure'
         env:
-          # FIXME: Change to 15 after verifying that the last step can fail.
           # See https://github.com/GitoxideLabs/gitoxide/issues/1358.
-          EXPECTED_FAILURE_COUNT: 13
+          EXPECTED_FAILURE_COUNT: 14
         run: |
           [xml]$junit = Get-Content -Path 'target/nextest/with-xml/junit.xml'
           if ($junit.testsuites.errors -ne 0) { exit 1 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,7 @@ jobs:
         env:
           GIX_TEST_IGNORE_ARCHIVES: 1
         run: |
-          stdbuf -oL -- cargo nextest --color=always run --workspace --no-fail-fast |&
-            tee nextest.log
+          cargo nextest --color=always run --workspace --no-fail-fast |& tee nextest.log
         continue-on-error: true
       - name: Check how many tests failed
         if: steps.nextest.outcome == 'failure'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,6 @@ jobs:
 
   test-fixtures-windows:
     runs-on: windows-latest
-    env:
-      # FIXME: Change to 15 after verifying that the last step can fail.
-      # See https://github.com/GitoxideLabs/gitoxide/issues/1358.
-      EXPECTED_FAILURE_COUNT: 13
     defaults:
       run:
         shell: bash  # Includes `-o pipefail`.
@@ -97,13 +93,19 @@ jobs:
         with:
           tool: nextest
       - name: "Test (nextest)"
+        id: nextest
         env:
           GIX_TEST_IGNORE_ARCHIVES: 1
         run: |
-          cargo nextest --color=always run --workspace --no-fail-fast |& tee nextest.log
+          stdbuf -oL -- cargo nextest --color=always run --workspace --no-fail-fast |&
+            tee nextest.log
         continue-on-error: true
-      - name: Allow up to ${{ env.EXPECTED_FAILURE_COUNT }} failures
-        if: failure()
+      - name: Check how many tests failed
+        if: steps.nextest.outcome == 'failure'
+        env:
+          # FIXME: Change to 15 after verifying that the last step can fail.
+          # See https://github.com/GitoxideLabs/gitoxide/issues/1358.
+          EXPECTED_FAILURE_COUNT: 13
         run: |
           set -x
           sed -Ei 's/\x1B\[[[:digit:];]*m//g' nextest.log  # Remove ANSI color codes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,6 @@ jobs:
 
   test-fixtures-windows:
     runs-on: windows-latest
-    defaults:
-      run:
-        shell: bash  # Includes `-o pipefail`.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -96,22 +93,18 @@ jobs:
         id: nextest
         env:
           GIX_TEST_IGNORE_ARCHIVES: 1
-        run: |
-          cargo nextest --color=always run --workspace --no-fail-fast |& tee nextest.log
+        run: cargo nextest --profile=with-xml run --workspace --no-fail-fast
         continue-on-error: true
       - name: Check how many tests failed
         if: steps.nextest.outcome == 'failure'
         env:
-          LC_ALL: C.utf8
           # FIXME: Change to 15 after verifying that the last step can fail.
           # See https://github.com/GitoxideLabs/gitoxide/issues/1358.
           EXPECTED_FAILURE_COUNT: 13
         run: |
-          set -x
-          sed -Ei 's/\x1B\[[[:digit:];]*m//g' nextest.log  # Remove ANSI color codes.
-          pattern='\n-{10,}\r?\n[ \t]+Summary\b[^\n]+[ \t]\K\d+(?= failed\b)'
-          count="$(grep -zoP "$pattern" nextest.log)"
-          ((count <= EXPECTED_FAILURE_COUNT))
+          [xml]$junit = Get-Content -Path 'target/nextest/with-xml/junit.xml'
+          if ($junit.testsuites.errors -ne 0) { exit 1 }
+          if ($junit.testsuites.failures -gt $env:EXPECTED_FAILURE_COUNT) { exit 1 }
 
   test-32bit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Check how many tests failed
         if: steps.nextest.outcome == 'failure'
         env:
+          LC_ALL: C
           # FIXME: Change to 15 after verifying that the last step can fail.
           # See https://github.com/GitoxideLabs/gitoxide/issues/1358.
           EXPECTED_FAILURE_COUNT: 13


### PR DESCRIPTION
This adds a CI test job, `test-fixtures-windows`, that runs tests on Windows with `GIX_TEST_IGNORE_ARCHIVES=1`, allows the job to succeed even when the test running step fails, but then, if it failed (as currently it always does), runs another step that checks that no tests reported *errors* and that the number of tests reporting *failures* does not exceed 14.

Although there are currently 15 tests that regularly fail when run this way, as listed in #1358, the performance test does currently seem ever to fail *on CI*. Setting it to 14 carries a risk of failure even when nothing new is broken, but should shed light on whether it does ever fail on CI. (If not, then it might be that my test machine is inadequate, rather than an actual performance bug.) This also makes it less likely to miss a new failure, per https://github.com/GitoxideLabs/gitoxide/issues/1358#issuecomment-2457946710 and https://github.com/GitoxideLabs/gitoxide/issues/1358#issuecomment-2459710189.

The approach taken is to add a `with-xml` nextest profile and use it for the `cargo nextest` step of the new job, then have the subsequent step use PowerShell to parse the generated XML as discussed in https://github.com/GitoxideLabs/gitoxide/issues/1358#issuecomment-2459072454 and https://github.com/GitoxideLabs/gitoxide/issues/1358#issuecomment-2459710189.

This feature branch includes the intermediate approaches rather than squashing them away. I think the details about their effects and disadvantages may be of value in the future. There are also failures that only occur with the other approach I attempted first, presumably relating either to the differing environments of PowerShell and Git Bash or to pecularities arising from `|&` redirection. I'll look into this in more detail sometime fairly soon and I'm not requesting that you examine it, but full details are in the commit messages if you wish to.

The main commit message of interest is 145ae49 (before the rebase, a5d3698), which describes the specific advantages of the XML approach over the ad-hoc parsing approach.

This may not be immediately ready, because:

- [ ] The new job is deliberately not a required job. But we should make sure it passes in *this* PR before the PR is merged (even though it has already been run in my fork), since the purpose of this PR is to introduce the job and demonstrate that it passes under existing conditions. (In particular, I just rebased this branch.)
- [ ] Relating to [#1358 (comment)](https://github.com/GitoxideLabs/gitoxide/issues/1358#issuecomment-2459710189), it may make sense to make the new job depend on an existing job, but as discussed there I don't know what the best way to do this is. Right now, no such dependency is expressed.
- [ ] This job seems to take the same amount of time as the `test-fast` job for `windows-latest`, when tested on my fork. Here, it is slower, but I think that is related to caching and would go away once merged. The new job omits some of what is done in the `test-fast` job--for example, it does not run doctests--and that seems to roughly cancel out the added time to run the fixture scripts. In view of this, maybe it should be made a required check? On the other hand, that could slow some things down if we want to allow PRs to be quickly merged even if they introduce new failures on Windows when `GIX_TEST_IGNORE_ARCHIVES=1`.