### PR TITLE
Bump Docker image to Debian 12 for `pure-rust-build`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   pure-rust-build:
     runs-on: ubuntu-latest
-    container: debian:buster
+    container: debian:bookworm
     steps:
       - uses: actions/checkout@v4
       - name: Prerequisites


### PR DESCRIPTION
This changes the major version of the Debian image used in the `pure-rust-build` CI job from Debian 10 (buster) to Debian 12 (bookworm).

Debian 10 is past long term support (LTS). See the "Index of releases" table on [the releases page](https://www.debian.org/releases/). Although third-party [Freexian ELTS](https://wiki.debian.org/LTS/Extended) updates, [in which](https://en.wikipedia.org/wiki/Debian_version_history#cite_note-elts-disclaim-13) some packages are maintained, are publicly available, the image on Docker Hub [has not received](https://hub.docker.com/_/debian/tags?name=buster) any updates since the end of its LTS period. In contrast, the Debian 11 (bullseye) [image](https://hub.docker.com/_/debian/tags?name=bullseye) and Debian 12 bookworm [image](https://hub.docker.com/_/debian/tags?name=bookworm) continue to be regularly updated, as of this writing.

This uses Debian 12 (bookworm) since it's the current stable version, but it should also be fine to use Debian 11 (bullseye). The main disadvantage is that it would have to be updated sooner. This newer version might also be faster, but I have not benchmarked and this job is not excessively slow. If it is preferable to check compatibility with an older release, then this can be changed to Debian 11.

This squashes a number of commits together because I made four commits first to test that the test can fail with `max` instead of `max-pure`, and to check the effect of various toolchain and library related packages on the outcome; then bumped the Debian image; then reverted each commit one by one to verify that the effect of those packages on the job, and more broadly the ability of the job to fail under conditions where it ought to, is preserved with no changes in Debian 12.

I am pleased to report that this is so. However, it may be that a comment should be added to clarify exactly what this job is for. This is because, on both Debian 10 and Debian 12, the packages that cause the job to fail when modified to build features that pull in native-code dependencies are not really failing due to a need for a *C toolchain*. This is what I would expect, since installing `gcc` and `libc-dev`, which this has job has always done since being introduced in ed4deac (#624), is installing a C toolchain. The packages whose absence makes this test work along the intended lines are `g++`, `cmake`, `make`, `pkgconf`, and `libssl-dev`. I am not completely sure what the comment should say, or if the test is testing *quite* what it is meant to. But none of that varies between Debian 10 and Debian 12, so I think it shouldn't block this.

I don't usually squash the entirety of a feature branch into a single commit, but in this case it seemed the best thing to do. But I've force-pushed the squashed commits immediately after opening this PR, so the [pre-squash](https://github.com/GitoxideLabs/gitoxide/commits/ab5d772bca80eaf187076e5d9259bd78636a0b71/) hashes are shown in [an event](https://github.com/GitoxideLabs/gitoxide/pull/1664#event-15236445344) here. They have CI status that can be observed [on my fork](https://github.com/EliahKagan/gitoxide/commits/ab5d772bca80eaf187076e5d9259bd78636a0b71/). (The detailed CI results will go away after a while on GitHub, and the commit messages make fairly clear what they indicate as well as what changes were made, so I think having nine commits instead of one here would not be better.)