### PR TITLE
Verify `pure-rust-build` has limited tools/headers, use `stable-slim`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   pure-rust-build:
     runs-on: ubuntu-latest
-    container: debian:bookworm-slim
+    container: debian:stable-slim
     steps:
       - uses: actions/checkout@v4
       - name: Prerequisites

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   pure-rust-build:
     runs-on: ubuntu-latest
-    container: debian:bookworm
+    container: debian:bookworm-slim
     steps:
       - uses: actions/checkout@v4
       - name: Prerequisites

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Prerequisites
-        run: apt-get update && apt-get install --no-install-recommends -y ca-certificates curl gcc libc-dev # gcc is required as OS abstraction
-      - name: install Rust via Rustup
-        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal;
+        run: |
+          apt-get update
+          apt-get install --no-install-recommends -y ca-certificates curl gcc libc-dev # gcc is required as OS abstraction
+      - name: Verify environment is sufficiently minimal for the test
+        run: |
+          set -x
+          for pattern in cmake g++ libssl-dev make pkgconf pkg-config; do
+              if dpkg-query --status -- "$pattern"; then
+                  exit 1
+              fi
+          done
+          for cmd in cmake g++ make pkgconf pkg-config; do
+              if command -v -- "$cmd"; then
+                  exit 1
+              fi
+          done
+      - name: Install Rust via Rustup
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
       - uses: Swatinem/rust-cache@v2
       - run: /github/home/.cargo/bin/cargo install --debug --locked --no-default-features --features max-pure --path .
 


### PR DESCRIPTION
As suggested in https://github.com/GitoxideLabs/gitoxide/pull/1664#pullrequestreview-2425258803, this checks that packages that are intended to be absent, for the `pure-rust-build` test's results to be trusted, really are absent. As detailed in 71ba940, it also checks if commands such as `g++` are available in the `$PATH`, in case they are provided in an unexpected way.

With that check in place, we can more easily change what Docker image we use for this job. Of the changes that are useful, I think the safest is to change from `bookworm` to `bookworm-slim`. The "slim" images vary in what they omit, but they shouldn't add anything extra, and in any case, the check should catch anything unexpected. See c84c17e. This passed.

A somewhat greater risk, but I think reasonable given the presence of the new steps that checks what's installed, is to use the `stable` label instead of `bookworm`, so that when a new stable release comes out, it is automatically used. I did this, with `stable-slim`. See 2a791c8. This also passed. This is the current state on the feature branch, as I open this PR. However, that commit can be dropped or reverted if specific-release labels are prefered.