### PR TITLE
Split cargo-deny job into two non-matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,23 +192,25 @@ jobs:
         # than allows is no problem either if it comes to that.
         continue-on-error: true
 
-  cargo-deny:
+  # This job is not required for PR auto-merge, so that sudden announcement of a
+  # new advisory does not keep otherwise OK pull requests from being integrated.
+  cargo-deny-advisories:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        checks:
-          - advisories
-          - bans licenses sources
-
-    # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          command: check ${{ matrix.checks }}
+          command: check advisories
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans licenses sources
 
   wasm:
     name: WebAssembly
@@ -300,6 +302,7 @@ jobs:
       # List all jobs that are intended NOT to block PR auto-merge here.
       EXPECTED_NONBLOCKING_JOBS: |-
         test-fixtures-windows
+        cargo-deny-advisories
         wasm
         tests-pass
 


### PR DESCRIPTION
This is the WASM de-matrixification that was intentionally omitted from #1668 so it could be considered separately (see also https://github.com/GitoxideLabs/gitoxide/pull/1668#pullrequestreview-2428784092).

This PR is intended to have only one commit, 38edb2c, and the changes are really +12 -9, not +1201 -742 as currently shown. The other commits are from #1668. This is currently a draft because I recommend against merging it until #1668 is merged, and it may also be a good idea to rebase this after #1668 is merged, which will make it easy to verify that merging this will only add one commit.

#### What this changes

Instead of conditionally applying `continue-on-error: true` at the job level to the `advisories` job, this splits `cargo-deny` into two job definitions, `cargo-deny-advisories` and `cargo-deny`, where *neither* has `continue-on-error` but `cargo-deny-advisories` is omitted as a dependency of the `tests-pass` job that makes jobs effectively required for PR auto-merge. This way, when there is an unaddressed advisory, the `cargo-deny-advisories` job unambiguously fails, even failing the workflow, but PRs can still auto-merge.

One implication of this is that, on Dependabot security update PRs, `@dependabot merge` and `@dependabot squash and merge` commands will only perform a merge if `cargo deny check advisories` reports no other outstanding advisories. This is because, when Dependabot is told to merge a PR, it only goes ahead with the merge if all checks pass (i.e. report a successful conclusion). This would be convenient for cases where, if the fix is not complete, further manual review is desired. It would otherwise be inconvenient, but then a usual PR auto-merge could be done instead (which is the more common practice here anyway).

#### Possible alternative

The main thing I can think of that would make this change unsuitable is if we actually just want to start treating `cargo deny check advisories` failures as hard errors and have them block merging. In that case, the current organization could be kept and the conditional `continue-on-error` could just be removed from it.