### PR TITLE
Split `test` CI job into `test` and `test-journey`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Setup dependencies
-        run: sudo apt-get install -y --no-install-recommends liblzma-dev tree
+        run: sudo apt-get install -y --no-install-recommends liblzma-dev
       - uses: extractions/setup-just@v2
       - uses: taiki-e/install-action@v2
         with:
@@ -91,8 +91,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Setup dependencies (macos)
         if: startsWith(matrix.os, 'macos')
-        run: brew install tree openssl gnu-sed
-      - name: "cargo check default features"
+        run: brew install openssl gnu-sed
+      - name: cargo check default features
         if: startsWith(matrix.os, 'windows')
         run: cargo check --workspace --bins --examples
       - uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,17 @@ jobs:
           GIX_TEST_IGNORE_ARCHIVES: '1'
         run: just ci-test
 
+  test-journey:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: extractions/setup-just@v2
+      - name: Run journey tests
+        run: just ci-journey-tests
+
   test-fast:
     strategy:
       matrix:
@@ -342,6 +353,7 @@ jobs:
     needs:
       - pure-rust-build
       - test
+      - test-journey
       - test-fast
       - test-32bit
       - lint

--- a/justfile
+++ b/justfile
@@ -12,10 +12,15 @@ alias nt := nextest
 # run all tests, clippy, including journey tests, try building docs
 test: clippy check doc unit-tests journey-tests-pure journey-tests-small journey-tests-async journey-tests
 
-# run all tests, without clippy, including journey tests, try building docs (and clear target on CI)
-ci-test: check doc unit-tests clear-target ci-journey-tests
+# run all tests, without clippy, including journey tests, try building docs (and clear target)
+ci-test-full: check doc unit-tests clear-target ci-journey-tests
 
-# run all journey tests, but assure these are running after `cargo clean` (and workaround a just-issue of deduplicating targets)
+# run all tests, without clippy, and try building docs (without clearing the target)
+ci-test: check doc unit-tests
+
+# run all journey tests
+# these should be run in a fresh clone or after `cargo clean`
+# (and workaround a just-issue of deduplicating targets)
 ci-journey-tests: journey-tests-pure journey-tests-small journey-tests-async journey-tests
 
 clear-target:

--- a/tests/journey/ein.sh
+++ b/tests/journey/ein.sh
@@ -28,7 +28,7 @@ title "Porcelain ${kind}"
     )
   )
   snapshot="$snapshot/porcelain"
-  (with_program tree
+  (with_program find
     (when "using the 'tool' subcommand"
       title "ein tool"
       (with "a repo with a tiny commit history"


### PR DESCRIPTION
As detailed in 711c2f5, this splits out the journey tests into their own job, making changes to both `justfile` and the CI test workflow to do so. This is the change recently discussed in #1668 (https://github.com/GitoxideLabs/gitoxide/pull/1668#issuecomment-2474788049, https://github.com/GitoxideLabs/gitoxide/pull/1668#issuecomment-2475485053). I've tried to avoid making code comments in the `justfile` more confusing when doing this, but I may end up opening a subsequent PR to fix them up, depending on the answer to #1673.

This also fixes up the remaining `with_program tree` in the journey tests, changing it to `with_program find` (f1a171b). All uses of `tree` in the journey tests were replaced with `find` in 3c1bfd5 (#861), but this particular `with_program` call was not updated to reflect that. This allows the test to run when `tree` is absent, and nothing else is using it, so this also no longer installs it in any CI jobs. The reason for including this change in this PR is that it was necessary to figure out which commands had to be run to prepare each of `test` and `test-journey`.