### PR TITLE
Assorted justfile and CI workflow maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CLICOLOR: '1'
+  NEXTEST_NO_TESTS: fail
 
 jobs:
   pure-rust-build:

--- a/justfile
+++ b/justfile
@@ -12,15 +12,10 @@ alias nt := nextest
 # run all tests, clippy, including journey tests, try building docs
 test: clippy check doc unit-tests journey-tests-pure journey-tests-small journey-tests-async journey-tests
 
-# run all tests, without clippy, including journey tests, try building docs (and clear target)
-ci-test-full: check doc unit-tests clear-target ci-journey-tests
-
-# run all tests, without clippy, and try building docs (without clearing the target)
+# run all tests, without clippy, and try building docs
 ci-test: check doc unit-tests
 
-# run all journey tests
-# these should be run in a fresh clone or after `cargo clean`
-# (and workaround a just-issue of deduplicating targets)
+# run all journey tests - should be run in a fresh clone or after `cargo clean`
 ci-journey-tests: journey-tests-pure journey-tests-small journey-tests-async journey-tests
 
 clear-target:

--- a/justfile
+++ b/justfile
@@ -191,7 +191,7 @@ unit-tests:
     cargo nextest run -p gix --no-default-features --features basic,extras,comfort,need-more-recent-msrv
     cargo nextest run -p gix --features async-network-client
     cargo nextest run -p gix --features blocking-network-client
-    cargo nextest run -p gitoxide-core --lib
+    cargo nextest run -p gitoxide-core --lib --no-tests=warn
 
 # These tests aren't run by default as they are flaky (even locally)
 unit-tests-flaky:

--- a/justfile
+++ b/justfile
@@ -245,10 +245,10 @@ audit:
     cargo deny check advisories bans licenses sources
 
 # run tests with `cargo nextest` (all unit-tests, no doc-tests, faster)
-nextest *FLAGS="--all":
+nextest *FLAGS="--workspace":
     cargo nextest run {{ FLAGS }}
 
-summarize EXPRESSION="all()": (nextest "--all --run-ignored all --no-fail-fast --status-level none --final-status-level none -E '" EXPRESSION "'")
+summarize EXPRESSION="all()": (nextest "--workspace --run-ignored all --no-fail-fast --status-level none --final-status-level none -E '" EXPRESSION "'")
 
 # run nightly rustfmt for its extra features, but check that it won't upset stable rustfmt
 fmt:


### PR DESCRIPTION
This makes a few small improvements to the `ci.yml` workflow and the `justfile`:

1. b9a6fb1 changes `--all` to `--workspace` that were missed in 14d472d ([#1654](https://github.com/GitoxideLabs/gitoxide/pull/1654))

2. 2fc93f7 expresses what I *think* is the intended effect of `nextest run -p ...` commands when `...` has no tests:

   - For `gitoxide-core`, it preserves [a warning that will otherwise become an error](https://github.com/GitoxideLabs/gitoxide/actions/runs/11833759354/job/32973071161#step:8:4815) in a future version of `nextest`. (I have verified that this is unaffected by [#1674](https://github.com/GitoxideLabs/gitoxide/pull/1674), except that the change there makes the message easier to notice.)
   - For everything else, on CI it treats it as an error.

3. eeccb4b removes `ci-test-full` as suggested in [#1674 (comment)](https://github.com/GitoxideLabs/gitoxide/pull/1674#discussion_r1841796294), removes the parenthesized text discussed in [#1673](https://github.com/GitoxideLabs/gitoxide/discussions/1673), and consolidates accordingly.

See the commit messages for further details.