### PR TITLE
Let journey tests fail without `find` and enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 **/generated-archives/*.tar* filter=lfs-disabled diff=lfs merge=lfs -text
 
 # assure line feeds don't interfere with our working copy hash
-**/tests/fixtures/**/*.sh text crlf=input	eol=lf
-/justfile text crlf=input	eol=lf
+*.sh text crlf=input eol=lf
+justfile text crlf=input eol=lf
 
 # have GitHub include fixture-making scripts when it counts code
 **/tests/fixtures/**/*.sh linguist-vendored=false

--- a/tests/journey/ein.sh
+++ b/tests/journey/ein.sh
@@ -28,144 +28,142 @@ title "Porcelain ${kind}"
     )
   )
   snapshot="$snapshot/porcelain"
-  (with_program find
-    (when "using the 'tool' subcommand"
-      title "ein tool"
-      (with "a repo with a tiny commit history"
-        (small-repo-in-sandbox
-          title "ein tool estimate-hours"
-          (when "running 'estimate-hours'"
-            snapshot="$snapshot/estimate-hours"
-            (with "no arguments"
-              it "succeeds and prints only a summary" && {
-                WITH_SNAPSHOT="$snapshot/no-args-success" \
-                expect_run_sh $SUCCESSFULLY "$exe tool estimate-hours 2>/dev/null"
-              }
-            )
-            (with "the show-pii argument"
-              it "succeeds and shows information identifying people before the summary" && {
-                WITH_SNAPSHOT="$snapshot/show-pii-success" \
-                expect_run_sh $SUCCESSFULLY "$exe tool estimate-hours --show-pii 2>/dev/null"
-              }
-            )
-            (with "the omit-unify-identities argument"
-              it "succeeds and doesn't show unified identities (in this case there is only one author anyway)" && {
-                WITH_SNAPSHOT="$snapshot/no-unify-identities-success" \
-                expect_run_sh $SUCCESSFULLY "$exe t estimate-hours --omit-unify-identities 2>/dev/null"
-              }
-            )
-            (with "the --file-stats argument"
-              it "succeeds and shows file statistics" && {
-                WITH_SNAPSHOT="$snapshot/file-stats-success" \
-                expect_run_sh $SUCCESSFULLY "$exe tool estimate-hours --file-stats 2>/dev/null"
-              }
-            )
-            (with "the --line-stats argument"
-              it "succeeds and shows line statistics" && {
-                WITH_SNAPSHOT="$snapshot/line-stats-success" \
-                expect_run_sh $SUCCESSFULLY "$exe tool estimate-hours --line-stats 2>/dev/null"
-              }
-            )
-            (with "all --stats arguments and pii"
-              it "succeeds and shows all statistics" && {
-                WITH_SNAPSHOT="$snapshot/all-stats-success" \
-                expect_run_sh $SUCCESSFULLY "$exe tool estimate-hours -pfl 2>/dev/null"
-              }
-            )
-            (with "a branch name that doesn't exist"
-              it "fails and shows a decent enough error message" && {
-                WITH_SNAPSHOT="$snapshot/invalid-branch-name-failure" \
-                expect_run_sh $WITH_FAILURE "$exe -q t estimate-hours . foobar"
-              }
-            )
+  (when "using the 'tool' subcommand"
+    title "ein tool"
+    (with "a repo with a tiny commit history"
+      (small-repo-in-sandbox
+        title "ein tool estimate-hours"
+        (when "running 'estimate-hours'"
+          snapshot="$snapshot/estimate-hours"
+          (with "no arguments"
+            it "succeeds and prints only a summary" && {
+              WITH_SNAPSHOT="$snapshot/no-args-success" \
+              expect_run_sh $SUCCESSFULLY "$exe tool estimate-hours 2>/dev/null"
+            }
+          )
+          (with "the show-pii argument"
+            it "succeeds and shows information identifying people before the summary" && {
+              WITH_SNAPSHOT="$snapshot/show-pii-success" \
+              expect_run_sh $SUCCESSFULLY "$exe tool estimate-hours --show-pii 2>/dev/null"
+            }
+          )
+          (with "the omit-unify-identities argument"
+            it "succeeds and doesn't show unified identities (in this case there is only one author anyway)" && {
+              WITH_SNAPSHOT="$snapshot/no-unify-identities-success" \
+              expect_run_sh $SUCCESSFULLY "$exe t estimate-hours --omit-unify-identities 2>/dev/null"
+            }
+          )
+          (with "the --file-stats argument"
+            it "succeeds and shows file statistics" && {
+              WITH_SNAPSHOT="$snapshot/file-stats-success" \
+              expect_run_sh $SUCCESSFULLY "$exe tool estimate-hours --file-stats 2>/dev/null"
+            }
+          )
+          (with "the --line-stats argument"
+            it "succeeds and shows line statistics" && {
+              WITH_SNAPSHOT="$snapshot/line-stats-success" \
+              expect_run_sh $SUCCESSFULLY "$exe tool estimate-hours --line-stats 2>/dev/null"
+            }
+          )
+          (with "all --stats arguments and pii"
+            it "succeeds and shows all statistics" && {
+              WITH_SNAPSHOT="$snapshot/all-stats-success" \
+              expect_run_sh $SUCCESSFULLY "$exe tool estimate-hours -pfl 2>/dev/null"
+            }
+          )
+          (with "a branch name that doesn't exist"
+            it "fails and shows a decent enough error message" && {
+              WITH_SNAPSHOT="$snapshot/invalid-branch-name-failure" \
+              expect_run_sh $WITH_FAILURE "$exe -q t estimate-hours . foobar"
+            }
           )
         )
       )
-      (with "a mix of repositories"
-        (sandbox
-          repo-with-remotes dir/one-origin origin https://example.com/one-origin
-          repo-with-remotes origin-and-fork origin https://example.com/origin-and-fork fork https://example.com/other/origin-and-fork
-          repo-with-remotes special-origin special-name https://example.com/special-origin
-          repo-with-remotes no-origin
-          repo-with-remotes a-non-bare-repo-with-extension.git origin https://example.com/a-repo-with-extension.git
-          snapshot="$snapshot/tool"
+    )
+    (with "a mix of repositories"
+      (sandbox
+        repo-with-remotes dir/one-origin origin https://example.com/one-origin
+        repo-with-remotes origin-and-fork origin https://example.com/origin-and-fork fork https://example.com/other/origin-and-fork
+        repo-with-remotes special-origin special-name https://example.com/special-origin
+        repo-with-remotes no-origin
+        repo-with-remotes a-non-bare-repo-with-extension.git origin https://example.com/a-repo-with-extension.git
+        snapshot="$snapshot/tool"
 
-          title "ein tool find"
-          (when "running 'find'"
-            snapshot="$snapshot/find"
-            (with "no arguments"
-              it "succeeds and prints a list of repository work directories" && {
-                WITH_SNAPSHOT="$snapshot/no-args-success" \
-                expect_run_sh $SUCCESSFULLY "$exe tool find 2>/dev/null"
-              }
-            )
-          )
-          title "ein tool organize"
-          (when "running 'organize'"
-            snapshot="$snapshot/organize"
-            (with "no arguments"
-              it "succeeds and informs about the operations that it WOULD do" && {
-                WITH_SNAPSHOT="$snapshot/no-args-success" \
-                expect_run_sh $SUCCESSFULLY "$exe tool organize 2>/dev/null"
-              }
-
-              it "does not change the directory structure at all" && {
-                WITH_SNAPSHOT="$snapshot/initial-directory-structure" \
-                expect_run_sh $SUCCESSFULLY 'find . -maxdepth 2 | sort'
-              }
-            )
-
-            (with "--execute"
-              it "succeeds" && {
-                WITH_SNAPSHOT="$snapshot/execute-success" \
-                expect_run_sh $SUCCESSFULLY "$exe tool organize --execute 2>/dev/null"
-              }
-
-              it "changes the directory structure" && {
-                WITH_SNAPSHOT="$snapshot/directory-structure-after-organize" \
-                expect_run_sh $SUCCESSFULLY 'find . -maxdepth 2 | sort'
-              }
-            )
-
-            (with "--execute again"
-              it "succeeds" && {
-                WITH_SNAPSHOT="$snapshot/execute-success" \
-                expect_run_sh $SUCCESSFULLY "$exe tool organize --execute 2>/dev/null"
-              }
-
-              it "does not alter the directory structure as these are already in place" && {
-                WITH_SNAPSHOT="$snapshot/directory-structure-after-organize" \
-                expect_run_sh $SUCCESSFULLY 'find . -maxdepth 2 | sort'
-              }
-            )
-
-            (with "--execute with move into subdirectory of itself"
-              (cd example.com
-                rm -Rf a-repo-with-extension origin-and-fork
-                mv one-origin ../
-                cd ..
-                rmdir example.com && mv one-origin example.com
-              )
-              it "succeeds" && {
-                WITH_SNAPSHOT="$snapshot/execute-success-new-root" \
-                expect_run_sh $SUCCESSFULLY "$exe tool organize --execute 2>/dev/null"
-              }
-
-              it "does alter the directory structure as these are already in place" && {
-                WITH_SNAPSHOT="$snapshot/directory-structure-after-organize-to-new-root" \
-                expect_run_sh $SUCCESSFULLY 'find . -maxdepth 2 -type d | sort'
-              }
-            )
-          )
-          if test "$kind" != "max-pure"; then
-          (with "running with no further arguments"
-            it "succeeds and informs about possible operations" && {
-              WITH_SNAPSHOT="$snapshot/no-args-failure" \
-              expect_run_sh $WITH_CLAP_FAILURE "$exe t"
+        title "ein tool find"
+        (when "running 'find'"
+          snapshot="$snapshot/find"
+          (with "no arguments"
+            it "succeeds and prints a list of repository work directories" && {
+              WITH_SNAPSHOT="$snapshot/no-args-success" \
+              expect_run_sh $SUCCESSFULLY "$exe tool find 2>/dev/null"
             }
           )
-          fi
         )
+        title "ein tool organize"
+        (when "running 'organize'"
+          snapshot="$snapshot/organize"
+          (with "no arguments"
+            it "succeeds and informs about the operations that it WOULD do" && {
+              WITH_SNAPSHOT="$snapshot/no-args-success" \
+              expect_run_sh $SUCCESSFULLY "$exe tool organize 2>/dev/null"
+            }
+
+            it "does not change the directory structure at all" && {
+              WITH_SNAPSHOT="$snapshot/initial-directory-structure" \
+              expect_run_sh $SUCCESSFULLY 'find . -maxdepth 2 | sort'
+            }
+          )
+
+          (with "--execute"
+            it "succeeds" && {
+              WITH_SNAPSHOT="$snapshot/execute-success" \
+              expect_run_sh $SUCCESSFULLY "$exe tool organize --execute 2>/dev/null"
+            }
+
+            it "changes the directory structure" && {
+              WITH_SNAPSHOT="$snapshot/directory-structure-after-organize" \
+              expect_run_sh $SUCCESSFULLY 'find . -maxdepth 2 | sort'
+            }
+          )
+
+          (with "--execute again"
+            it "succeeds" && {
+              WITH_SNAPSHOT="$snapshot/execute-success" \
+              expect_run_sh $SUCCESSFULLY "$exe tool organize --execute 2>/dev/null"
+            }
+
+            it "does not alter the directory structure as these are already in place" && {
+              WITH_SNAPSHOT="$snapshot/directory-structure-after-organize" \
+              expect_run_sh $SUCCESSFULLY 'find . -maxdepth 2 | sort'
+            }
+          )
+
+          (with "--execute with move into subdirectory of itself"
+            (cd example.com
+              rm -Rf a-repo-with-extension origin-and-fork
+              mv one-origin ../
+              cd ..
+              rmdir example.com && mv one-origin example.com
+            )
+            it "succeeds" && {
+              WITH_SNAPSHOT="$snapshot/execute-success-new-root" \
+              expect_run_sh $SUCCESSFULLY "$exe tool organize --execute 2>/dev/null"
+            }
+
+            it "does alter the directory structure as these are already in place" && {
+              WITH_SNAPSHOT="$snapshot/directory-structure-after-organize-to-new-root" \
+              expect_run_sh $SUCCESSFULLY 'find . -maxdepth 2 -type d | sort'
+            }
+          )
+        )
+        if test "$kind" != "max-pure"; then
+        (with "running with no further arguments"
+          it "succeeds and informs about possible operations" && {
+            WITH_SNAPSHOT="$snapshot/no-args-failure" \
+            expect_run_sh $WITH_CLAP_FAILURE "$exe t"
+          }
+        )
+        fi
       )
     )
   )

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -549,20 +549,17 @@ title "gix commit-graph"
                   expect_run $WITH_FAILURE test -e "${PACK_FILE}".idx
                 }
 
-                (with_program find
-
-                  if test "$kind" = "small" ; then
-                    suffix=miniz-oxide
-                  elif test "$kind" = "max-pure"; then
-                    suffix=miniz-oxide-max
-                  else
-                    suffix=zlib-ng
-                  fi
-                  it "creates all pack objects, but the broken ones" && {
-                    WITH_SNAPSHOT="$snapshot/broken-with-objects-dir-skip-checks-success-tree-$suffix" \
-                    expect_run_sh $SUCCESSFULLY 'find . -type f | sort'
-                  }
-                )
+                if test "$kind" = "small" ; then
+                  suffix=miniz-oxide
+                elif test "$kind" = "max-pure"; then
+                  suffix=miniz-oxide-max
+                else
+                  suffix=zlib-ng
+                fi
+                it "creates all pack objects, but the broken ones" && {
+                  WITH_SNAPSHOT="$snapshot/broken-with-objects-dir-skip-checks-success-tree-$suffix" \
+                  expect_run_sh $SUCCESSFULLY 'find . -type f | sort'
+                }
               )
             )
           )
@@ -582,12 +579,10 @@ title "gix commit-graph"
                                                      "${PACK_FILE}.pack" .
           }
 
-          (with_program find
-            it "creates all pack objects" && {
-              WITH_SNAPSHOT="$snapshot/with-objects-dir-success-tree" \
-              expect_run_sh $SUCCESSFULLY 'find . -type f | sort'
-            }
-          )
+          it "creates all pack objects" && {
+            WITH_SNAPSHOT="$snapshot/with-objects-dir-success-tree" \
+            expect_run_sh $SUCCESSFULLY 'find . -type f | sort'
+          }
         )
       )
     )

--- a/tests/utilities.sh
+++ b/tests/utilities.sh
@@ -7,21 +7,6 @@ RED="$(tput setaf 1 2>/dev/null || echo -n '')"
 OFFSET=( )
 STEP="  "
 
-function with_program () {
-  local program="${1:?}"
-  hash "$program" &>/dev/null || {
-    function expect_run () {
-      echo 1>&2 "${WHITE} - skipped (missing program)"
-    }
-    function expect_run_sh () {
-      echo 1>&2 "${WHITE} - skipped (missing program)"
-    }
-    function expect_run_sh_no_pipefail () {
-      echo 1>&2 "${WHITE} - skipped (missing program)"
-    }
-  }
-}
-
 function on_ci () {
   [ -n "${CI-}" ] || {
     function expect_run () {


### PR DESCRIPTION
f1a171b (#1674) included the conservative step of correcting the last remaining `with_program tree` to `with_program find` and no longer installing `tree` on CI. However, we can go further: any environment without `find` is unsuitable for running journey tests (and, more broadly, broken for general purpose usage). `find` is required by POSIX, is in practice present on all but the most minimal Unix-like systems (and installable on those), and is present in Git Bash.

`with_program` skips tests when the named tool is not found, so using it does not prevent bugs from being concealed. More importantly, all the assertions covered under `with_progam find` were `expect_run_sh $SUCCESSFULLY` assertions, so if `find` were absent, they would fail, revealing the problem. I think that it is better for journey tests that use `find` to fail, when run in strange environments that don't have `find`.

This removes all such calls in bc6e4be. As detailed in that commit message, even with scoping considerations in mind, the subshells introduced with `with_find` calls are no longer needed either, so this removes those and dedents. (This, the changes here are significantly less than a +/- line count would suggest.) These were also the only remaining calls to `with_program`, so 05e176c removes that function definition.

While beginning to work on this, I noticed that shell scripts other than those related to fixtures don't have LF line endings enforced in `.gitattributes` and would end up being checked out with CRLF line endings on Windows. This is undesirable even if `bash` on Windows typically tolerates it, as detailed in 1a3f4e3, which therefore simplifies that part of `.gitattributes` to force LF for all shell scripts.