### PR TITLE
Have `pure-rust-build` job find what compiles C code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           #!/bin/sh -e
           printf '%s\n' "$0 $*" |
             flock /run/lock/wrapper1.fbd136bd-9b1b-448d-84a9-e18be53ae63c.lock \
-            tee -a /var/log/wrapper1.log /dev/tty >/dev/null
+            tee -a -- /var/log/wrapper1.log ~/ci-stdout >/dev/null
           exec "$0.orig" "$@"
           EOF
 
@@ -85,6 +85,7 @@ jobs:
 
           chmod +x /usr/local/bin/wrap1 /usr/local/bin/wrapper1
           mkdir /run/lock/wrapper1.fbd136bd-9b1b-448d-84a9-e18be53ae63c.lock
+          ln -s -- "/proc/$$/fd/1" ~/ci-stdout
 
           find /usr/lib/gcc \( -name cc1 -o -name cc1plus \) \
             -print -exec /usr/local/bin/wrap1 {} \;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
 
           chmod +x /usr/local/bin/wrap1 /usr/local/bin/wrapper1
           mkdir /run/lock/wrapper1.fbd136bd-9b1b-448d-84a9-e18be53ae63c.lock
+          (set -x; ls -l "/proc/$$/fd/1")  # See what's going on.
           ln -s -- "/proc/$$/fd/1" ~/ci-stdout
 
           find /usr/lib/gcc \( -name cc1 -o -name cc1plus \) \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           #!/bin/sh -e
           printf '%s\n' "$0 $*" |
             flock /run/lock/wrapper1.fbd136bd-9b1b-448d-84a9-e18be53ae63c.lock \
-            tee -a -- /var/log/wrapper1.log ~/ci-stdout >/dev/null
+            tee -a -- /var/log/wrapper1.log ~/display >/dev/null  # We'll link ~/display later.
           exec "$0.orig" "$@"
           EOF
 
@@ -85,13 +85,13 @@ jobs:
 
           chmod +x /usr/local/bin/wrap1 /usr/local/bin/wrapper1
           mkdir /run/lock/wrapper1.fbd136bd-9b1b-448d-84a9-e18be53ae63c.lock
-          (set -x; ls -l "/proc/$$/fd/1")  # See what's going on.
-          ln -s -- "/proc/$$/fd/1" ~/ci-stdout
 
           find /usr/lib/gcc \( -name cc1 -o -name cc1plus \) \
             -print -exec /usr/local/bin/wrap1 {} \;
       - name: Build max-pure with minimal dev tools and log cc1
-        run: cargo install --debug --locked --no-default-features --features max-pure --path .
+        run: |
+          ln -s -- "/proc/$$/fd/1" ~/display  # Bypass `cc1` redirection.
+          cargo install --debug --locked --no-default-features --features max-pure --path .
       - name: Show logged C and C++ compilations (should be none)
         run: |
           ! cat /var/log/wrapper1.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,10 @@ jobs:
       - name: Wrap cc1 (and cc1plus if present) to record calls
         run: |
           cat >/usr/local/bin/wrapper1 <<'EOF'
-          #!/bin/sh
-          printf '%s %s\n' "$0" "$*" |
+          #!/bin/sh -e
+          printf '%s\n' "$0 $*" |
             flock /run/lock/wrapper1.fbd136bd-9b1b-448d-84a9-e18be53ae63c.lock \
-            tee -a /var/log/wrapper1.log >/dev/null  # TODO: Also log to terminal device?
+            tee -a /var/log/wrapper1.log /dev/tty >/dev/null
           exec "$0.orig" "$@"
           EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
         run: |
           cat >/usr/local/bin/wrapper1 <<'EOF'
           #!/bin/sh
-          printf '%s %s\n' "$0" "$*" >>/var/log/wrapper1.log
+          printf '%s %s\n' "$0" "$*" |
+            flock /run/lock/wrapper1.fbd136bd-9b1b-448d-84a9-e18be53ae63c.lock \
+            tee -a /var/log/wrapper1.log >/dev/null  # TODO: Also log to terminal device?
           exec "$0.orig" "$@"
           EOF
 
@@ -82,6 +84,7 @@ jobs:
           EOF
 
           chmod +x /usr/local/bin/wrap1 /usr/local/bin/wrapper1
+          mkdir /run/lock/wrapper1.fbd136bd-9b1b-448d-84a9-e18be53ae63c.lock
 
           find /usr/lib/gcc \( -name cc1 -o -name cc1plus \) \
             -print -exec /usr/local/bin/wrap1 {} \;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           apt-get update
           apt-get install --no-install-recommends -y -- "${prerequisites[@]}"
         shell: bash
-      - name: Verify environment is sufficiently minimal for the test
+      - name: Verify that we are in an environment with minimal dev tools
         run: |
           set -x
           for pattern in cmake g++ libssl-dev make pkgconf pkg-config; do
@@ -64,14 +64,32 @@ jobs:
           pattern='.*\b(-sys|cc|cmake|pkg-config|vcpkg)\b.*'
           ! GREP_COLORS='ms=30;48;5;214' grep --color=always -Ex -C 1000000 -e "$pattern" tree.txt
         continue-on-error: true
-      - name: Do max-pure build with minimal environment
+      - name: Wrap cc1 (and cc1plus if present) to record calls
+        run: |
+          cat >/usr/local/bin/wrapper1 <<'EOF'
+          #!/bin/sh
+          printf '%s %s\n' "$0" "$*" >>/var/log/wrapper1.log
+          exec "$0.orig" "$@"
+          EOF
+
+          cat >/usr/local/bin/wrap1 <<'EOF'
+          #!/bin/sh -e
+          dir="$(dirname -- "$1")"
+          base="$(basename -- "$1")"
+          cd -- "$dir"
+          mv -- "$base" "$base.orig"
+          ln -s -- /usr/local/bin/wrapper1 "$base"
+          EOF
+
+          chmod +x /usr/local/bin/wrap1 /usr/local/bin/wrapper1
+
+          find /usr/lib/gcc \( -name cc1 -o -name cc1plus \) \
+            -print -exec /usr/local/bin/wrap1 {} \;
+      - name: Build max-pure with minimal dev tools and log cc1
         run: cargo install --debug --locked --no-default-features --features max-pure --path .
-      - name: Clear target
-        run: cargo clean
-      - name: Break GCC's ability to compile C or C++
-        run: find /usr/lib/gcc \( -name cc1 -o -name cc1plus \) -print -delete
-      - name: Do max-pure build without being able to compile C or C++
-        run: cargo install --debug --locked --no-default-features --features max-pure --path .
+      - name: Show logged C and C++ compilations (should be none)
+        run: |
+          ! cat /var/log/wrapper1.log
         continue-on-error: true
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           apt-get update
           apt-get install --no-install-recommends -y -- "${prerequisites[@]}"
         shell: bash
-      - name: Verify that we are in an environment with minimal dev tools
+      - name: Verify that we are in an environment with limited dev tools
         run: |
           set -x
           for pattern in cmake g++ libssl-dev make pkgconf pkg-config; do
@@ -88,7 +88,7 @@ jobs:
 
           find /usr/lib/gcc \( -name cc1 -o -name cc1plus \) \
             -print -exec /usr/local/bin/wrap1 {} \;
-      - name: Build max-pure with minimal dev tools and log cc1
+      - name: Build max-pure with limited dev tools and log cc1
         run: |
           ln -s -- "/proc/$$/fd/1" ~/display  # Bypass `cc1` redirection.
           cargo install --debug --locked --no-default-features --features max-pure --path .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,24 @@ jobs:
           done
       - name: Install Rust via Rustup
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-      - uses: Swatinem/rust-cache@v2
-      - run: /github/home/.cargo/bin/cargo install --debug --locked --no-default-features --features max-pure --path .
+      - name: Add Rust tools to path
+        run: echo "PATH=$HOME/.cargo/bin:$PATH" >> "$GITHUB_ENV"
+      - name: Generate dependency tree
+        run: cargo tree --locked --no-default-features --features max-pure > tree.txt
+      - name: Scan for dependencies that build C or C++ code
+        run: |
+          pattern='.*\b(-sys|cc|cmake|pkg-config|vcpkg)\b.*'
+          ! GREP_COLORS='ms=30;48;5;214' grep --color=always -Ex -C 1000000 -e "$pattern" tree.txt
+        continue-on-error: true
+      - name: Do max-pure build with minimal environment
+        run: cargo install --debug --locked --no-default-features --features max-pure --path .
+      - name: Clear target
+        run: cargo clean
+      - name: Break GCC's ability to compile C or C++
+        run: find /usr/lib/gcc \( -name cc1 -o -name cc1plus \) -print -delete
+      - name: Do max-pure build without being able to compile C or C++
+        run: cargo install --debug --locked --no-default-features --features max-pure --path .
+        continue-on-error: true
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This causes the `pure-rust-build` CI job to provide more insight about what and how some of gitoxide's dependencies, even with `max-pure`, compile C code. This is related to, and hoped to help with, #1681, but it is not a fix for it, because this does not change any of the project's dependencies. It only augments that CI job. The approach is twofold:

1. Look for crates in the dependency tree that very strongly suggest that this is happening. Unless none are found, show the full tree and highlight the lines that show such dependencies.
2. Instrument `cc1`, which `gcc` calls to do the actual work of compiling C and otherwise is rarely called, interleaving a log of its calls with high-level `cargo` output (while still omitting all other forms of verbose output), and also displaying the `cc1` log afterwards.

The new steps detect when and, to a large extent, how and why building `max-pure` builds C code. They would be able to fail the job except that, for now, I have used step-level `continue-on-error` to prevent this.

The commit messages have further details, and some rationale and coverage of subtleties. They also reflect an initially different approach that I replaced with (2). Before moving aside `cc1` and putting in place a script that mocks it, reports the call, and delegates to it, I had deleted `cc1` to observe the first error from the build (e1555bd).

That approach is currently not nearly as good, because it requires two builds (to maintain full coverage of what was previously tested) and because it only reveals the *first* failure, whereas instrumenting `cc1` reveals all calls to it (f0c7d42).

However, I've left it in the history, in part because it's a technique that might revisited in the future when a fix or greater progress on #1681 are in place. I've also left in some small false starts related to logging, since I think that make it easier to discern why a few things are being done the way they are.