### PR TITLE
Add lookup_entry and lookup_entry_by_path to TreeRef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,6 +2187,7 @@ dependencies = [
  "gix-hash 0.15.1",
  "gix-hashtable 0.6.0",
  "gix-odb",
+ "gix-path 0.10.13",
  "gix-testtools",
  "gix-utils 0.1.13",
  "gix-validate 0.9.2",

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -50,6 +50,7 @@ gix-hashtable = { version = "^0.6.0", path = "../gix-hashtable" }
 gix-validate = { version = "^0.9.2", path = "../gix-validate" }
 gix-actor = { version = "^0.33.1", path = "../gix-actor" }
 gix-date = { version = "^0.9.2", path = "../gix-date" }
+gix-path = { version = "^0.10.12", path = "../gix-path" }
 gix-utils = { version = "^0.1.13", path = "../gix-utils" }
 
 itoa = "1.0.1"

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -56,7 +56,7 @@ impl<'a> TreeRef<'a> {
     ///
     pub fn lookup_entry<I, P>(
         &self,
-        odb: impl crate::Find + crate::FindExt,
+        odb: impl crate::FindExt,
         buffer: &'a mut Vec<u8>,
         path: I,
     ) -> Result<Option<tree::Entry>, Error>

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -11,6 +11,75 @@ impl<'a> TreeRefIter<'a> {
     pub fn from_bytes(data: &'a [u8]) -> TreeRefIter<'a> {
         TreeRefIter { data }
     }
+
+    /// Follow a sequence of `path` components starting from this instance, and look them up one by one until the last component
+    /// is looked up and its tree entry is returned.
+    ///
+    /// # Performance Notes
+    ///
+    /// Searching tree entries is currently done in sequence, which allows the search to be allocation free. It would be possible
+    /// to reuse a vector and use a binary search instead, which might be able to improve performance over all.
+    /// However, a benchmark should be created first to have some data and see which trade-off to choose here.
+    ///
+    pub fn lookup_entry<I, P>(
+        &self,
+        odb: impl crate::FindExt,
+        buffer: &'a mut Vec<u8>,
+        path: I,
+    ) -> Result<Option<tree::Entry>, Error>
+    where
+        I: IntoIterator<Item = P>,
+        P: PartialEq<BStr>,
+    {
+        buffer.clear();
+
+        let mut path = path.into_iter().peekable();
+        buffer.extend_from_slice(&self.data);
+        while let Some(component) = path.next() {
+            match TreeRefIter::from_bytes(&buffer)
+                .filter_map(Result::ok)
+                .find(|entry| component.eq(entry.filename))
+            {
+                Some(entry) => {
+                    if path.peek().is_none() {
+                        return Ok(Some(entry.into()));
+                    } else {
+                        let next_id = entry.oid.to_owned();
+                        let obj = odb.find(&next_id, buffer)?;
+                        if !obj.kind.is_tree() {
+                            return Ok(None);
+                        }
+                    }
+                }
+                None => return Ok(None),
+            }
+        }
+        Ok(None)
+    }
+
+    /// Like [`Self::lookup_entry()`], but takes a `Path` directly via `relative_path`, a path relative to this tree.
+    ///
+    /// # Note
+    ///
+    /// If any path component contains illformed UTF-8 and thus can't be converted to bytes on platforms which can't do so natively,
+    /// the returned component will be empty which makes the lookup fail.
+    pub fn lookup_entry_by_path(
+        &self,
+        odb: impl crate::Find,
+        buffer: &'a mut Vec<u8>,
+        relative_path: impl AsRef<std::path::Path>,
+    ) -> Result<Option<tree::Entry>, Error> {
+        use crate::bstr::ByteSlice;
+        self.lookup_entry(
+            odb,
+            buffer,
+            relative_path.as_ref().components().map(|c: std::path::Component<'_>| {
+                gix_path::os_str_into_bstr(c.as_os_str())
+                    .unwrap_or_else(|_| "".into())
+                    .as_bytes()
+            }),
+        )
+    }
 }
 
 impl<'a> TreeRef<'a> {
@@ -43,70 +112,6 @@ impl<'a> TreeRef<'a> {
             .binary_search_by(|e| e.cmp(&search))
             .ok()
             .map(|idx| self.entries[idx])
-    }
-
-    /// Follow a sequence of `path` components starting from this instance, and look them up one by one until the last component
-    /// is looked up and its tree entry is returned.
-    ///
-    /// # Performance Notes
-    ///
-    /// Searching tree entries is currently done in sequence, which allows the search to be allocation free. It would be possible
-    /// to reuse a vector and use a binary search instead, which might be able to improve performance over all.
-    /// However, a benchmark should be created first to have some data and see which trade-off to choose here.
-    ///
-    pub fn lookup_entry<I, P>(
-        &self,
-        odb: impl crate::FindExt,
-        buffer: &'a mut Vec<u8>,
-        path: I,
-    ) -> Result<Option<tree::Entry>, Error>
-    where
-        I: IntoIterator<Item = P>,
-        P: PartialEq<BStr>,
-    {
-        let mut path = path.into_iter().peekable();
-        let mut entries = self.entries.clone();
-
-        while let Some(component) = path.next() {
-            match entries.iter().find(|entry| component.eq(entry.filename)) {
-                Some(entry) => {
-                    if path.peek().is_none() {
-                        return Ok(Some((*entry).into()));
-                    } else {
-                        let next_id = entry.oid.to_owned();
-                        let obj = odb.find_tree(&next_id, buffer)?;
-
-                        entries = obj.entries;
-                    }
-                }
-                None => return Ok(None),
-            }
-        }
-        Ok(None)
-    }
-
-    /// Like [`Self::lookup_entry()`], but takes a `Path` directly via `relative_path`, a path relative to this tree.
-    ///
-    /// # Note
-    ///
-    /// If any path component contains illformed UTF-8 and thus can't be converted to bytes on platforms which can't do so natively,
-    /// the returned component will be empty which makes the lookup fail.
-    pub fn lookup_entry_by_path(
-        &self,
-        odb: impl crate::Find,
-        buffer: &'a mut Vec<u8>,
-        relative_path: impl AsRef<std::path::Path>,
-    ) -> Result<Option<tree::Entry>, Error> {
-        use crate::bstr::ByteSlice;
-        self.lookup_entry(
-            odb,
-            buffer,
-            relative_path.as_ref().components().map(|c: std::path::Component<'_>| {
-                gix_path::os_str_into_bstr(c.as_os_str())
-                    .unwrap_or_else(|_| "".into())
-                    .as_bytes()
-            }),
-        )
     }
 
     /// Create an instance of the empty tree.

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -23,7 +23,7 @@ impl<'a> TreeRefIter<'a> {
     ///
     pub fn lookup_entry<I, P>(
         &self,
-        odb: impl crate::FindExt,
+        odb: impl crate::Find,
         buffer: &'a mut Vec<u8>,
         path: I,
     ) -> Result<Option<tree::Entry>, Error>
@@ -45,9 +45,11 @@ impl<'a> TreeRefIter<'a> {
                         return Ok(Some(entry.into()));
                     } else {
                         let next_id = entry.oid.to_owned();
-                        let obj = odb.find(&next_id, buffer)?;
-                        if !obj.kind.is_tree() {
-                            return Ok(None);
+                        let obj = odb.try_find(&next_id, buffer)?;
+                        if let Some(obj) = obj {
+                            if !obj.kind.is_tree() {
+                                return Ok(None);
+                            }
                         }
                     }
                 }

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -3,30 +3,26 @@ use winnow::{error::ParserError, prelude::*};
 
 use crate::{tree, tree::EntryRef, TreeRef, TreeRefIter};
 
-/// The error type returned by the [`Tree`](crate::Tree) trait.
-pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-
 impl<'a> TreeRefIter<'a> {
     /// Instantiate an iterator from the given tree data.
     pub fn from_bytes(data: &'a [u8]) -> TreeRefIter<'a> {
         TreeRefIter { data }
     }
 
-    /// Follow a sequence of `path` components starting from this instance, and look them up one by one until the last component
-    /// is looked up and its tree entry is returned.
+    /// Follow a sequence of `path` components starting from this instance, and look them up in `odb` one by one using `buffer`
+    /// until the last component is looked up and its tree entry is returned.
     ///
     /// # Performance Notes
     ///
     /// Searching tree entries is currently done in sequence, which allows the search to be allocation free. It would be possible
     /// to reuse a vector and use a binary search instead, which might be able to improve performance over all.
     /// However, a benchmark should be created first to have some data and see which trade-off to choose here.
-    ///
     pub fn lookup_entry<I, P>(
         &self,
         odb: impl crate::Find,
         buffer: &'a mut Vec<u8>,
         path: I,
-    ) -> Result<Option<tree::Entry>, Error>
+    ) -> Result<Option<tree::Entry>, crate::find::Error>
     where
         I: IntoIterator<Item = P>,
         P: PartialEq<BStr>,
@@ -34,9 +30,9 @@ impl<'a> TreeRefIter<'a> {
         buffer.clear();
 
         let mut path = path.into_iter().peekable();
-        buffer.extend_from_slice(&self.data);
+        buffer.extend_from_slice(self.data);
         while let Some(component) = path.next() {
-            match TreeRefIter::from_bytes(&buffer)
+            match TreeRefIter::from_bytes(buffer)
                 .filter_map(Result::ok)
                 .find(|entry| component.eq(entry.filename))
             {
@@ -46,10 +42,9 @@ impl<'a> TreeRefIter<'a> {
                     } else {
                         let next_id = entry.oid.to_owned();
                         let obj = odb.try_find(&next_id, buffer)?;
-                        if let Some(obj) = obj {
-                            if !obj.kind.is_tree() {
-                                return Ok(None);
-                            }
+                        let Some(obj) = obj else { return Ok(None) };
+                        if !obj.kind.is_tree() {
+                            return Ok(None);
                         }
                     }
                 }
@@ -59,7 +54,9 @@ impl<'a> TreeRefIter<'a> {
         Ok(None)
     }
 
-    /// Like [`Self::lookup_entry()`], but takes a `Path` directly via `relative_path`, a path relative to this tree.
+    /// Like [`Self::lookup_entry()`], but takes any [`AsRef<Path>`](`std::path::Path`) directly via `relative_path`,
+    /// a path relative to this tree.
+    /// `odb` and `buffer` are used to lookup intermediate trees.
     ///
     /// # Note
     ///
@@ -70,7 +67,7 @@ impl<'a> TreeRefIter<'a> {
         odb: impl crate::Find,
         buffer: &'a mut Vec<u8>,
         relative_path: impl AsRef<std::path::Path>,
-    ) -> Result<Option<tree::Entry>, Error> {
+    ) -> Result<Option<tree::Entry>, crate::find::Error> {
         use crate::bstr::ByteSlice;
         self.lookup_entry(
             odb,

--- a/gix-object/tests/object/tree/iter.rs
+++ b/gix-object/tests/object/tree/iter.rs
@@ -64,7 +64,7 @@ fn lookup_entry_toplevel() -> crate::Result {
     let root_tree_id = hex_to_id("ff7e7d2aecae1c3fb15054b289a4c58aa65b8646");
 
     let mut buf = Vec::new();
-    let root_tree = odb.find_tree(&root_tree_id, &mut buf)?;
+    let root_tree = odb.find_tree_iter(&root_tree_id, &mut buf)?;
 
     let mut buf = Vec::new();
     let entry = root_tree.lookup_entry_by_path(&odb, &mut buf, "bin").unwrap().unwrap();
@@ -81,7 +81,7 @@ fn lookup_entry_nested_path() -> crate::Result {
     let root_tree_id = hex_to_id("ff7e7d2aecae1c3fb15054b289a4c58aa65b8646");
 
     let mut buf = Vec::new();
-    let root_tree = odb.find_tree(&root_tree_id, &mut buf)?;
+    let root_tree = odb.find_tree_iter(&root_tree_id, &mut buf)?;
 
     let mut buf = Vec::new();
     let entry = root_tree

--- a/gix-object/tests/object/tree/iter.rs
+++ b/gix-object/tests/object/tree/iter.rs
@@ -60,14 +60,7 @@ fn everything() -> crate::Result {
 
 #[test]
 fn lookup_entry_toplevel() -> crate::Result {
-    let odb = utils::tree_odb()?;
-    let root_tree_id = hex_to_id("ff7e7d2aecae1c3fb15054b289a4c58aa65b8646");
-
-    let mut buf = Vec::new();
-    let root_tree = odb.find_tree_iter(&root_tree_id, &mut buf)?;
-
-    let mut buf = Vec::new();
-    let entry = root_tree.lookup_entry_by_path(&odb, &mut buf, "bin").unwrap().unwrap();
+    let entry = utils::lookup_entry_by_path("bin")?;
 
     assert!(matches!(entry, Entry { .. }));
     assert_eq!(entry.filename, "bin");
@@ -77,17 +70,7 @@ fn lookup_entry_toplevel() -> crate::Result {
 
 #[test]
 fn lookup_entry_nested_path() -> crate::Result {
-    let odb = utils::tree_odb()?;
-    let root_tree_id = hex_to_id("ff7e7d2aecae1c3fb15054b289a4c58aa65b8646");
-
-    let mut buf = Vec::new();
-    let root_tree = odb.find_tree_iter(&root_tree_id, &mut buf)?;
-
-    let mut buf = Vec::new();
-    let entry = root_tree
-        .lookup_entry_by_path(&odb, &mut buf, "file/a")
-        .unwrap()
-        .unwrap();
+    let entry = utils::lookup_entry_by_path("file/a")?;
 
     assert!(matches!(entry, Entry { .. }));
     assert_eq!(entry.filename, "a");
@@ -96,8 +79,23 @@ fn lookup_entry_nested_path() -> crate::Result {
 }
 
 mod utils {
+    use crate::hex_to_id;
+
+    use gix_object::FindExt;
+
     pub(super) fn tree_odb() -> gix_testtools::Result<gix_odb::Handle> {
         let root = gix_testtools::scripted_fixture_read_only("make_trees.sh")?;
         Ok(gix_odb::at(root.join(".git/objects"))?)
+    }
+
+    pub(super) fn lookup_entry_by_path(path: &str) -> gix_testtools::Result<gix_object::tree::Entry> {
+        let odb = tree_odb()?;
+        let root_tree_id = hex_to_id("ff7e7d2aecae1c3fb15054b289a4c58aa65b8646");
+
+        let mut buf = Vec::new();
+        let root_tree = odb.find_tree_iter(&root_tree_id, &mut buf)?;
+
+        let mut buf = Vec::new();
+        Ok(root_tree.lookup_entry_by_path(&odb, &mut buf, path).unwrap().unwrap())
     }
 }

--- a/gix-object/tests/object/tree/iter.rs
+++ b/gix-object/tests/object/tree/iter.rs
@@ -1,7 +1,8 @@
+use bstr::BString;
 use gix_object::{
     bstr::ByteSlice,
     tree::{self, Entry, EntryRef},
-    FindExt, TreeRefIter,
+    TreeRefIter,
 };
 use pretty_assertions::assert_eq;
 
@@ -62,8 +63,11 @@ fn everything() -> crate::Result {
 fn lookup_entry_toplevel() -> crate::Result {
     let entry = utils::lookup_entry_by_path("bin")?;
 
-    assert!(matches!(entry, Entry { .. }));
-    assert_eq!(entry.filename, "bin");
+    let mode: tree::EntryMode = tree::EntryMode(33188);
+    let filename: BString = "bin".into();
+    let oid = hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391");
+
+    assert_eq!(entry, Entry { mode, filename, oid });
 
     Ok(())
 }
@@ -72,8 +76,11 @@ fn lookup_entry_toplevel() -> crate::Result {
 fn lookup_entry_nested_path() -> crate::Result {
     let entry = utils::lookup_entry_by_path("file/a")?;
 
-    assert!(matches!(entry, Entry { .. }));
-    assert_eq!(entry.filename, "a");
+    let mode: tree::EntryMode = tree::EntryMode(33188);
+    let filename: BString = "a".into();
+    let oid = hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391");
+
+    assert_eq!(entry, Entry { mode, filename, oid });
 
     Ok(())
 }

--- a/gix-object/tests/object/tree/iter.rs
+++ b/gix-object/tests/object/tree/iter.rs
@@ -1,6 +1,6 @@
 use gix_object::{
     bstr::ByteSlice,
-    tree::{self, EntryRef},
+    tree::{self, Entry, EntryRef},
     FindExt, TreeRefIter,
 };
 use pretty_assertions::assert_eq;
@@ -69,7 +69,7 @@ fn lookup_entry_toplevel() -> crate::Result {
     let mut buf = Vec::new();
     let entry = root_tree.lookup_entry_by_path(&odb, &mut buf, "bin").unwrap().unwrap();
 
-    assert!(matches!(entry, EntryRef { .. }));
+    assert!(matches!(entry, Entry { .. }));
     assert_eq!(entry.filename, "bin");
 
     Ok(())
@@ -89,7 +89,7 @@ fn lookup_entry_nested_path() -> crate::Result {
         .unwrap()
         .unwrap();
 
-    assert!(matches!(entry, EntryRef { .. }));
+    assert!(matches!(entry, Entry { .. }));
     assert_eq!(entry.filename, "a");
 
     Ok(())

--- a/gix-object/tests/object/tree/iter.rs
+++ b/gix-object/tests/object/tree/iter.rs
@@ -67,7 +67,7 @@ fn lookup_entry_toplevel() -> crate::Result {
     let filename: BString = "bin".into();
     let oid = hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391");
 
-    assert_eq!(entry, Entry { mode, filename, oid });
+    assert_eq!(entry, Some(Entry { mode, filename, oid }));
 
     Ok(())
 }
@@ -80,7 +80,16 @@ fn lookup_entry_nested_path() -> crate::Result {
     let filename: BString = "a".into();
     let oid = hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391");
 
-    assert_eq!(entry, Entry { mode, filename, oid });
+    assert_eq!(entry, Some(Entry { mode, filename, oid }));
+
+    Ok(())
+}
+
+#[test]
+fn lookup_entry_that_does_not_exist() -> crate::Result {
+    let entry = utils::lookup_entry_by_path("file/does-not-exist")?;
+
+    assert_eq!(entry, None);
 
     Ok(())
 }
@@ -95,7 +104,7 @@ mod utils {
         Ok(gix_odb::at(root.join(".git/objects"))?)
     }
 
-    pub(super) fn lookup_entry_by_path(path: &str) -> gix_testtools::Result<gix_object::tree::Entry> {
+    pub(super) fn lookup_entry_by_path(path: &str) -> gix_testtools::Result<Option<gix_object::tree::Entry>> {
         let odb = tree_odb()?;
         let root_tree_id = hex_to_id("ff7e7d2aecae1c3fb15054b289a4c58aa65b8646");
 
@@ -103,6 +112,6 @@ mod utils {
         let root_tree = odb.find_tree_iter(&root_tree_id, &mut buf)?;
 
         let mut buf = Vec::new();
-        Ok(root_tree.lookup_entry_by_path(&odb, &mut buf, path).unwrap().unwrap())
+        Ok(root_tree.lookup_entry_by_path(&odb, &mut buf, path).unwrap())
     }
 }


### PR DESCRIPTION
This PR is related to a comment in my `gix blame` PR: https://github.com/GitoxideLabs/gitoxide/pull/1453#discussion_r1843679728.

I wrote the new code in the context of #1453 and then cherry-picked the result into this separate PR. I initially took both methods from https://github.com/GitoxideLabs/gitoxide/blob/9ab86a23d45941c4f0a3239e0cb57d4161dd279c/gix/src/object/tree/mod.rs#L51-L93 and https://github.com/GitoxideLabs/gitoxide/blob/9ab86a23d45941c4f0a3239e0cb57d4161dd279c/gix/src/object/tree/mod.rs#L138-L154, respectively. I left the doc comments untouched as they seem adequate in their new context as well. The code was modified to work with the APIs available in `gix-object`. I needed to add `gix-path` as a dependency in order to have access to `gix_path::os_str_into_bstr`.
