### PR TITLE
Check for unrecognized `*-sys` dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
           pattern='.*\b(-sys|cc|cmake|pkg-config|vcpkg)\b.*'
           ! GREP_COLORS='ms=30;48;5;214' grep --color=always -Ex -C 1000000 -e "$pattern" tree.txt
         continue-on-error: true
+      - name: Check for unrecognized *-sys dependencies
+        run: |
+          ! grep -qP '(?<!\blinux-raw)-sys\b' tree.txt
       - name: Wrap cc1 (and cc1plus if present) to record calls
         run: |
           cat >/usr/local/bin/wrapper1 <<'EOF'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Verify that we are in an environment with limited dev tools
         run: |
           set -x
-          for pattern in cmake g++ libssl-dev make pkgconf pkg-config; do
-            if dpkg-query --status -- "$pattern"; then
+          for package in cmake g++ libssl-dev make pkgconf pkg-config; do
+            if dpkg-query --status -- "$package"; then
               exit 1
             fi
           done


### PR DESCRIPTION
This is a regression test for the improvement in 3506afb (#1684) that fixed the unintended `libsqlite3-sys` dependency of `max-pure` reported in #1681. This also tries to guard against the introduction of other such crates as `max-pure` dependencies.

Specifically, this builds on #1682 by adding another step to `pure-rust-build` -- this one short, and allowed to fail the job (i.e. not `continue-on-error`) -- that verifies there are no dependencies named like `*-sys`, other than `linux-raw-sys`, which is known about.

I've verified in my fork that the new step fails when applied prior to 3506afb (#1684), and passes afterwards.

*Edit:* I had meant to do things in such a way as to verify that here, too, but I forgot about how checks are actually run as if on a merge commit that would integrate a PR rather than at the tip of the PR (https://github.com/actions/checkout/issues/504), even though that behavior is something I had recently reviewed for something else. I've edited out the misleading details that were inaccurate with respect to upstream checks.

I've also taken this opportunity to improve a shell variable I had somewhat misnamed, in another `pure-rust-build` step.