### PR TITLE
Announce `gitoxide` releases via discussion comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           "v$manifest_version" )
             echo 'OK: Release name/version agrees with Cargo.toml version.'
             ;;
-          TEST-* | *-DO-NOT-USE )
+          TEST-* | *-DO-NOT-USE )  # NOTE: If changed, change it in `announce-release` below, too.
             echo 'OK: Release name/version is strange but marked as such.'
             ;;
           "$manifest_version" )
@@ -426,6 +426,85 @@ jobs:
       - name: Publish the release
         if: vars.DRY_RUN_RELEASE != 'true' && vars.DRY_RUN_RELEASE != 'yes' && vars.DRY_RUN_RELEASE != '1'
         run: gh release --repo="$REPOSITORY" edit "$VERSION" --draft=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  announce-release:
+    runs-on: ubuntu-latest
+
+    needs: [ create-release, publish-release ]
+
+    permissions:
+      contents: read
+      discussions: write
+
+    env:
+      VERSION: ${{ needs.create-release.outputs.version }}
+
+    steps:
+      - name: Find the discussion ID
+        run: |
+          [[ "$DISCUSSION_URL" =~ ^https://github\.com/([^/:@]+)/([^/:@]+)/discussions/([0-9]+)$ ]]
+          owner="${BASH_REMATCH[1]}"
+          name="${BASH_REMATCH[2]}"
+          number="${BASH_REMATCH[3]}"
+
+          id="$(gh api graphql -f query='
+          query GetDiscussionId($owner: String!, $name: String!, $number: Int!) {
+            repository(owner: $owner, name: $name) {
+              discussion(number: $number) {
+                id
+              }
+            }
+          }' -F owner="$owner" -F name="$name" -F number="$number" --jq .data.repository.discussion.id)"
+
+          echo "DISCUSSION_ID=$id" >> "$GITHUB_ENV"
+        env:
+          DISCUSSION_URL: ${{ vars.RELEASE_ANNOUNCEMENTS_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # FIXME: Also consider a release of any name as a test, if it has not been published!
+      - name: Avoid announcing a test in a non-test thread
+        run: |
+          case "$VERSION" in
+          TEST-* | *-DO-NOT-USE )  # NOTE: Should be the same pattern as in `create-release` above.
+            echo "Looks like we're testing releasing. Checking discussion title."
+
+            title="$(gh api graphql -f query='
+            query($id: ID!) {
+              node(id: $id) {
+                ... on Discussion {
+                  title
+                }
+              }
+            }' -F id="$DISCUSSION_ID" --jq .data.node.title)"
+
+            grep -Eiqz '^[[(]?test\b' <<<"$title"
+            ;;
+          esac
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compose the comment
+        run: |
+          grep -Eqx '[[:alnum:]._+-]+' <<<"$VERSION"  # Ensure the version needs no sanitization.
+          release_url="https://github.com/$REPOSITORY/releases/tag/$VERSION"
+          comment_body="\`gitoxide\` [$VERSION]($release_url) has been released."
+          echo "COMMENT_BODY=$comment_body" >> "$GITHUB_ENV"
+        env:
+          REPOSITORY: ${{ github.repository }}
+
+      - name: Post the comment
+        run: |
+          gh api graphql -f query='
+          mutation PostComment($discussionId: ID!, $body: String!) {
+            addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+              comment {
+                id
+                body
+              }
+            }
+          }' -F discussionId="$DISCUSSION_ID" -F body="$COMMENT_BODY"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,6 +429,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Comment in a locked discussion that notifies about only `gitoxide` (e.g. not `gix-*`) releases.
   announce-release:
     runs-on: ubuntu-latest
 
@@ -463,13 +464,12 @@ jobs:
 
           echo "DISCUSSION_ID=$id" >> "$GITHUB_ENV"
 
-      # FIXME: Uncomment name-checking case, after testing the draft-checking case!
       - name: Avoid announcing a test in a non-test thread
         run: |
           case "$VERSION" in
-          # TEST-* | *-DO-NOT-USE )  # NOTE: Should be the same pattern as in `create-release` above.
-          #   echo "The release name indicates testing, so we'll only post if the thread is for that."
-          #   ;;
+          TEST-* | *-DO-NOT-USE )  # NOTE: Should be the same pattern as in `create-release` above.
+            echo "The release name indicates testing, so we'll only post if the thread is for that."
+            ;;
           * )
             is_draft="$(gh release --repo="$REPOSITORY" view "$VERSION" --json isDraft --jq .isDraft)"
             if [ "$is_draft" = false ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,7 +439,10 @@ jobs:
       discussions: write
 
     env:
+      REPOSITORY: ${{ github.repository }}
       VERSION: ${{ needs.create-release.outputs.version }}
+      DISCUSSION_URL: ${{ vars.RELEASE_ANNOUNCEMENTS_URL }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Find the discussion ID
@@ -459,43 +462,40 @@ jobs:
           }' -F owner="$owner" -F name="$name" -F number="$number" --jq .data.repository.discussion.id)"
 
           echo "DISCUSSION_ID=$id" >> "$GITHUB_ENV"
-        env:
-          DISCUSSION_URL: ${{ vars.RELEASE_ANNOUNCEMENTS_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # FIXME: Also consider a release of any name as a test, if it has not been published!
+      # FIXME: Uncomment name-checking case, after testing the draft-checking case!
       - name: Avoid announcing a test in a non-test thread
         run: |
           case "$VERSION" in
-          TEST-* | *-DO-NOT-USE )  # NOTE: Should be the same pattern as in `create-release` above.
-            echo "Looks like we're testing releasing. Checking discussion title."
-
-            title="$(gh api graphql -f query='
-            query($id: ID!) {
-              node(id: $id) {
-                ... on Discussion {
-                  title
-                }
-              }
-            }' -F id="$DISCUSSION_ID" --jq .data.node.title)"
-
-            grep -Eiqz '^[[(]?test\b' <<<"$title"
+          # TEST-* | *-DO-NOT-USE )  # NOTE: Should be the same pattern as in `create-release` above.
+          #   echo "The release name indicates testing, so we'll only post if the thread is for that."
+          #   ;;
+          * )
+            is_draft="$(gh release --repo="$REPOSITORY" view "$VERSION" --json isDraft --jq .isDraft)"
+            if [ "$is_draft" = false ]; then
+              exit 0  # OK to post in a non-test announcement thread.
+            fi
+            echo "The release is not published, so we'll only post if the thread is for testing."
             ;;
           esac
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Compose the comment
+          title="$(gh api graphql -f query='
+          query($id: ID!) {
+            node(id: $id) {
+              ... on Discussion {
+                title
+              }
+            }
+          }' -F id="$DISCUSSION_ID" --jq .data.node.title)"
+
+          grep -Eiqz '^[[(]?test\b' <<<"$title"
+
+      - name: Post the comment
         run: |
           grep -Eqx '[[:alnum:]._+-]+' <<<"$VERSION"  # Ensure the version needs no sanitization.
           release_url="https://github.com/$REPOSITORY/releases/tag/$VERSION"
           comment_body="\`gitoxide\` [$VERSION]($release_url) has been released."
-          echo "COMMENT_BODY=$comment_body" >> "$GITHUB_ENV"
-        env:
-          REPOSITORY: ${{ github.repository }}
 
-      - name: Post the comment
-        run: |
           gh api graphql -f query='
           mutation PostComment($discussionId: ID!, $body: String!) {
             addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
@@ -504,9 +504,7 @@ jobs:
                 body
               }
             }
-          }' -F discussionId="$DISCUSSION_ID" -F body="$COMMENT_BODY"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          }' -F discussionId="$DISCUSSION_ID" -F body="$comment_body"
 
   installation:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,7 +435,7 @@ jobs:
     needs: [ create-release, publish-release ]
 
     permissions:
-      contents: read
+      contents: write  # Needed to distinguish unpublished (still draft) from missing releases.
       discussions: write
 
     env:


### PR DESCRIPTION
Fixes #1311

This repository produces releases associated with all of the gitoxide-related crates: `gitoxide`, but also the many `gix-*` crates (and `gitoxide-core`). The narrowest readily available way to use GitHub to subscribe for notifications about releases has so far been to watch all releases (*Watch → Custom*, "Releases"). But this is not specific to releases associated with any particular crate.

It is possible to set up something to filter tag names, but that is inconvenient if one is not already doing similar automation. It would not integrate with ordinary uses of GitHub's web-based or emailed notifications. Furthermore, the `gitoxide` crate differs from the others in some important ways. One way is how, because it ships binaries, it is the crate most often packaged in downstream distributions. I believe this the main *ongoing* situation described in #1311.

Secondarily, but also related to ameliorating #1311, it seems to me that having an easy way to subscribe specifically to announcements for GitHub releases associated with the `gitoxide` crate (i.e., `v*` tag releases) would also make it somewhat easier for users unfamiliar with the project's structure to identify which releases are "top-level." In particular, although the main binary for gitoxide shall one day be `ein`, currently `gix` probably has the most functionality that is regularly used, and there is also a crate named `gix`, which is a library crate providing facilities such as `Repository`, and which is not the crate that carries the `gix` binary.

Fortunately, it is possible to allow users to subscribe to such notifications through GitHub, by having them automatically posted in a discussion created for that purpose. This pull request adds an `announce-release` job to the release workflow, that runs after the `publish-release` job and creates a discussion comment saying that the release has been created and linking to the release page for it. This is usable because:

- Discussions can be easily subscribed to and unsubscribed from individually.
- Discussions can be locked, so that only "collaborators" can post to them, so that users who subscribe to them don't get extra notifications.
- Locking a discussion does not impose any restrictions on subscribing.
- GitHub Actions jobs can post comments to discussions with the GitHub GraphQL API, if they declare `discussions: write` permissions.
- `discussions: write` permissions are automatically sufficient to post new comments even in locked threads.

It seems to me that such an automatically commented discussion thread is likely to help some downstream package maintainers, and to be of interest to some other users.

I tested this in a discussion in my fork, https://github.com/EliahKagan/gitoxide/discussions/6, which can be examined to see what the comments look like.

As for the hyperlinks in them, for releases that are actually published, the links go to the releases page. That same URL for an unpublished release goes to the tag page. This can be confirmed by comparing the URLs:

- https://github.com/EliahKagan/gitoxide/releases/tag/v0.39.0-alpha.2-DO-NOT-USE, which is associated with a draft release in my fork
- https://github.com/GitoxideLabs/gitoxide/releases/tag/v0.38.0, which is associated with a non-draft release in this upstream repository.

If this PR is to be merged, then there are three changes to this upstream repository that should also be made:

1. A new discussion should be created and given an appropriate title and brief body explaining its purpose.

   The title should not start like `test`, `[test`, or `(test` or any case variants: when a release seems like it is for testing releasing rather than being a "real" release, the job will refuse to post a comment about it unless the discussion is titled that way. Since this would be the "production" discussion thread, we want that refusal.

2. The new discussion should be locked. (It would be fine to allow reactions to be posted, though, since those do not generate notifications. One chooses whether to allow them when locking the discussion.)

3. A new [GitHub Actions variable](https://github.com/GitoxideLabs/gitoxide/settings/variables/actions) named `RELEASE_ANNOUNCEMENTS_URL` should be created, and given the full URL of the discussion as its value.

I would be able to do (1) myself and would be happy to do so, but I would not be able to do (2) or (3).