### PR TITLE
Reveal local-time DST ambiguity where it occurs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,6 +1690,7 @@ dependencies = [
  "itoa",
  "jiff",
  "once_cell",
+ "pretty_assertions",
  "serde",
  "thiserror 2.0.3",
 ]

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -28,9 +28,10 @@ thiserror = "2.0.0"
 document-features = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
+gix-hash = { path = "../gix-hash" }
 gix-testtools = { path = "../tests/tools" }
 once_cell = "1.12.0"
-gix-hash = { path = "../gix-hash" }
+pretty_assertions = "1.4.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gix-date/tests/time/parse.rs
+++ b/gix-date/tests/time/parse.rs
@@ -156,6 +156,7 @@ mod relative {
 
     use gix_date::time::Sign;
     use jiff::{ToSpan, Zoned};
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn large_offsets() {
@@ -182,11 +183,15 @@ mod relative {
 
         let cases = [
             ("2 weeks ago", 2.weeks()),
-            ("20160 minutes ago", 20_160.minutes()), // 2 weeks
-            ("20 weeks ago", 20.weeks()),
-            ("201600 minutes ago", 201_600.minutes()), // 20 weeks
-            ("40 weeks ago", 40.weeks()),
-            ("403200 minutes ago", 403_200.minutes()), // 40 weeks
+            ("14 weeks ago", 14.weeks()),
+            ("26 weeks ago", 26.weeks()),
+            ("38 weeks ago", 38.weeks()),
+            ("50 weeks ago", 50.weeks()),
+            ("20160 minutes ago", 20_160.minutes()),   // 2 weeks
+            ("141120 minutes ago", 141_120.minutes()), // 14 weeks
+            ("262080 minutes ago", 262_080.minutes()), // 26 weeks
+            ("383040 minutes ago", 383_040.minutes()), // 38 weeks
+            ("504000 minutes ago", 504_000.minutes()), // 50 weeks
         ];
 
         let times = cases.map(|(input, _)| gix_date::parse(input, Some(now)).unwrap());

--- a/gix-date/tests/time/parse.rs
+++ b/gix-date/tests/time/parse.rs
@@ -185,6 +185,8 @@ mod relative {
             ("20160 minutes ago", 20_160.minutes()), // 2 weeks
             ("20 weeks ago", 20.weeks()),
             ("201600 minutes ago", 201_600.minutes()), // 20 weeks
+            ("40 weeks ago", 40.weeks()),
+            ("403200 minutes ago", 403_200.minutes()), // 40 weeks
         ];
 
         let times = cases.map(|(input, _)| gix_date::parse(input, Some(now)).unwrap());
@@ -192,7 +194,7 @@ mod relative {
         assert_eq!(times.map(|_| Sign::Plus), times.map(|time| time.sign));
         assert_eq!(times.map(|_| 0), times.map(|time| time.offset));
 
-        let expected = cases.map(|(_, span)|
+        let expected = cases.map(|(_, span)| {
             Zoned::try_from(now)
                 .unwrap()
                 // account for the loss of precision when creating `Time` with seconds
@@ -204,7 +206,7 @@ mod relative {
                 .unwrap()
                 .saturating_sub(span)
                 .timestamp()
-        );
+        });
         let actual = times.map(|time| jiff::Timestamp::from_second(time.seconds).unwrap());
         assert_eq!(actual, expected, "relative times differ");
     }


### PR DESCRIPTION
This more effectively observes #1696 by expanding `gix-date::date time::parse::relative::various` to have multiple sub-cases. That issue describes a procedure to modify the test code to bring back the failure. This supersedes that procedure. This is to say that, with the changes in this PR, a system where the bug can be observed at any time of the year should always observe it.

Two very important things this does *not* do:

- This neither fixes nor in any way mitigates [#1696](https://github.com/GitoxideLabs/gitoxide/issues/1696).

- No failure occurs, and thus [#1696](https://github.com/GitoxideLabs/gitoxide/issues/1696) remains unobserved, *when*

  1. The system is set (or overridden via `TZ`) to UTC. Thus, this still does not cause a failure on CI. *Or*
  2. The system is set to local time, but in a time zone that does not make daylight savings related clock adjustments. I believe most countries actually do not observe daylight savings clock adjustments, though many do.

To make the results easy to understand and to show full results in the known failure cases, this does not place the existing code inside an outer loop, but instead populates arrays corresponding to the cases, so that assertions can be made comparing the arrays. `pretty_assertions::assert_eq!` is used, in the same manner as elsewhere in the test suite, to allow such output to be easily readable.

In addition to testing more cases, for each "*X* weeks ago" case, a corresponding "*Y* minutes ago" case is also included, where $Y = 10080 X$. Failures occur only in "*X* weeks ago" cases (that include exactly one daylight saving clock adjustment).

Even accounting for the weeks/minutes doubling up of sub-cases, and for variations in daylight savings rules creating the need to check more intervals than one might intuitively expect to need to check, I think this this has more sub-cases than needed. ac17b62 includes a description of why I did it this way and how it might be improved.

I have verified on GNU/Linux, macOS, and Windows that these tests fail in the expected way when run in North American Eastern Time (`America/New York`), but pass when `TZ=UTC` is set. That failure does not occur on CI is further demonstration that when UTC is configured there is not failure (which we should expect, since UTC has no DST-related adjustments). Because CI does not observe the failures, relevant failure output is included in each commit message.