### PR TITLE
Parse relative months and years

### DIFF
--- a/gix-date/src/parse.rs
+++ b/gix-date/src/parse.rs
@@ -153,7 +153,8 @@ mod relative {
             "hour" => Span::new().try_hours(units),
             "day" => Span::new().try_days(units),
             "week" => Span::new().try_weeks(units),
-            // TODO months & years? YES
+            "month" => Span::new().try_months(units),
+            "year" => Span::new().try_years(units),
             // Ignore values you don't know, assume seconds then (so does git)
             _ => return None,
         };

--- a/gix-date/src/parse.rs
+++ b/gix-date/src/parse.rs
@@ -156,7 +156,7 @@ mod relative {
             "month" => Span::new().try_months(units),
             "year" => Span::new().try_years(units),
             // Ignore values you don't know, assume seconds then (so does git)
-            _ => return None,
+            _anything => Span::new().try_seconds(units),
         };
         Some(result.map_err(|_| Error::RelativeTimeConversion))
     }

--- a/gix-date/tests/time/parse.rs
+++ b/gix-date/tests/time/parse.rs
@@ -184,6 +184,7 @@ mod relative {
         // For comparison, a few are the same as in: https://github.com/git/git/blob/master/t/t0006-date.sh
         let cases = [
             ("5 seconds ago", 5.seconds()),
+            ("12345 florx ago", 12_345.seconds()), // Anything parses as seconds
             ("5 minutes ago", 5.minutes()),
             ("5 hours ago", 5.hours()),
             ("5 days ago", 5.days()),


### PR DESCRIPTION
*Update: This now also fixes #1696. See 856b385 and https://github.com/GitoxideLabs/gitoxide/pull/1702#pullrequestreview-2457392772.*

This extends `gix_date::parse::relative::span` to recognize times with "months" and "years", as in "3 months ago" and "2 years ago".

The actual change here is very simple, because it is directly facilitated by #1474.

The units "seconds", "minutes", "hours", "days", and "weeks" continue to be recognized (as before). Relative times like "1 year, 2 months ago" remain unrecognized.

For background, see 43b6c06 (#498), c5c6bf6, https://github.com/GitoxideLabs/gitoxide/pull/1474#discussion_r1694769988, and https://github.com/GitoxideLabs/gitoxide/issues/1696#issuecomment-2495526654.

Note that this change does not fix issue #1696, which continues to apply to the interpretation of "days" and "weeks", and now also applies in the same way to the interpretation of "months" and "years". (It continues not to apply to the interpretation of "seconds", "minutes", and "hours".)

The tests are updated to cover "months" and "years", as well as to exercise a wider range of relative times, including showing which units (e.g. "days") are affected by #1696. A few sub-cases, of those adjusted or added here, test strings from a related test in Git, to allow comparison. But most are not related to cases there.

As before, the tests pass on CI, or when the time zone is otherwise UTC, or with local time zones that never have DST adjustments.

The sub-cases are reordered to be monotone increasing in the magnitude of the relative intervals tested (and thus monotone decreasing in the associated absolute timestamps), and the original input is kept zipped into the `actual` and `expected` arrays being compared. This way, if the assertion fails (such as due to #1696), it is clear and readable which sub-cases failed and exactly how, as well as what all the sub-cases are and what each sub-case tests.

Reordering the sub-cases and preserving the inputs they parse in this way avoids the disadvantages of #1697 while keeping, and expanding on, its benefits.

Failure, where it occurs, now looks like:

    --- STDERR:              gix-date::date time::parse::relative::various ---
    thread 'time::parse::relative::various' panicked at gix-date\tests\time\parse.rs:252:9:
    assertion failed: `(left == right)`: relative times differ

    Diff < left / right > :
     [
         (
             "5 seconds ago",
             2024-11-24T23:51:49Z,
         ),
         (
             "5 minutes ago",
             2024-11-24T23:46:54Z,
         ),
         (
             "5 hours ago",
             2024-11-24T18:51:54Z,
         ),
         (
             "5 days ago",
             2024-11-19T23:51:54Z,
         ),
         (
             "3 weeks ago",
             2024-11-03T23:51:54Z,
         ),
         (
             "21 days ago",
             2024-11-03T23:51:54Z,
         ),
         (
             "504 hours ago",
             2024-11-03T23:51:54Z,
         ),
         (
             "30240 minutes ago",
             2024-11-03T23:51:54Z,
         ),
         (
             "2 months ago",
    <        2024-09-24T23:51:54Z,
    >        2024-09-24T22:51:54Z,
         ),
         (
             "1460 hours ago",
             2024-09-25T03:51:54Z,
         ),
         (
             "87600 minutes ago",
             2024-09-25T03:51:54Z,
         ),
         (
             "14 weeks ago",
    <        2024-08-18T23:51:54Z,
    >        2024-08-18T22:51:54Z,
         ),
         (
             "98 days ago",
    <        2024-08-18T23:51:54Z,
    >        2024-08-18T22:51:54Z,
         ),
         (
             "2352 hours ago",
             2024-08-18T23:51:54Z,
         ),
         (
             "141120 minutes ago",
             2024-08-18T23:51:54Z,
         ),
         (
             "5 months ago",
    <        2024-06-24T23:51:54Z,
    >        2024-06-24T22:51:54Z,
         ),
         (
             "3650 hours ago",
             2024-06-25T21:51:54Z,
         ),
         (
             "219000 minutes ago",
             2024-06-25T21:51:54Z,
         ),
         (
             "26 weeks ago",
    <        2024-05-26T23:51:54Z,
    >        2024-05-26T22:51:54Z,
         ),
         (
             "182 days ago",
    <        2024-05-26T23:51:54Z,
    >        2024-05-26T22:51:54Z,
         ),
         (
             "4368 hours ago",
             2024-05-26T23:51:54Z,
         ),
         (
             "262080 minutes ago",
             2024-05-26T23:51:54Z,
         ),
         (
             "8 months ago",
    <        2024-03-24T23:51:54Z,
    >        2024-03-24T22:51:54Z,
         ),
         (
             "5840 hours ago",
             2024-03-26T15:51:54Z,
         ),
         (
             "350400 minutes ago",
             2024-03-26T15:51:54Z,
         ),
         (
             "38 weeks ago",
             2024-03-03T23:51:54Z,
         ),
         (
             "266 days ago",
             2024-03-03T23:51:54Z,
         ),
         (
             "6384 hours ago",
             2024-03-03T23:51:54Z,
         ),
         (
             "383040 minutes ago",
             2024-03-03T23:51:54Z,
         ),
         (
             "11 months ago",
             2023-12-24T23:51:54Z,
         ),
         (
             "8030 hours ago",
             2023-12-26T09:51:54Z,
         ),
         (
             "481800 minutes ago",
             2023-12-26T09:51:54Z,
         ),
         (
             "14 months ago",
    <        2023-09-24T23:51:54Z,
    >        2023-09-24T22:51:54Z,
         ),
         (
             "21 months ago",
             2023-02-24T23:51:54Z,
         ),
         (
             "2 years ago",
             2022-11-24T23:51:54Z,
         ),
         (
             "20 years ago",
             2004-11-24T23:51:54Z,
         ),
         (
             "630720000 seconds ago",
             2004-11-29T23:51:54Z,
         ),
     ]

---

I've posted https://github.com/GitoxideLabs/gitoxide/issues/1696#issuecomment-2496472747 about why I think the changes here may be okay to do even before the main in https://github.com/GitoxideLabs/gitoxide/issues/1696#issuecomment-2495526654 (that would actually fix issue #1696) is not yet done.

It may be that this is an excessive number of lines of test output to show in a commit message (3082d40). I've included it, as I have done in previous changes to that test, since it will not be seen on CI or even in all local time zones, and since it makes much clearer how and why the test's output format has changed.

Ordinarily, I would not be reluctant to make a commit message that long. But in this case, it's a conventional commit with `feat:`, so I expect it to make its way into the changelog. The test is probably of less interest to future readers of the changelog and in any case is not, really, technically even part of the feature. I could put the test in its own commit, as I often do with tests. But the description of what the output looks like would be inaccurate if that commit precedes the commit that adds support for months and years--it produces a parsing error until support is added, whereas the test output that is informative is the output showing that we still, and better, see what is going on with #1696.

Anyway, I don't know if that is really to be considered a problem, but I mention it so that it will be noticed if it is.