### PR TITLE
Omit `NEXTEST_NO_TESTS: fail`, now that it's the default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CLICOLOR: '1'
-  NEXTEST_NO_TESTS: fail
 
 jobs:
   pure-rust-build:

--- a/justfile
+++ b/justfile
@@ -186,7 +186,7 @@ unit-tests:
     cargo nextest run -p gix --no-default-features --features basic,extras,comfort,need-more-recent-msrv
     cargo nextest run -p gix --features async-network-client
     cargo nextest run -p gix --features blocking-network-client
-    cargo nextest run -p gitoxide-core --lib --no-tests=warn
+    cargo nextest run -p gitoxide-core --lib
 
 # These tests aren't run by default as they are flaky (even locally)
 unit-tests-flaky:

--- a/justfile
+++ b/justfile
@@ -186,7 +186,7 @@ unit-tests:
     cargo nextest run -p gix --no-default-features --features basic,extras,comfort,need-more-recent-msrv
     cargo nextest run -p gix --features async-network-client
     cargo nextest run -p gix --features blocking-network-client
-    cargo nextest run -p gitoxide-core --lib
+    cargo nextest run -p gitoxide-core --lib --no-tests=warn
 
 # These tests aren't run by default as they are flaky (even locally)
 unit-tests-flaky:


### PR DESCRIPTION
This PR changes `ci.yml` to no longer explicitly tell `cargo nextest` to treat the unexpected absence of any test cases as an error, since that is now that runner's default behavior.

In 2fc93f7 (#1675), I added this to the top-level `env` in `ci.yml`, to get failures whenever a `cargo nextest` command looks for tests to run but doesn't find any:

https://github.com/GitoxideLabs/gitoxide/blob/1435193c5fa1d08a8ff0e588b7f3dffdbd80b0ce/.github/workflows/ci.yml#L22

That commit also added `--no-tests=warn` in the one place where we deliberately have that happen:

https://github.com/GitoxideLabs/gitoxide/blob/1435193c5fa1d08a8ff0e588b7f3dffdbd80b0ce/justfile#L189

Yesterday, `cargo-nextest` v0.9.85 was [released](https://github.com/nextest-rs/nextest/releases/tag/cargo-nextest-0.9.85). This includes the planned change https://github.com/nextest-rs/nextest/discussions/1646 that makes failure the default behavior here. That makes `NEXTEST_NO_TESTS: fail` superfluous. The change in this PR is done in two commits, to verify that it is now superfluous, but they can be squashed into one if desired.

Whether we should continue to set that explicitly is subjective, which is why I'm opening a PR just for it without including anything else (so it's easy to make a decision about this, whatever the decision is). It seems to me that we shouldn't, on the grounds that it was effectively a workaround for the preferable default `cargo nextest` not automatically treating that as an error, as well as a preparation for the `nextest` behavior change that has come in as of v0.9.85.