### PR TITLE
Run test fixture scripts on Windows with Git Bash

### DIFF
--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -743,7 +743,10 @@ fn populate_meta_dir(destination_dir: &Path, script_identity: u32) -> std::io::R
     )?;
     std::fs::write(
         meta_dir.join(META_GIT_VERSION),
-        std::process::Command::new(GIT_PROGRAM).arg("--version").output()?.stdout,
+        std::process::Command::new(GIT_PROGRAM)
+            .arg("--version")
+            .output()?
+            .stdout,
     )?;
     Ok(meta_dir)
 }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -87,7 +87,7 @@ static EXCLUDE_LUT: Lazy<Mutex<Option<gix_worktree::Stack>>> = Lazy::new(|| {
     Mutex::new(cache)
 });
 /// The major, minor and patch level of the git version on the system.
-pub static GIT_VERSION: Lazy<(u8, u8, u8)> = Lazy::new(|| parse_gix_version().expect("git version to be parsable"));
+pub static GIT_VERSION: Lazy<(u8, u8, u8)> = Lazy::new(|| parse_git_version().expect("git version to be parsable"));
 
 /// Define how [`scripted_fixture_writable_with_args()`] uses produces the writable copy.
 pub enum Creation {
@@ -116,9 +116,9 @@ pub fn should_skip_as_git_version_is_smaller_than(major: u8, minor: u8, patch: u
     *GIT_VERSION < (major, minor, patch)
 }
 
-fn parse_gix_version() -> Result<(u8, u8, u8)> {
-    let gix_program = cfg!(windows).then(|| "git.exe").unwrap_or("git");
-    let output = std::process::Command::new(gix_program).arg("--version").output()?;
+fn parse_git_version() -> Result<(u8, u8, u8)> {
+    let git_program = cfg!(windows).then(|| "git.exe").unwrap_or("git");
+    let output = std::process::Command::new(git_program).arg("--version").output()?;
 
     git_version_from_bytes(&output.stdout)
 }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -104,7 +104,7 @@ static GIT_CORE_DIR: Lazy<PathBuf> = Lazy::new(|| {
     output
         .stdout
         .strip_suffix(b"\n")
-        .expect("malformed output from `git --exec-path`")
+        .expect("`git --exec-path` output to be well-formed")
         .to_os_str()
         .expect("no invalid UTF-8 in `--exec-path` except as OS allows")
         .into()

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -93,6 +93,23 @@ const GIT_PROGRAM: &str = "git.exe";
 #[cfg(not(windows))]
 const GIT_PROGRAM: &str = "git";
 
+static GIT_CORE_DIR: Lazy<PathBuf> = Lazy::new(|| {
+    let output = std::process::Command::new(GIT_PROGRAM)
+        .arg("--exec-path")
+        .output()
+        .expect("can execute `git --exec-path`");
+
+    assert!(output.status.success(), "`git --exec-path` failed");
+
+    output
+        .stdout
+        .strip_suffix(b"\n")
+        .expect("malformed output from `git --exec-path`")
+        .to_os_str()
+        .expect("no invalid UTF-8 in `--exec-path` except as OS allows")
+        .into()
+});
+
 /// The major, minor and patch level of the git version on the system.
 pub static GIT_VERSION: Lazy<(u8, u8, u8)> = Lazy::new(|| parse_git_version().expect("git version to be parsable"));
 
@@ -186,22 +203,6 @@ pub fn run_git(working_dir: &Path, args: &[&str]) -> std::io::Result<std::proces
 
 /// Spawn a git daemon process to host all repository at or below `working_dir`.
 pub fn spawn_git_daemon(working_dir: impl AsRef<Path>) -> std::io::Result<GitDaemon> {
-    static EXEC_PATH: Lazy<PathBuf> = Lazy::new(|| {
-        let output = std::process::Command::new(GIT_PROGRAM)
-            .arg("--exec-path")
-            .output()
-            .expect("can execute `git --exec-path`");
-
-        assert!(output.status.success(), "`git --exec-path` failed");
-
-        output
-            .stdout
-            .strip_suffix(b"\n")
-            .expect("malformed output from `git --exec-path`")
-            .to_os_str()
-            .expect("no invalid UTF-8 in `--exec-path` except as OS allows")
-            .into()
-    });
     let mut ports: Vec<_> = (9419u16..9419 + 100).collect();
     fastrand::shuffle(&mut ports);
     let addr_at = |port| std::net::SocketAddr::from(([127, 0, 0, 1], port));
@@ -210,11 +211,12 @@ pub fn spawn_git_daemon(working_dir: impl AsRef<Path>) -> std::io::Result<GitDae
         listener.local_addr().expect("listener address is available").port()
     };
 
-    let child = std::process::Command::new(EXEC_PATH.join(if cfg!(windows) { "git-daemon.exe" } else { "git-daemon" }))
-        .current_dir(working_dir)
-        .args(["--verbose", "--base-path=.", "--export-all", "--user-path"])
-        .arg(format!("--port={free_port}"))
-        .spawn()?;
+    let child =
+        std::process::Command::new(GIT_CORE_DIR.join(if cfg!(windows) { "git-daemon.exe" } else { "git-daemon" }))
+            .current_dir(working_dir)
+            .args(["--verbose", "--base-path=.", "--export-all", "--user-path"])
+            .arg(format!("--port={free_port}"))
+            .spawn()?;
 
     let server_addr = addr_at(free_port);
     for time in gix_lock::backoff::Exponential::default_with_random() {
@@ -566,7 +568,7 @@ fn scripted_fixture_read_only_with_args_inner(
                     Err(err)
                         if err.kind() == std::io::ErrorKind::PermissionDenied || err.raw_os_error() == Some(193) /* windows */ =>
                     {
-                        cmd = std::process::Command::new("bash");
+                        cmd = std::process::Command::new(bash_program());
                         configure_command(cmd.arg(script_absolute_path), &args, &script_result_directory).output()?
                     }
                     Err(err) => return Err(err.into()),
@@ -640,6 +642,22 @@ fn configure_command<'a, I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
         .env("GIT_CONFIG_VALUE_2", "main")
         .env("GIT_CONFIG_KEY_3", "protocol.file.allow")
         .env("GIT_CONFIG_VALUE_3", "always")
+}
+
+fn bash_program() -> &'static Path {
+    if cfg!(windows) {
+        static GIT_BASH: Lazy<Option<PathBuf>> = Lazy::new(|| {
+            GIT_CORE_DIR
+                .parent()?
+                .parent()?
+                .parent()
+                .map(|installation_dir| installation_dir.join("bin").join("bash.exe"))
+                .filter(|bash| bash.is_file())
+        });
+        GIT_BASH.as_deref().unwrap_or(Path::new("bash.exe"))
+    } else {
+        Path::new("bash")
+    }
 }
 
 fn write_failure_marker(failure_marker: &Path) {
@@ -980,5 +998,44 @@ mod tests {
         let status = output.status.code().expect("terminated normally");
         assert_eq!(lines, Vec::<&str>::new(), "should be no config variables from files");
         assert_eq!(status, 0, "reading the config should succeed");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn bash_program_ok_for_platform() {
+        let path = bash_program();
+        assert!(path.is_absolute());
+
+        let for_version = std::process::Command::new(path)
+            .arg("--version")
+            .output()
+            .expect("can pass it `--version`");
+        assert!(for_version.status.success(), "passing `--version` succeeds");
+        let version_line = for_version
+            .stdout
+            .lines()
+            .nth(0)
+            .expect("`--version` output has first line");
+        assert!(
+            version_line.ends_with(b"-pc-msys)"), // On Windows, "-pc-linux-gnu)" would be WSL.
+            "it is an MSYS bash (such as Git Bash)"
+        );
+
+        let for_uname_os = std::process::Command::new(path)
+            .args(["-c", "uname -o"])
+            .output()
+            .expect("can tell it to run `uname -o`");
+        assert!(for_uname_os.status.success(), "telling it to run `uname -o` succeeds");
+        assert_eq!(
+            for_uname_os.stdout.trim_end(),
+            b"Msys",
+            "it runs commands in an MSYS environment"
+        );
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn bash_program_ok_for_platform() {
+        assert_eq!(bash_program(), Path::new("bash"));
     }
 }


### PR DESCRIPTION
Fixes #1359

### Background

When executing a test fixture script directly fails, we use the fallback strategy of running it with `bash`. Running them directly always fails on Windows (at least in gitoxide's own test suite, where fixture scripts really are shell scripts, rather than binary executables or batch files). That's fine, since we fall back to running them with `bash` and (at least in gitoxide's own test suite) they are all `bash` scripts.

The problem, though, is that this does not always run the correct `bash`. This is analogous to the problem described in https://github.com/gitpython-developers/GitPython/pull/1791, except that, due to the subtleties of how `std::process::Command` performs path search, there are, for the time being, readily available workarounds.

### What this changes

This pull request fixes that problem in gix-testtools by using the Git Bash `bash.exe` interpreter associated with a Git for Windows installation, if that can be found. See the commit messages for substantial further details, especially fe3f2d1, which covers various design considerations.

A few other minor improvements are also included, when they directly helped with implementing this fix or with making it understandable; see the other commit messages for those.

### Testing

This problem is not currently observed on CI because of specific details of the environment there and how it interacts with `std::process::Command` path search. But I have verified the fix locally on a Windows 10 machine where--as in most Windows 10 systems--attempting to run the test suite from PowerShell without modifying the `PATH` produces numerous failures, with or without the use of generated archives.

With the changes in this PR, there are no more failures that way than when running it in a Git Bash environment (which had worked around #1359).

- Without `GIX_TEST_IGNORE_ARCHIVES`, there are zero failures now.

- With `GIX_TEST_IGNORE_ARCHIVES=1`, there are only the 15 known failures documented in [#1358](https://github.com/GitoxideLabs/gitoxide/issues/1358).\
  Such a run, with the code as it is in this PR, is [shown in full in this new gist](https://gist.github.com/EliahKagan/5ef9ec783c95ebbdd9bea1985a97ee02).

I also included a test to verify that Bash is an MSYS-like build and that the environment it runs Unix commands in appears to be an MSYS-like environment.

### Prior work and acknowledgement

The in-progress PR https://github.com/gitpython-developers/GitPython/pull/1791 in GitPython, which is about finding the `bash.exe` associated with a Git for Windows installation to run hooks, is highly relevant.

I'd like to acknowledge @emanspeaks, who implemented the original `git`-executable-relative approach – to which I had proposed finding `bash.exe` relative to `git-core` as a refinement in https://github.com/gitpython-developers/GitPython/pull/1791#discussion_r1456370583 – and who also implemented [that refinement itself](https://github.com/gitpython-developers/GitPython/pull/1791/files#diff-35a18a749eb4d6efad45e56e78a9554926be5526e2ba2159b44311e718450e88R398-R403):

```python
if os.name != "nt":
    return "bash"
gitcore = Path(cls()._call_process("--exec-path"))
gitroot = gitcore.parent.parent.parent
gitbash = gitroot / "bin" / "bash.exe"
return str(gitbash) if gitbash.exists() else "bash.exe"
```

Note the very similar logic that this PR subsequently implements:

https://github.com/GitoxideLabs/gitoxide/blob/fe3f2d128a1478af97999025b46c7b146e778524/tests/tools/src/lib.rs#L648-L660

Where [`GIT_CORE_DIR`](https://github.com/GitoxideLabs/gitoxide/blob/fe3f2d128a1478af97999025b46c7b146e778524/tests/tools/src/lib.rs#L96-L111) is obtained from a call to `git --exec-path`.

### Scope

This PR only modifies `gix-testtools`. Such an approach should possibly also be part of the logic for running scripts in `gix-command` but is initially implemented only for running fixture scripts in the test suite, as discussed in https://github.com/GitoxideLabs/gitoxide/issues/1359#issuecomment-2316614616 and https://github.com/GitoxideLabs/gitoxide/issues/1359#issuecomment-2316727583, as well as in the fe3f2d1 commit message.

### Future directions

Two possible further changes and their relationship to this change are noted at the bottom of the fe3f2d1 commit message.

Before bringing this into other crates, I would be interested to examine whether it is compatible with installations of Git for Windows that differ from the usual layout. I believe the most common way such an installation arises is with [MinGit](https://github.com/git-for-windows/git/wiki/MinGit).