### PR TITLE
Enhance builder-likeness of `commit::topo::Builder` in `gix-traverse`

### DIFF
--- a/gix-traverse/src/commit/topo/init.rs
+++ b/gix-traverse/src/commit/topo/init.rs
@@ -28,11 +28,7 @@ where
         tips: impl IntoIterator<Item = impl Into<ObjectId>>,
         ends: Option<impl IntoIterator<Item = impl Into<ObjectId>>>,
     ) -> Self {
-        let mut builder = Self::new(find).with_tips(tips);
-        if let Some(ends) = ends {
-            builder = builder.with_ends(ends);
-        };
-        builder
+        Self::new(find).with_tips(tips).with_ends(ends.into_iter().flatten())
     }
 
     /// Create a new `Builder` for a [`Topo`] that reads commits from a
@@ -49,16 +45,18 @@ where
         }
     }
 
-    /// Add commits to start reading from. The behavior is similar to specifying
-    /// additional `ends` in `git rev-list --topo-order ^ends tips`.
+    /// Add commits to start reading from.
+    ///
+    /// The behavior is similar to specifying additional `ends` in `git rev-list --topo-order ^ends tips`.
     pub fn with_tips(mut self, tips: impl IntoIterator<Item = impl Into<ObjectId>>) -> Self {
         self.tips.extend(tips.into_iter().map(Into::into));
         self
     }
 
-    /// Add commits ending the traversal. These commits themselves will not be
-    /// read, i.e. the behavior is similar to specifying additional `ends` in
-    /// `git rev-list --topo-order ^ends tips`.
+    /// Add commits ending the traversal.
+    ///
+    /// These commits themselves will not be read, i.e. the behavior is similar to specifying additional
+    /// `ends` in `git rev-list --topo-order ^ends tips`.
     pub fn with_ends(mut self, ends: impl IntoIterator<Item = impl Into<ObjectId>>) -> Self {
         self.ends.extend(ends.into_iter().map(Into::into));
         self

--- a/gix-traverse/src/commit/topo/init.rs
+++ b/gix-traverse/src/commit/topo/init.rs
@@ -44,6 +44,14 @@ where
         }
     }
 
+    /// Add commits ending the traversal. These commits themselves will not be
+    /// read, i.e. the behavior is similar to specifying additional `ends` in
+    /// `git rev-list --topo-order ^ends tips`.
+    pub fn with_ends(mut self, ends: impl IntoIterator<Item = impl Into<ObjectId>>) -> Self {
+        self.ends.extend(ends.into_iter().map(Into::into));
+        self
+    }
+
     /// Set a `predicate` to filter out revisions from the walk. Can be used to
     /// implement e.g. filtering on paths or time. This does *not* exclude the
     /// parent(s) of a revision that is excluded. Specify a revision as an 'end'

--- a/gix-traverse/src/commit/topo/init.rs
+++ b/gix-traverse/src/commit/topo/init.rs
@@ -44,6 +44,13 @@ where
         }
     }
 
+    /// Add commits to start reading from. The behavior is similar to specifying
+    /// additional `ends` in `git rev-list --topo-order ^ends tips`.
+    pub fn with_tips(mut self, tips: impl IntoIterator<Item = impl Into<ObjectId>>) -> Self {
+        self.tips.extend(tips.into_iter().map(Into::into));
+        self
+    }
+
     /// Add commits ending the traversal. These commits themselves will not be
     /// read, i.e. the behavior is similar to specifying additional `ends` in
     /// `git rev-list --topo-order ^ends tips`.

--- a/gix-traverse/src/commit/topo/init.rs
+++ b/gix-traverse/src/commit/topo/init.rs
@@ -28,20 +28,11 @@ where
         tips: impl IntoIterator<Item = impl Into<ObjectId>>,
         ends: Option<impl IntoIterator<Item = impl Into<ObjectId>>>,
     ) -> Self {
-        let tips = tips.into_iter().map(Into::into).collect::<Vec<_>>();
-        let ends = ends
-            .map(|e| e.into_iter().map(Into::into).collect::<Vec<_>>())
-            .unwrap_or_default();
-
-        Self {
-            commit_graph: Default::default(),
-            find,
-            sorting: Default::default(),
-            parents: Default::default(),
-            tips,
-            ends,
-            predicate: |_| true,
-        }
+        let mut builder = Self::new(find).with_tips(tips);
+        if let Some(ends) = ends {
+            builder = builder.with_ends(ends);
+        };
+        builder
     }
 
     /// Create a new `Builder` for a [`Topo`] that reads commits from a

--- a/gix-traverse/src/commit/topo/init.rs
+++ b/gix-traverse/src/commit/topo/init.rs
@@ -44,6 +44,20 @@ where
         }
     }
 
+    /// Create a new `Builder` for a [`Topo`] that reads commits from a
+    /// repository with `find`.
+    pub fn new(find: Find) -> Self {
+        Self {
+            commit_graph: Default::default(),
+            find,
+            sorting: Default::default(),
+            parents: Default::default(),
+            tips: Default::default(),
+            ends: Default::default(),
+            predicate: |_| true,
+        }
+    }
+
     /// Add commits to start reading from. The behavior is similar to specifying
     /// additional `ends` in `git rev-list --topo-order ^ends tips`.
     pub fn with_tips(mut self, tips: impl IntoIterator<Item = impl Into<ObjectId>>) -> Self {


### PR DESCRIPTION
Previously, the only way to create a `Builder` would be via `Builder::from_iters`. That function takes as arguments both the tips and ends, and used to be the only possibility for specifying either of them during the building process.

I would argue that the whole point of a builder is the ability to start with a minimal, setup and configure the resulting entity bit by bit. This would imo include the optional ends of a `Topo`, and I would also argue that there are valid use-cases in which a user would also like to add multiple distinct sets of tips without the need for `Iterator` chaining or, in the worst case, collecting them in another data structure first.

These changes introduce a set of functions enabling alternative usage patterns.