### PR TITLE
Allow `topo::Builder::with_tips` and `with_ends` for non-default pred

### DIFF
--- a/gix-traverse/src/commit/topo/init.rs
+++ b/gix-traverse/src/commit/topo/init.rs
@@ -45,23 +45,6 @@ where
         }
     }
 
-    /// Add commits to start reading from.
-    ///
-    /// The behavior is similar to specifying additional `ends` in `git rev-list --topo-order ^ends tips`.
-    pub fn with_tips(mut self, tips: impl IntoIterator<Item = impl Into<ObjectId>>) -> Self {
-        self.tips.extend(tips.into_iter().map(Into::into));
-        self
-    }
-
-    /// Add commits ending the traversal.
-    ///
-    /// These commits themselves will not be read, i.e. the behavior is similar to specifying additional
-    /// `ends` in `git rev-list --topo-order ^ends tips`.
-    pub fn with_ends(mut self, ends: impl IntoIterator<Item = impl Into<ObjectId>>) -> Self {
-        self.ends.extend(ends.into_iter().map(Into::into));
-        self
-    }
-
     /// Set a `predicate` to filter out revisions from the walk. Can be used to
     /// implement e.g. filtering on paths or time. This does *not* exclude the
     /// parent(s) of a revision that is excluded. Specify a revision as an 'end'
@@ -87,6 +70,23 @@ where
     Find: gix_object::Find,
     Predicate: FnMut(&oid) -> bool,
 {
+    /// Add commits to start reading from.
+    ///
+    /// The behavior is similar to specifying additional `ends` in `git rev-list --topo-order ^ends tips`.
+    pub fn with_tips(mut self, tips: impl IntoIterator<Item = impl Into<ObjectId>>) -> Self {
+        self.tips.extend(tips.into_iter().map(Into::into));
+        self
+    }
+
+    /// Add commits ending the traversal.
+    ///
+    /// These commits themselves will not be read, i.e. the behavior is similar to specifying additional
+    /// `ends` in `git rev-list --topo-order ^ends tips`.
+    pub fn with_ends(mut self, ends: impl IntoIterator<Item = impl Into<ObjectId>>) -> Self {
+        self.ends.extend(ends.into_iter().map(Into::into));
+        self
+    }
+
     /// Set the `sorting` to use for the topological walk.
     pub fn sorting(mut self, sorting: Sorting) -> Self {
         self.sorting = sorting;


### PR DESCRIPTION
We recently (in #1716) introduced the associated fns `with_tips` and `with_ends` for adding tips and ends after initial creation of a `Builder`. We erroneously added them to the one impl constraining the predicate to a specific function pointer type for the default predicate. This meant that tips and ends could only be added until the predicate is set to a `FnMut` that can not be coerced to that same type.

This change lifts this limitation by moving `with_tips` and `with_ends` to the more generic impl for `Builder`.

--

Sorry for the noise. I should have paid more attention where I put those functions. Btw: the rationale for this change also holds for `with_predicate` imo. Typically users will only set a predicate once and not change it afterwards, but it doesn't exactly hurt to have it in the impl generic over `Predicate`.