### PR TITLE
Fix a non-"set" `dirwalk::Options` method that took `self` by reference

### DIFF
--- a/gix/src/dirwalk/options.rs
+++ b/gix/src/dirwalk/options.rs
@@ -173,7 +173,7 @@ impl Options {
     /// if `true` it will be excluded as the symlink is considered a directory.
     ///
     /// In other words, for Git compatibility this flag should be `false`, the default, for `git2` compatibility it should be `true`.
-    pub fn symlinks_to_directories_are_ignored_like_directories(&mut self, toggle: bool) -> &mut Self {
+    pub fn symlinks_to_directories_are_ignored_like_directories(mut self, toggle: bool) -> Self {
         self.symlinks_to_directories_are_ignored_like_directories = toggle;
         self
     }

--- a/gix/src/dirwalk/options.rs
+++ b/gix/src/dirwalk/options.rs
@@ -115,13 +115,13 @@ impl Options {
         self
     }
     /// Controls the way untracked files are emitted. By default, this is happening immediately and without any simplification.
-    pub fn emit_untracked(mut self, toggle: EmissionMode) -> Self {
-        self.emit_untracked = toggle;
+    pub fn emit_untracked(mut self, mode: EmissionMode) -> Self {
+        self.emit_untracked = mode;
         self
     }
     /// Like [`emit_untracked()`](Self::emit_untracked), but only requires a mutably borrowed instance.
-    pub fn set_emit_untracked(&mut self, toggle: EmissionMode) -> &mut Self {
-        self.emit_untracked = toggle;
+    pub fn set_emit_untracked(&mut self, mode: EmissionMode) -> &mut Self {
+        self.emit_untracked = mode;
         self
     }
     /// If `toggle` is `true`, emit empty directories as well. Note that a directory also counts as empty if it has any
@@ -180,8 +180,8 @@ impl Options {
 
     /// Like [`symlinks_to_directories_are_ignored_like_directories()`](Self::symlinks_to_directories_are_ignored_like_directories),
     /// but only requires a mutably borrowed instance.
-    pub fn set_symlinks_to_directories_are_ignored_like_directories(&mut self, value: bool) -> &mut Self {
-        self.symlinks_to_directories_are_ignored_like_directories = value;
+    pub fn set_symlinks_to_directories_are_ignored_like_directories(&mut self, toggle: bool) -> &mut Self {
+        self.symlinks_to_directories_are_ignored_like_directories = toggle;
         self
     }
 }


### PR DESCRIPTION
#### The bug

While looking into the (quite different) bug reported in #1629, I initialized an `Options` instance like:

```rust
let options: gix::dirwalk::Options = repo
    .dirwalk_options()?
    .recurse_repositories(false)
    .emit_pruned(false)
    .emit_ignored(None)
    .for_deletion(None)
    .emit_untracked(gix::dir::walk::EmissionMode::Matching)
    .emit_empty_directories(false)
    .classify_untracked_bare_repositories(true)
    .emit_collapsed(None)
    .symlinks_to_directories_are_ignored_like_directories(false);
```

Before the `symlinks_to_directories_are_ignored_like_directories(false)` call was added, I was able to pass it to `dirwalk_iter`, but then I was unable to do so. Adding that last call changed the type of `options` from `Options` to `&mut Options`.

It turns out that, unlike the other `gix::dirwalk::Options` methods whose names don't start with `set_`, which take and return `self` by value, the `symlinks_to_directories_are_ignored_like_directories` method takes and returns `self` by mutable reference, which is to say that it is inadvertently equivalent to its `set_*` counterpart.

#### The fix

The methods of `gix::dirwalk::Options` are paired, where for each option `X` of `Options`, a method named like `X` takes and returns `self` by value, and a method `set_X` takes and returns `self` by mutable reference.

But in `symlinks_to_directories_are_ignored_like_directories`, both took `self` by mutable reference. This fixes that. The effect of this fix is to allow building `Options` with a call to that method as the last factory method call (and using it where `Options` is accepted but `&mut Options` is not).

Most code that consumes the crate should be unaffected, but:

- Code where calls were ordered unnaturally to avoid putting such a call last should be able to be improved.
- Code that used the method like its `set_*` countepart `set_symlinks_to_directories_are_ignored_like_directories` will be broken. That's what makes this fix a breaking change. Any such code can be fixed by modifying it to call the `set_*` version instead, which is probably what would have been intended anyway.

#### I didn't write a test

I'm not sure if a test is desired for this. I lean toward thinking that no test is needed. But it shouldn't be hard to write a test that "fails" by failing to compile in the absence of this change, along the lines of the above code.

#### Other changes included here

This also renames some of those methods' parameters more systematically. This was motivated by those two methods' non-`self` parameters being named differently, but this second change goes slightly beyond fixing that.