### PR TITLE
gix command api

### DIFF
--- a/gix-command/src/lib.rs
+++ b/gix-command/src/lib.rs
@@ -131,7 +131,7 @@ mod prepare {
         /// Use a shell, but try to split arguments by hand if this can be safely done without a shell.
         ///
         /// If that's not the case, use a shell instead.
-        pub fn with_shell_allow_argument_splitting(mut self) -> Self {
+        pub fn with_shell_allow_manual_argument_splitting(mut self) -> Self {
             self.allow_manual_arg_splitting = true;
             self.with_shell()
         }

--- a/gix-command/src/lib.rs
+++ b/gix-command/src/lib.rs
@@ -136,6 +136,12 @@ mod prepare {
             self.with_shell()
         }
 
+        /// Use a shell, but prohibit splitting arguments by hand even if this could be safely done without a shell.
+        pub fn with_shell_disallow_manual_argument_splitting(mut self) -> Self {
+            self.allow_manual_arg_splitting = false;
+            self.with_shell()
+        }
+
         /// Configure the process to use `stdio` for _stdin.
         pub fn stdin(mut self, stdio: Stdio) -> Self {
             self.stdin = stdio;

--- a/gix-command/tests/command.rs
+++ b/gix-command/tests/command.rs
@@ -246,7 +246,7 @@ mod prepare {
     #[test]
     fn multiple_arguments_in_one_line_with_auto_split() {
         let cmd = std::process::Command::from(
-            gix_command::prepare("echo first second third").with_shell_allow_argument_splitting(),
+            gix_command::prepare("echo first second third").with_shell_allow_manual_argument_splitting(),
         );
         assert_eq!(
             format!("{cmd:?}"),
@@ -313,8 +313,9 @@ mod prepare {
 
     #[test]
     fn single_and_complex_arguments_with_auto_split() {
-        let cmd =
-            std::process::Command::from(gix_command::prepare("ls --foo=\"a b\"").with_shell_allow_argument_splitting());
+        let cmd = std::process::Command::from(
+            gix_command::prepare("ls --foo=\"a b\"").with_shell_allow_manual_argument_splitting(),
+        );
         assert_eq!(
             format!("{cmd:?}"),
             format!(r#""ls" "--foo=a b""#),
@@ -332,8 +333,9 @@ mod prepare {
 
     #[test]
     fn single_and_complex_arguments_will_not_auto_split_on_special_characters() {
-        let cmd =
-            std::process::Command::from(gix_command::prepare("ls --foo=~/path").with_shell_allow_argument_splitting());
+        let cmd = std::process::Command::from(
+            gix_command::prepare("ls --foo=~/path").with_shell_allow_manual_argument_splitting(),
+        );
         assert_eq!(
             format!("{cmd:?}"),
             format!(r#""{SH}" "-c" "ls --foo=~/path" "--""#),

--- a/gix-command/tests/command.rs
+++ b/gix-command/tests/command.rs
@@ -323,6 +323,14 @@ mod prepare {
     }
 
     #[test]
+    fn single_and_complex_arguments_without_auto_split() {
+        let cmd = std::process::Command::from(
+            gix_command::prepare("ls --foo=\"a b\"").with_shell_disallow_manual_argument_splitting(),
+        );
+        assert_eq!(format!("{cmd:?}"), quoted(&[SH, "-c", r#"ls --foo=\"a b\""#, "--"]));
+    }
+
+    #[test]
     fn single_and_complex_arguments_will_not_auto_split_on_special_characters() {
         let cmd =
             std::process::Command::from(gix_command::prepare("ls --foo=~/path").with_shell_allow_argument_splitting());

--- a/gix-credentials/src/program/mod.rs
+++ b/gix-credentials/src/program/mod.rs
@@ -82,7 +82,7 @@ impl Program {
                 args.insert_str(0, git_program.to_string_lossy().as_ref());
                 gix_command::prepare(gix_path::from_bstr(args.as_bstr()).into_owned())
                     .arg(action.as_arg(true))
-                    .with_shell_allow_argument_splitting()
+                    .with_shell_allow_manual_argument_splitting()
                     .into()
             }
             Kind::ExternalShellScript(for_shell)


### PR DESCRIPTION
- **feat: add `Prepare::with_shell_disallow_manual_argument_splitting()`.**
- **fix!: rename `Prepare::with_shell_allow_argument_splitting()` to `Prepare::with_shell_allow_manual_argument_splitting()`**
- **adapt to changes in `gix-command`**
