### PR TITLE
Reenable git-daemon journey tests on CI by disabling artifact caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
       - uses: extractions/setup-just@v2
       - name: Run journey tests
         run: just ci-journey-tests

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -109,7 +109,7 @@ title "gix (with repository)"
 
         # for some reason, on CI the daemon always shuts down before we can connect,
         # or isn't actually ready despite having accepted the first connection already.
-        (not_on_ci with "git:// protocol"
+        (with "git:// protocol"
           launch-git-daemon
           (with "version 1"
             it "generates the correct output" && {
@@ -278,7 +278,7 @@ title "gix commit-graph"
           )
         )
         fi
-        (not_on_ci with "git:// protocol"
+        (with "git:// protocol"
           launch-git-daemon
           (with "version 1"
             (with "NO output directory"


### PR DESCRIPTION
Running journey tests that use `git-daemon` broke in the `test-journey` CI job since #1634 for unknown reasons, and they were disabled in 9566488, as discussed in https://github.com/GitoxideLabs/gitoxide/pull/1634#pullrequestreview-2507044578.

This reenables them those journey tests on CI, and fixes them by disabling the `rust-cache` step that caches compiled artifacts. It's rather odd that this works, but [it very much does seem to](https://github.com/EliahKagan/gitoxide/actions/runs/12363538568/job/34510235401).

**See https://github.com/GitoxideLabs/gitoxide/pull/1634#discussion_r1887990759 for full details** on this in a broader context, as well as other things I've tried and why none of the other things I've tried are ready to go yet.

I view this as a workaround rather than full-blown fix, but it seems to me that it's worth doing as a way to let those tests run on CI in a way that doesn't break anything else. With caching turned off, the `test-journey` job takes up to about 6:30 to finish; it seems to me that this may be acceptable even if not ideal, given the significantly greater running time of some of the other jobs.

This is, of course, only turning off artifact caching for the `test-journey` job, not for any other jobs.