### PR TITLE
radicle tuning

### DIFF
--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -94,7 +94,6 @@ where
     .await?;
     let mut negotiate = Negotiate { refmap: &refmap };
     gix::protocol::fetch(
-        &refmap,
         &mut negotiate,
         |read_pack, progress, should_interrupt| {
             receive_pack_blocking(
@@ -123,7 +122,6 @@ where
             shallow_file: "no shallow file required as we reject it to keep it simple".into(),
             shallow: &Default::default(),
             tags: Default::default(),
-            expected_object_hash: Default::default(),
             reject_shallow_remote: true,
         },
     )

--- a/gix-protocol/src/fetch/error.rs
+++ b/gix-protocol/src/fetch/error.rs
@@ -4,11 +4,6 @@
 pub enum Error {
     #[error("Could not decode server reply")]
     FetchResponse(#[from] crate::fetch::response::Error),
-    #[error("Cannot fetch from a remote that uses {remote} while local repository uses {local} for object hashes")]
-    IncompatibleObjectHash {
-        local: gix_hash::Kind,
-        remote: gix_hash::Kind,
-    },
     #[error(transparent)]
     Negotiate(#[from] crate::fetch::negotiate::Error),
     #[error(transparent)]
@@ -26,11 +21,6 @@ pub enum Error {
     LockShallowFile(#[from] gix_lock::acquire::Error),
     #[error("Receiving objects from shallow remotes is prohibited due to the value of `clone.rejectShallow`")]
     RejectShallowRemote,
-    #[error("None of the refspec(s) {} matched any of the {num_remote_refs} refs on the remote", refspecs.iter().map(|r| r.to_ref().instruction().to_bstring().to_string()).collect::<Vec<_>>().join(", "))]
-    NoMapping {
-        refspecs: Vec<gix_refspec::RefSpec>,
-        num_remote_refs: usize,
-    },
     #[error("Failed to consume the pack sent by the remove")]
     ConsumePack(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("Failed to read remaining bytes in stream")]

--- a/gix-protocol/src/fetch/types.rs
+++ b/gix-protocol/src/fetch/types.rs
@@ -12,8 +12,6 @@ pub struct Options<'a> {
     pub shallow: &'a Shallow,
     /// Describe how to handle tags when fetching.
     pub tags: Tags,
-    /// The hash the remote repository is expected to use, as it's what the local repository is initialized as.
-    pub expected_object_hash: gix_hash::Kind,
     /// If `true`, if we fetch from a remote that only offers shallow clones, the operation will fail with an error
     /// instead of writing the shallow boundary to the shallow file.
     pub reject_shallow_remote: bool,

--- a/gix/src/remote/connection/fetch/error.rs
+++ b/gix/src/remote/connection/fetch/error.rs
@@ -40,6 +40,11 @@ pub enum Error {
         feature: &'static str,
         description: &'static str,
     },
+    #[error("None of the refspec(s) {} matched any of the {num_remote_refs} refs on the remote", refspecs.iter().map(|r| r.to_ref().instruction().to_bstring().to_string()).collect::<Vec<_>>().join(", "))]
+    NoMapping {
+        refspecs: Vec<gix_refspec::RefSpec>,
+        num_remote_refs: usize,
+    },
     #[error("Could not write 'shallow' file to incorporate remote updates after fetching")]
     WriteShallowFile(#[from] crate::shallow::write::Error),
     #[error("'shallow' file could not be locked in preparation for writing changes")]

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -109,7 +109,7 @@ title "gix (with repository)"
 
         # for some reason, on CI the daemon always shuts down before we can connect,
         # or isn't actually ready despite having accepted the first connection already.
-        (with "git:// protocol"
+        (not_on_ci with "git:// protocol"
           launch-git-daemon
           (with "version 1"
             it "generates the correct output" && {
@@ -278,7 +278,7 @@ title "gix commit-graph"
           )
         )
         fi
-        (with "git:// protocol"
+        (not_on_ci with "git:// protocol"
           launch-git-daemon
           (with "version 1"
             (with "NO output directory"


### PR DESCRIPTION
Make adjustments needed to make the final integration into [`heartwood`](https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5) smoother.

### Tasks

* [x] make all necessary changes
* [x] bypass flaky CI

### Notes

* `gix-negotiate` is pulled in even though it's not used at all. Some types make this crate necessary though and I don't think it's worth trying to factor it out.

