### PR TITLE
Revert "Try not caching journey test dependencies"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - uses: extractions/setup-just@v2
       - name: Run journey tests
         run: just ci-journey-tests


### PR DESCRIPTION
This reverts commit bf2abdb41e22e27f599e845152b0b4643ec17235, the supporting change in #1725 that refrained from caching build artifacts from the `test-journey` job, since that no longer needs to be avoided now that `git-daemon` journey tests aren't run on CI.

In 9566488 (#1634), journey tests that use `git-daemon` were disabled on CI. #1725 tried reenabling them (65788e8) and fixing them by no longer caching build artifacts with the `rust-cache` action in the `test-journey` job (bf2abdb). This worked at the time, but the exact reason it worked or how reliable it would be were unknown. It stopped working shortly thereafter in 25b8480 (#1726), and those journey tests were re-disabled on CI in d1d3f7c, which reverted 65788e8. However, bf2abdb was not reverted at that time.

(The change in d1d3f7c from #1726, taken together with this commit, effectively constitute a revert of PR #1725.)

---

I think it's faster with caching. I estimated that it would be a couple minutes faster usually, but when I test it on my fork it's closer to being only a minute faster, and sometimes not even that much faster.

A possible further benefit of caching, though minor, is that it reliably produces the problem on CI if the now-skipped `git-daemon` journey test cases are enabled: That would be bad if they were enabled, but it's one less change to make to produce the problem in any further work that attempts to reliably produce the problem to investigate it.

You might prefer phrasing such as "we did not know why it worked" over the current "the exact reason it worked [was] unknown." I've clarified why I thought it might help and why I think timing may still be the issue in https://github.com/GitoxideLabs/gitoxide/pull/1726#discussion_r1890893381. But I am not at all attached to any wording here and I'd be pleased to rebase to reword the message if desired.