### PR TITLE
fix pack receive

### DIFF
--- a/gitoxide-core/src/net.rs
+++ b/gitoxide-core/src/net.rs
@@ -36,4 +36,20 @@ mod impls {
 }
 
 #[cfg(any(feature = "async-client", feature = "blocking-client"))]
-pub use gix::protocol::transport::connect;
+#[gix::protocol::maybe_async::maybe_async]
+pub async fn connect<Url, E>(
+    url: Url,
+    options: gix::protocol::transport::client::connect::Options,
+) -> Result<
+    gix::protocol::SendFlushOnDrop<Box<dyn gix::protocol::transport::client::Transport + Send>>,
+    gix::protocol::transport::client::connect::Error,
+>
+where
+    Url: TryInto<gix::url::Url, Error = E>,
+    gix::url::parse::Error: From<E>,
+{
+    Ok(gix::protocol::SendFlushOnDrop::new(
+        gix::protocol::transport::connect(url, options).await?,
+        false,
+    ))
+}

--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -64,7 +64,7 @@ where
 
     let agent = gix::protocol::agent(gix::env::agent());
     let mut handshake = gix::protocol::fetch::handshake(
-        &mut transport,
+        &mut transport.inner,
         gix::protocol::credentials::builtin,
         vec![("agent".into(), Some(agent.clone()))],
         &mut progress,
@@ -85,7 +85,7 @@ where
         &fetch_refspecs,
         gix::protocol::fetch::Context {
             handshake: &mut handshake,
-            transport: &mut transport,
+            transport: &mut transport.inner,
             user_agent: user_agent.clone(),
             trace_packetlines,
         },
@@ -114,7 +114,7 @@ where
         &ctx.should_interrupt,
         gix::protocol::fetch::Context {
             handshake: &mut handshake,
-            transport: &mut transport,
+            transport: &mut transport.inner,
             user_agent,
             trace_packetlines,
         },

--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -3,6 +3,7 @@ use crate::pack::receive::protocol::fetch::negotiate;
 use crate::OutputFormat;
 use gix::config::tree::Key;
 use gix::protocol::maybe_async;
+use gix::remote::fetch::Error;
 use gix::DynNestedProgress;
 pub use gix::{
     hash::ObjectId,
@@ -92,6 +93,15 @@ where
         gix::protocol::fetch::refmap::init::Options::default(),
     )
     .await?;
+
+    if refmap.mappings.is_empty() && !refmap.remote_refs.is_empty() {
+        return Err(Error::NoMapping {
+            refspecs: refmap.refspecs.clone(),
+            num_remote_refs: refmap.remote_refs.len(),
+        }
+        .into());
+    }
+
     let mut negotiate = Negotiate { refmap: &refmap };
     gix::protocol::fetch(
         &mut negotiate,

--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -140,10 +140,13 @@ impl gix::protocol::fetch::Negotiate for Negotiate<'_> {
         })
     }
 
-    fn add_wants(&mut self, arguments: &mut Arguments, _remote_ref_target_known: &[bool]) {
+    fn add_wants(&mut self, arguments: &mut Arguments, _remote_ref_target_known: &[bool]) -> bool {
+        let mut has_want = false;
         for id in self.refmap.mappings.iter().filter_map(|m| m.remote.as_id()) {
             arguments.want(id);
+            has_want = true;
         }
+        has_want
     }
 
     fn one_round(

--- a/gix-protocol/src/fetch/error.rs
+++ b/gix-protocol/src/fetch/error.rs
@@ -21,8 +21,8 @@ pub enum Error {
     LockShallowFile(#[from] gix_lock::acquire::Error),
     #[error("Receiving objects from shallow remotes is prohibited due to the value of `clone.rejectShallow`")]
     RejectShallowRemote,
-    #[error("Failed to consume the pack sent by the remove")]
-    ConsumePack(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("Failed to consume the pack sent by the remote")]
+    ConsumePack(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("Failed to read remaining bytes in stream")]
     ReadRemainingBytes(#[source] std::io::Error),
 }

--- a/gix-protocol/src/fetch/function.rs
+++ b/gix-protocol/src/fetch/function.rs
@@ -101,6 +101,11 @@ where
                 let _round = gix_trace::detail!("negotiate round", round = rounds.len() + 1);
                 progress.step();
                 progress.set_name(format!("negotiate (round {})", rounds.len() + 1));
+                if should_interrupt.load(Ordering::Relaxed) {
+                    return Err(Error::Negotiate(negotiate::Error::NegotiationFailed {
+                        rounds: rounds.len(),
+                    }));
+                }
 
                 let is_done = match negotiate.one_round(&mut state, &mut arguments, previous_response.as_ref()) {
                     Ok((round, is_done)) => {

--- a/gix-protocol/src/fetch/types.rs
+++ b/gix-protocol/src/fetch/types.rs
@@ -70,7 +70,9 @@ mod with_fetch {
         /// Typically invokes [`negotiate::mark_complete_and_common_ref()`].
         fn mark_complete_and_common_ref(&mut self) -> Result<negotiate::Action, negotiate::Error>;
         /// Typically invokes [`negotiate::add_wants()`].
-        fn add_wants(&mut self, arguments: &mut fetch::Arguments, remote_ref_target_known: &[bool]);
+        /// Returns `true` if wants were added, or `false` if the negotiation should be aborted.
+        #[must_use]
+        fn add_wants(&mut self, arguments: &mut fetch::Arguments, remote_ref_target_known: &[bool]) -> bool;
         /// Typically invokes [`negotiate::one_round()`].
         fn one_round(
             &mut self,

--- a/gix/src/remote/connection/fetch/receive_pack.rs
+++ b/gix/src/remote/connection/fetch/receive_pack.rs
@@ -274,7 +274,7 @@ impl gix_protocol::fetch::Negotiate for Negotiate<'_, '_, '_> {
         )
     }
 
-    fn add_wants(&mut self, arguments: &mut Arguments, remote_ref_target_known: &[bool]) {
+    fn add_wants(&mut self, arguments: &mut Arguments, remote_ref_target_known: &[bool]) -> bool {
         negotiate::add_wants(
             self.objects,
             arguments,
@@ -282,7 +282,7 @@ impl gix_protocol::fetch::Negotiate for Negotiate<'_, '_, '_> {
             remote_ref_target_known,
             self.shallow,
             negotiate::make_refmapping_ignore_predicate(self.tags, self.ref_map),
-        );
+        )
     }
 
     fn one_round(

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -109,7 +109,7 @@ title "gix (with repository)"
 
         # for some reason, on CI the daemon always shuts down before we can connect,
         # or isn't actually ready despite having accepted the first connection already.
-        (not_on_ci with "git:// protocol"
+        (with "git:// protocol"
           launch-git-daemon
           (with "version 1"
             it "generates the correct output" && {
@@ -278,7 +278,7 @@ title "gix commit-graph"
           )
         )
         fi
-        (not_on_ci with "git:// protocol"
+        (with "git:// protocol"
           launch-git-daemon
           (with "version 1"
             (with "NO output directory"


### PR DESCRIPTION
This also re-enabled git-daemon on CI, which technically was just a workaround as it basically also didn't work locally.

In any case, now it works as it won't leave the server in a strange state due to not indicating the end of interaction.

My guess is that somehow the server would see its slots filled up with hanging processes, leading it to stop accepting
connections and probably also to stop going down.
