### PR TITLE
fix: fix check to detect `git-lfs` managed files that weren't checked out.

### DIFF
--- a/gix-revision/tests/revision/spec/parse/anchor/at_symbol.rs
+++ b/gix-revision/tests/revision/spec/parse/anchor/at_symbol.rs
@@ -48,6 +48,31 @@ fn reflog_by_date_for_current_branch() {
 }
 
 #[test]
+fn reflog_by_unix_timestamp_for_current_branch() {
+    let rec = parse("@{100000000}");
+
+    assert!(rec.kind.is_none());
+    assert_eq!(rec.find_ref[0], None,);
+    assert_eq!(
+        rec.prefix[0], None,
+        "neither ref nor prefixes are set, straight to navigation"
+    );
+    assert_eq!(
+        rec.current_branch_reflog_entry[0],
+        Some("100000000 +0000".to_string()),
+        "This number is the first to count as date"
+    );
+    assert_eq!(rec.calls, 1);
+
+    let rec = parse("@{99999999}");
+    assert_eq!(
+        rec.current_branch_reflog_entry[0],
+        Some("99999999".to_string()),
+        "one less is an offset though"
+    );
+}
+
+#[test]
 fn reflog_by_date_with_date_parse_failure() {
     let err = try_parse("@{foo}").unwrap_err();
     assert!(matches!(err, spec::parse::Error::Time {input, source} if input == "foo" && source.is_some()));

--- a/gix/tests/gix/repository/mod.rs
+++ b/gix/tests/gix/repository/mod.rs
@@ -27,14 +27,18 @@ mod revision {
     fn date() -> crate::Result {
         let repo = crate::named_repo("make_rev_parse_repo.sh")?;
         let actual = repo
-            .rev_parse_single("old@{10 years ago}")
+            .rev_parse_single("old@{20 years ago}")
             .expect("it returns the oldest possible rev when overshooting");
         assert_eq!(actual, hex_to_id("be2f093f0588eaeb71e1eff7451b18c2a9b1d765"));
 
         let actual = repo
-            .rev_parse_single("old@{1 month ago}")
+            .rev_parse_single("old@{1732184844}")
             .expect("it finds something in the middle");
-        assert_eq!(actual, hex_to_id("b29405fe9147a3a366c4048fbe295ea04de40fa6"));
+        assert_eq!(
+            actual,
+            hex_to_id("b29405fe9147a3a366c4048fbe295ea04de40fa6"),
+            "It also figures out that we don't mean an index, but a date"
+        );
         Ok(())
     }
 }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -680,7 +680,7 @@ fn should_skip_all_archive_creation() -> bool {
 }
 
 fn is_lfs_pointer_file(path: &Path) -> bool {
-    const PREFIX: &[u8] = b"version https://gix-lfs";
+    const PREFIX: &[u8] = b"version https://git-lfs";
     let mut buf = [0_u8; PREFIX.len()];
     std::fs::OpenOptions::new()
         .read(true)


### PR DESCRIPTION
Previously it would detect them incorrectly due to a find-and-replace
error.
