### PR TITLE
Clarify and expand descriptions of `NonFile`s

### DIFF
--- a/gitoxide-core/src/repository/clean.rs
+++ b/gitoxide-core/src/repository/clean.rs
@@ -188,7 +188,7 @@ pub(crate) mod function {
             }
 
             match disk_kind {
-                Kind::NonFile => {
+                Kind::Untrackable => {
                     if debug {
                         writeln!(err, "DBG: skipped non-file at '{}'", entry.rela_path).ok();
                     }
@@ -265,7 +265,7 @@ pub(crate) mod function {
                     "WOULD remove"
                 },
                 suffix = match disk_kind {
-                    Kind::NonFile => unreachable!("always skipped earlier"),
+                    Kind::Untrackable => unreachable!("always skipped earlier"),
                     Kind::Directory if entry.property == Some(gix::dir::entry::Property::EmptyDirectory) => {
                         " empty"
                     }

--- a/gitoxide-core/src/repository/clean.rs
+++ b/gitoxide-core/src/repository/clean.rs
@@ -190,7 +190,7 @@ pub(crate) mod function {
             match disk_kind {
                 Kind::Untrackable => {
                     if debug {
-                        writeln!(err, "DBG: skipped non-file at '{}'", entry.rela_path).ok();
+                        writeln!(err, "DBG: skipped untrackable entry at '{}'", entry.rela_path).ok();
                     }
                     continue;
                 }

--- a/gix-dir/src/entry.rs
+++ b/gix-dir/src/entry.rs
@@ -26,11 +26,13 @@ pub enum Property {
 /// The kind of the entry, seated in their kinds available on disk.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum Kind {
-    /// Something that is not a file, like a named pipe or character device.
+    /// Something that is not a regular file, directory, or symbolic link.
     ///
-    /// These can only exist in the filesystem.
+    /// These can only exist in the filesystem, because Git repositories do not support them.
+    /// They do not appear as blobs in a repository, and their type is not specifiable in a tree object.
+    /// Examples include named pipes (FIFOs), character devices, block devices, and sockets.
     NonFile,
-    /// The entry is a blob, executable or not.
+    /// The entry is a blob, representing a regular file, executable or not.
     File,
     /// The entry is a symlink.
     Symlink,

--- a/gix-dir/src/entry.rs
+++ b/gix-dir/src/entry.rs
@@ -28,10 +28,11 @@ pub enum Property {
 pub enum Kind {
     /// Something that is not a regular file, directory, or symbolic link.
     ///
-    /// These can only exist in the filesystem, because Git repositories do not support them.
-    /// They do not appear as blobs in a repository, and their type is not specifiable in a tree object.
+    /// These can only exist in the filesystem,
+    /// because Git repositories do not support them, thus they cannot be tracked.
+    /// Hence, they do not appear as blobs in a repository, and their type is not specifiable in a tree object.
     /// Examples include named pipes (FIFOs), character devices, block devices, and sockets.
-    NonFile,
+    Untrackable,
     /// The entry is a blob, representing a regular file, executable or not.
     File,
     /// The entry is a symlink.
@@ -163,7 +164,7 @@ impl From<std::fs::FileType> for Kind {
         } else if value.is_file() {
             Kind::File
         } else {
-            Kind::NonFile
+            Kind::Untrackable
         }
     }
 }

--- a/gix-dir/tests/dir/walk.rs
+++ b/gix-dir/tests/dir/walk.rs
@@ -68,7 +68,7 @@ fn one_top_level_fifo() {
 
     assert_eq!(
         entries,
-        &[entry("top", Untracked, NonFile),],
+        &[entry("top", Untracked, Untrackable),],
         "Non-files are like normal files, but with a different state"
     );
 }
@@ -103,9 +103,9 @@ fn fifo_in_traversal() {
         &[
             entry_nokind(".git", Pruned).with_property(DotGit).with_match(Always),
             entry("dir-with-file/nested-file", Untracked, File),
-            entry("dir/nested", Untracked, NonFile),
+            entry("dir/nested", Untracked, Untrackable),
             entry("file", Untracked, File),
-            entry("top", Untracked, NonFile),
+            entry("top", Untracked, Untrackable),
         ],
         "Non-files only differ by their disk-kind"
     );

--- a/gix-dir/tests/dir/walk.rs
+++ b/gix-dir/tests/dir/walk.rs
@@ -69,7 +69,7 @@ fn one_top_level_fifo() {
     assert_eq!(
         entries,
         &[entry("top", Untracked, Untrackable),],
-        "Non-files are like normal files, but with a different state"
+        "Untrackable entries are like normal files, but with a different state"
     );
 }
 
@@ -107,7 +107,7 @@ fn fifo_in_traversal() {
             entry("file", Untracked, File),
             entry("top", Untracked, Untrackable),
         ],
-        "Non-files only differ by their disk-kind"
+        "Untrackable entries only differ by their disk-kind"
     );
 }
 

--- a/gix-status/src/index_as_worktree/types.rs
+++ b/gix-status/src/index_as_worktree/types.rs
@@ -103,7 +103,9 @@ impl Outcome {
 pub enum Change<T = (), U = ()> {
     /// This corresponding file does not exist in the worktree anymore.
     Removed,
-    /// The type of file changed compared to the worktree, i.e. a symlink is now a file, or a file was replaced with a named pipe.
+    /// The type of file changed compared to the worktree.
+    ///
+    /// Examples include when a symlink is now a regular file, or a regular file was replaced with a named pipe.
     ///
     /// ### Deviation
     ///

--- a/gix-status/src/index_as_worktree_with_renames/mod.rs
+++ b/gix-status/src/index_as_worktree_with_renames/mod.rs
@@ -388,7 +388,7 @@ pub(super) mod function {
         impl<T, U> gix_dir::walk::Delegate for Delegate<'_, '_, T, U> {
             fn emit(&mut self, entry: EntryRef<'_>, collapsed_directory_status: Option<Status>) -> Action {
                 // Status never shows untracked non-files
-                if entry.disk_kind != Some(gix_dir::entry::Kind::NonFile) {
+                if entry.disk_kind != Some(gix_dir::entry::Kind::Untrackable) {
                     let entry = entry.to_owned();
                     self.tx.send(Event::DirEntry(entry, collapsed_directory_status)).ok();
                 }
@@ -469,7 +469,7 @@ pub(super) mod function {
                     ModificationOrDirwalkEntry::Modification(c) => c.entry.mode.to_tree_entry_mode(),
                     ModificationOrDirwalkEntry::DirwalkEntry { entry, .. } => entry.disk_kind.map(|kind| {
                         match kind {
-                            Kind::NonFile => {
+                            Kind::Untrackable => {
                                 // Trees are never tracked for rewrites, so we 'pretend'.
                                 gix_object::tree::EntryKind::Tree
                             }
@@ -507,7 +507,7 @@ pub(super) mod function {
             };
 
             Ok(match kind {
-                Kind::NonFile => {
+                Kind::Untrackable => {
                     // Go along with unreadable files, they are passed along without rename tracking.
                     return Ok(object_hash.null());
                 }

--- a/gix-status/src/index_as_worktree_with_renames/mod.rs
+++ b/gix-status/src/index_as_worktree_with_renames/mod.rs
@@ -387,7 +387,7 @@ pub(super) mod function {
 
         impl<T, U> gix_dir::walk::Delegate for Delegate<'_, '_, T, U> {
             fn emit(&mut self, entry: EntryRef<'_>, collapsed_directory_status: Option<Status>) -> Action {
-                // Status never shows untracked non-files
+                // Status never shows untracked entries of untrackable type
                 if entry.disk_kind != Some(gix_dir::entry::Kind::Untrackable) {
                     let entry = entry.to_owned();
                     self.tx.send(Event::DirEntry(entry, collapsed_directory_status)).ok();


### PR DESCRIPTION
This is a minor documentation revision, to make clearer what a `NonFile`/"non-file" is, as discussed in https://github.com/GitoxideLabs/gitoxide/pull/1730#discussion_r1894381449. At least for now, they are named the same, but the term is more specifically defined.

A couple of possible other names that it could be changed to:

- `Other` as suggested in [#1730 (comment)](https://github.com/GitoxideLabs/gitoxide/pull/1730#discussion_r1894381449). As noted, this is natural. But it is not specific. If Git uses this as a technical term, as suggested, then it should probably be used. I was unable to find it in a cursory search of `git/git` on GitHub, though. I didn't find anything for "NonFile" and everything I found for "non-file" was in phrases like "non-file mailmap," "non-file remote," "non-file backend," and "non-file argument."
- `NonTrackable`, or variations such as `Untrackable` and `NotTrackable` - This idea is from [a commit message in a test](https://github.com/GitoxideLabs/gitoxide/pull/1730/files#diff-406a24eeee8cf467af52b3054214a1d2337eb2b6647169f10de369462bbbe949R14) that refers to the condition of not being a `NonFile` as that of being a "trackable file." I think this is also intuitive when considered abstractly, and accurate. But I'm not sure if it would be intuitive in practice.

Instead of changing it to one of those here, I've just clarified and expanded the documentation. This is with the idea that, with the documentation adjusted this way, it should be possible to figure out if any other name still confers a significant improvement in clarity.

There is another conceptually related change that I made to nearby documentation that is not really covered by this. I'll post a review comment on it so that if it is considered out of scope or unwanted then it can be undone.,