### PR TITLE
Skip uninteresting commits for blame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,7 @@ dependencies = [
 name = "gix-blame"
 version = "0.0.0"
 dependencies = [
+ "gix-commitgraph 0.26.0",
  "gix-diff",
  "gix-filter",
  "gix-fs 0.13.0",
@@ -1547,10 +1548,12 @@ dependencies = [
  "gix-object 0.47.0",
  "gix-odb",
  "gix-ref 0.50.0",
+ "gix-revwalk 0.18.0",
  "gix-testtools",
  "gix-trace 0.1.12",
  "gix-traverse 0.44.0",
  "gix-worktree 0.39.0",
+ "smallvec",
  "thiserror 2.0.3",
 ]
 

--- a/gix-blame/Cargo.toml
+++ b/gix-blame/Cargo.toml
@@ -14,6 +14,8 @@ rust-version = "1.70"
 doctest = false
 
 [dependencies]
+gix-commitgraph = { version = "^0.26.0", path = "../gix-commitgraph" }
+gix-revwalk = { version = "^0.18.0", path = "../gix-revwalk" }
 gix-trace = { version = "^0.1.12", path = "../gix-trace" }
 gix-diff = { version = "^0.50.0", path = "../gix-diff", default-features = false, features = ["blob"] }
 gix-object = { version = "^0.47.0", path = "../gix-object" }
@@ -21,6 +23,7 @@ gix-hash = { version = "^0.16.0", path = "../gix-hash" }
 gix-worktree = { version = "^0.39.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }
 gix-traverse = { version = "^0.44.0", path = "../gix-traverse" }
 
+smallvec = "1.10.0"
 thiserror = "2.0.0"
 
 [dev-dependencies]

--- a/gix-blame/src/error.rs
+++ b/gix-blame/src/error.rs
@@ -29,4 +29,8 @@ pub enum Error {
     DiffTree(#[from] gix_diff::tree::Error),
     #[error("Invalid line range was given, line range is expected to be a 1-based inclusive range in the format '<start>,<end>'")]
     InvalidLineRange,
+    #[error("Failure to decode commit during traversal")]
+    DecodeCommit(#[from] gix_object::decode::Error),
+    #[error("Failed to get parent from commitgraph during traversal")]
+    GetParentFromCommitGraph(#[from] gix_commitgraph::file::commit::Error),
 }

--- a/gix-blame/src/file/mod.rs
+++ b/gix-blame/src/file/mod.rs
@@ -66,7 +66,7 @@ fn process_change(
 
                     // Nothing to do with `hunk` except shifting it,
                     // but `unchanged` needs to be checked against the next hunk to catch up.
-                    new_hunks_to_blame.push(hunk.cloned_blame(suspect, parent).shift_by(parent, *offset));
+                    new_hunks_to_blame.push(hunk.passed_blame(suspect, parent).shift_by(parent, *offset));
                     (None, Some(Change::Unchanged(unchanged)))
                 }
                 (false, false) => {
@@ -95,7 +95,7 @@ fn process_change(
 
                         // Nothing to do with `hunk` except shifting it,
                         // but `unchanged` needs to be checked against the next hunk to catch up.
-                        new_hunks_to_blame.push(hunk.cloned_blame(suspect, parent).shift_by(parent, *offset));
+                        new_hunks_to_blame.push(hunk.passed_blame(suspect, parent).shift_by(parent, *offset));
                         (None, Some(Change::Unchanged(unchanged)))
                     }
                 }
@@ -125,7 +125,7 @@ fn process_change(
                         }
                         Either::Right((before, after)) => {
                             // requeue the left side `before` after offsetting it…
-                            new_hunks_to_blame.push(before.cloned_blame(suspect, parent).shift_by(parent, *offset));
+                            new_hunks_to_blame.push(before.passed_blame(suspect, parent).shift_by(parent, *offset));
                             // …and treat `after` as `new_hunk`, which contains the `added` range.
                             after
                         }
@@ -162,7 +162,7 @@ fn process_change(
                         Either::Left(hunk) => hunk,
                         Either::Right((before, after)) => {
                             // Keep looking for the left side of the unblamed portion.
-                            new_hunks_to_blame.push(before.cloned_blame(suspect, parent).shift_by(parent, *offset));
+                            new_hunks_to_blame.push(before.passed_blame(suspect, parent).shift_by(parent, *offset));
                             after
                         }
                     };
@@ -220,7 +220,7 @@ fn process_change(
                         //       <---->  (added)
 
                         // Retry `hunk` once there is overlapping changes to process.
-                        new_hunks_to_blame.push(hunk.cloned_blame(suspect, parent).shift_by(parent, *offset));
+                        new_hunks_to_blame.push(hunk.passed_blame(suspect, parent).shift_by(parent, *offset));
 
                         // Let hunks catchup with this change.
                         (
@@ -273,7 +273,7 @@ fn process_change(
                     }
                     Either::Right((before, after)) => {
                         // `before` isn't affected by deletion, so keep it for later.
-                        new_hunks_to_blame.push(before.cloned_blame(suspect, parent).shift_by(parent, *offset));
+                        new_hunks_to_blame.push(before.passed_blame(suspect, parent).shift_by(parent, *offset));
                         // after will be affected by offset, and we will see if there are more changes affecting it.
                         after
                     }
@@ -285,7 +285,7 @@ fn process_change(
                 //         |  (line_number_in_destination)
 
                 // Catchup with changes.
-                new_hunks_to_blame.push(hunk.cloned_blame(suspect, parent).shift_by(parent, *offset));
+                new_hunks_to_blame.push(hunk.passed_blame(suspect, parent).shift_by(parent, *offset));
 
                 (
                     None,
@@ -295,7 +295,7 @@ fn process_change(
         }
         (Some(hunk), None) => {
             // nothing to do - changes are exhausted, re-evaluate `hunk`.
-            new_hunks_to_blame.push(hunk.cloned_blame(suspect, parent).shift_by(parent, *offset));
+            new_hunks_to_blame.push(hunk.passed_blame(suspect, parent).shift_by(parent, *offset));
             (None, None)
         }
         (None, Some(Change::Unchanged(_))) => {
@@ -402,18 +402,20 @@ impl UnblamedHunk {
         }
     }
 
+    /// This is like [`Self::pass_blame()`], but easier to use in places where the 'passing' is
+    /// done 'inline'.
+    fn passed_blame(mut self, from: ObjectId, to: ObjectId) -> Self {
+        if let Some(range_in_suspect) = self.suspects.remove(&from) {
+            self.suspects.insert(to, range_in_suspect);
+        }
+        self
+    }
+
     /// Transfer all ranges from the commit at `from` to the commit at `to`.
     fn pass_blame(&mut self, from: ObjectId, to: ObjectId) {
         if let Some(range_in_suspect) = self.suspects.remove(&from) {
             self.suspects.insert(to, range_in_suspect);
         }
-    }
-
-    /// This is like [`Self::clone_blame()`], but easier to use in places
-    /// where the cloning is done 'inline'.
-    fn cloned_blame(mut self, from: ObjectId, to: ObjectId) -> Self {
-        self.clone_blame(from, to);
-        self
     }
 
     fn clone_blame(&mut self, from: ObjectId, to: ObjectId) {

--- a/gix-blame/src/file/tests.rs
+++ b/gix-blame/src/file/tests.rs
@@ -115,7 +115,7 @@ mod process_change {
             [
                 UnblamedHunk {
                     range_in_blamed_file: 0..2,
-                    suspects: [(suspect, 0..2), (parent, 0..2)].into()
+                    suspects: [(parent, 0..2)].into()
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 2..3,
@@ -155,7 +155,7 @@ mod process_change {
             [
                 UnblamedHunk {
                     range_in_blamed_file: 10..12,
-                    suspects: [(suspect, 10..12), (parent, 5..7)].into()
+                    suspects: [(parent, 5..7)].into()
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 12..13,
@@ -196,7 +196,7 @@ mod process_change {
             [
                 UnblamedHunk {
                     range_in_blamed_file: 12..14,
-                    suspects: [(suspect, 7..9), (parent, 7..9)].into()
+                    suspects: [(parent, 7..9)].into()
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 14..15,
@@ -306,7 +306,7 @@ mod process_change {
             [
                 UnblamedHunk {
                     range_in_blamed_file: 3..4,
-                    suspects: [(suspect, 2..3), (parent, 0..1)].into()
+                    suspects: [(parent, 0..1)].into()
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 4..6,
@@ -399,7 +399,7 @@ mod process_change {
             [
                 UnblamedHunk {
                     range_in_blamed_file: 71..107,
-                    suspects: [(suspect, 70..106), (parent, 70..106)].into()
+                    suspects: [(parent, 70..106)].into()
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 107..109,
@@ -434,7 +434,7 @@ mod process_change {
             [
                 UnblamedHunk {
                     range_in_blamed_file: 149..155,
-                    suspects: [(suspect, 137..143), (parent, 137..143)].into()
+                    suspects: [(parent, 137..143)].into()
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 155..156,
@@ -468,7 +468,7 @@ mod process_change {
             new_hunks_to_blame,
             [UnblamedHunk {
                 range_in_blamed_file: 3..6,
-                suspects: [(suspect, 2..5), (parent, 5..8)].into()
+                suspects: [(parent, 5..8)].into()
             }]
         );
         assert_eq!(offset_in_destination, Offset::Deleted(3));
@@ -584,7 +584,7 @@ mod process_change {
             new_hunks_to_blame,
             [UnblamedHunk {
                 range_in_blamed_file: 15..16,
-                suspects: [(suspect, 17..18), (parent, 16..17)].into()
+                suspects: [(parent, 16..17)].into()
             }]
         );
         assert_eq!(offset_in_destination, Offset::Added(1));
@@ -677,7 +677,7 @@ mod process_change {
             new_hunks_to_blame,
             [UnblamedHunk {
                 range_in_blamed_file: 12..14,
-                suspects: [(suspect, 13..15), (parent, 10..12)].into()
+                suspects: [(parent, 10..12)].into()
             }]
         );
         assert_eq!(offset_in_destination, Offset::Added(1));
@@ -706,7 +706,7 @@ mod process_change {
             new_hunks_to_blame,
             [UnblamedHunk {
                 range_in_blamed_file: 110..114,
-                suspects: [(suspect, 109..113), (parent, 106..110)].into()
+                suspects: [(parent, 106..110)].into()
             }]
         );
         assert_eq!(offset_in_destination, Offset::Added(3));
@@ -762,7 +762,7 @@ mod process_change {
             new_hunks_to_blame,
             [UnblamedHunk {
                 range_in_blamed_file: 0..5,
-                suspects: [(suspect, 0..5), (parent, 0..5)].into()
+                suspects: [(parent, 0..5)].into()
             }]
         );
         assert_eq!(offset_in_destination, Offset::Added(0));
@@ -821,7 +821,7 @@ mod process_change {
             new_hunks_to_blame,
             [UnblamedHunk {
                 range_in_blamed_file: 0..5,
-                suspects: [(suspect, 0..5), (parent, 0..5)].into()
+                suspects: [(parent, 0..5)].into()
             }]
         );
         assert_eq!(offset_in_destination, Offset::Added(0));
@@ -883,7 +883,7 @@ mod process_change {
             new_hunks_to_blame,
             [UnblamedHunk {
                 range_in_blamed_file: 2..14,
-                suspects: [(suspect, 2..14), (parent, 2..14)].into()
+                suspects: [(parent, 2..14)].into()
             }]
         );
         assert_eq!(offset_in_destination, Offset::Deleted(4));
@@ -1003,7 +1003,7 @@ mod process_changes {
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 4..6,
-                    suspects: [(suspect, 4..6), (parent, 0..2)].into(),
+                    suspects: [(parent, 0..2)].into(),
                 },
             ]
         );
@@ -1026,7 +1026,7 @@ mod process_changes {
             [
                 UnblamedHunk {
                     range_in_blamed_file: 0..2,
-                    suspects: [(suspect, 0..2), (parent, 0..2)].into(),
+                    suspects: [(parent, 0..2)].into(),
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 2..4,
@@ -1034,7 +1034,7 @@ mod process_changes {
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 4..6,
-                    suspects: [(suspect, 4..6), (parent, 2..4)].into(),
+                    suspects: [(parent, 2..4)].into(),
                 },
             ]
         );
@@ -1065,7 +1065,7 @@ mod process_changes {
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 4..6,
-                    suspects: [(suspect, 4..6), (parent, 0..2)].into(),
+                    suspects: [(parent, 0..2)].into(),
                 }
             ]
         );
@@ -1088,7 +1088,7 @@ mod process_changes {
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 1..6,
-                    suspects: [(suspect, 1..6), (parent, 0..5)].into(),
+                    suspects: [(parent, 0..5)].into(),
                 }
             ]
         );
@@ -1111,7 +1111,7 @@ mod process_changes {
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 3..6,
-                    suspects: [(suspect, 1..4), (parent, 0..3)].into(),
+                    suspects: [(parent, 0..3)].into(),
                 }
             ]
         );
@@ -1134,7 +1134,7 @@ mod process_changes {
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 4..6,
-                    suspects: [(suspect, 4..6), (parent, 3..5)].into(),
+                    suspects: [(parent, 3..5)].into(),
                 }
             ]
         );
@@ -1152,7 +1152,7 @@ mod process_changes {
             new_hunks_to_blame,
             [UnblamedHunk {
                 range_in_blamed_file: 4..6,
-                suspects: [(suspect, 3..5), (parent, 0..2)].into(),
+                suspects: [(parent, 0..2)].into(),
             }]
         );
     }
@@ -1174,7 +1174,7 @@ mod process_changes {
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 2..3,
-                    suspects: [(suspect, 1..2), (parent, 2..3)].into(),
+                    suspects: [(parent, 2..3)].into(),
                 }
             ]
         );
@@ -1201,7 +1201,7 @@ mod process_changes {
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 2..3,
-                    suspects: [(suspect, 2..3), (parent, 0..1)].into(),
+                    suspects: [(parent, 0..1)].into(),
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 3..4,
@@ -1237,7 +1237,7 @@ mod process_changes {
             [
                 UnblamedHunk {
                     range_in_blamed_file: 0..16,
-                    suspects: [(suspect, 0..16), (parent, 0..16)].into()
+                    suspects: [(parent, 0..16)].into()
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 16..17,
@@ -1245,11 +1245,11 @@ mod process_changes {
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 17..30,
-                    suspects: [(suspect, 17..30), (parent, 16..29)].into()
+                    suspects: [(parent, 16..29)].into()
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 31..37,
-                    suspects: [(suspect, 31..37), (parent, 30..36)].into()
+                    suspects: [(parent, 30..36)].into()
                 }
             ]
         );
@@ -1285,11 +1285,11 @@ mod process_changes {
             [
                 UnblamedHunk {
                     range_in_blamed_file: 1..3,
-                    suspects: [(suspect, 1..3), (parent, 1..3)].into(),
+                    suspects: [(parent, 1..3)].into(),
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 5..6,
-                    suspects: [(suspect, 5..6), (parent, 5..6)].into(),
+                    suspects: [(parent, 5..6)].into(),
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 6..7,
@@ -1301,7 +1301,7 @@ mod process_changes {
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 9..10,
-                    suspects: [(suspect, 9..10), (parent, 6..7)].into(),
+                    suspects: [(parent, 6..7)].into(),
                 },
             ]
         );
@@ -1327,7 +1327,7 @@ mod process_changes {
                 },
                 UnblamedHunk {
                     range_in_blamed_file: 4..7,
-                    suspects: [(suspect, 4..7), (parent, 3..6)].into()
+                    suspects: [(parent, 3..6)].into()
                 }
             ]
         );

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -110,7 +110,7 @@ mod baseline {
 struct Fixture {
     odb: gix_odb::Handle,
     resource_cache: gix_diff::blob::Platform,
-    commits: Vec<Result<gix_traverse::commit::Info, gix_traverse::commit::topo::Error>>,
+    suspect: ObjectId,
 }
 
 impl Fixture {
@@ -136,10 +136,6 @@ impl Fixture {
         use gix_ref::file::ReferenceExt;
 
         let head_id = reference.peel_to_id_in_place(&store, &odb)?;
-
-        let commits: Vec<_> = gix_traverse::commit::topo::Builder::from_iters(&odb, [head_id], None::<Vec<ObjectId>>)
-            .build()?
-            .collect();
 
         let git_dir = worktree_path.join(".git");
         let index = gix_index::File::at(git_dir.join("index"), gix_hash::Kind::Sha1, false, Default::default())?;
@@ -174,7 +170,7 @@ impl Fixture {
         Ok(Fixture {
             odb,
             resource_cache,
-            commits,
+            suspect: head_id,
         })
     }
 }
@@ -186,12 +182,13 @@ macro_rules! mktest {
             let Fixture {
                 odb,
                 mut resource_cache,
-                commits,
+                suspect,
             } = Fixture::new()?;
 
             let lines_blamed = gix_blame::file(
                 &odb,
-                commits,
+                suspect,
+                None,
                 &mut resource_cache,
                 format!("{}.txt", $case).as_str().into(),
                 None,
@@ -247,12 +244,13 @@ fn diff_disparity() {
         let Fixture {
             odb,
             mut resource_cache,
-            commits,
+            suspect,
         } = Fixture::new().unwrap();
 
         let lines_blamed = gix_blame::file(
             &odb,
-            commits,
+            suspect,
+            None,
             &mut resource_cache,
             format!("{case}.txt").as_str().into(),
             None,
@@ -274,12 +272,19 @@ fn line_range() {
     let Fixture {
         odb,
         mut resource_cache,
-        commits,
+        suspect,
     } = Fixture::new().unwrap();
 
-    let lines_blamed = gix_blame::file(&odb, commits, &mut resource_cache, "simple.txt".into(), Some(1..2))
-        .unwrap()
-        .entries;
+    let lines_blamed = gix_blame::file(
+        &odb,
+        suspect,
+        None,
+        &mut resource_cache,
+        "simple.txt".into(),
+        Some(1..2),
+    )
+    .unwrap()
+    .entries;
 
     assert_eq!(lines_blamed.len(), 2);
 

--- a/gix-traverse/src/commit/mod.rs
+++ b/gix-traverse/src/commit/mod.rs
@@ -67,12 +67,18 @@ pub struct Info {
     pub commit_time: Option<gix_date::SecondsSinceUnixEpoch>,
 }
 
-enum Either<'buf, 'cache> {
+/// Information about a commit that can be obtained either from a [`gix_object::CommitRefIter`] or
+/// a [`gix_commitgraph::file::Commit`].
+pub enum Either<'buf, 'cache> {
+    /// See [`gix_object::CommitRefIter`].
     CommitRefIter(gix_object::CommitRefIter<'buf>),
+    /// See [`gix_commitgraph::file::Commit`].
     CachedCommit(gix_commitgraph::file::Commit<'cache>),
 }
 
-fn find<'cache, 'buf, Find>(
+/// Find information about a commit by either getting it from a [`gix_commitgraph::Graph`], if
+/// present, or a [`gix_object::CommitRefIter`] otherwise.
+pub fn find<'cache, 'buf, Find>(
     cache: Option<&'cache gix_commitgraph::Graph>,
     objects: Find,
     id: &gix_hash::oid,


### PR DESCRIPTION
This PR is a PoC. It is a first attempt at implementing custom graph traversal for `blame::file`. This allows us to skip commits that we know don’t contain changes to the file being blamed. The PR is rough around the edges and contains a lot of `TODO`s and `todo!()`s.

A first round of tests showed a significant reduction in the number of commits traversed for `gix blame STABILITY.md`:

```
# before
Statistics {
    commits_traversed: 9261,
    commits_to_tree: 10710,
    trees_decoded: 10710,
    trees_diffed: 37,
    blobs_diffed: 36,
}

# after
Statistics {
    commits_traversed: 3657,
    commits_to_tree: 3749,
    trees_decoded: 3749,
    trees_diffed: 37,
    blobs_diffed: 36,
}
```

Also, profiling `gix blame STABILITY.md` on my machine revealed that the command took about 20 % less time to run.
