### PR TITLE
Cancel tree diffing early when matching path is found

### DIFF
--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -28,7 +28,9 @@ pub struct Statistics {
     pub commits_to_tree: usize,
     /// The amount of trees that were decoded to find the entry of the file to blame.
     pub trees_decoded: usize,
-    /// The amount of fully-fledged tree-diffs to see if the filepath was added, deleted or modified.
+    /// The amount of tree-diffs to see if the filepath was added, deleted or modified. These diffs
+    /// are likely partial as they are cancelled as soon as a change to the blamed file is
+    /// detected.
     pub trees_diffed: usize,
     /// The amount of blobs there were compared to each other to learn what changed between commits.
     /// Note that in order to diff a blob, one needs to load both versions from the database.


### PR DESCRIPTION
This PR is ready for review, but it still requires a couple of iterations before it can be considered ready to be merged.

It introduces a custom `Recorder` that is mainly a slimmed down version of `gix_diff::tree::Recorder`. `Recorder` shortens diffing by cancelling it as soon as a change to `interesting_path` is found. This is based on the assumption that there will be at most one change per file path.

The results seem promising. Compared to the existing implementation, I was able to observe a speedup of about 5 % for `gix blame STABILITY.md`.

```
gitoxide on  main [$?] is 📦 v0.40.0 via 🦀 v1.83.0 took 9s
❯ hyperfine "$HOME/github/Byron/gitoxide/target/release/gix blame STABILITY.md" "$HOME/worktrees/gitoxide/branch-3/target/release/gix blame STABILITY.md"
Benchmark 1: /home/christoph/github/Byron/gitoxide/target/release/gix blame STABILITY.md
  Time (mean ± σ):     507.0 ms ±   7.6 ms    [User: 485.4 ms, System: 19.5 ms]
  Range (min … max):   498.6 ms … 520.3 ms    10 runs

Benchmark 2: /home/christoph/worktrees/gitoxide/branch-3/target/release/gix blame STABILITY.md
  Time (mean ± σ):     483.0 ms ±   4.7 ms    [User: 458.3 ms, System: 22.4 ms]
  Range (min … max):   475.7 ms … 491.5 ms    10 runs

Summary
  '/home/christoph/worktrees/gitoxide/branch-3/target/release/gix blame STABILITY.md' ran
    1.05 ± 0.02 times faster than '/home/christoph/github/Byron/gitoxide/target/release/gix blame STABILITY.md'
```

For `gix blame Cargo.lock`, the speedup was in the range of 25 % to 30 %.

```
gitoxide on  main [$?] is 📦 v0.40.0 via 🦀 v1.83.0 took 9s
❯ hyperfine "$HOME/github/Byron/gitoxide/target/release/gix blame Cargo.lock" "$HOME/worktrees/gitoxide/branch-3/target/release/gix blame Cargo.lock"
Benchmark 1: /home/christoph/github/Byron/gitoxide/target/release/gix blame Cargo.lock
  Time (mean ± σ):      2.579 s ±  0.009 s    [User: 2.374 s, System: 0.197 s]
  Range (min … max):    2.568 s …  2.593 s    10 runs

Benchmark 2: /home/christoph/worktrees/gitoxide/branch-3/target/release/gix blame Cargo.lock
  Time (mean ± σ):      2.022 s ±  0.007 s    [User: 1.821 s, System: 0.192 s]
  Range (min … max):    2.010 s …  2.034 s    10 runs

Summary
  '/home/christoph/worktrees/gitoxide/branch-3/target/release/gix blame Cargo.lock' ran
    1.28 ± 0.01 times faster than '/home/christoph/github/Byron/gitoxide/target/release/gix blame Cargo.lock'
```

I also ran `gix blame` on all files in `gitoxide` to make sure the changed version’s output exactly matched the current version’s output.

# Open questions

- Can we ignore `gix_diff::tree`’s return value or is this a bad idea?
- Where does `Recorder` go and can we find a better name for this struct?
- Would it make sense to rename `stats.trees_diffed` to `stats.trees_partially_diffed`?
