### PR TITLE
handle many packs better

### DIFF
--- a/gix-odb/src/lib.rs
+++ b/gix-odb/src/lib.rs
@@ -119,7 +119,7 @@ pub struct Store {
 
     /// The below state acts like a slot-map with each slot is mutable when the write lock is held, but readable independently of it.
     /// This allows multiple file to be loaded concurrently if there is multiple handles requesting to load packs or additional indices.
-    /// The map is static and cannot typically change.
+    /// The map is static and cannot change.
     /// It's read often and changed rarely.
     pub(crate) files: Vec<types::MutableIndexAndPack>,
 

--- a/gix/src/commit.rs
+++ b/gix/src/commit.rs
@@ -1,6 +1,8 @@
 //!
 #![allow(clippy::empty_docs)]
 
+use std::convert::Infallible;
+
 /// An empty array of a type usable with the `gix::easy` API to help declaring no parents should be used
 pub const NO_PARENT_IDS: [gix_hash::ObjectId; 0] = [];
 
@@ -20,6 +22,12 @@ pub enum Error {
     WriteObject(#[from] crate::object::write::Error),
     #[error(transparent)]
     ReferenceEdit(#[from] crate::reference::edit::Error),
+}
+
+impl From<std::convert::Infallible> for Error {
+    fn from(_value: Infallible) -> Self {
+        unreachable!("cannot be invoked")
+    }
 }
 
 ///

--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -102,6 +102,8 @@ pub(crate) fn update(
                 let update = if is_implicit_tag {
                     Mode::ImplicitTagNotSentByRemote.into()
                 } else {
+                    // Assure the ODB is not to blame for the missing object.
+                    repo.try_find_object(remote_id)?;
                     Mode::RejectedSourceObjectNotFound { id: remote_id.into() }.into()
                 };
                 updates.push(update);

--- a/gix/src/remote/connection/fetch/update_refs/update.rs
+++ b/gix/src/remote/connection/fetch/update_refs/update.rs
@@ -23,6 +23,8 @@ mod error {
         PeelToId(#[from] crate::reference::peel::Error),
         #[error("Failed to follow a symbolic reference to assure worktree isn't affected")]
         FollowSymref(#[from] gix_ref::file::find::existing::Error),
+        #[error(transparent)]
+        FindObject(#[from] crate::object::find::Error),
     }
 }
 


### PR DESCRIPTION
This is related to the issue originally reported here: https://github.com/frewsxcv/rust-crates-index/issues/181.

At least past of the problem is that there are more and more packs accumulating, and eventually the pack-map is full.
This leads to objects not being found anymore (outside of any possible race conditions).

### Tasks

* [x] reproduce the 'pack overflow' issue: `Object de01e95cf873164afae15e080903b6a7b22d6329 as referred to by "refs/remotes/origin/master" could not be found`
    - [x] fix it
* [x] reproduce the consistency issue: `/gix-odb-0.66.0/src/store_impls/dynamic/load_index.rs:374:13: if the generation changed, the slot index must have changed for sure`
    - [x] fix it
