### PR TITLE
Fix `gix_path::env::login_shell()` by removing it

### DIFF
--- a/gitoxide-core/src/lib.rs
+++ b/gitoxide-core/src/lib.rs
@@ -30,6 +30,7 @@
 #![deny(rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
+use anyhow::bail;
 use std::str::FromStr;
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
@@ -81,6 +82,51 @@ pub mod repository;
 
 mod discover;
 pub use discover::discover;
+
+pub fn env(mut out: impl std::io::Write, format: OutputFormat) -> anyhow::Result<()> {
+    if format != OutputFormat::Human {
+        bail!("JSON output isn't supported");
+    };
+
+    let width = 15;
+    writeln!(
+        out,
+        "{field:>width$}: {}",
+        std::path::Path::new(gix::path::env::shell()).display(),
+        field = "shell",
+    )?;
+    writeln!(
+        out,
+        "{field:>width$}: {:?}",
+        gix::path::env::installation_config_prefix(),
+        field = "config prefix",
+    )?;
+    writeln!(
+        out,
+        "{field:>width$}: {:?}",
+        gix::path::env::installation_config(),
+        field = "config",
+    )?;
+    writeln!(
+        out,
+        "{field:>width$}: {}",
+        gix::path::env::exe_invocation().display(),
+        field = "git exe",
+    )?;
+    writeln!(
+        out,
+        "{field:>width$}: {:?}",
+        gix::path::env::system_prefix(),
+        field = "system prefix",
+    )?;
+    writeln!(
+        out,
+        "{field:>width$}: {:?}",
+        gix::path::env::core_dir(),
+        field = "core dir",
+    )?;
+    Ok(())
+}
 
 #[cfg(all(feature = "async-client", feature = "blocking-client"))]
 compile_error!("Cannot set both 'blocking-client' and 'async-client' features as they are mutually exclusive");

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -36,17 +36,17 @@ pub fn installation_config_prefix() -> Option<&'static Path> {
 /// as it could possibly be found in `PATH`.
 /// Note that the returned path might not be a path on disk.
 pub fn shell() -> &'static OsStr {
-    static PATH: Lazy<Option<OsString>> = Lazy::new(|| {
+    static PATH: Lazy<OsString> = Lazy::new(|| {
         if cfg!(windows) {
-            installation_config_prefix()
-                .and_then(|p| p.parent())
+            core_dir()
+                .and_then(|p| p.ancestors().nth(3) /* skip mingw64/libexec/git-core */)
                 .map(|p| p.join("usr").join("bin").join("sh.exe"))
-                .map(Into::into)
+                .map_or_else(|| OsString::from("sh"), Into::into)
         } else {
-            Some("/bin/sh".into())
+            "/bin/sh".into()
         }
     });
-    PATH.as_deref().unwrap_or(OsStr::new("sh"))
+    PATH.as_ref()
 }
 
 /// Return the name of the Git executable to invoke it.

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -30,7 +30,7 @@ pub fn installation_config_prefix() -> Option<&'static Path> {
 
 /// Return the shell that Git would use, the shell to execute commands from.
 ///
-/// On Windows, this is the full path to `sh.exe` bundled with it, and on
+/// On Windows, this is the full path to `sh.exe` bundled with Git, and on
 /// Unix it's `/bin/sh` as posix compatible shell.
 /// If the bundled shell on Windows cannot be found, `sh` is returned as the name of a shell
 /// as it could possibly be found in `PATH`.
@@ -39,7 +39,7 @@ pub fn shell() -> &'static OsStr {
     static PATH: Lazy<OsString> = Lazy::new(|| {
         if cfg!(windows) {
             core_dir()
-                .and_then(|p| p.ancestors().nth(3) /* skip mingw64/libexec/git-core */)
+                .and_then(|p| p.ancestors().nth(3)) // Skip something like mingw64/libexec/git-core.
                 .map(|p| p.join("usr").join("bin").join("sh.exe"))
                 .map_or_else(|| OsString::from("sh"), Into::into)
         } else {
@@ -122,7 +122,7 @@ static GIT_CORE_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| {
     }
 
     BString::new(output.stdout)
-        .trim_with(|b| b.is_ascii_whitespace())
+        .strip_suffix(b"\n")?
         .to_path()
         .ok()?
         .to_owned()

--- a/gix-path/tests/path/env.rs
+++ b/gix-path/tests/path/env.rs
@@ -25,6 +25,14 @@ fn installation_config() {
 }
 
 #[test]
+fn core_dir() {
+    assert!(
+        gix_path::env::core_dir().expect("Git is always in PATH").is_dir(),
+        "The core directory is a valid directory"
+    );
+}
+
+#[test]
 fn system_prefix() {
     assert_ne!(
         gix_path::env::system_prefix(),

--- a/gix-path/tests/path/env.rs
+++ b/gix-path/tests/path/env.rs
@@ -27,7 +27,9 @@ fn installation_config() {
 #[test]
 fn core_dir() {
     assert!(
-        gix_path::env::core_dir().expect("Git is always in PATH").is_dir(),
+        gix_path::env::core_dir()
+            .expect("Git is always in PATH when we run tests")
+            .is_dir(),
         "The core directory is a valid directory"
     );
 }

--- a/gix-path/tests/path/env.rs
+++ b/gix-path/tests/path/env.rs
@@ -8,13 +8,11 @@ fn exe_invocation() {
 }
 
 #[test]
-fn login_shell() {
-    // On CI, the $SHELL variable isn't necessarily set. Maybe other ways to get the login shell should be used then.
-    if !gix_testtools::is_ci::cached() {
-        assert!(gix_path::env::login_shell()
-            .expect("There should always be the notion of a shell used by git")
-            .exists());
-    }
+fn shell() {
+    assert!(
+        std::path::Path::new(gix_path::env::shell()).exists(),
+        "On CI and on Unix we'd expect a full path to the shell that exists on disk"
+    );
 }
 
 #[test]

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -146,6 +146,15 @@ pub fn main() -> Result<()> {
     }
 
     match cmd {
+        Subcommands::Env => prepare_and_run(
+            "env",
+            trace,
+            verbose,
+            progress,
+            progress_keep_open,
+            None,
+            move |_progress, out, _err| core::env(out, format),
+        ),
         Subcommands::Merge(merge::Platform { cmd }) => match cmd {
             merge::SubCommands::File {
                 resolve_with,

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -145,6 +145,7 @@ pub enum Subcommands {
     Corpus(corpus::Platform),
     MergeBase(merge_base::Command),
     Merge(merge::Platform),
+    Env,
     Diff(diff::Platform),
     Log(log::Platform),
     Worktree(worktree::Platform),


### PR DESCRIPTION
Thanks to the review of @EliahKagan we can stop the proliferation of a bad idea in its tracks and replace it with what hopefully is a better idea.

Follow-up on #1752 .

### Tasks

* [x] replace `login_shell()` with an alternative
* [x] improve the heurstic by which `sh.exe` is located on windows.
* [x] add `gix env` to print out such paths more easily

### Notes for the Reviewer

* On Windows, `git --exec-path` is always called even though one might do without under some circumstances. This optimization can be done later once this function is widely enough used.


