### PR TITLE
fix: worktrees of submodules now know their correct worktree

### DIFF
--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "archive generation from of a worktree stream"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project dealing .gitattributes files"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-bitmap/Cargo.toml
+++ b/gix-bitmap/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dedicated implementing the standard git bitmap format"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 exclude = ["CHANGELOG.md"]
 
 [lib]

--- a/gix-blame/Cargo.toml
+++ b/gix-blame/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dedicated to implementing a 'blame' algorithm"
 authors = ["Christoph Rüßler <christoph.ruessler@mailbox.org>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-chunk/Cargo.toml
+++ b/gix-chunk/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://github.com/git/git/blob/seen/Documentation/technical/ch
 license = "MIT OR Apache-2.0"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-command/Cargo.toml
+++ b/gix-command/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project handling internal git command execution"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/lib.rs", "LICENSE-*"]
 
 [lib]

--- a/gix-commitgraph/Cargo.toml
+++ b/gix-commitgraph/Cargo.toml
@@ -10,7 +10,7 @@ description = "Read-only access to the git commitgraph file format"
 authors = ["Conor Davis <gitoxide@conor.fastmail.fm>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-config-value/Cargo.toml
+++ b/gix-config-value/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project providing git-config value parsing"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 keywords = ["git-config", "git", "config", "gitoxide"]
 categories = ["config", "parser-implementations"]
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.65"
+rust-version = "1.70"
 autotests = false
 
 [features]

--- a/gix-config/src/file/mutable/mod.rs
+++ b/gix-config/src/file/mutable/mod.rs
@@ -9,10 +9,10 @@ pub(crate) mod section;
 pub(crate) mod value;
 
 fn escape_value(value: &BStr) -> BString {
-    let starts_with_whitespace = value.first().map_or(false, u8::is_ascii_whitespace);
+    let starts_with_whitespace = value.first().is_some_and(u8::is_ascii_whitespace);
     let ends_with_whitespace = value
         .get(value.len().saturating_sub(1))
-        .map_or(false, u8::is_ascii_whitespace);
+        .is_some_and(u8::is_ascii_whitespace);
     let contains_comment_indicators = value.find_byteset(b";#").is_some();
     let quote = starts_with_whitespace || ends_with_whitespace || contains_comment_indicators;
 

--- a/gix-config/src/file/mutable/section.rs
+++ b/gix-config/src/file/mutable/section.rs
@@ -274,11 +274,7 @@ impl<'a, 'event> SectionMut<'a, 'event> {
     /// Performs the removal, assuming the range is valid.
     fn remove_internal(&mut self, range: Range<usize>, fix_whitespace: bool) -> Cow<'event, BStr> {
         let events = &mut self.section.body.0;
-        if fix_whitespace
-            && events
-                .get(range.end)
-                .map_or(false, |ev| matches!(ev, Event::Newline(_)))
-        {
+        if fix_whitespace && events.get(range.end).is_some_and(|ev| matches!(ev, Event::Newline(_))) {
             events.remove(range.end);
         }
         let value = events
@@ -294,7 +290,7 @@ impl<'a, 'event> SectionMut<'a, 'event> {
                 .start
                 .checked_sub(1)
                 .and_then(|pos| events.get(pos))
-                .map_or(false, |ev| matches!(ev, Event::Whitespace(_)))
+                .is_some_and(|ev| matches!(ev, Event::Whitespace(_)))
         {
             events.remove(range.start - 1);
         }

--- a/gix-config/src/parse/section/header.rs
+++ b/gix-config/src/parse/section/header.rs
@@ -62,7 +62,7 @@ fn validated_name(name: Cow<'_, BStr>) -> Result<Cow<'_, BStr>, Error> {
 impl Header<'_> {
     ///Return true if this is a header like `[legacy.subsection]`, or false otherwise.
     pub fn is_legacy(&self) -> bool {
-        self.separator.as_deref().map_or(false, |n| n == ".")
+        self.separator.as_deref().is_some_and(|n| n == ".")
     }
 
     /// Return the subsection name, if present, i.e. "origin" in `[remote "origin"]`.

--- a/gix-config/src/source.rs
+++ b/gix-config/src/source.rs
@@ -71,7 +71,7 @@ impl Source {
                     .transpose()
                     .ok()
                     .flatten()
-                    .map_or(false, |b| b.0)
+                    .is_some_and(|b| b.0)
                 {
                     None
                 } else {
@@ -84,7 +84,7 @@ impl Source {
                     .transpose()
                     .ok()
                     .flatten()
-                    .map_or(false, |b| b.0)
+                    .is_some_and(|b| b.0)
                 {
                     None
                 } else {

--- a/gix-config/tests/Cargo.toml
+++ b/gix-config/tests/Cargo.toml
@@ -8,7 +8,7 @@ description = "Tests for the gix-config crate"
 license = "MIT OR Apache-2.0"
 authors = ["Edward Shen <code@eddie.sh>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 publish = false
 
 

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project to interact with git credentials helpers"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -9,7 +9,7 @@ description = "Calculate differences between various git objects"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 autotests = false
 
 [features]

--- a/gix-diff/src/blob/pipeline.rs
+++ b/gix-diff/src/blob/pipeline.rs
@@ -406,7 +406,7 @@ impl Pipeline {
                         if matches!(mode, EntryKind::Blob | EntryKind::BlobExecutable)
                             && convert == Mode::ToWorktreeAndBinaryToText
                             || (convert == Mode::ToGitUnlessBinaryToTextIsPresent
-                                && driver.map_or(false, |d| d.binary_to_text_command.is_some()))
+                                && driver.is_some_and(|d| d.binary_to_text_command.is_some()))
                         {
                             let res =
                                 self.worktree_filter

--- a/gix-diff/src/index/function.rs
+++ b/gix-diff/src/index/function.rs
@@ -59,7 +59,7 @@ where
     let pattern_matches = RefCell::new(|relative_path, entry: &gix_index::Entry| {
         pathspec
             .pattern_matching_relative_path(relative_path, Some(entry.mode.is_submodule()), pathspec_attributes)
-            .map_or(false, |m| !m.is_excluded())
+            .is_some_and(|m| !m.is_excluded())
     });
 
     let (mut lhs_iter, mut rhs_iter) = (

--- a/gix-diff/tests/Cargo.toml
+++ b/gix-diff/tests/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 description = "Tests for the gix-diff crate"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [[test]]
 doctest = false

--- a/gix-diff/tests/diff/tree_with_rewrites.rs
+++ b/gix-diff/tests/diff/tree_with_rewrites.rs
@@ -1004,7 +1004,7 @@ fn realistic_renames_disabled_2() -> crate::Result {
     // Directories are associated with their children, making a bundling possible.
     insta::assert_debug_snapshot!(changes.into_iter()
                                      .filter(|c| !c.entry_mode().is_tree() ||
-                                                  c.relation().map_or(false, |r| matches!(r, Relation::Parent(_)))
+                                                  c.relation().is_some_and(|r| matches!(r, Relation::Parent(_)))
                                      ).collect::<Vec<_>>(), @r#"
     [
         Deletion {
@@ -1427,7 +1427,7 @@ fn realistic_renames_2() -> crate::Result {
     // Look how nicely it captures and associates this directory rename.
     insta::assert_debug_snapshot!(changes.into_iter()
                                      .filter(|c| !c.entry_mode().is_tree() ||
-                                                  c.relation().map_or(false, |r| matches!(r, Relation::Parent(_)))
+                                                  c.relation().is_some_and(|r| matches!(r, Relation::Parent(_)))
                                      ).collect::<Vec<_>>(), @r#"
     [
         Rewrite {
@@ -1690,7 +1690,7 @@ fn realistic_renames_3_without_identity() -> crate::Result {
     // Look how nicely it captures and associates this directory rename.
     insta::assert_debug_snapshot!(changes.into_iter()
                                      .filter(|c| !c.entry_mode().is_tree() ||
-                                                  c.relation().map_or(false, |r| matches!(r, Relation::Parent(_)))
+                                                  c.relation().is_some_and(|r| matches!(r, Relation::Parent(_)))
                                      ).collect::<Vec<_>>(), @r#"
     [
         Rewrite {

--- a/gix-dir/Cargo.toml
+++ b/gix-dir/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing with directory walks"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-dir/src/entry.rs
+++ b/gix-dir/src/entry.rs
@@ -190,7 +190,7 @@ impl Status {
         for_deletion: Option<ForDeletionMode>,
         worktree_root_is_repository: bool,
     ) -> bool {
-        let is_dir_on_disk = file_type.map_or(false, |ft| {
+        let is_dir_on_disk = file_type.is_some_and(|ft| {
             if worktree_root_is_repository {
                 ft.is_dir()
             } else {
@@ -203,13 +203,13 @@ impl Status {
         match self {
             Status::Pruned => false,
             Status::Ignored(_) => {
-                for_deletion.map_or(false, |fd| {
+                for_deletion.is_some_and(|fd| {
                     matches!(
                         fd,
                         ForDeletionMode::FindNonBareRepositoriesInIgnoredDirectories
                             | ForDeletionMode::FindRepositoriesInIgnoredDirectories
                     )
-                }) || pathspec_match.map_or(false, |m| !m.should_ignore())
+                }) || pathspec_match.is_some_and(|m| !m.should_ignore())
             }
             Status::Untracked | Status::Tracked => true,
         }

--- a/gix-dir/src/walk/function.rs
+++ b/gix-dir/src/walk/function.rs
@@ -83,7 +83,7 @@ pub fn walk(
         delegate,
     );
     if !can_recurse {
-        if buf.is_empty() && !root_info.disk_kind.map_or(false, |kind| kind.is_dir()) {
+        if buf.is_empty() && !root_info.disk_kind.is_some_and(|kind| kind.is_dir()) {
             return Err(Error::WorktreeRootIsFile { root: root.to_owned() });
         }
         if options.precompose_unicode {
@@ -159,7 +159,7 @@ pub(super) fn can_recurse(
     worktree_root_is_repository: bool,
     delegate: &mut dyn Delegate,
 ) -> bool {
-    let is_dir = info.disk_kind.map_or(false, |k| k.is_dir());
+    let is_dir = info.disk_kind.is_some_and(|k| k.is_dir());
     if !is_dir {
         return false;
     }

--- a/gix-dir/src/walk/readdir.rs
+++ b/gix-dir/src/walk/readdir.rs
@@ -26,7 +26,7 @@ pub(super) fn recursive(
     out: &mut Outcome,
     state: &mut State,
 ) -> Result<(Action, bool), Error> {
-    if ctx.should_interrupt.map_or(false, |flag| flag.load(Ordering::Relaxed)) {
+    if ctx.should_interrupt.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
         return Err(Error::Interrupted);
     }
     out.read_dir_calls += 1;
@@ -303,12 +303,10 @@ impl Mark {
             if kind == Some(entry::Kind::Repository) {
                 return None;
             }
-            if pathspec_match.map_or(false, |m| {
-                matches!(m, PathspecMatch::Verbatim | PathspecMatch::Excluded)
-            }) {
+            if pathspec_match.is_some_and(|m| matches!(m, PathspecMatch::Verbatim | PathspecMatch::Excluded)) {
                 return None;
             }
-            matching_entries += usize::from(pathspec_match.map_or(false, |m| !m.should_ignore()));
+            matching_entries += usize::from(pathspec_match.is_some_and(|m| !m.should_ignore()));
             match status {
                 Status::Pruned => {
                     unreachable!("BUG: pruned aren't ever held, check `should_hold()`")

--- a/gix-discover/Cargo.toml
+++ b/gix-discover/Cargo.toml
@@ -9,7 +9,7 @@ description = "Discover git repositories and check if a directory is a git repos
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-discover/src/upwards/mod.rs
+++ b/gix-discover/src/upwards/mod.rs
@@ -89,7 +89,7 @@ pub(crate) mod function {
         let mut current_height = 0;
         let mut cursor_metadata = Some(dir_metadata);
         'outer: loop {
-            if max_height.map_or(false, |x| current_height > x) {
+            if max_height.is_some_and(|x| current_height > x) {
                 return Err(Error::NoGitRepositoryWithinCeiling {
                     path: dir.into_owned(),
                     ceiling_height: current_height,
@@ -168,7 +168,7 @@ pub(crate) mod function {
                     }
                 }
             }
-            if cursor.parent().map_or(false, |p| p.as_os_str().is_empty()) {
+            if cursor.parent().is_some_and(|p| p.as_os_str().is_empty()) {
                 cursor = cwd.to_path_buf();
                 dir_made_absolute = true;
             }

--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.39.1"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-fetchhead/Cargo.toml
+++ b/gix-fetchhead/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project to read and write .git/FETCH_HEAD"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-filter/Cargo.toml
+++ b/gix-filter/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing git filters"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-filter/examples/arrow.rs
+++ b/gix-filter/examples/arrow.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut args = std::env::args();
     let sub_command = args.nth(1).ok_or("Need sub-command")?;
     let next_arg = args.next(); // possibly %f
-    let needs_failure = next_arg.as_deref().map_or(false, |file| file.ends_with("fail"));
+    let needs_failure = next_arg.as_deref().is_some_and(|file| file.ends_with("fail"));
     if needs_failure {
         panic!("failure requested for {sub_command}");
     }
@@ -40,7 +40,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .meta
                     .iter()
                     .find_map(|(key, value)| (key == "pathname").then_some(value))
-                    .map_or(false, |path| path.ends_with(b"fail"));
+                    .is_some_and(|path| path.ends_with(b"fail"));
                 let pathname = request
                     .meta
                     .iter()

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate providing file system specific utilities to `gitoxide`"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-fsck/Cargo.toml
+++ b/gix-fsck/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 description = "Verifies the connectivity and validity of objects in the database"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-glob/Cargo.toml
+++ b/gix-glob/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing with pattern matching"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-glob/src/pattern.rs
+++ b/gix-glob/src/pattern.rs
@@ -135,7 +135,7 @@ impl Pattern {
                     value
                         .len()
                         .checked_sub(text.len())
-                        .map_or(false, |start| text.eq_ignore_ascii_case(&value[start..]))
+                        .is_some_and(|start| text.eq_ignore_ascii_case(&value[start..]))
                 } else {
                     value.ends_with(text.as_ref())
                 }
@@ -144,7 +144,7 @@ impl Pattern {
                 if mode.contains(wildmatch::Mode::IGNORE_CASE) {
                     if !value
                         .get(..pos)
-                        .map_or(false, |value| value.eq_ignore_ascii_case(&self.text[..pos]))
+                        .is_some_and(|value| value.eq_ignore_ascii_case(&self.text[..pos]))
                     {
                         return false;
                     }

--- a/gix-glob/src/wildmatch.rs
+++ b/gix-glob/src/wildmatch.rs
@@ -240,7 +240,7 @@ pub(crate) mod function {
                             }
                             BRACKET_OPEN if matches!(p.peek(), Some((_, COLON))) => {
                                 p.next();
-                                while p.peek().map_or(false, |t| t.1 != BRACKET_CLOSE) {
+                                while p.peek().is_some_and(|t| t.1 != BRACKET_CLOSE) {
                                     p.next();
                                 }
                                 let closing_bracket_idx = match p.next() {

--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-hashtable/Cargo.toml
+++ b/gix-hashtable/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate that provides hashtable based data structures optimized t
 authors = ["Pascal Kuthe <pascal.kuthe@semimod.de>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-ignore/Cargo.toml
+++ b/gix-ignore/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project dealing .gitignore files"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -9,7 +9,7 @@ description = "A work-in-progress crate of the gitoxide project dedicated implem
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.65"
+rust-version = "1.70"
 autotests = false
 
 

--- a/gix-index/src/access/mod.rs
+++ b/gix-index/src/access/mod.rs
@@ -331,8 +331,8 @@ impl State {
                 .get(..prefix_len)
                 .map_or_else(|| e.path(self) <= &prefix[..e.path.len()], |p| p < prefix)
         });
-        let mut high = low
-            + self.entries[low..].partition_point(|e| e.path(self).get(..prefix_len).map_or(false, |p| p <= prefix));
+        let mut high =
+            low + self.entries[low..].partition_point(|e| e.path(self).get(..prefix_len).is_some_and(|p| p <= prefix));
 
         let low_entry = &self.entries.get(low)?;
         if low_entry.stage_raw() != 0 {

--- a/gix-index/src/extension/untracked_cache.rs
+++ b/gix-index/src/extension/untracked_cache.rs
@@ -40,7 +40,7 @@ pub const SIGNATURE: Signature = *b"UNTR";
 // #[allow(unused)]
 /// Decode an untracked cache extension from `data`, assuming object hashes are of type `object_hash`.
 pub fn decode(data: &[u8], object_hash: gix_hash::Kind) -> Option<UntrackedCache> {
-    if !data.last().map_or(false, |b| *b == 0) {
+    if !data.last().is_some_and(|b| *b == 0) {
         return None;
     }
     let (identifier_len, data) = var_int(data)?;

--- a/gix-index/tests/Cargo.toml
+++ b/gix-index/tests/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 description = "Integration tests for gix-index"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [[test]]
 name = "integrate"

--- a/gix-lfs/Cargo.toml
+++ b/gix-lfs/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing with handling git large file support"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-lock/Cargo.toml
+++ b/gix-lock/Cargo.toml
@@ -9,7 +9,7 @@ description = "A git-style lock-file implementation"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-macros/Cargo.toml
+++ b/gix-macros/Cargo.toml
@@ -13,7 +13,7 @@ authors = [
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 proc-macro = true

--- a/gix-mailmap/Cargo.toml
+++ b/gix-mailmap/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project for parsing mailmap files"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-merge/Cargo.toml
+++ b/gix-merge/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing merge algorithms"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lints]
 workspace = true

--- a/gix-merge/src/tree/mod.rs
+++ b/gix-merge/src/tree/mod.rs
@@ -233,10 +233,7 @@ impl Conflict {
         };
         match how.tree_merge {
             treat_as_unresolved::TreeMerge::Undecidable => {
-                self.resolution.is_err()
-                    || self
-                        .content_merge()
-                        .map_or(false, |info| content_merge_unresolved(&info))
+                self.resolution.is_err() || self.content_merge().is_some_and(|info| content_merge_unresolved(&info))
             }
             treat_as_unresolved::TreeMerge::EvasiveRenames | treat_as_unresolved::TreeMerge::ForcedResolution => {
                 match &self.resolution {
@@ -246,13 +243,13 @@ impl Conflict {
                             how.tree_merge == treat_as_unresolved::TreeMerge::ForcedResolution
                                 || self
                                     .content_merge()
-                                    .map_or(false, |merged_blob| content_merge_unresolved(&merged_blob))
+                                    .is_some_and(|merged_blob| content_merge_unresolved(&merged_blob))
                         }
                         Resolution::OursModifiedTheirsRenamedAndChangedThenRename {
                             merged_blob,
                             final_location,
                             ..
-                        } => final_location.is_some() || merged_blob.as_ref().map_or(false, content_merge_unresolved),
+                        } => final_location.is_some() || merged_blob.as_ref().is_some_and(content_merge_unresolved),
                         Resolution::OursModifiedTheirsModifiedThenBlobContentMerge { merged_blob } => {
                             content_merge_unresolved(merged_blob)
                         }

--- a/gix-negotiate/Cargo.toml
+++ b/gix-negotiate/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing negotiation algorithms"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-negotiate/src/consecutive.rs
+++ b/gix-negotiate/src/consecutive.rs
@@ -148,7 +148,7 @@ impl Negotiator for Algorithm {
     fn in_common_with_remote(&mut self, id: ObjectId, graph: &mut crate::Graph<'_, '_>) -> Result<bool, Error> {
         let known_to_be_common = graph
             .get(&id)
-            .map_or(false, |commit| commit.data.flags.contains(Flags::COMMON));
+            .is_some_and(|commit| commit.data.flags.contains(Flags::COMMON));
         self.mark_common(id, Mark::ThisCommitAndAncestors, Ancestors::DirectUnseen, graph)?;
         Ok(known_to_be_common)
     }

--- a/gix-negotiate/src/skipping.rs
+++ b/gix-negotiate/src/skipping.rs
@@ -116,7 +116,7 @@ impl Negotiator for Algorithm {
     fn known_common(&mut self, id: ObjectId, graph: &mut crate::Graph<'_, '_>) -> Result<(), Error> {
         if graph
             .get(&id)
-            .map_or(false, |commit| commit.data.flags.contains(Flags::SEEN))
+            .is_some_and(|commit| commit.data.flags.contains(Flags::SEEN))
         {
             return Ok(());
         }
@@ -126,7 +126,7 @@ impl Negotiator for Algorithm {
     fn add_tip(&mut self, id: ObjectId, graph: &mut crate::Graph<'_, '_>) -> Result<(), Error> {
         if graph
             .get(&id)
-            .map_or(false, |commit| commit.data.flags.contains(Flags::SEEN))
+            .is_some_and(|commit| commit.data.flags.contains(Flags::SEEN))
         {
             return Ok(());
         }
@@ -168,7 +168,7 @@ impl Negotiator for Algorithm {
 
     fn in_common_with_remote(&mut self, id: ObjectId, graph: &mut crate::Graph<'_, '_>) -> Result<bool, Error> {
         let mut was_seen = false;
-        let known_to_be_common = graph.get(&id).map_or(false, |commit| {
+        let known_to_be_common = graph.get(&id).is_some_and(|commit| {
             was_seen = commit.data.flags.contains(Flags::SEEN);
             commit.data.flags.contains(Flags::COMMON)
         });

--- a/gix-note/Cargo.toml
+++ b/gix-note/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing with git notes"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-object/src/tree/editor.rs
+++ b/gix-object/src/tree/editor.rs
@@ -257,7 +257,7 @@ impl Editor<'_> {
         let mut path_buf = self.path_buf.borrow_mut();
         let mut cursor = self.trees.get_mut(path_buf.as_bstr()).expect("root is always present");
         let mut rela_path = rela_path.into_iter().peekable();
-        let new_kind_is_tree = kind_and_id.map_or(false, |(kind, _, _)| kind == EntryKind::Tree);
+        let new_kind_is_tree = kind_and_id.is_some_and(|(kind, _, _)| kind == EntryKind::Tree);
         while let Some(name) = rela_path.next() {
             let name = name.as_ref();
             if name.is_empty() {
@@ -336,7 +336,7 @@ impl Editor<'_> {
             if needs_sorting {
                 cursor.entries.sort();
             }
-            if is_last && kind_and_id.map_or(false, |(_, _, mode)| mode == UpsertMode::Normal) {
+            if is_last && kind_and_id.is_some_and(|(_, _, mode)| mode == UpsertMode::Normal) {
                 break;
             }
             push_path_component(&mut path_buf, name);

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 description = "Implements various git object databases"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 autotests = false
 
 [lib]

--- a/gix-odb/src/memory.rs
+++ b/gix-odb/src/memory.rs
@@ -162,7 +162,7 @@ where
     T: gix_object::Exists,
 {
     fn exists(&self, id: &gix_hash::oid) -> bool {
-        self.memory.as_ref().map_or(false, |map| map.borrow().contains_key(id)) || self.inner.exists(id)
+        self.memory.as_ref().is_some_and(|map| map.borrow().contains_key(id)) || self.inner.exists(id)
     }
 }
 

--- a/gix-odb/tests/Cargo.toml
+++ b/gix-odb/tests/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 description = "Tests for gix-odb with feature-toggle support"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 publish = false
 
 [features]

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 description = "Implements git packs and related data structures"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 autotests = false
 
 [lib]

--- a/gix-pack/tests/Cargo.toml
+++ b/gix-pack/tests/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 description = "Please use `gix-<thiscrate>` instead ('git' -> 'gix')"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [features]
 gix-features-parallel = ["gix-features/parallel"]

--- a/gix-packetline-blocking/Cargo.toml
+++ b/gix-packetline-blocking/Cargo.toml
@@ -9,7 +9,7 @@ description = "A duplicate of `gix-packetline` with the `blocking-io` feature pr
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project implementing the pkt-line seriali
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-path/Cargo.toml
+++ b/gix-path/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project dealing paths and their conversio
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-pathspec/Cargo.toml
+++ b/gix-pathspec/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing magical pathspecs"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [lib]

--- a/gix-pathspec/tests/search/mod.rs
+++ b/gix-pathspec/tests/search/mod.rs
@@ -644,7 +644,7 @@ mod baseline {
                                 attrs.pattern_matching_relative_path(rela_path, case, Some(is_dir), out)
                             },
                         )
-                        .map_or(false, |m| !m.is_excluded())
+                        .is_some_and(|m| !m.is_excluded())
                 })
                 .cloned()
                 .collect();

--- a/gix-prompt/Cargo.toml
+++ b/gix-prompt/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project for handling prompts in the termi
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project for implementing git protocols"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "!**/tests/**/*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-protocol/src/fetch/negotiate.rs
+++ b/gix-protocol/src/fetch/negotiate.rs
@@ -181,7 +181,7 @@ where
         {
             remote_ref_target_known[mapping_idx] = true;
             cutoff_date = cutoff_date.unwrap_or_default().max(commit.commit_time).into();
-        } else if want_id.map_or(false, |maybe_annotated_tag| objects.exists(maybe_annotated_tag)) {
+        } else if want_id.is_some_and(|maybe_annotated_tag| objects.exists(maybe_annotated_tag)) {
             remote_ref_target_known[mapping_idx] = true;
         }
     }
@@ -263,12 +263,12 @@ pub fn make_refmapping_ignore_predicate(fetch_tags: Tags, ref_map: &RefMap) -> i
         .then(|| fetch_tags.to_refspec())
         .flatten();
     move |mapping| {
-        tag_refspec_to_ignore.map_or(false, |tag_spec| {
+        tag_refspec_to_ignore.is_some_and(|tag_spec| {
             mapping
                 .spec_index
                 .implicit_index()
                 .and_then(|idx| ref_map.extra_refspecs.get(idx))
-                .map_or(false, |spec| spec.to_ref() == tag_spec)
+                .is_some_and(|spec| spec.to_ref() == tag_spec)
         })
     }
 }

--- a/gix-quote/Cargo.toml
+++ b/gix-quote/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing with various quotations used by git"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-rebase/Cargo.toml
+++ b/gix-rebase/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing rebases"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate to handle git references"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 autotests = false
 
 [lib]

--- a/gix-ref/src/store/file/find.rs
+++ b/gix-ref/src/store/file/find.rs
@@ -232,7 +232,7 @@ impl file::Store {
                     MainRef | MainPseudoRef => (commondir.into(), sn),
                     LinkedRef { name: worktree_name } => sn
                         .category()
-                        .map_or(false, |cat| cat.is_worktree_private())
+                        .is_some_and(|cat| cat.is_worktree_private())
                         .then(|| {
                             if is_reflog {
                                 (linked_git_dir(worktree_name).into(), sn)

--- a/gix-ref/src/store/file/loose/iter.rs
+++ b/gix-ref/src/store/file/loose/iter.rs
@@ -37,7 +37,7 @@ impl Iterator for SortedLoosePaths {
         for entry in self.file_walk.as_mut()?.by_ref() {
             match entry {
                 Ok(entry) => {
-                    if !entry.file_type().map_or(false, |ft| ft.is_file()) {
+                    if !entry.file_type().is_ok_and(|ft| ft.is_file()) {
                         continue;
                     }
                     let full_path = entry.path().into_owned();

--- a/gix-ref/src/store/file/overlay_iter.rs
+++ b/gix-ref/src/store/file/overlay_iter.rs
@@ -118,7 +118,7 @@ impl Iterator for LooseThenPacked<'_, '_> {
     fn next(&mut self) -> Option<Self::Item> {
         fn advance_to_non_private(iter: &mut Peekable<SortedLoosePaths>) {
             while let Some(Ok((_path, name))) = iter.peek() {
-                if name.category().map_or(false, |cat| cat.is_worktree_private()) {
+                if name.category().is_some_and(|cat| cat.is_worktree_private()) {
                     iter.next();
                 } else {
                     break;

--- a/gix-ref/src/store/file/transaction/prepare.rs
+++ b/gix-ref/src/store/file/transaction/prepare.rs
@@ -430,7 +430,7 @@ fn possibly_adjust_name_for_prefixes(name: &FullNameRef) -> Option<FullName> {
                 Tag | LocalBranch | RemoteBranch | Note => name.into(),
                 MainRef | LinkedRef { .. } => sn
                     .category()
-                    .map_or(false, |cat| !cat.is_worktree_private())
+                    .is_some_and(|cat| !cat.is_worktree_private())
                     .then_some(sn),
             }
             .map(ToOwned::to_owned)

--- a/gix-ref/tests/Cargo.toml
+++ b/gix-ref/tests/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 description = "Test the gix-ref crate with feature toggles"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [features]
 gix-features-parallel = ["gix-features/parallel"] # test sorted parallel loose file traversal

--- a/gix-refspec/Cargo.toml
+++ b/gix-refspec/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project for parsing and representing refs
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project dealing with finding names for re
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-revision/src/merge_base/function.rs
+++ b/gix-revision/src/merge_base/function.rs
@@ -162,11 +162,10 @@ fn paint_down_to_common(
     }
 
     let mut out = Vec::new();
-    while queue.iter_unordered().any(|id| {
-        graph
-            .get(id)
-            .map_or(false, |commit| !commit.data.contains(Flags::STALE))
-    }) {
+    while queue
+        .iter_unordered()
+        .any(|id| graph.get(id).is_some_and(|commit| !commit.data.contains(Flags::STALE)))
+    {
         let (info, commit_id) = queue.pop().expect("we have non-stale");
         let commit = graph.get_mut(&commit_id).expect("everything queued is in graph");
         let mut flags_without_result = commit.data & (Flags::COMMIT1 | Flags::COMMIT2 | Flags::STALE);

--- a/gix-revision/src/spec/parse/function.rs
+++ b/gix-revision/src/spec/parse/function.rs
@@ -355,7 +355,7 @@ where
                 if *pos != 0 && (next, next_next) == (Some(&b'.'), Some(&b'.')) {
                     return false;
                 }
-                next == Some(&b'{') || next.map_or(false, |b| SEPARATORS.contains(b))
+                next == Some(&b'{') || next.is_some_and(|b| SEPARATORS.contains(b))
             } else if SEPARATORS.contains(b) {
                 true
             } else {

--- a/gix-revwalk/Cargo.toml
+++ b/gix-revwalk/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate providing utilities for walking the revision graph"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-sec/Cargo.toml
+++ b/gix-sec/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project providing a shared trust model"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-sequencer/Cargo.toml
+++ b/gix-sequencer/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project handling sequences of human-aided operations"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-shallow/Cargo.toml
+++ b/gix-shallow/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 description = "Handle files specifying the shallow boundary"
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project dealing with 'git status'-like fu
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>", "Pascal Kuthe <pascal.kuthe@semimod.de>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 autotests = false
 
 [lib]

--- a/gix-status/src/index_as_worktree/function.rs
+++ b/gix-status/src/index_as_worktree/function.rs
@@ -277,7 +277,7 @@ impl<'index> State<'_, 'index> {
                     self.attr_stack
                         .set_case(case)
                         .at_entry(relative_path, Some(is_dir_to_mode(is_dir)), objects)
-                        .map_or(false, |platform| platform.matching_attributes(out))
+                        .is_ok_and(|platform| platform.matching_attributes(out))
                 },
             )
             .map_or(true, |m| m.is_excluded());

--- a/gix-status/src/index_as_worktree_with_renames/mod.rs
+++ b/gix-status/src/index_as_worktree_with_renames/mod.rs
@@ -101,7 +101,7 @@ pub(super) mod function {
                                             stack
                                                 .set_case(case)
                                                 .at_entry(relative_path, Some(is_dir_to_mode(is_dir)), &objects)
-                                                .map_or(false, |platform| platform.matching_attributes(out))
+                                                .is_ok_and(|platform| platform.matching_attributes(out))
                                         },
                                         excludes: excludes.as_mut(),
                                         objects: &objects,

--- a/gix-status/tests/Cargo.toml
+++ b/gix-status/tests/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate to drive gix-status tests with different features"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>", "Pascal Kuthe <pascal.kuthe@semimod.de>"]
 edition = "2021"
 publish = false
-rust-version = "1.65"
+rust-version = "1.70"
 
 [[test]]
 name = "status"

--- a/gix-submodule/Cargo.toml
+++ b/gix-submodule/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing git submodules"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-submodule/src/is_active_platform.rs
+++ b/gix-submodule/src/is_active_platform.rs
@@ -40,7 +40,7 @@ impl IsActivePlatform {
         if let Some(val) = self.search.as_mut().map(|search| {
             search
                 .pattern_matching_relative_path(name, Some(true), attributes)
-                .map_or(false, |m| !m.is_excluded())
+                .is_some_and(|m| !m.is_excluded())
         }) {
             return Ok(val);
         }

--- a/gix-tempfile/Cargo.toml
+++ b/gix-tempfile/Cargo.toml
@@ -9,7 +9,7 @@ description = "A tempfile implementation with a global registry to assure cleanu
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [[example]]
 name = "delete-tempfiles-on-sigterm"

--- a/gix-tempfile/src/registry.rs
+++ b/gix-tempfile/src/registry.rs
@@ -21,10 +21,7 @@ pub fn cleanup_tempfiles_signal_safe() {
         for idx in 0..one_past_last_index {
             if let Some(entry) = REGISTRY.try_entry(idx) {
                 entry.and_modify(|tempfile| {
-                    if tempfile
-                        .as_ref()
-                        .map_or(false, |tf| tf.owning_process_id == current_pid)
-                    {
+                    if tempfile.as_ref().is_some_and(|tf| tf.owning_process_id == current_pid) {
                         if let Some(tempfile) = tempfile.take() {
                             tempfile.drop_without_deallocation();
                         }
@@ -55,7 +52,7 @@ pub fn cleanup_tempfiles() {
     let current_pid = std::process::id();
     #[cfg(feature = "hp-hashmap")]
     REGISTRY.iter_mut().for_each(|mut tf| {
-        if tf.as_ref().map_or(false, |tf| tf.owning_process_id == current_pid) {
+        if tf.as_ref().is_some_and(|tf| tf.owning_process_id == current_pid) {
             tf.take();
         }
     });

--- a/gix-tix/Cargo.toml
+++ b/gix-tix/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A tool like `tig`, but minimal, fast and efficient"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-trace/Cargo.toml
+++ b/gix-trace/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.11"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project dedicated to implementing the git
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-transport/src/client/blocking_io/http/mod.rs
+++ b/gix-transport/src/client/blocking_io/http/mod.rs
@@ -281,7 +281,7 @@ impl<H: Http> Transport<H> {
         let wanted_content_type = format!("application/x-{}-{}", service.as_str(), kind);
         if !headers.lines().collect::<Result<Vec<_>, _>>()?.iter().any(|l| {
             let mut tokens = l.split(':');
-            tokens.next().zip(tokens.next()).map_or(false, |(name, value)| {
+            tokens.next().zip(tokens.next()).is_some_and(|(name, value)| {
                 name.eq_ignore_ascii_case("content-type") && value.trim() == wanted_content_type
             })
         }) {

--- a/gix-transport/src/client/blocking_io/http/reqwest/remote.rs
+++ b/gix-transport/src/client/blocking_io/http/reqwest/remote.rs
@@ -27,7 +27,7 @@ impl crate::IsSpuriousError for Error {
     fn is_spurious(&self) -> bool {
         match self {
             Error::Reqwest(err) => {
-                err.is_timeout() || err.is_connect() || err.status().map_or(false, |status| status.is_server_error())
+                err.is_timeout() || err.is_connect() || err.status().is_some_and(|status| status.is_server_error())
             }
             _ => false,
         }

--- a/gix-transport/src/client/blocking_io/ssh/mod.rs
+++ b/gix-transport/src/client/blocking_io/ssh/mod.rs
@@ -125,7 +125,7 @@ pub fn connect(
                 }),
         );
         gix_features::trace::debug!(cmd = ?cmd, "invoking `ssh` for feature check");
-        kind = if cmd.status().ok().map_or(false, |status| status.success()) {
+        kind = if cmd.status().ok().is_some_and(|status| status.success()) {
             ProgramKind::Ssh
         } else {
             ProgramKind::Simple

--- a/gix-traverse/Cargo.toml
+++ b/gix-traverse/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 autotests = false
 
 [lib]

--- a/gix-traverse/tests/Cargo.toml
+++ b/gix-traverse/tests/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "Integration tests for the gix-traverse crate"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [[test]]
 name = "traverse"

--- a/gix-tui/Cargo.toml
+++ b/gix-tui/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dedicated to a terminal user interface to interact with git repositories"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 
 [[bin]]
 name = "gixi"

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project implementing parsing and serializ
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*", "tests/baseline/**/*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-utils/Cargo.toml
+++ b/gix-utils/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate with `gitoxide` utilities that don't need feature toggles"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-validate/Cargo.toml
+++ b/gix-validate/Cargo.toml
@@ -9,7 +9,7 @@ description = "Validation functions for various kinds of names in git"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix-validate/src/path.rs
+++ b/gix-validate/src/path.rs
@@ -150,21 +150,21 @@ fn is_win_device(input: &BStr) -> bool {
     // Hence, justification for this asymmetry is merely to do exactly the same as Git does,
     // and to have exactly the same behaviour during validation (for worktree-writes).
     if in3.eq_ignore_ascii_case(b"COM")
-        && input.get(3).map_or(false, |n| *n >= b'1' && *n <= b'9')
+        && input.get(3).is_some_and(|n| *n >= b'1' && *n <= b'9')
         && is_done_windows(input.get(4..))
     {
         return true;
     }
     if in3.eq_ignore_ascii_case(b"LPT")
-        && input.get(3).map_or(false, u8::is_ascii_digit)
+        && input.get(3).is_some_and(u8::is_ascii_digit)
         && is_done_windows(input.get(4..))
     {
         return true;
     }
     if in3.eq_ignore_ascii_case(b"CON")
         && (is_done_windows(input.get(3..))
-            || (input.get(3..6).map_or(false, |n| n.eq_ignore_ascii_case(b"IN$")) && is_done_windows(input.get(6..)))
-            || (input.get(3..7).map_or(false, |n| n.eq_ignore_ascii_case(b"OUT$")) && is_done_windows(input.get(7..))))
+            || (input.get(3..6).is_some_and(|n| n.eq_ignore_ascii_case(b"IN$")) && is_done_windows(input.get(6..)))
+            || (input.get(3..7).is_some_and(|n| n.eq_ignore_ascii_case(b"OUT$")) && is_done_windows(input.get(7..))))
     {
         return true;
     }
@@ -231,16 +231,10 @@ fn is_dot_hfs(input: &BStr, search_case_insensitive: &str) -> bool {
 }
 
 fn is_dot_git_ntfs(input: &BStr) -> bool {
-    if input
-        .get(..4)
-        .map_or(false, |input| input.eq_ignore_ascii_case(b".git"))
-    {
+    if input.get(..4).is_some_and(|input| input.eq_ignore_ascii_case(b".git")) {
         return is_done_ntfs(input.get(4..));
     }
-    if input
-        .get(..5)
-        .map_or(false, |input| input.eq_ignore_ascii_case(b"git~1"))
-    {
+    if input.get(..5).is_some_and(|input| input.eq_ignore_ascii_case(b"git~1")) {
         return is_done_ntfs(input.get(5..));
     }
     false
@@ -253,9 +247,10 @@ fn is_dot_git_ntfs(input: &BStr) -> bool {
 fn is_dot_ntfs(input: &BStr, search_case_insensitive: &str, ntfs_shortname_prefix: &str) -> bool {
     if input.first() == Some(&b'.') {
         let end_pos = 1 + search_case_insensitive.len();
-        if input.get(1..end_pos).map_or(false, |input| {
-            input.eq_ignore_ascii_case(search_case_insensitive.as_bytes())
-        }) {
+        if input
+            .get(1..end_pos)
+            .is_some_and(|input| input.eq_ignore_ascii_case(search_case_insensitive.as_bytes()))
+        {
             is_done_ntfs(input.get(end_pos..))
         } else {
             false
@@ -265,12 +260,12 @@ fn is_dot_ntfs(input: &BStr, search_case_insensitive: &str, ntfs_shortname_prefi
         if search_case_insensitive
             .get(..6)
             .zip(input.get(..6))
-            .map_or(false, |(ntfs_prefix, first_6_of_input)| {
+            .is_some_and(|(ntfs_prefix, first_6_of_input)| {
                 first_6_of_input.eq_ignore_ascii_case(ntfs_prefix)
                     && input.get(6) == Some(&b'~')
                     // It's notable that only `~1` to `~4` are possible before the disambiguation algorithm
                     // switches to using the `ntfs_shortname_prefix`, which is checked hereafter.
-                    && input.get(7).map_or(false, |num| (b'1'..=b'4').contains(num))
+                    && input.get(7).is_some_and(|num| (b'1'..=b'4').contains(num))
             })
         {
             return is_done_ntfs(input.get(8..));

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project implementing setting the worktree
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 autotests = false
 
 [lib]

--- a/gix-worktree-state/tests/Cargo.toml
+++ b/gix-worktree-state/tests/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate for running tests with feature toggles on gix-worktree-st
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 publish = false
-rust-version = "1.65"
+rust-version = "1.70"
 
 [[test]]
 name = "worktree"

--- a/gix-worktree-stream/Cargo.toml
+++ b/gix-worktree-stream/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "generate a byte-stream from a git-tree"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project for shared worktree related types
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 autotests = false
 
 [lib]

--- a/gix-worktree/src/stack/platform.rs
+++ b/gix-worktree/src/stack/platform.rs
@@ -23,7 +23,7 @@ impl<'a> Platform<'a> {
     #[doc(alias = "is_path_ignored", alias = "git2")]
     pub fn is_excluded(&self) -> bool {
         self.matching_exclude_pattern()
-            .map_or(false, |m| !m.pattern.is_negative())
+            .is_some_and(|m| !m.pattern.is_negative())
     }
 
     /// See if a non-negative ignore-pattern matches and obtain the kind of exclude, or return `None`

--- a/gix-worktree/tests/Cargo.toml
+++ b/gix-worktree/tests/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate for testing the gix-worktree crate with feature toggles"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.70"
 publish = false
 
 [[test]]

--- a/gix-worktree/tests/worktree/stack/ignore.rs
+++ b/gix-worktree/tests/worktree/stack/ignore.rs
@@ -159,7 +159,7 @@ fn check_against_baseline() -> crate::Result {
                     );
                 }
                 // Paths read from the index are relative to the repo, and they don't exist locally due tot skip-worktree
-                if m.source.map_or(false, std::path::Path::exists) {
+                if m.source.is_some_and(std::path::Path::exists) {
                     assert_eq!(
                         m.source.map(|p| p.canonicalize().unwrap()),
                         Some(worktree_dir.join(source_file.to_str_lossy().as_ref()).canonicalize()?)

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.69.1"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [lib]
 doctest = false

--- a/gix/src/pathspec.rs
+++ b/gix/src/pathspec.rs
@@ -135,7 +135,7 @@ impl<'repo> Pathspec<'repo> {
                 stack
                     .set_case(case)
                     .at_entry(relative_path, Some(is_dir_to_mode(is_dir)), &self.repo.objects)
-                    .map_or(false, |platform| platform.matching_attributes(out))
+                    .is_ok_and(|platform| platform.matching_attributes(out))
             },
         )
     }
@@ -144,7 +144,7 @@ impl<'repo> Pathspec<'repo> {
     /// `true` if `relative_path` is included in the set of positive pathspecs, while not being excluded.
     pub fn is_included<'a>(&mut self, relative_path: impl Into<&'a BStr>, is_dir: Option<bool>) -> bool {
         self.pattern_matching_relative_path(relative_path, is_dir)
-            .map_or(false, |m| !m.is_excluded())
+            .is_some_and(|m| !m.is_excluded())
     }
 
     /// Return an iterator over all entries along with their path if the path matches the pathspec, or `None` if the pathspec is
@@ -189,7 +189,7 @@ impl PathspecDetached {
                 stack
                     .set_case(case)
                     .at_entry(relative_path, Some(is_dir_to_mode(is_dir)), &self.odb)
-                    .map_or(false, |platform| platform.matching_attributes(out))
+                    .is_ok_and(|platform| platform.matching_attributes(out))
             },
         )
     }
@@ -198,7 +198,7 @@ impl PathspecDetached {
     /// `true` if `relative_path` is included in the set of positive pathspecs, while not being excluded.
     pub fn is_included<'a>(&mut self, relative_path: impl Into<&'a BStr>, is_dir: Option<bool>) -> bool {
         self.pattern_matching_relative_path(relative_path, is_dir)
-            .map_or(false, |m| !m.is_excluded())
+            .is_some_and(|m| !m.is_excluded())
     }
 }
 

--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -90,7 +90,7 @@ pub(crate) fn update(
                     remote,
                     local,
                     spec,
-                    implicit_tag_refspec.map_or(false, |tag_spec| spec.to_ref() == tag_spec),
+                    implicit_tag_refspec.is_some_and(|tag_spec| spec.to_ref() == tag_spec),
                 )
             })
         },
@@ -170,7 +170,7 @@ pub(crate) fn update(
                                                 });
                                             match ancestors {
                                                 Ok(mut ancestors) => {
-                                                    ancestors.any(|cid| cid.map_or(false, |c| c.id == local_id))
+                                                    ancestors.any(|cid| cid.is_ok_and(|c| c.id == local_id))
                                                 }
                                                 Err(_) => {
                                                     force = true;

--- a/gix/src/repository/dirwalk.rs
+++ b/gix/src/repository/dirwalk.rs
@@ -92,7 +92,7 @@ impl Repository {
                     stack
                         .set_case(case)
                         .at_entry(relative_path, Some(is_dir_to_mode(is_dir)), &self.objects)
-                        .map_or(false, |platform| platform.matching_attributes(out))
+                        .is_ok_and(|platform| platform.matching_attributes(out))
                 },
                 excludes: Some(&mut excludes.inner),
                 objects: &self.objects,

--- a/gix/src/repository/shallow.rs
+++ b/gix/src/repository/shallow.rs
@@ -5,9 +5,7 @@ use crate::{config::tree::gitoxide, Repository};
 impl Repository {
     /// Return `true` if the repository is a shallow clone, i.e. contains history only up to a certain depth.
     pub fn is_shallow(&self) -> bool {
-        self.shallow_file()
-            .metadata()
-            .map_or(false, |m| m.is_file() && m.len() > 0)
+        self.shallow_file().metadata().is_ok_and(|m| m.is_file() && m.len() > 0)
     }
 
     /// Return a shared list of shallow commits which is updated automatically if the in-memory snapshot has become stale

--- a/gix/src/repository/worktree.rs
+++ b/gix/src/repository/worktree.rs
@@ -2,12 +2,17 @@ use crate::{worktree, Worktree};
 
 /// Interact with individual worktrees and their information.
 impl crate::Repository {
-    /// Return a list of all _linked_ worktrees sorted by private git dir path as a lightweight proxy.
+    /// Return a list of all **linked** worktrees sorted by private git dir path as a lightweight proxy.
+    ///
+    /// This means the number is `0` even if there is the main worktree, as it is not counted as linked worktree.
+    /// This also means it will be `1` if there is one linked worktree next to the main worktree.
+    /// It's worth noting that a *bare* repository may have one or more linked worktrees, but has no *main* worktree,
+    /// which is the reason why the *possibly* available main worktree isn't listed here.
     ///
     /// Note that these need additional processing to become usable, but provide a first glimpse a typical worktree information.
     pub fn worktrees(&self) -> std::io::Result<Vec<worktree::Proxy<'_>>> {
         let mut res = Vec::new();
-        let iter = match std::fs::read_dir(self.common_dir().join("worktrees")) {
+        let iter = match std::fs::read_dir(dbg!(self.common_dir()).join("worktrees")) {
             Ok(iter) => iter,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(res),
             Err(err) => return Err(err),

--- a/gix/src/revision/spec/parse/delegate/navigate.rs
+++ b/gix/src/revision/spec/parse/delegate/navigate.rs
@@ -242,7 +242,7 @@ impl delegate::Navigate for Delegate<'_> {
                                     .peeled()
                                     .ok()?
                                     .filter_map(Result::ok)
-                                    .filter(|r| r.id().header().ok().map_or(false, |obj| obj.kind().is_commit()))
+                                    .filter(|r| r.id().header().ok().is_some_and(|obj| obj.kind().is_commit()))
                                     .filter_map(|r| r.detach().peeled),
                             )
                             .sorting(crate::revision::walk::Sorting::ByCommitTime(Default::default()))
@@ -335,7 +335,7 @@ impl delegate::Navigate for Delegate<'_> {
                     let exists = self
                         .repo
                         .work_dir()
-                        .map_or(false, |root| root.join(gix_path::from_bstr(path)).exists());
+                        .is_some_and(|root| root.join(gix_path::from_bstr(path)).exists());
                     self.err.push(Error::IndexLookup {
                         desired_path: path.into(),
                         desired_stage: stage,

--- a/gix/src/status/index_worktree.rs
+++ b/gix/src/status/index_worktree.rs
@@ -169,7 +169,7 @@ impl Repository {
     where
         E: From<crate::repository::attributes::Error> + From<crate::pathspec::init::Error>,
     {
-        let empty_patterns_match_prefix = options.map_or(false, |opts| opts.empty_patterns_match_prefix);
+        let empty_patterns_match_prefix = options.is_some_and(|opts| opts.empty_patterns_match_prefix);
         let attrs_and_excludes = self.attributes(
             index,
             crate::worktree::stack::state::attributes::Source::WorktreeThenIdMapping,
@@ -264,7 +264,7 @@ mod submodule_status {
             let Ok(Some(mut submodules)) = repo.submodules() else {
                 return Ok(None);
             };
-            let Some(sm) = submodules.find(|sm| sm.path().map_or(false, |path| path == rela_path)) else {
+            let Some(sm) = submodules.find(|sm| sm.path().is_ok_and(|path| path == rela_path)) else {
                 return Ok(None);
             };
             let (ignore, check_dirty) = match self.mode {

--- a/gix/src/status/iter/types.rs
+++ b/gix/src/status/iter/types.rs
@@ -77,7 +77,7 @@ impl Outcome {
     /// If they are not written back, subsequent `status` operations will take longer to complete, whereas the
     /// additional work can be prevented by writing the changes back to the index.
     pub fn has_changes(&self) -> bool {
-        self.changes.as_ref().map_or(false, |changes| !changes.is_empty())
+        self.changes.as_ref().is_some_and(|changes| !changes.is_empty())
     }
 
     /// Write the changes if there are any back to the index file.

--- a/gix/src/status/tree_index.rs
+++ b/gix/src/status/tree_index.rs
@@ -131,7 +131,7 @@ impl Repository {
                         Some(crate::pathspec::is_dir_to_mode(is_dir)),
                         &pathspec.repo.objects,
                     )
-                    .map_or(false, |platform| platform.matching_attributes(out))
+                    .is_ok_and(|platform| platform.matching_attributes(out))
             },
         )?;
 

--- a/gix/src/submodule/mod.rs
+++ b/gix/src/submodule/mod.rs
@@ -155,7 +155,7 @@ impl Submodule<'_> {
                 attributes
                     .set_case(case)
                     .at_entry(relative_path, Some(is_dir_to_mode(is_dir)), &self.state.repo.objects)
-                    .map_or(false, |platform| platform.matching_attributes(out))
+                    .is_ok_and(|platform| platform.matching_attributes(out))
             }
         })?;
         Ok(is_active)
@@ -417,7 +417,7 @@ pub mod status {
                 return None;
             }
             let is_dirty =
-                self.checked_out_head_id != self.index_id || self.changes.as_ref().map_or(false, |c| !c.is_empty());
+                self.checked_out_head_id != self.index_id || self.changes.as_ref().is_some_and(|c| !c.is_empty());
             Some(is_dirty)
         }
     }

--- a/gix/tests/fixtures/generated-archives/.gitignore
+++ b/gix/tests/fixtures/generated-archives/.gitignore
@@ -7,3 +7,4 @@
 /make_core_worktree_repo.tar
 /make_signatures_repo.tar
 /make_diff_repos.tar
+/make_submodule_with_worktree.tar

--- a/gix/tests/fixtures/make_submodule_with_worktree.sh
+++ b/gix/tests/fixtures/make_submodule_with_worktree.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+git init -q module1
+(cd module1
+  touch this
+  git add . && git commit -q -m c1
+)
+
+git init submodule-with-extra-worktree-host
+(cd submodule-with-extra-worktree-host
+  git submodule add ../module1 m1
+  (cd m1
+    git worktree add ../../worktree-of-submodule
+  )
+)

--- a/gix/tests/gix/clone.rs
+++ b/gix/tests/gix/clone.rs
@@ -677,7 +677,7 @@ mod blocking_io {
                 .handshake
                 .capabilities
                 .capability("ls-refs")
-                .map_or(false, |cap| cap.supports("unborn").unwrap_or(false));
+                .is_some_and(|cap| cap.supports("unborn").unwrap_or(false));
             if supports_unborn {
                 assert_eq!(
                     head.referent_name().expect("present").as_bstr(),

--- a/gix/tests/gix/remote/fetch.rs
+++ b/gix/tests/gix/remote/fetch.rs
@@ -457,10 +457,10 @@ mod blocking_and_async_io {
                     assert_eq!(negotiate.rounds.len(), 1);
                     assert_eq!(write_pack_bundle.index.data_hash, hex_to_id(expected_data_hash), );
                     assert_eq!(write_pack_bundle.index.num_objects, 3 + num_objects_offset, "{fetch_tags:?}");
-                    assert!(write_pack_bundle.data_path.as_deref().map_or(false, std::path::Path::is_file));
-                    assert!(write_pack_bundle.index_path.as_deref().map_or(false, std::path::Path::is_file));
+                    assert!(write_pack_bundle.data_path.as_deref().is_some_and(std::path::Path::is_file));
+                    assert!(write_pack_bundle.index_path.as_deref().is_some_and(std::path::Path::is_file));
                     assert_eq!(update_refs.edits.len(), expected_ref_edits, "{fetch_tags:?}");
-                    assert_eq!(write_pack_bundle.keep_path.as_deref().map_or(false, std::path::Path::is_file), update_refs.edits.is_empty(),".keep are kept if there was no edit to prevent `git gc` from clearing out the pack as it's not referred to necessarily");
+                    assert_eq!(write_pack_bundle.keep_path.as_deref().is_some_and(std::path::Path::is_file), update_refs.edits.is_empty(),".keep are kept if there was no edit to prevent `git gc` from clearing out the pack as it's not referred to necessarily");
                 },
                 _ => unreachable!("Naive negotiation sends the same have and wants, resulting in an empty pack (technically no change, but we don't detect it) - empty packs are fine")
             }
@@ -547,8 +547,8 @@ mod blocking_and_async_io {
                             write_pack_bundle.index.index_hash,
                             hex_to_id("d07c527cf14e524a8494ce6d5d08e28079f5c6ea")
                         );
-                        assert!(write_pack_bundle.data_path.map_or(false, |f| f.is_file()));
-                        assert!(write_pack_bundle.index_path.map_or(false, |f| f.is_file()));
+                        assert!(write_pack_bundle.data_path.is_some_and(|f| f.is_file()));
+                        assert!(write_pack_bundle.index_path.is_some_and(|f| f.is_file()));
                         assert_eq!(update_refs.edits.len(), 2);
 
                         let edit = &update_refs.edits[0];
@@ -578,7 +578,7 @@ mod blocking_and_async_io {
                         }
 
                         assert!(
-                            !write_pack_bundle.keep_path.map_or(false, |f| f.is_file()),
+                            !write_pack_bundle.keep_path.is_some_and(|f| f.is_file()),
                             ".keep files are deleted if there is one edit"
                         );
 

--- a/gix/tests/gix/submodule.rs
+++ b/gix/tests/gix/submodule.rs
@@ -358,6 +358,29 @@ mod open {
             wd.join("this").is_file(),
             "The submodule itself has the file, so it should be in the worktree"
         );
+
+        assert_eq!(sm_repo.worktrees()?.len(), 1, "only a single linked worktree");
+        Ok(())
+    }
+
+    #[test]
+    fn list_submodule_worktrees() -> crate::Result {
+        let sm_repo = named_subrepo_opts(
+            "make_submodule_with_worktree.sh",
+            "submodule-with-extra-worktree-host/m1",
+            gix::open::Options::isolated(),
+        )?;
+        let wd = sm_repo.work_dir().expect("workdir is present");
+        assert!(
+            sm_repo.rev_parse_single(":this").is_ok(),
+            "the file is in the submodule"
+        );
+        assert!(
+            wd.join("this").is_file(),
+            "The submodule itself has the file, so it should be in the worktree"
+        );
+
+        assert_eq!(sm_repo.worktrees()?.len(), 1, "only a single linked worktree");
         Ok(())
     }
 

--- a/gix/tests/gix/submodule.rs
+++ b/gix/tests/gix/submodule.rs
@@ -11,7 +11,6 @@ mod open {
     use gix::submodule;
 
     use crate::submodule::repo;
-    use crate::util::named_subrepo_opts;
 
     #[test]
     fn various() -> crate::Result {
@@ -343,8 +342,9 @@ mod open {
     }
 
     #[test]
+    #[cfg(feature = "revision")]
     fn submodule_worktrees() -> crate::Result {
-        let sm_repo = named_subrepo_opts(
+        let sm_repo = crate::util::named_subrepo_opts(
             "make_submodule_with_worktree.sh",
             "worktree-of-submodule",
             gix::open::Options::isolated(),
@@ -364,8 +364,9 @@ mod open {
     }
 
     #[test]
+    #[cfg(feature = "revision")]
     fn list_submodule_worktrees() -> crate::Result {
-        let sm_repo = named_subrepo_opts(
+        let sm_repo = crate::util::named_subrepo_opts(
             "make_submodule_with_worktree.sh",
             "submodule-with-extra-worktree-host/m1",
             gix::open::Options::isolated(),

--- a/gix/tests/gix/submodule.rs
+++ b/gix/tests/gix/submodule.rs
@@ -11,6 +11,7 @@ mod open {
     use gix::submodule;
 
     use crate::submodule::repo;
+    use crate::util::named_subrepo_opts;
 
     #[test]
     fn various() -> crate::Result {
@@ -338,6 +339,25 @@ mod open {
         assert!(sm.open()?.is_some(), "repo available as it was cloned");
         assert!(sm.index_id()?.is_none(), "no actual submodule");
         assert!(sm.head_id()?.is_none(), "no actual submodule");
+        Ok(())
+    }
+
+    #[test]
+    fn submodule_worktrees() -> crate::Result {
+        let sm_repo = named_subrepo_opts(
+            "make_submodule_with_worktree.sh",
+            "worktree-of-submodule",
+            gix::open::Options::isolated(),
+        )?;
+        let wd = sm_repo.work_dir().expect("workdir is present");
+        assert!(
+            sm_repo.rev_parse_single(":this").is_ok(),
+            "the file is in the submodule"
+        );
+        assert!(
+            wd.join("this").is_file(),
+            "The submodule itself has the file, so it should be in the worktree"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
Previously they would use a very incorrect worktree which would cause the status to be calculated very wrongly.

Fixes #1759 .


### Tasks

* [x] reproduce the issue
* [x] fix it
