### PR TITLE
Add `gix blame -L start,end`

### DIFF
--- a/gitoxide-core/src/repository/blame.rs
+++ b/gitoxide-core/src/repository/blame.rs
@@ -5,6 +5,7 @@ use std::ffi::OsStr;
 pub fn blame_file(
     mut repo: gix::Repository,
     file: &OsStr,
+    range: Option<std::ops::Range<u32>>,
     out: impl std::io::Write,
     err: Option<&mut dyn std::io::Write>,
 ) -> anyhow::Result<()> {
@@ -40,7 +41,7 @@ pub fn blame_file(
             .with_commit_graph(repo.commit_graph_if_enabled()?)
             .build()?;
     let mut resource_cache = repo.diff_resource_cache_for_tree_diff()?;
-    let outcome = gix::blame::file(&repo.objects, traverse, &mut resource_cache, file.as_bstr())?;
+    let outcome = gix::blame::file(&repo.objects, traverse, &mut resource_cache, file.as_bstr(), range)?;
     let statistics = outcome.statistics;
     write_blame_entries(out, outcome)?;
 

--- a/gix-blame/src/error.rs
+++ b/gix-blame/src/error.rs
@@ -27,4 +27,6 @@ pub enum Error {
     Traverse(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error(transparent)]
     DiffTree(#[from] gix_diff::tree::Error),
+    #[error("Invalid line range was given, line range is expected to be a 1-based inclusive range in the format '<start>,<end>'")]
+    InvalidLineRange,
 }

--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -25,6 +25,10 @@ use std::ops::Range;
 ///    - The first commit returned here is the first eligible commit to be responsible for parts of `file_path`.
 /// * `file_path`
 ///    - A *slash-separated* worktree-relative path to the file to blame.
+/// * `range`
+///    - A 1-based inclusive range, in order to mirror `git`’s behaviour. `Some(20..40)` represents
+///      21 lines, spanning from line 20 up to and including line 40. This will be converted to
+///      `19..40` internally as the algorithm uses 0-based ranges that are exclusive at the end.
 /// * `resource_cache`
 ///    - Used for diffing trees.
 ///
@@ -61,6 +65,7 @@ pub fn file<E>(
     traverse: impl IntoIterator<Item = Result<gix_traverse::commit::Info, E>>,
     resource_cache: &mut gix_diff::blob::Platform,
     file_path: &BStr,
+    range: Option<Range<u32>>,
 ) -> Result<Outcome, Error>
 where
     E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
@@ -85,19 +90,37 @@ where
             .tokenize()
             .map(|token| interner.intern(token))
             .count()
-    };
+    } as u32;
 
     // Binary or otherwise empty?
     if num_lines_in_blamed == 0 {
         return Ok(Outcome::default());
     }
 
-    let mut hunks_to_blame = vec![{
-        let range_in_blamed_file = 0..num_lines_in_blamed as u32;
-        UnblamedHunk {
-            range_in_blamed_file: range_in_blamed_file.clone(),
-            suspects: [(suspect, range_in_blamed_file)].into(),
+    // This function assumes that `range` has 1-based inclusive line numbers and converts it to the
+    // format internally used: 0-based line numbers stored in ranges that are exclusive at the
+    // end.
+    let one_based_inclusive_to_zero_based_exclusive_range = || -> Result<Range<u32>, Error> {
+        if let Some(range) = range {
+            if range.start == 0 {
+                return Err(Error::InvalidLineRange);
+            }
+            let start = range.start - 1;
+            let end = range.end;
+            if start >= num_lines_in_blamed || end > num_lines_in_blamed || start == end {
+                return Err(Error::InvalidLineRange);
+            }
+            Ok(start..end)
+        } else {
+            Ok(0..num_lines_in_blamed)
         }
+    };
+
+    let range_in_blamed_file = one_based_inclusive_to_zero_based_exclusive_range()?;
+
+    let mut hunks_to_blame = vec![UnblamedHunk {
+        range_in_blamed_file: range_in_blamed_file.clone(),
+        suspects: [(suspect, range_in_blamed_file)].into(),
     }];
 
     let mut out = Vec::new();

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -194,6 +194,7 @@ macro_rules! mktest {
                 commits,
                 &mut resource_cache,
                 format!("{}.txt", $case).as_str().into(),
+                None,
             )?
             .entries;
 
@@ -254,6 +255,7 @@ fn diff_disparity() {
             commits,
             &mut resource_cache,
             format!("{case}.txt").as_str().into(),
+            None,
         )
         .unwrap()
         .entries;
@@ -265,6 +267,26 @@ fn diff_disparity() {
 
         assert_eq!(lines_blamed, baseline, "{case}");
     }
+}
+
+#[test]
+fn line_range() {
+    let Fixture {
+        odb,
+        mut resource_cache,
+        commits,
+    } = Fixture::new().unwrap();
+
+    let lines_blamed = gix_blame::file(&odb, commits, &mut resource_cache, "simple.txt".into(), Some(1..2))
+        .unwrap()
+        .entries;
+
+    assert_eq!(lines_blamed.len(), 2);
+
+    let git_dir = fixture_path().join(".git");
+    let baseline = Baseline::collect(git_dir.join("simple-lines-1-2.baseline")).unwrap();
+
+    assert_eq!(lines_blamed, baseline);
 }
 
 fn fixture_path() -> PathBuf {

--- a/gix-blame/tests/fixtures/make_blame_repo.sh
+++ b/gix-blame/tests/fixtures/make_blame_repo.sh
@@ -199,6 +199,7 @@ git commit -q -m c14.2
 git merge branch-that-has-one-of-the-changes || true
 
 git blame --porcelain simple.txt > .git/simple.baseline
+git blame --porcelain -L 1,2 simple.txt > .git/simple-lines-1-2.baseline
 git blame --porcelain multiline-hunks.txt > .git/multiline-hunks.baseline
 git blame --porcelain deleted-lines.txt > .git/deleted-lines.baseline
 git blame --porcelain deleted-lines-multiple-hunks.txt > .git/deleted-lines-multiple-hunks.baseline

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -1542,7 +1542,11 @@ pub fn main() -> Result<()> {
                 },
             ),
         },
-        Subcommands::Blame { statistics, file } => prepare_and_run(
+        Subcommands::Blame {
+            statistics,
+            file,
+            range,
+        } => prepare_and_run(
             "blame",
             trace,
             verbose,
@@ -1550,7 +1554,13 @@ pub fn main() -> Result<()> {
             progress_keep_open,
             None,
             move |_progress, out, err| {
-                core::repository::blame::blame_file(repository(Mode::Lenient)?, &file, out, statistics.then_some(err))
+                core::repository::blame::blame_file(
+                    repository(Mode::Lenient)?,
+                    &file,
+                    range,
+                    out,
+                    statistics.then_some(err),
+                )
             },
         ),
         Subcommands::Completions { shell, out_dir } => {

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -4,6 +4,8 @@ use clap_complete::Shell;
 use gitoxide_core as core;
 use gix::bstr::BString;
 
+use crate::shared::AsRange;
+
 #[derive(Debug, clap::Parser)]
 #[clap(name = "gix", about = "The git underworld", version = option_env!("GIX_VERSION"))]
 #[clap(subcommand_required = true)]
@@ -162,6 +164,9 @@ pub enum Subcommands {
         statistics: bool,
         /// The file to create the blame information for.
         file: std::ffi::OsString,
+        /// Only blame lines in the given 1-based inclusive range '<start>,<end>', e.g. '20,40'.
+        #[clap(short='L', value_parser=AsRange)]
+        range: Option<std::ops::Range<u32>>,
     },
     /// Generate shell completions to stdout or a directory.
     #[clap(visible_alias = "generate-completions", visible_alias = "shell-completions")]


### PR DESCRIPTION
This enables running blame for a portion of a file. This feature will be helful for debugging `gix blame`, in particular in the context of #1743.
