### PR TITLE
Reenable fuzzing PRs again (seems OK with new nightly)

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,46 @@
+name: CIFuzz
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/**'
+      - 'ci/**'
+      - 'etc/**'
+      - 'src/**'
+      - 'tests/**'
+      - 'cargo-*/**'
+      - 'gix*/**'
+      - '*.toml'
+      - Makefile
+  workflow_dispatch:
+
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: none  # The fuzzing actions don't use our github.token at all.
+
+    steps:
+      - name: Build Fuzzers
+        id: build
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        with:
+          oss-fuzz-project-name: gitoxide
+          language: rust
+
+      - name: Run Fuzzers
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        with:
+          oss-fuzz-project-name: gitoxide
+          language: rust
+          fuzz-seconds: 600
+
+      - name: Upload Crash
+        uses: actions/upload-artifact@v4
+        if: failure() && steps.build.outcome == 'success'
+        with:
+          name: artifacts
+          path: ./out/artifacts


### PR DESCRIPTION
This reverts commit a661a8a0ab94f956f9036dd41a87ed46a8282bfe ("deactivate fuzzing as it's not building anymore for unrelated reasons") from #1768. I'm not totally clear on the specific cause, but it [appeared to be serde-related](https://github.com/GitoxideLabs/gitoxide/actions/runs/12793249538/job/35665920198#step:4:426) as in previous failures that went away when a more current nightly build was used.

Whereas in the past this required changes in oss-fuzz to update the rust toolchain (https://github.com/EliahKagan/gitoxide/pull/1, https://github.com/google/oss-fuzz/pull/12512, https://github.com/GitoxideLabs/gitoxide/pull/1596), this time it looks like all that was required was to wait for a new nightly build. I say this based on testing in https://github.com/EliahKagan/gitoxide/pull/8, with [these results](https://github.com/EliahKagan/gitoxide/actions/runs/12841676362/job/35812374129) run three times.

I think that may, at least in principle, not be exactly equivalent to running it from here. So I waited for it to complete before marking this as ready to review (the fuzzing job is not a required check, so auto-merge would not wait for it). It [passes here](https://github.com/GitoxideLabs/gitoxide/actions/runs/12842184518/job/35812781634?pr=1776) as well.