### PR TITLE
Test GNU/Linux ARM builds on the new ARM CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,9 +204,11 @@ jobs:
         container-arch: [ i386, arm32v7 ]
         include:
           - container-arch: i386
+            runner-arch: amd64
             runner-os: ubuntu-latest
             toolchain: stable-i686-unknown-linux-gnu
           - container-arch: arm32v7
+            runner-arch: arm64
             runner-os: ubuntu-24.04-arm
             toolchain: stable-armv7-unknown-linux-gnueabihf
       fail-fast: false  # FIXME: Probably remove this.
@@ -226,10 +228,10 @@ jobs:
             git
             jq
             libssl-dev
-            # libstdc++6:amd64  # To support external 64-bit Node.js for actions.
+            libstdc++6:${{ matrix.runner-arch }}  # To support external 64-bit Node.js for actions.
             pkgconf
           )
-          # dpkg --add-architecture amd64
+          dpkg --add-architecture ${{ matrix.runner-arch }}
           apt-get update
           apt-get install --no-install-recommends -y -- "${prerequisites[@]}"
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,6 @@ jobs:
             runner-arch: arm64
             runner-os: ubuntu-24.04-arm
             toolchain: stable-armv7-unknown-linux-gnueabihf
-      fail-fast: false  # FIXME: Probably remove this.
 
     runs-on: ${{ matrix.runner-os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,9 +199,21 @@ jobs:
             etc/test-fixtures-windows-expected-failures-see-issue-1358.txt actual-failures.txt
 
   test-32bit:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container-arch: [ i386, arm32v7 ]
+        include:
+          - container-arch: i386
+            runner-os: ubuntu-latest
+            toolchain: stable-i686-unknown-linux-gnu
+          - container-arch: arm32v7
+            runner-os: ubuntu-24.04-arm
+            toolchain: stable-armv7-unknown-linux-gnueabihf
+      fail-fast: false  # FIXME: Probably remove this.
 
-    container: i386/debian:stable-slim
+    runs-on: ${{ matrix.runner-os }}
+
+    container: ${{ matrix.container-arch }}/debian:stable-slim
 
     steps:
       - name: Prerequisites
@@ -214,17 +226,18 @@ jobs:
             git
             jq
             libssl-dev
-            libstdc++6:amd64  # To support external 64-bit Node.js for actions.
+            # libstdc++6:amd64  # To support external 64-bit Node.js for actions.
             pkgconf
           )
-          dpkg --add-architecture amd64
+          # dpkg --add-architecture amd64
           apt-get update
           apt-get install --no-install-recommends -y -- "${prerequisites[@]}"
         shell: bash
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable-i686-unknown-linux-gnu  # Otherwise it may misdetect based on the amd64 kernel.
+          # Avoid possible misdetection based on the 64-bit running kernel.
+          toolchain: ${{ matrix.toolchain }}
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
@@ -260,8 +273,9 @@ jobs:
         run: cross check -p gix --target ${{ matrix.target }}
       - name: Test (unit)
         run: |
-          # Run some high-level unit tests that exercise various pure Rust code to ease building test binaries.
-          # We would prefer `-p gix`. But with `cross`, fixture scripts try to run amd64 `git` as an armv7 binary.
+          # Run some high-level unit tests that exercise various pure Rust code to ease building
+          # test binaries. We would prefer `-p gix`. But with `cross`, fixture scripts try to run
+          # the host `git` as an armv7 binary.
           cross test -p gix-hashtable --target ${{ matrix.target }}
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
           - windows-latest
           - macos-latest
           - ubuntu-latest
+          - ubuntu-24.04-arm
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,35 +251,6 @@ jobs:
           GIX_TEST_IGNORE_ARCHIVES: '1'
         run: cargo nextest run --workspace --no-fail-fast
 
-  test-32bit-cross:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        target: [ armv7-linux-androideabi ]
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
-      - name: Install cross
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cross
-      - name: check
-        run: cross check -p gix --target ${{ matrix.target }}
-      - name: Test (unit)
-        run: |
-          # Run some high-level unit tests that exercise various pure Rust code to ease building
-          # test binaries. We would prefer `-p gix`. But with `cross`, fixture scripts try to run
-          # the host `git` as an armv7 binary.
-          cross test -p gix-hashtable --target ${{ matrix.target }}
-
   lint:
     runs-on: ubuntu-latest
 
@@ -455,7 +426,6 @@ jobs:
       - test-journey
       - test-fast
       - test-32bit
-      - test-32bit-cross
       - lint
       - cargo-deny
       - check-packetline


### PR DESCRIPTION
While ARM64 runners for macOS have been available, and not limited to enterprise or paid customers, for a while now, free Linux ARM runners for public projects were not likewise available. [They are now available](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/) in public preview, as of a couple days ago. This PR extends and modifies `cy.yml` to makes use of them, by:

- Adding an `ubuntu-24.04-arm` job to `test-fast`.
- Making `test-32bit` a matrix job definition, and adding a 32-bit ARMv7 job to it. The 32-bit x86 job uses a container on an x86-64 runner, just as before, while the new 32-bit ARM job uses a container on an ARM64 runner. (Although GitHub Actions supports 32-bit ARM runners in the sense that the runner software can run on such a system, there are no GitHub-hosted 32-bit ARM runners..)
- Removing the `test-32bit-cross` job, which was not able to run many tests; it was only testing `gix-hashtable`. Its value seems less now that `test-32bit` covers ARMv7. However, it may be worth reviewing the specific target, in case it is a goal to continue running some tests with a `androideabi` target. (If so, it should be possible to add that as a target to a non-cross 64-bit or 32-bit environment.)