### PR TITLE
Fix shortcoming regarding time crate

### DIFF
--- a/SHORTCOMINGS.md
+++ b/SHORTCOMINGS.md
@@ -39,4 +39,3 @@ This file is for tracking features that are less well implemented or less powerf
 ### `gix-features`
 
 * **sha1** isn't hardened (i.e. doesn't have collision detection). Needs [to be contributed](https://github.com/GitoxideLabs/gitoxide/issues/585).
-* **local time** is currently impeded by [this issue](https://github.com/time-rs/time/issues/293#issuecomment-909158529) but it's planned to resolve it eventually.


### PR DESCRIPTION
Very minor change: was looking for easy to fix issues and saw this in shortcomings, but seems that this crate has already transitioned over to using `jiff` instead of `time` and that the linked files are no longer in the same place as they were in the issue (alternatively if I've misunderstood the changes since, I'd be happy to add the local time function as `jiff` does not have the segfault issue `time` had)