### PR TITLE
When adding +x, get and set mode through the file descriptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,6 +2928,7 @@ dependencies = [
  "gix-path 0.10.14",
  "gix-worktree 0.39.0",
  "io-close",
+ "rustix",
  "thiserror 2.0.3",
 ]
 

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -29,3 +29,9 @@ gix-filter = { version = "^0.17.0", path = "../gix-filter" }
 io-close = "0.3.7"
 thiserror = "2.0.0"
 bstr = { version = "1.3.0", default-features = false }
+
+[target.'cfg(unix)'.dependencies]
+rustix = { version = "0.38.20", default-features = false, features = [
+    "std",
+    "fs",
+] }

--- a/gix-worktree-state/src/checkout/chunk.rs
+++ b/gix-worktree-state/src/checkout/chunk.rs
@@ -177,7 +177,6 @@ where
     // We process each key and do as the filter process tells us, while collecting data about the overall progress.
     let keys: BTreeSet<_> = delayed_filter_results.iter().map(|d| d.key.clone()).collect();
     let mut unknown_paths = Vec::new();
-    let mut rela_path_as_path = Default::default();
     for key in keys {
         loop {
             let rela_paths = ctx.filters.driver_state_mut().list_delayed_paths(&key)?;
@@ -229,10 +228,7 @@ where
                 entry::finalize_entry(
                     delayed.entry,
                     write.inner.into_inner().map_err(std::io::IntoInnerError::into_error)?,
-                    set_executable_after_creation.then(|| {
-                        rela_path_as_path = gix_path::from_bstr(delayed.entry_path);
-                        rela_path_as_path.as_ref()
-                    }),
+                    set_executable_after_creation,
                 )?;
                 delayed_files += 1;
                 files.fetch_add(1, Ordering::Relaxed);

--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -135,7 +135,7 @@ where
             };
 
             // For possibly existing, overwritten files, we must change the file mode explicitly.
-            finalize_entry(entry, file, set_executable_after_creation.then_some(dest))?;
+            finalize_entry(entry, file, set_executable_after_creation)?;
             num_bytes
         }
         gix_index::entry::Mode::SYMLINK => {
@@ -275,16 +275,15 @@ pub(crate) fn open_file(
     try_op_or_unlink(path, overwrite_existing, |p| options.open(p)).map(|f| (f, set_executable_after_creation))
 }
 
-/// Close `file` and store its stats in `entry`, possibly setting `file` executable depending on
-/// `set_executable_after_creation`.
+/// Close `file` and store its stats in `entry`, possibly setting `file` executable.
 pub(crate) fn finalize_entry(
     entry: &mut gix_index::Entry,
     file: std::fs::File,
-    #[cfg_attr(windows, allow(unused_variables))] set_executable_after_creation: Option<&Path>,
+    #[cfg_attr(windows, allow(unused_variables))] set_executable_after_creation: bool,
 ) -> Result<(), crate::checkout::Error> {
     // For possibly existing, overwritten files, we must change the file mode explicitly.
     #[cfg(unix)]
-    if let Some(path) = set_executable_after_creation {
+    if set_executable_after_creation {
         set_executable(&file)?;
     }
     // NOTE: we don't call `file.sync_all()` here knowing that some filesystems don't handle this well.

--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -289,7 +289,8 @@ pub(crate) fn finalize_entry(
         if let Some(new_perm) = set_mode_executable(old_perm) {
             // TODO: If we keep `fchmod`, maybe change `set_mode_executable` not to use `std::fs::Permissions`.
             use std::os::unix::fs::PermissionsExt;
-            let mode = rustix::fs::Mode::from_bits(new_perm.mode())
+            let raw_mode = new_perm.mode().try_into().expect("mode fits in `st_mode`");
+            let mode = rustix::fs::Mode::from_bits(raw_mode)
                 .expect("`set_mode_executable` shouldn't preserve or add unknown bits");
             rustix::fs::fchmod(&file, mode).map_err(std::io::Error::from)?;
         }

--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -298,9 +298,9 @@ pub(crate) fn finalize_entry(
 /// See `let_readers_execute` for the exact details of how the mode is transformed.
 #[cfg(unix)]
 fn set_executable(file: &std::fs::File) -> Result<(), std::io::Error> {
-    let old_raw_mode = rustix::fs::fstat(&file)?.st_mode;
+    let old_raw_mode = rustix::fs::fstat(file)?.st_mode;
     let new_mode = let_readers_execute(old_raw_mode);
-    rustix::fs::fchmod(&file, new_mode)?;
+    rustix::fs::fchmod(file, new_mode)?;
     Ok(())
 }
 

--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -287,7 +287,10 @@ pub(crate) fn finalize_entry(
     if let Some(path) = set_executable_after_creation {
         let old_perm = std::fs::symlink_metadata(path)?.permissions();
         if let Some(new_perm) = set_mode_executable(old_perm) {
-            std::fs::set_permissions(path, new_perm)?;
+            // TODO: If the `fchmod` approach is kept, `set_mode_executable` shouldn't operate on std::fs::Permissions.
+            use std::os::{fd::AsFd, unix::fs::PermissionsExt};
+            rustix::fs::fchmod(file.as_fd(), new_perm.mode().into())
+                .map_err(|errno| std::io::Error::from_raw_os_error(errno.raw_os_error()))?;
         }
     }
     // NOTE: we don't call `file.sync_all()` here knowing that some filesystems don't handle this well.


### PR DESCRIPTION
Fixes #1786

This changes `finalize_entry` so it uses the open file descriptor, rather than the path, to read the old mode and write the new mode. (This is the PR mentioned in https://github.com/GitoxideLabs/gitoxide/issues/1786#issuecomment-2611744264.)

#### How it worked before

Previously:

- The old mode was read using `lstat`, called indirectly through the higher-level function `std::fs::symlink_metadata`.

  https://github.com/GitoxideLabs/gitoxide/blob/02efddd0a093295746dcb640bae1652b80daf45c/gix-worktree-state/src/checkout/entry.rs#L288

- The new mode was set using `chmod`, called indirectly through the higher-level function `std::fs::set_permissions`.

  https://github.com/GitoxideLabs/gitoxide/blob/02efddd0a093295746dcb640bae1652b80daf45c/gix-worktree-state/src/checkout/entry.rs#L290

  It is [documented](https://doc.rust-lang.org/stable/std/fs/fn.set_permissions.html) to use `chmod`, which may not be ideal, since if we are to continue to operate on a path here, `lchmod` is probably what we want.

#### How it would work now

With the changes in this PR, `gix-worktree-state` takes a direct dependency on `rustix`. I think this may be okay since `gix-worktree-state` already depends on `gix-index`, which depends on `rustix`. (I used the same version range and features as were used there.)

It uses the `fstat` and `fchmod` functions that `rustix` lightly wraps--as well as the `RawMode` and `Mode` types to avoid having to handle conversions and casts on systems like macOS where `mode_t` is 16-bit--to implement the new behavior of operating on the open file descriptor instead of the path:

- The old mode is read using `fstat`:

  https://github.com/GitoxideLabs/gitoxide/blob/5372911fa092d0bda4f9a159fb9e88ce9608d2aa/gix-worktree-state/src/checkout/entry.rs#L301

- The new is set using `fchmod`:

  https://github.com/GitoxideLabs/gitoxide/blob/5372911fa092d0bda4f9a159fb9e88ce9608d2aa/gix-worktree-state/src/checkout/entry.rs#L303

#### Caveat 1 (but maybe benefit?): We must not dereference symlinks

Because `fchmod` operates on a file descriptor, it changes the permissions of whatever file is open. If we opened this file through a symlink, then this may be the wrong thing to do. I believe that this will not happen, at least on a Unix-like system. We have, typically, opened this file to write to it. So we try hard not to open a symlink, and I think avoid this in a way that completely robust, at least on systems where we are setting executable permissions. But this is an area I recommend be considered and examined when reviewing this PR.

See https://github.com/GitoxideLabs/gitoxide/issues/1786#issuecomment-2611744264 for more information on this and related issues, including an area where I think this PR may actually improve resilience to wrongly following symlinks.

#### Caveat 2 (minor): Was the path intended to be used for more?

There is one other area I suggest giving special attention when reviewing this PR, though I very much doubt it is a problem: I was surprised that the `rela_path_as_path` variable introduced near the top of `set_executable_after_creation` was actually only used for arranging for executable permissions to be added. Given the way the code was written, I wonder if it was intended to use it for more than that.

---

There is some more information in the commit messages. In particular, 588e6b0 presents the curious `rela_path_as_path` situation.