### PR TITLE
add `PrepareFetch::with_leave_dirty()` to avoid cleanup on drop.

### DIFF
--- a/gix/src/clone/access.rs
+++ b/gix/src/clone/access.rs
@@ -67,8 +67,10 @@ impl PrepareFetch {
 
 impl Drop for PrepareFetch {
     fn drop(&mut self) {
-        if let Some(repo) = self.repo.take() {
-            std::fs::remove_dir_all(repo.work_dir().unwrap_or_else(|| repo.path())).ok();
+        if !self.leave_dirty {
+            if let Some(repo) = self.repo.take() {
+                std::fs::remove_dir_all(repo.work_dir().unwrap_or_else(|| repo.path())).ok();
+            }
         }
     }
 }

--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -172,8 +172,10 @@ impl PrepareCheckout {
 
 impl Drop for PrepareCheckout {
     fn drop(&mut self) {
-        if let Some(repo) = self.repo.take() {
-            std::fs::remove_dir_all(repo.work_dir().unwrap_or_else(|| repo.path())).ok();
+        if !self.leave_dirty {
+            if let Some(repo) = self.repo.take() {
+                std::fs::remove_dir_all(repo.work_dir().unwrap_or_else(|| repo.path())).ok();
+            }
         }
     }
 }

--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -227,6 +227,7 @@ impl PrepareFetch {
             crate::clone::PrepareCheckout {
                 repo: repo.into(),
                 ref_name: self.ref_name.clone(),
+                leave_dirty: self.leave_dirty,
             },
             fetch_outcome,
         ))

--- a/gix/src/clone/mod.rs
+++ b/gix/src/clone/mod.rs
@@ -37,6 +37,7 @@ pub struct PrepareFetch {
     /// The name of the reference to fetch. If `None`, the reference pointed to by `HEAD` will be checked out.
     #[cfg_attr(not(feature = "blocking-network-client"), allow(dead_code))]
     ref_name: Option<gix_ref::PartialName>,
+    leave_dirty: bool,
 }
 
 /// The error returned by [`PrepareFetch::new()`].
@@ -126,6 +127,7 @@ impl PrepareFetch {
             configure_connection: None,
             shallow: remote::fetch::Shallow::NoChange,
             ref_name: None,
+            leave_dirty: false,
         })
     }
 }
@@ -140,6 +142,7 @@ pub struct PrepareCheckout {
     pub(self) repo: Option<crate::Repository>,
     /// The name of the reference to check out. If `None`, the reference pointed to by `HEAD` will be checked out.
     pub(self) ref_name: Option<gix_ref::PartialName>,
+    pub(self) leave_dirty: bool,
 }
 
 // This module encapsulates functionality that works with both feature toggles. Can be combined with `fetch`
@@ -168,6 +171,13 @@ mod access_feat {
         /// Set additional options to adjust parts of the fetch operation that are not affected by the git configuration.
         pub fn with_fetch_options(mut self, opts: crate::remote::ref_map::Options) -> Self {
             self.fetch_options = opts;
+            self
+        }
+
+        /// Set whether to delete the repo directory when the PrepareFetch or PrepareCheckout
+        /// object is dropped.
+        pub fn with_leave_dirty(mut self, leave_dirty: bool) -> Self {
+            self.leave_dirty = leave_dirty;
             self
         }
     }


### PR DESCRIPTION
I want to be able to use `PrepareFetch` etc. on a given directory without it being deleted on failure.

Currently I'm checking out to a temporary directory and moving them to the target directory, which may generally be a better idea than this MR :shrug:.

I'm not sure about the `leave_dirty` name, `persist` is used for a similar concept. I'm open to suggestions.