### PR TITLE
update msrv to 1.79, add `rust-toolchain.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.41.0"
 default-run = "gix"
 include = ["src/**/*", "/build.rs", "LICENSE-*", "README.md"]
 resolver = "2"
+rust-version = "1.70"
 
 [[bin]]
 name = "ein"
@@ -306,6 +307,13 @@ members = [
     "gix-traverse/tests",
     "gix-shallow"
 ]
+
+[workspace.package]
+repository = "https://github.com/GitoxideLabs/gitoxide"
+authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+rust-version = "1.79"
 
 [workspace.dependencies]
 

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -3,11 +3,11 @@ lints.workspace = true
 [package]
 name = "gitoxide-core"
 description = "The library implementing all capabilities of the gitoxide CLI"
-repository = "https://github.com/GitoxideLabs/gitoxide"
+repository.workspace = true
 version = "0.45.0"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-license = "MIT OR Apache-2.0"
-edition = "2021"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [lib]
 doctest = false

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -4,12 +4,12 @@ lints.workspace = true
 name = "gix-actor"
 version = "0.33.2"
 description = "A way to identify git actors"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
-edition = "2021"
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-archive"
 version = "0.19.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "archive generation from of a worktree stream"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-attributes"
 version = "0.24.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing .gitattributes files"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-bitmap/Cargo.toml
+++ b/gix-bitmap/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-bitmap"
 version = "0.2.14"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dedicated implementing the standard git bitmap format"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 exclude = ["CHANGELOG.md"]
 
 [lib]

--- a/gix-blame/Cargo.toml
+++ b/gix-blame/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-blame"
 version = "0.0.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dedicated to implementing a 'blame' algorithm"
 authors = ["Christoph Rüßler <christoph.ruessler@mailbox.org>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-chunk/Cargo.toml
+++ b/gix-chunk/Cargo.toml
@@ -4,13 +4,13 @@ lints.workspace = true
 name = "gix-chunk"
 version = "0.4.11"
 description = "Interact with the git chunk file format used in multi-pack index and commit-graph files"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-repository = "https://github.com/GitoxideLabs/gitoxide"
+authors.workspace = true
+repository.workspace = true
 documentation = "https://github.com/git/git/blob/seen/Documentation/technical/chunk-format.txt"
-license = "MIT OR Apache-2.0"
-edition = "2021"
+license.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-command/Cargo.toml
+++ b/gix-command/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-command"
 version = "0.4.1"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project handling internal git command execution"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/lib.rs", "LICENSE-*"]
 
 [lib]

--- a/gix-commitgraph/Cargo.toml
+++ b/gix-commitgraph/Cargo.toml
@@ -3,14 +3,14 @@ lints.workspace = true
 [package]
 name = "gix-commitgraph"
 version = "0.26.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
+repository.workspace = true
 documentation = "https://git-scm.com/docs/commit-graph#:~:text=The%20commit-graph%20file%20is%20a%20supplemental%20data%20structure,or%20in%20the%20info%20directory%20of%20an%20alternate."
-license = "MIT OR Apache-2.0"
+license.workspace = true
 description = "Read-only access to the git commitgraph file format"
 authors = ["Conor Davis <gitoxide@conor.fastmail.fm>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-config-value/Cargo.toml
+++ b/gix-config-value/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-config-value"
 version = "0.14.11"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project providing git-config value parsing"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -3,15 +3,15 @@ lints.workspace = true
 [package]
 name = "gix-config"
 version = "0.43.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
+repository.workspace = true
 description = "A git-config file parser and editor from the gitoxide project"
-license = "MIT OR Apache-2.0"
+license.workspace = true
 authors = ["Edward Shen <code@eddie.sh>"]
-edition = "2021"
+edition.workspace = true
 keywords = ["git-config", "git", "config", "gitoxide"]
 categories = ["config", "parser-implementations"]
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version.workspace = true
 autotests = false
 
 [features]

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-credentials"
 version = "0.27.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project to interact with git credentials helpers"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-date"
 version = "0.9.3"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project parsing dates the way git does"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-diff"
 version = "0.50.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "Calculate differences between various git objects"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 autotests = false
 
 [features]

--- a/gix-dir/Cargo.toml
+++ b/gix-dir/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-dir"
 version = "0.12.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing with directory walks"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-discover/Cargo.toml
+++ b/gix-discover/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-discover"
 version = "0.38.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "Discover git repositories and check if a directory is a git repository"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-features"
 description = "A crate to integrate various capabilities using compile-time feature flags"
-repository = "https://github.com/GitoxideLabs/gitoxide"
+repository.workspace = true
 version = "0.40.0"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-fetchhead/Cargo.toml
+++ b/gix-fetchhead/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-fetchhead"
 version = "0.0.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project to read and write .git/FETCH_HEAD"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-filter/Cargo.toml
+++ b/gix-filter/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-filter"
 version = "0.17.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project implementing git filters"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-fs"
 version = "0.13.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate providing file system specific utilities to `gitoxide`"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-fsck/Cargo.toml
+++ b/gix-fsck/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-fsck"
 version = "0.9.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
+repository.workspace = true
 authors = ["Cameron Esfahani <cesfahani@gmail.com>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]
-license = "MIT OR Apache-2.0"
+license.workspace = true
 description = "Verifies the connectivity and validity of objects in the database"
-edition = "2021"
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-glob/Cargo.toml
+++ b/gix-glob/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-glob"
 version = "0.18.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing with pattern matching"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -4,12 +4,12 @@ lints.workspace = true
 name = "gix-hash"
 version = "0.16.0"
 description = "Borrowed and owned git hash digests used to identify git objects"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
-edition = "2021"
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-hashtable/Cargo.toml
+++ b/gix-hashtable/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-hashtable"
 version = "0.7.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate that provides hashtable based data structures optimized to utilize ObjectId keys"
 authors = ["Pascal Kuthe <pascal.kuthe@semimod.de>"]
-edition = "2021"
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-ignore/Cargo.toml
+++ b/gix-ignore/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-ignore"
 version = "0.13.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing .gitignore files"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-index"
 version = "0.38.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A work-in-progress crate of the gitoxide project dedicated implementing the git index file"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version.workspace = true
 autotests = false
 
 

--- a/gix-lfs/Cargo.toml
+++ b/gix-lfs/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-lfs"
 version = "0.0.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing with handling git large file support"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-lock/Cargo.toml
+++ b/gix-lock/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-lock"
 version = "16.0.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A git-style lock-file implementation"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-macros/Cargo.toml
+++ b/gix-macros/Cargo.toml
@@ -3,17 +3,17 @@ lints.workspace = true
 [package]
 name = "gix-macros"
 version = "0.1.5"
-edition = "2021"
+edition.workspace = true
 description = "Proc-macro utilities for gix"
 authors = [
     "Jiahao XU <Jiahao_XU@outlook.com>",
     "Andre Bogus <bogusandre@gmail.com>",
     "Sebastian Thiel <sebastian.thiel@icloud.com>",
 ]
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/gix-mailmap/Cargo.toml
+++ b/gix-mailmap/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-mailmap"
 version = "0.25.2"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project for parsing mailmap files"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-merge/Cargo.toml
+++ b/gix-merge/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "gix-merge"
 version = "0.3.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project implementing merge algorithms"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/gix-negotiate/Cargo.toml
+++ b/gix-negotiate/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-negotiate"
 version = "0.18.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project implementing negotiation algorithms"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-note/Cargo.toml
+++ b/gix-note/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-note"
 version = "0.0.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing with git notes"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -4,12 +4,12 @@ lints.workspace = true
 name = "gix-object"
 version = "0.47.0"
 description = "Immutable and mutable git objects with decoding and encoding support"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
-edition = "2021"
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-odb"
 version = "0.67.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Implements various git object databases"
-edition = "2021"
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 autotests = false
 
 [lib]

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-pack"
 version = "0.57.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Implements git packs and related data structures"
-edition = "2021"
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 autotests = false
 
 [lib]

--- a/gix-packetline-blocking/Cargo.toml
+++ b/gix-packetline-blocking/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-packetline-blocking"
 version = "0.18.2"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A duplicate of `gix-packetline` with the `blocking-io` feature pre-selected"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-packetline"
 version = "0.18.3"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project implementing the pkt-line serialization format"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-path/Cargo.toml
+++ b/gix-path/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-path"
 version = "0.10.14"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing paths and their conversions"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-pathspec/Cargo.toml
+++ b/gix-pathspec/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-pathspec"
 version = "0.9.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing magical pathspecs"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [lib]

--- a/gix-prompt/Cargo.toml
+++ b/gix-prompt/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-prompt"
 version = "0.9.1"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project for handling prompts in the terminal"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-protocol"
 version = "0.48.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project for implementing git protocols"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*", "!**/tests/**/*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-quote/Cargo.toml
+++ b/gix-quote/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-quote"
 version = "0.4.15"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing with various quotations used by git"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-rebase/Cargo.toml
+++ b/gix-rebase/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-rebase"
 version = "0.0.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing rebases"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-ref"
 version = "0.50.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate to handle git references"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 autotests = false
 
 [lib]

--- a/gix-refspec/Cargo.toml
+++ b/gix-refspec/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-refspec"
 version = "0.28.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project for parsing and representing refspecs"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-revision"
 version = "0.32.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing with finding names for revisions and parsing specifications"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-revwalk/Cargo.toml
+++ b/gix-revwalk/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-revwalk"
 version = "0.18.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate providing utilities for walking the revision graph"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-sec/Cargo.toml
+++ b/gix-sec/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-sec"
 version = "0.10.11"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project providing a shared trust model"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-sequencer/Cargo.toml
+++ b/gix-sequencer/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-sequencer"
 version = "0.0.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project handling sequences of human-aided operations"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-shallow/Cargo.toml
+++ b/gix-shallow/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-shallow"
 version = "0.2.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Handle files specifying the shallow boundary"
-edition = "2021"
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-status"
 version = "0.17.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing with 'git status'-like functionality"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>", "Pascal Kuthe <pascal.kuthe@semimod.de>"]
-edition = "2021"
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 autotests = false
 
 [lib]

--- a/gix-submodule/Cargo.toml
+++ b/gix-submodule/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-submodule"
 version = "0.17.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dealing git submodules"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-tempfile/Cargo.toml
+++ b/gix-tempfile/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-tempfile"
 version = "16.0.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A tempfile implementation with a global registry to assure cleanup"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*", "README.md"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [[example]]
 name = "delete-tempfiles-on-sigterm"

--- a/gix-tix/Cargo.toml
+++ b/gix-tix/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-tix"
 version = "0.0.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A tool like `tig`, but minimal, fast and efficient"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-trace/Cargo.toml
+++ b/gix-trace/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-trace"
 description = "A crate to provide minimal `tracing` support that can be turned off to zero cost"
-repository = "https://github.com/GitoxideLabs/gitoxide"
+repository.workspace = true
 version = "0.1.12"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-transport"
 version = "0.45.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dedicated to implementing the git transport layer"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-traverse/Cargo.toml
+++ b/gix-traverse/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-traverse"
 version = "0.44.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 autotests = false
 
 [lib]

--- a/gix-tui/Cargo.toml
+++ b/gix-tui/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-tui"
 version = "0.0.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project dedicated to a terminal user interface to interact with git repositories"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [[bin]]
 name = "gixi"

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-url"
 version = "0.29.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project implementing parsing and serialization of gix-url"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*", "tests/baseline/**/*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-utils/Cargo.toml
+++ b/gix-utils/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-utils"
 version = "0.1.14"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate with `gitoxide` utilities that don't need feature toggles"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-validate/Cargo.toml
+++ b/gix-validate/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-validate"
 version = "0.9.3"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "Validation functions for various kinds of names in git"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-worktree-state"
 version = "0.17.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project implementing setting the worktree to a particular state"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 autotests = false
 
 [lib]

--- a/gix-worktree-stream/Cargo.toml
+++ b/gix-worktree-stream/Cargo.toml
@@ -3,12 +3,12 @@ lints.workspace = true
 [package]
 name = "gix-worktree-stream"
 version = "0.19.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "generate a byte-stream from a git-tree"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
-rust-version = "1.70"
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -3,13 +3,13 @@ lints.workspace = true
 [package]
 name = "gix-worktree"
 version = "0.39.0"
-repository = "https://github.com/GitoxideLabs/gitoxide"
-license = "MIT OR Apache-2.0"
+repository.workspace = true
+license.workspace = true
 description = "A crate of the gitoxide project for shared worktree related types and utilities."
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 autotests = false
 
 [lib]

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -2,14 +2,14 @@ lints.workspace = true
 
 [package]
 name = "gix"
-repository = "https://github.com/GitoxideLabs/gitoxide"
+repository.workspace = true
 description = "Interact with git repositories just like git would"
-license = "MIT OR Apache-2.0"
+license.workspace = true
 version = "0.70.0"
-authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [lib]
 doctest = false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.79"


### PR DESCRIPTION
Closes #1808

Additionally, use the root `[workspace.package]` as a source of truth for all crates `repository`, `edition`, `license`, and `rust-version`. Also used for `authors` only if the only author listed was Sebastian Thiel.