### PR TITLE
fix hardcoded path test on nixos

### DIFF
--- a/gix-command/tests/command.rs
+++ b/gix-command/tests/command.rs
@@ -507,7 +507,7 @@ mod spawn {
     #[cfg(unix)]
     #[test]
     fn direct_command_with_absolute_command_path() -> crate::Result {
-        assert!(gix_command::prepare("/bin/ls").spawn()?.wait()?.success());
+        assert!(gix_command::prepare("/usr/bin/env").spawn()?.wait()?.success());
         Ok(())
     }
 


### PR DESCRIPTION
nixos provides the following contents in `/bin` and `/usr/bin`:

    /bin:
    sh

    /usr/bin:
    env

That's it. From what I know, every linux distribution, as well as macos, has `/usr/bin/env`