### PR TITLE
Get and set mode using std, still on open file descriptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,7 +2928,6 @@ dependencies = [
  "gix-path 0.10.14",
  "gix-worktree 0.39.0",
  "io-close",
- "rustix",
  "thiserror 2.0.3",
 ]
 

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -29,9 +29,3 @@ gix-filter = { version = "^0.17.0", path = "../gix-filter" }
 io-close = "0.3.7"
 thiserror = "2.0.0"
 bstr = { version = "1.3.0", default-features = false }
-
-[target.'cfg(unix)'.dependencies]
-rustix = { version = "0.38.20", default-features = false, features = [
-    "std",
-    "fs",
-] }

--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -311,7 +311,7 @@ fn set_executable(file: &std::fs::File) -> Result<(), std::io::Error> {
 /// Set-user-ID and set-group-ID bits are unset for safety. The sticky bit is also unset.
 ///
 /// This returns only mode bits, not file type. The return value can be used in chmod or fchmod.
-#[cfg(unix)]
+#[cfg(any(unix, test))]
 fn let_readers_execute(mut mode: u32) -> u32 {
     assert_eq!(mode & 0o170000, 0o100000, "bug in caller if not from a regular file");
     mode &= 0o777; // Clear type, non-rwx mode bits (setuid, setgid, sticky).
@@ -319,7 +319,7 @@ fn let_readers_execute(mut mode: u32) -> u32 {
     mode
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
     #[test]
     fn let_readers_execute() {


### PR DESCRIPTION
This replaces explicit `fstat` and `fchmod` calls (via `rustix`) with `File::metadata` and `File::set_permissions`, respectively.

The change here is confined to `gix-worktree-state` and, more specifically, to the operation of checking the mode of an open file and setting a new mode based on it with some executable bits added.

#### Background

In practice, currently, on Unix-like systems:

- `File::metadata` either:

    * calls `fstat`, *or*
    * calls `statx` in a way that causes it to operate similarly to `fstat` (this is used on Linux, in versions with `statx`).

  This is not explicitly documented, though calling `stat` or `lstat`, or calling `statx` in a way that would cause it to behave like `stat` or `lstat` rather than `fstat`, would not preserve the documented behavior of `File::metadata`, which operates on a `File` and does not take a path.

- `File::set_permissions` calls `fchmod`.

  This is explicitly documented and `fchmod` is listed as an alias for documentation purposes. But it is noted as an implementation detail that may change without warning. However, calling `chmod` or `lchmod` would not preserve the documented behavior of `File::set_permissions`, which (like `File::metadata`) operates on a `File` and does not take a path.

#### Rationale

While the above details can, in principle, change without warning, per [Platform-specific behavior](https://doc.rust-lang.org/stable/std/io/index.html#platform-specific-behavior), it seems that, in preserving the documented semantics of operating on the file referenced by the file descriptor (rather than a path), the behavior would still have to be correct for our use here.

This pull request intends to maintain the effect of #1803 with two minor improvements for maintainability and clarity:

- No longer require `gix-worktree-state` to depend directly on `rustix`. (This is minor because it still depends transitively on it through `gix-fs`, though some uses of `rustix::fs` in `gix-fs` might likewise be possible to replace in the future.)

- Use the standard library's slightly higher level interface where modes are treated as `u32` even on operating systems where they are different (e.g. `u16` on macOS). This removes operations that do not correspond to what the code is conceptually doing. It also lets the function that computes the new mode from the old mode no longer depend on a type that differs across Unix-like targets.

Importantly, this continues to differ from the pre-#1803 behavior of using functions that operated on paths.

#### Relationship between functions that get and set mode bits

For reading metadata on a file on Unix-like systems, the current general correspondence between Rust `std`, POSIX functions, and `statx`, where the rightmost three columns pertain to how `statx` is called, is:

| std::fs::*       | POSIX | fd       | path | *distinctive* flags |
|------------------|-------|----------|------|---------------------|
| metadata         | stat  | AT_FDCWD | path | (none)              |
| symlink_metadata | lstat | AT_FDCWD | path | AT_SYMLINK_NOFOLLOW |
| File::metadata   | fstat | file     | ""   | AT_EMPTY_PATH       |

For writing metadata on a file on Unix-like systems, the current correspondence between Rust `std` and POSIX functions is:

| std::fs::*            | POSIX  |
|-----------------------| -------|
| set_permissions       | chmod  |
| (none)                | lchmod |
| File::set_permissions | fchmod |

#### Future directions

It may be that some uses of `rustix::fs` facilities can be similarly replaced in `gix_fs`, but this PR does not include any such changes.