### PR TITLE
Clarify description of `single` escaping

### DIFF
--- a/gix-quote/src/single.rs
+++ b/gix-quote/src/single.rs
@@ -2,8 +2,8 @@ use bstr::{BStr, BString, ByteSlice, ByteVec};
 
 /// Transforms the given `value` to be suitable for use as an argument for Bourne shells by wrapping it into single quotes.
 ///
-/// Every single-quote `'` is escaped with `\'`, every exclamation mark `!` is escaped with `\!`, and the entire string is enclosed
-/// in single quotes.
+/// Every single-quote `'` is escaped as `'\''`, every exclamation mark `!` is escaped as `'\!'`,
+/// and the entire string is enclosed in single quotes.
 pub fn single(mut value: &BStr) -> BString {
     let mut quoted = BString::new(b"'".to_vec());
 


### PR DESCRIPTION
This improves how `gix_quote::single` documents how it handles the cases it treats specially.

The fix in #717 (discussed in #713) wasn't accompanied by a change to the documentation, which continued either to describe the preceding behavior or to be ambiguous. This changes it to describe the current behavior unambiguously. Only documentation is changed.