### PR TITLE
Rename `Exponential` backoff to `Quadratic`

### DIFF
--- a/gix-lock/src/acquire.rs
+++ b/gix-lock/src/acquire.rs
@@ -14,7 +14,7 @@ pub enum Fail {
     /// Fail after the first unsuccessful attempt of obtaining a lock.
     #[default]
     Immediately,
-    /// Retry after failure with exponentially longer sleep times to block the current thread.
+    /// Retry after failure with quadratically longer sleep times to block the current thread.
     /// Fail once the given duration is exceeded, similar to [Fail::Immediately]
     AfterDurationWithBackoff(Duration),
 }
@@ -176,7 +176,7 @@ fn lock_with_mode<T>(
     match mode {
         Fail::Immediately => try_lock(&lock_path, directory, cleanup),
         Fail::AfterDurationWithBackoff(time) => {
-            for wait in backoff::Exponential::default_with_random().until_no_remaining(time) {
+            for wait in backoff::Quadratic::default_with_random().until_no_remaining(time) {
                 attempts += 1;
                 match try_lock(&lock_path, directory, cleanup.clone()) {
                     Ok(v) => return Ok((lock_path, v)),

--- a/gix-utils/src/backoff.rs
+++ b/gix-utils/src/backoff.rs
@@ -9,17 +9,17 @@ fn randomize(backoff_ms: usize) -> usize {
     }
 }
 
-/// A utility to calculate steps for exponential backoff similar to how it's done in `git`.
-pub struct Exponential<Fn> {
+/// A utility to calculate steps for quadratic backoff similar to how it's done in `git`.
+pub struct Quadratic<Fn> {
     multiplier: usize,
     max_multiplier: usize,
     exponent: usize,
     transform: Fn,
 }
 
-impl Default for Exponential<fn(usize) -> usize> {
+impl Default for Quadratic<fn(usize) -> usize> {
     fn default() -> Self {
-        Exponential {
+        Quadratic {
             multiplier: 1,
             max_multiplier: 1000,
             exponent: 1,
@@ -28,10 +28,10 @@ impl Default for Exponential<fn(usize) -> usize> {
     }
 }
 
-impl Exponential<fn(usize) -> usize> {
-    /// Create a new exponential backoff iterator that backs off in randomized, ever increasing steps.
+impl Quadratic<fn(usize) -> usize> {
+    /// Create a new quadratic backoff iterator that backs off in randomized, ever increasing steps.
     pub fn default_with_random() -> Self {
-        Exponential {
+        Quadratic {
             multiplier: 1,
             max_multiplier: 1000,
             exponent: 1,
@@ -40,7 +40,7 @@ impl Exponential<fn(usize) -> usize> {
     }
 }
 
-impl<Transform> Exponential<Transform>
+impl<Transform> Quadratic<Transform>
 where
     Transform: Fn(usize) -> usize,
 {
@@ -62,7 +62,7 @@ where
     }
 }
 
-impl<Transform> Iterator for Exponential<Transform>
+impl<Transform> Iterator for Quadratic<Transform>
 where
     Transform: Fn(usize) -> usize,
 {

--- a/gix-utils/tests/backoff/mod.rs
+++ b/gix-utils/tests/backoff/mod.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use gix_utils::backoff::Exponential;
+use gix_utils::backoff::Quadratic;
 
 const EXPECTED_TILL_SECOND: &[usize] = &[
     1usize, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225, 256, 289, 324, 361, 400, 441, 484, 529, 576,
@@ -8,9 +8,9 @@ const EXPECTED_TILL_SECOND: &[usize] = &[
 ];
 
 #[test]
-fn random_exponential_produces_values_in_the_correct_range() {
+fn random_quadratic_produces_values_in_the_correct_range() {
     let mut num_identities = 0;
-    for (actual, expected) in Exponential::default_with_random().zip(EXPECTED_TILL_SECOND) {
+    for (actual, expected) in Quadratic::default_with_random().zip(EXPECTED_TILL_SECOND) {
         let actual: usize = actual.as_millis().try_into().unwrap();
         if actual == *expected {
             num_identities += 1;
@@ -33,9 +33,9 @@ fn random_exponential_produces_values_in_the_correct_range() {
 #[test]
 fn how_many_iterations_for_a_second_of_waittime() {
     let max = Duration::from_millis(1000);
-    assert_eq!(Exponential::default().until_no_remaining(max).count(), 14);
+    assert_eq!(Quadratic::default().until_no_remaining(max).count(), 14);
     assert_eq!(
-        Exponential::default()
+        Quadratic::default()
             .until_no_remaining(max)
             .reduce(|acc, n| acc + n)
             .unwrap(),
@@ -47,7 +47,7 @@ fn how_many_iterations_for_a_second_of_waittime() {
 #[test]
 fn output_with_default_settings() {
     assert_eq!(
-        Exponential::default().take(33).collect::<Vec<_>>(),
+        Quadratic::default().take(33).collect::<Vec<_>>(),
         EXPECTED_TILL_SECOND
             .iter()
             .map(|n| Duration::from_millis(*n as u64))

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -219,6 +219,7 @@ pub fn spawn_git_daemon(working_dir: impl AsRef<Path>) -> std::io::Result<GitDae
             .spawn()?;
 
     let server_addr = addr_at(free_port);
+    // TODO(deps): Upgrading dependencies will require changing `Exponential` to `Quadratic`.
     for time in gix_lock::backoff::Exponential::default_with_random() {
         std::thread::sleep(time);
         if std::net::TcpStream::connect(server_addr).is_ok() {
@@ -652,8 +653,8 @@ fn configure_command<'a, I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
 }
 
 fn bash_program() -> &'static Path {
-    // TODO: use `gix_path::env::login_shell()` when available.
     if cfg!(windows) {
+        // TODO(deps): Once `gix_path::env::shell()` is available, maybe do `shell().parent()?.join("bash.exe")`
         static GIT_BASH: Lazy<Option<PathBuf>> = Lazy::new(|| {
             GIT_CORE_DIR
                 .parent()?


### PR DESCRIPTION
This renames `backoff::Exponential` to `backoff::Quadratic` and updates references to it, including in comments. For more details, see the commit message, and https://github.com/gitpython-developers/gitdb/pull/115#discussion_r1903215598 where this change was suggested.

---

I don't know if or how I should update the use in `gix-testtools`, which depends on a version of `gix-utils` older than what is tracked in the repository (#1510). The reference is in the `spawn_git_daemon` function:

https://github.com/GitoxideLabs/gitoxide/blob/38a0d9a083afab33e8a3cb66ab4acbc4e83d8486/tests/tools/src/lib.rs#L222

*Edit:* I added a comment to note it for later, when the dependencies of `gix-testtools` are advanced to newer versions. While I was at it, I also changed another dependency-related comment, by rewriting and moving it to refer to a way of using `shell()`, rather than `login_shell()` which was removed in #1758.