### PR TITLE
Upgrade to Winnow 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6009,9 +6009,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
  "gix-utils 0.1.13",
  "itoa",
  "thiserror 1.0.69",
- "winnow",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -1456,7 +1456,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "thiserror 2.0.3",
- "winnow",
+ "winnow 0.7.0",
 ]
 
 [[package]]
@@ -1631,7 +1631,7 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.3",
  "unicode-bom",
- "winnow",
+ "winnow 0.7.0",
 ]
 
 [[package]]
@@ -2190,7 +2190,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror 1.0.69",
- "winnow",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -2216,7 +2216,7 @@ dependencies = [
  "smallvec",
  "termtree",
  "thiserror 2.0.3",
- "winnow",
+ "winnow 0.7.0",
 ]
 
 [[package]]
@@ -2417,7 +2417,7 @@ dependencies = [
  "maybe-async",
  "serde",
  "thiserror 2.0.3",
- "winnow",
+ "winnow 0.7.0",
 ]
 
 [[package]]
@@ -2463,7 +2463,7 @@ dependencies = [
  "gix-validate 0.8.5",
  "memmap2",
  "thiserror 1.0.69",
- "winnow",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -2486,7 +2486,7 @@ dependencies = [
  "memmap2",
  "serde",
  "thiserror 2.0.3",
- "winnow",
+ "winnow 0.7.0",
 ]
 
 [[package]]
@@ -2721,7 +2721,7 @@ dependencies = [
  "serial_test",
  "tar",
  "tempfile",
- "winnow",
+ "winnow 0.7.0",
  "xz2",
 ]
 
@@ -5271,7 +5271,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -6012,6 +6012,15 @@ name = "winnow"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
 dependencies = [
  "memchr",
 ]

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -27,7 +27,7 @@ bstr = { version = "1.3.0", default-features = false, features = [
     "std",
     "unicode",
 ] }
-winnow = { version = "0.6.26", features = ["simd"] }
+winnow = { version = "0.7.0", features = ["simd"] }
 itoa = "1.0.1"
 serde = { version = "1.0.114", optional = true, default-features = false, features = [
     "derive",

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -27,7 +27,7 @@ bstr = { version = "1.3.0", default-features = false, features = [
     "std",
     "unicode",
 ] }
-winnow = { version = "0.6", features = ["simd"] }
+winnow = { version = "0.6.26", features = ["simd"] }
 itoa = "1.0.1"
 serde = { version = "1.0.114", optional = true, default-features = false, features = [
     "derive",

--- a/gix-actor/src/signature/decode.rs
+++ b/gix-actor/src/signature/decode.rs
@@ -201,7 +201,7 @@ mod tests {
                             .map_err(to_bstr_err)
                             .expect_err("parse fails as > is missing")
                             .to_string(),
-                        "in fail at 'hello < 12345 -1215'\n  0: invalid Closing '>' not found at 'hello < 12345 -1215'\n  1: expected `<name> <<email>> <timestamp> <+|-><HHMM>` at 'hello < 12345 -1215'\n"
+                        " at 'hello < 12345 -1215'\n  0: invalid Closing '>' not found at 'hello < 12345 -1215'\n  1: expected `<name> <<email>> <timestamp> <+|-><HHMM>` at 'hello < 12345 -1215'\n"
                     );
         }
 

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -26,7 +26,7 @@ gix-sec = { version = "^0.10.11", path = "../gix-sec" }
 gix-ref = { version = "^0.50.0", path = "../gix-ref" }
 gix-glob = { version = "^0.18.0", path = "../gix-glob" }
 
-winnow = { version = "0.6", features = ["simd"] }
+winnow = { version = "0.6.26", features = ["simd"] }
 memchr = "2"
 thiserror = "2.0.0"
 unicode-bom = { version = "2.0.3" }

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -26,7 +26,7 @@ gix-sec = { version = "^0.10.11", path = "../gix-sec" }
 gix-ref = { version = "^0.50.0", path = "../gix-ref" }
 gix-glob = { version = "^0.18.0", path = "../gix-glob" }
 
-winnow = { version = "0.6.26", features = ["simd"] }
+winnow = { version = "0.7.0", features = ["simd"] }
 memchr = "2"
 thiserror = "2.0.0"
 unicode-bom = { version = "2.0.3" }

--- a/gix-config/src/parse/nom/mod.rs
+++ b/gix-config/src/parse/nom/mod.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use bstr::{BStr, ByteSlice};
 use winnow::{
     combinator::{alt, delimited, opt, preceded, repeat},
-    error::{ErrorKind, InputError as NomError, ParserError as _},
+    error::{InputError as NomError, ParserError as _},
     prelude::*,
     stream::{Offset as _, Stream as _},
     token::{one_of, take_till, take_while},
@@ -78,7 +78,7 @@ fn newlines_from(input: &[u8], start: winnow::stream::Checkpoint<&[u8], &[u8]>) 
     start_input.next_slice(offset).iter().filter(|c| **c == b'\n').count()
 }
 
-fn comment<'i>(i: &mut &'i [u8]) -> PResult<Comment<'i>, NomError<&'i [u8]>> {
+fn comment<'i>(i: &mut &'i [u8]) -> ModalResult<Comment<'i>, NomError<&'i [u8]>> {
     (
         one_of([';', '#']),
         take_till(0.., |c| c == b'\n').map(|text: &[u8]| Cow::Borrowed(text.as_bstr())),
@@ -94,7 +94,7 @@ fn section<'i>(
     i: &mut &'i [u8],
     node: &mut ParseNode,
     dispatch: &mut dyn FnMut(Event<'i>),
-) -> PResult<(), NomError<&'i [u8]>> {
+) -> ModalResult<(), NomError<&'i [u8]>> {
     let start = i.checkpoint();
     let header = section_header(i).map_err(|e| {
         i.reset(&start);
@@ -129,7 +129,7 @@ fn section<'i>(
     Ok(())
 }
 
-fn section_header<'i>(i: &mut &'i [u8]) -> PResult<section::Header<'i>, NomError<&'i [u8]>> {
+fn section_header<'i>(i: &mut &'i [u8]) -> ModalResult<section::Header<'i>, NomError<&'i [u8]>> {
     // No spaces must be between section name and section start
     let name = preceded('[', take_while(1.., is_section_char).map(bstr::ByteSlice::as_bstr)).parse_next(i)?;
 
@@ -150,7 +150,7 @@ fn section_header<'i>(i: &mut &'i [u8]) -> PResult<section::Header<'i>, NomError
         };
 
         if header.name.is_empty() {
-            return Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Fail));
+            return Err(winnow::error::ErrMode::from_input(i));
         }
         return Ok(header);
     }
@@ -169,7 +169,7 @@ fn is_section_char(c: u8) -> bool {
     c.is_ascii_alphanumeric() || c == b'-' || c == b'.'
 }
 
-fn sub_section<'i>(i: &mut &'i [u8]) -> PResult<Cow<'i, BStr>, NomError<&'i [u8]>> {
+fn sub_section<'i>(i: &mut &'i [u8]) -> ModalResult<Cow<'i, BStr>, NomError<&'i [u8]>> {
     let mut output = Cow::Borrowed(Default::default());
     if let Some(sub) = opt(subsection_subset).parse_next(i)? {
         output = Cow::Borrowed(sub.as_bstr());
@@ -181,15 +181,15 @@ fn sub_section<'i>(i: &mut &'i [u8]) -> PResult<Cow<'i, BStr>, NomError<&'i [u8]
     Ok(output)
 }
 
-fn subsection_subset<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], NomError<&'i [u8]>> {
+fn subsection_subset<'i>(i: &mut &'i [u8]) -> ModalResult<&'i [u8], NomError<&'i [u8]>> {
     alt((subsection_unescaped, subsection_escaped_char)).parse_next(i)
 }
 
-fn subsection_unescaped<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], NomError<&'i [u8]>> {
+fn subsection_unescaped<'i>(i: &mut &'i [u8]) -> ModalResult<&'i [u8], NomError<&'i [u8]>> {
     take_while(1.., is_subsection_unescaped_char).parse_next(i)
 }
 
-fn subsection_escaped_char<'i>(i: &mut &'i [u8]) -> PResult<&'i [u8], NomError<&'i [u8]>> {
+fn subsection_escaped_char<'i>(i: &mut &'i [u8]) -> ModalResult<&'i [u8], NomError<&'i [u8]>> {
     preceded('\\', one_of(is_subsection_escapable_char).take()).parse_next(i)
 }
 
@@ -205,7 +205,7 @@ fn key_value_pair<'i>(
     i: &mut &'i [u8],
     node: &mut ParseNode,
     dispatch: &mut dyn FnMut(Event<'i>),
-) -> PResult<(), NomError<&'i [u8]>> {
+) -> ModalResult<(), NomError<&'i [u8]>> {
     *node = ParseNode::Name;
     if let Some(name) = opt(config_name).parse_next(i)? {
         dispatch(Event::SectionValueName(section::ValueName(Cow::Borrowed(name))));
@@ -223,7 +223,7 @@ fn key_value_pair<'i>(
 
 /// Parses the config name of a config pair. Assumes the input has already been
 /// trimmed of any leading whitespace.
-fn config_name<'i>(i: &mut &'i [u8]) -> PResult<&'i BStr, NomError<&'i [u8]>> {
+fn config_name<'i>(i: &mut &'i [u8]) -> ModalResult<&'i BStr, NomError<&'i [u8]>> {
     (
         one_of(|c: u8| c.is_ascii_alphabetic()),
         take_while(0.., |c: u8| c.is_ascii_alphanumeric() || c == b'-'),
@@ -233,7 +233,7 @@ fn config_name<'i>(i: &mut &'i [u8]) -> PResult<&'i BStr, NomError<&'i [u8]>> {
         .parse_next(i)
 }
 
-fn config_value<'i>(i: &mut &'i [u8], dispatch: &mut dyn FnMut(Event<'i>)) -> PResult<(), NomError<&'i [u8]>> {
+fn config_value<'i>(i: &mut &'i [u8], dispatch: &mut dyn FnMut(Event<'i>)) -> ModalResult<(), NomError<&'i [u8]>> {
     if opt('=').parse_next(i)?.is_some() {
         dispatch(Event::KeyValueSeparator);
         if let Some(whitespace) = opt(take_spaces1).parse_next(i)? {
@@ -251,7 +251,7 @@ fn config_value<'i>(i: &mut &'i [u8], dispatch: &mut dyn FnMut(Event<'i>)) -> PR
 
 /// Handles parsing of known-to-be values. This function handles both single
 /// line values as well as values that are continuations.
-fn value_impl<'i>(i: &mut &'i [u8], dispatch: &mut dyn FnMut(Event<'i>)) -> PResult<(), NomError<&'i [u8]>> {
+fn value_impl<'i>(i: &mut &'i [u8], dispatch: &mut dyn FnMut(Event<'i>)) -> ModalResult<(), NomError<&'i [u8]>> {
     let start_checkpoint = i.checkpoint();
     let mut value_start_checkpoint = i.checkpoint();
     let mut value_end = None;
@@ -278,17 +278,17 @@ fn value_impl<'i>(i: &mut &'i [u8], dispatch: &mut dyn FnMut(Event<'i>)) -> PRes
                     let escape_index = escaped_index - 1;
                     let Some(mut c) = i.next_token() else {
                         i.reset(&start_checkpoint);
-                        return Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Token));
+                        return Err(winnow::error::ErrMode::from_input(i));
                     };
                     let mut consumed = 1;
                     if c == b'\r' {
                         c = i.next_token().ok_or_else(|| {
                             i.reset(&start_checkpoint);
-                            winnow::error::ErrMode::from_error_kind(i, ErrorKind::Token)
+                            winnow::error::ErrMode::from_input(i)
                         })?;
                         if c != b'\n' {
                             i.reset(&start_checkpoint);
-                            return Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Slice));
+                            return Err(winnow::error::ErrMode::from_input(i));
                         }
                         consumed += 1;
                     }
@@ -313,7 +313,7 @@ fn value_impl<'i>(i: &mut &'i [u8], dispatch: &mut dyn FnMut(Event<'i>)) -> PRes
                         b'n' | b't' | b'\\' | b'b' | b'"' => {}
                         _ => {
                             i.reset(&start_checkpoint);
-                            return Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Token));
+                            return Err(winnow::error::ErrMode::from_input(i));
                         }
                     }
                 }
@@ -326,7 +326,7 @@ fn value_impl<'i>(i: &mut &'i [u8], dispatch: &mut dyn FnMut(Event<'i>)) -> PRes
     }
     if is_in_quotes {
         i.reset(&start_checkpoint);
-        return Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Slice));
+        return Err(winnow::error::ErrMode::from_input(i));
     }
 
     let value_end = match value_end {
@@ -360,13 +360,13 @@ fn value_impl<'i>(i: &mut &'i [u8], dispatch: &mut dyn FnMut(Event<'i>)) -> PRes
     Ok(())
 }
 
-fn take_spaces1<'i>(i: &mut &'i [u8]) -> PResult<&'i BStr, NomError<&'i [u8]>> {
+fn take_spaces1<'i>(i: &mut &'i [u8]) -> ModalResult<&'i BStr, NomError<&'i [u8]>> {
     take_while(1.., winnow::stream::AsChar::is_space)
         .map(bstr::ByteSlice::as_bstr)
         .parse_next(i)
 }
 
-fn take_newlines1<'i>(i: &mut &'i [u8]) -> PResult<&'i BStr, NomError<&'i [u8]>> {
+fn take_newlines1<'i>(i: &mut &'i [u8]) -> ModalResult<&'i BStr, NomError<&'i [u8]>> {
     repeat(1..1024, alt(("\r\n", "\n")))
         .map(|()| ())
         .take()

--- a/gix-config/src/parse/nom/tests.rs
+++ b/gix-config/src/parse/nom/tests.rs
@@ -167,6 +167,8 @@ mod config_name {
 }
 
 mod section {
+    use winnow::error::InputError;
+
     use crate::parse::{
         error::ParseNode,
         tests::util::{
@@ -177,7 +179,10 @@ mod section {
         Event, Section,
     };
 
-    fn section<'a>(mut i: &'a [u8], node: &mut ParseNode) -> winnow::IResult<&'a [u8], Section<'a>> {
+    fn section<'a>(
+        mut i: &'a [u8],
+        node: &mut ParseNode,
+    ) -> winnow::ModalResult<(&'a [u8], Section<'a>), InputError<&'a [u8]>> {
         let mut header = None;
         let mut events = Vec::new();
         super::section(&mut i, node, &mut |e| match &header {
@@ -507,13 +512,17 @@ mod section {
 
 mod value_continuation {
     use bstr::ByteSlice;
+    use winnow::error::InputError;
 
     use crate::parse::{
         tests::util::{newline_custom_event, newline_event, value_done_event, value_not_done_event},
         Event,
     };
 
-    pub fn value_impl<'a>(mut i: &'a [u8], events: &mut Vec<Event<'a>>) -> winnow::IResult<&'a [u8], ()> {
+    pub fn value_impl<'a>(
+        mut i: &'a [u8],
+        events: &mut Vec<Event<'a>>,
+    ) -> winnow::ModalResult<(&'a [u8], ()), InputError<&'a [u8]>> {
         super::value_impl(&mut i, &mut |e| events.push(e)).map(|_| (i, ()))
     }
 
@@ -772,6 +781,8 @@ mod value_no_continuation {
 }
 
 mod key_value_pair {
+    use winnow::error::InputError;
+
     use crate::parse::{
         error::ParseNode,
         tests::util::{name_event, value_event, whitespace_event},
@@ -782,7 +793,7 @@ mod key_value_pair {
         mut i: &'a [u8],
         node: &mut ParseNode,
         events: &mut Vec<Event<'a>>,
-    ) -> winnow::IResult<&'a [u8], ()> {
+    ) -> winnow::ModalResult<(&'a [u8], ()), InputError<&'a [u8]>> {
         super::key_value_pair(&mut i, node, &mut |e| events.push(e)).map(|_| (i, ()))
     }
 

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -59,7 +59,7 @@ bstr = { version = "1.3.0", default-features = false, features = [
     "std",
     "unicode",
 ] }
-winnow = { version = "0.6.26", features = ["simd"] }
+winnow = { version = "0.7.0", features = ["simd"] }
 smallvec = { version = "1.4.0", features = ["write"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = [
     "derive",

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -59,7 +59,7 @@ bstr = { version = "1.3.0", default-features = false, features = [
     "std",
     "unicode",
 ] }
-winnow = { version = "0.6.18", features = ["simd"] }
+winnow = { version = "0.6.26", features = ["simd"] }
 smallvec = { version = "1.4.0", features = ["write"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = [
     "derive",

--- a/gix-object/src/commit/decode.rs
+++ b/gix-object/src/commit/decode.rs
@@ -5,7 +5,6 @@ use winnow::{
     combinator::{alt, eof, opt, preceded, repeat, terminated},
     error::{AddContext, ParserError, StrContext},
     prelude::*,
-    stream::Stream as _,
     token::{rest, take_till},
 };
 

--- a/gix-object/src/commit/decode.rs
+++ b/gix-object/src/commit/decode.rs
@@ -2,28 +2,26 @@ use std::borrow::Cow;
 
 use smallvec::SmallVec;
 use winnow::{
-    combinator::{alt, eof, opt, preceded, repeat, rest, terminated},
+    combinator::{alt, eof, opt, preceded, repeat, terminated},
     error::{AddContext, ParserError, StrContext},
     prelude::*,
     stream::Stream as _,
-    token::take_till,
+    token::{rest, take_till},
 };
 
 use crate::{parse, parse::NL, BStr, ByteSlice, CommitRef};
 
 pub fn message<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8], StrContext>>(
     i: &mut &'a [u8],
-) -> PResult<&'a BStr, E> {
+) -> ModalResult<&'a BStr, E> {
     if i.is_empty() {
         // newline + [message]
         let start = i.checkpoint();
-        return Err(
-            winnow::error::ErrMode::from_error_kind(i, winnow::error::ErrorKind::Eof).add_context(
-                i,
-                &start,
-                StrContext::Expected("newline + <message>".into()),
-            ),
-        );
+        return Err(winnow::error::ErrMode::from_input(i).add_context(
+            i,
+            &start,
+            StrContext::Expected("newline + <message>".into()),
+        ));
     }
     preceded(NL, rest.map(ByteSlice::as_bstr))
         .context(StrContext::Expected(
@@ -34,7 +32,7 @@ pub fn message<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8], StrContext>>(
 
 pub fn commit<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8], StrContext>>(
     i: &mut &'a [u8],
-) -> PResult<CommitRef<'a>, E> {
+) -> ModalResult<CommitRef<'a>, E> {
     (
         (|i: &mut _| parse::header_field(i, b"tree", parse::hex_hash))
             .context(StrContext::Expected("tree <40 lowercase hex char>".into())),

--- a/gix-object/src/commit/message/body.rs
+++ b/gix-object/src/commit/message/body.rs
@@ -1,10 +1,10 @@
 use std::ops::Deref;
 
 use winnow::{
-    combinator::{eof, rest, separated_pair, terminated},
-    error::{ErrorKind, ParserError},
+    combinator::{eof, separated_pair, terminated},
+    error::ParserError,
     prelude::*,
-    token::take_until,
+    token::{rest, take_until},
 };
 
 use crate::{
@@ -31,12 +31,12 @@ pub struct TrailerRef<'a> {
     pub value: &'a BStr,
 }
 
-fn parse_single_line_trailer<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<(&'a BStr, &'a BStr), E> {
+fn parse_single_line_trailer<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> ModalResult<(&'a BStr, &'a BStr), E> {
     *i = i.trim_end();
     let (token, value) = separated_pair(take_until(1.., b":".as_ref()), b": ", rest).parse_next(i)?;
 
     if token.trim_end().len() != token.len() || value.trim_start().len() != value.len() {
-        Err(winnow::error::ErrMode::from_error_kind(i, ErrorKind::Fail).cut())
+        Err(winnow::error::ErrMode::from_input(i).cut())
     } else {
         Ok((token.as_bstr(), value.as_bstr()))
     }

--- a/gix-object/src/commit/message/decode.rs
+++ b/gix-object/src/commit/message/decode.rs
@@ -1,18 +1,18 @@
 use winnow::{
-    combinator::{alt, eof, preceded, rest, terminated},
+    combinator::{alt, eof, preceded, terminated},
     error::ParserError,
     prelude::*,
     stream::{Offset, Stream},
-    token::take_till,
+    token::{rest, take_till},
 };
 
 use crate::bstr::{BStr, ByteSlice};
 
-pub(crate) fn newline<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a [u8], E> {
+pub(crate) fn newline<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> ModalResult<&'a [u8], E> {
     alt((b"\n", b"\r\n")).parse_next(i)
 }
 
-fn subject_and_body<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<(&'a BStr, Option<&'a BStr>), E> {
+fn subject_and_body<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> ModalResult<(&'a BStr, Option<&'a BStr>), E> {
     let start_i = *i;
     let start = i.checkpoint();
     while !i.is_empty() {

--- a/gix-object/src/parse.rs
+++ b/gix-object/src/parse.rs
@@ -41,14 +41,14 @@ pub(crate) fn any_header_field_multi_line<'a, E: ParserError<&'a [u8]> + AddCont
 pub(crate) fn header_field<'a, T, E: ParserError<&'a [u8]>>(
     i: &mut &'a [u8],
     name: &'static [u8],
-    parse_value: impl Parser<&'a [u8], T, E>,
+    parse_value: impl ModalParser<&'a [u8], T, E>,
 ) -> ModalResult<T, E> {
     terminated(preceded(terminated(name, SPACE), parse_value), NL).parse_next(i)
 }
 
 pub(crate) fn any_header_field<'a, T, E: ParserError<&'a [u8]>>(
     i: &mut &'a [u8],
-    parse_value: impl Parser<&'a [u8], T, E>,
+    parse_value: impl ModalParser<&'a [u8], T, E>,
 ) -> ModalResult<(&'a [u8], T), E> {
     terminated((terminated(take_till(1.., SPACE_OR_NL), SPACE), parse_value), NL).parse_next(i)
 }

--- a/gix-object/src/parse.rs
+++ b/gix-object/src/parse.rs
@@ -14,7 +14,7 @@ const SPACE_OR_NL: &[u8] = b" \n";
 
 pub(crate) fn any_header_field_multi_line<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8], StrContext>>(
     i: &mut &'a [u8],
-) -> PResult<(&'a [u8], BString), E> {
+) -> ModalResult<(&'a [u8], BString), E> {
     (
         terminated(take_till(1.., SPACE_OR_NL), SPACE),
         (
@@ -42,14 +42,14 @@ pub(crate) fn header_field<'a, T, E: ParserError<&'a [u8]>>(
     i: &mut &'a [u8],
     name: &'static [u8],
     parse_value: impl Parser<&'a [u8], T, E>,
-) -> PResult<T, E> {
+) -> ModalResult<T, E> {
     terminated(preceded(terminated(name, SPACE), parse_value), NL).parse_next(i)
 }
 
 pub(crate) fn any_header_field<'a, T, E: ParserError<&'a [u8]>>(
     i: &mut &'a [u8],
     parse_value: impl Parser<&'a [u8], T, E>,
-) -> PResult<(&'a [u8], T), E> {
+) -> ModalResult<(&'a [u8], T), E> {
     terminated((terminated(take_till(1.., SPACE_OR_NL), SPACE), parse_value), NL).parse_next(i)
 }
 
@@ -57,7 +57,7 @@ fn is_hex_digit_lc(b: u8) -> bool {
     matches!(b, b'0'..=b'9' | b'a'..=b'f')
 }
 
-pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a BStr, E> {
+pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> ModalResult<&'a BStr, E> {
     take_while(
         gix_hash::Kind::shortest().len_in_hex()..=gix_hash::Kind::longest().len_in_hex(),
         is_hex_digit_lc,
@@ -68,6 +68,6 @@ pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a B
 
 pub(crate) fn signature<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8], StrContext>>(
     i: &mut &'a [u8],
-) -> PResult<gix_actor::SignatureRef<'a>, E> {
+) -> ModalResult<gix_actor::SignatureRef<'a>, E> {
     gix_actor::signature::decode(i)
 }

--- a/gix-object/src/tag/decode.rs
+++ b/gix-object/src/tag/decode.rs
@@ -1,16 +1,16 @@
 use winnow::{
-    combinator::{alt, delimited, eof, opt, preceded, rest, terminated},
+    combinator::{alt, delimited, eof, opt, preceded, terminated},
     error::{AddContext, ParserError, StrContext},
     prelude::*,
     stream::AsChar,
-    token::{take_until, take_while},
+    token::{rest, take_until, take_while},
 };
 
 use crate::{parse, parse::NL, BStr, ByteSlice, TagRef};
 
 pub fn git_tag<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8], StrContext>>(
     i: &mut &'a [u8],
-) -> PResult<TagRef<'a>, E> {
+) -> ModalResult<TagRef<'a>, E> {
     (
         (|i: &mut _| parse::header_field(i, b"object", parse::hex_hash))
             .context(StrContext::Expected("object <40 lowercase hex char>".into())),
@@ -36,7 +36,7 @@ pub fn git_tag<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8], StrContext>>(
         .parse_next(i)
 }
 
-pub fn message<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<(&'a BStr, Option<&'a BStr>), E> {
+pub fn message<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> ModalResult<(&'a BStr, Option<&'a BStr>), E> {
     const PGP_SIGNATURE_BEGIN: &[u8] = b"\n-----BEGIN PGP SIGNATURE-----";
     const PGP_SIGNATURE_END: &[u8] = b"-----END PGP SIGNATURE-----";
 

--- a/gix-object/src/tag/ref_iter.rs
+++ b/gix-object/src/tag/ref_iter.rs
@@ -86,8 +86,7 @@ impl<'a> TagRefIter<'a> {
                 let kind = (|i: &mut _| parse::header_field(i, b"type", take_while(1.., AsChar::is_alpha)))
                     .context(StrContext::Expected("type <object kind>".into()))
                     .parse_next(input)?;
-                let kind = Kind::from_bytes(kind)
-                    .map_err(|_| winnow::error::ErrMode::from_error_kind(input, winnow::error::ErrorKind::Verify))?;
+                let kind = Kind::from_bytes(kind).map_err(|_| winnow::error::ErrMode::from_input(input))?;
                 *state = Name;
                 Token::TargetKind(kind)
             }

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -159,7 +159,7 @@ impl<'a> Iterator for TreeRefIter<'a> {
                 self.data = &[];
                 #[allow(clippy::unit_arg)]
                 Some(Err(crate::decode::Error::with_err(
-                    winnow::error::ErrMode::from_error_kind(&failing, winnow::error::ErrorKind::Verify),
+                    winnow::error::ErrMode::from_input(&failing),
                     failing,
                 )))
             }
@@ -236,16 +236,13 @@ mod decode {
         ))
     }
 
-    pub fn tree<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<TreeRef<'a>, E> {
+    pub fn tree<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> ModalResult<TreeRef<'a>, E> {
         let mut out = Vec::new();
         let mut i = &**i;
         while !i.is_empty() {
             let Some((rest, entry)) = fast_entry(i) else {
                 #[allow(clippy::unit_arg)]
-                return Err(winnow::error::ErrMode::from_error_kind(
-                    &i,
-                    winnow::error::ErrorKind::Verify,
-                ));
+                return Err(winnow::error::ErrMode::from_input(&i));
             };
             i = rest;
             out.push(entry);

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -93,7 +93,7 @@ bstr = { version = "1.3.0", default-features = false, features = [
     "std",
     "unicode",
 ] }
-winnow = { version = "0.6.26", features = ["simd"] }
+winnow = { version = "0.7.0", features = ["simd"] }
 
 # for async-client
 async-trait = { version = "0.1.51", optional = true }

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -93,7 +93,7 @@ bstr = { version = "1.3.0", default-features = false, features = [
     "std",
     "unicode",
 ] }
-winnow = { version = "0.6", features = ["simd"] }
+winnow = { version = "0.6.26", features = ["simd"] }
 
 # for async-client
 async-trait = { version = "0.1.51", optional = true }

--- a/gix-protocol/src/remote_progress.rs
+++ b/gix-protocol/src/remote_progress.rs
@@ -71,13 +71,13 @@ impl RemoteProgress<'_> {
     }
 }
 
-fn parse_number(i: &mut &[u8]) -> PResult<usize, ()> {
+fn parse_number(i: &mut &[u8]) -> ModalResult<usize, ()> {
     take_till(0.., |c: u8| !c.is_ascii_digit())
         .try_map(gix_utils::btoi::to_signed)
         .parse_next(i)
 }
 
-fn next_optional_percentage(i: &mut &[u8]) -> PResult<Option<u32>, ()> {
+fn next_optional_percentage(i: &mut &[u8]) -> ModalResult<Option<u32>, ()> {
     opt(terminated(
         preceded(
             take_till(0.., |c: u8| c.is_ascii_digit()),
@@ -88,11 +88,11 @@ fn next_optional_percentage(i: &mut &[u8]) -> PResult<Option<u32>, ()> {
     .parse_next(i)
 }
 
-fn next_optional_number(i: &mut &[u8]) -> PResult<Option<usize>, ()> {
+fn next_optional_number(i: &mut &[u8]) -> ModalResult<Option<usize>, ()> {
     opt(preceded(take_till(0.., |c: u8| c.is_ascii_digit()), parse_number)).parse_next(i)
 }
 
-fn parse_progress<'i>(line: &mut &'i [u8]) -> PResult<RemoteProgress<'i>, ()> {
+fn parse_progress<'i>(line: &mut &'i [u8]) -> ModalResult<RemoteProgress<'i>, ()> {
     let action = take_till(1.., |c| c == b':').parse_next(line)?;
     let percent = next_optional_percentage.parse_next(line)?;
     let step = next_optional_number.parse_next(line)?;

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -33,7 +33,7 @@ gix-lock = { version = "^16.0.0", path = "../gix-lock" }
 gix-tempfile = { version = "^16.0.0", default-features = false, path = "../gix-tempfile" }
 
 thiserror = "2.0.0"
-winnow = { version = "0.6", features = ["simd"] }
+winnow = { version = "0.6.26", features = ["simd"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 
 # packed refs

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -33,7 +33,7 @@ gix-lock = { version = "^16.0.0", path = "../gix-lock" }
 gix-tempfile = { version = "^16.0.0", default-features = false, path = "../gix-tempfile" }
 
 thiserror = "2.0.0"
-winnow = { version = "0.6.26", features = ["simd"] }
+winnow = { version = "0.7.0", features = ["simd"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 
 # packed refs

--- a/gix-ref/src/parse.rs
+++ b/gix-ref/src/parse.rs
@@ -6,7 +6,7 @@ fn is_hex_digit_lc(b: u8) -> bool {
 }
 
 /// Copy from https://github.com/GitoxideLabs/gitoxide/blob/64872690e60efdd9267d517f4d9971eecd3b875c/gix-object/src/parse.rs#L60-L67
-pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a BStr, E> {
+pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> ModalResult<&'a BStr, E> {
     // NOTE: It's important to be able to read all hashes, do not parameterize it. Hashes can be rejected at a later stage
     // if needed.
     take_while(
@@ -17,6 +17,6 @@ pub fn hex_hash<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a B
     .parse_next(i)
 }
 
-pub fn newline<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a [u8], E> {
+pub fn newline<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> ModalResult<&'a [u8], E> {
     alt((b"\r\n", b"\n")).parse_next(i)
 }

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -76,10 +76,10 @@ pub mod decode {
     use crate::{file::log::LineRef, parse::hex_hash};
     use gix_object::bstr::{BStr, ByteSlice};
     use winnow::{
-        combinator::{alt, eof, fail, opt, preceded, rest, terminated},
+        combinator::{alt, eof, fail, opt, preceded, terminated},
         error::{AddContext, ParserError, StrContext},
         prelude::*,
-        token::take_while,
+        token::{rest, take_while},
     };
 
     ///
@@ -121,7 +121,7 @@ pub mod decode {
         }
     }
 
-    fn message<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> PResult<&'a BStr, E> {
+    fn message<'a, E: ParserError<&'a [u8]>>(i: &mut &'a [u8]) -> ModalResult<&'a BStr, E> {
         if i.is_empty() {
             rest.map(ByteSlice::as_bstr).parse_next(i)
         } else {
@@ -133,7 +133,7 @@ pub mod decode {
 
     fn one<'a, E: ParserError<&'a [u8]> + AddContext<&'a [u8], StrContext>>(
         bytes: &mut &'a [u8],
-    ) -> PResult<LineRef<'a>, E> {
+    ) -> ModalResult<LineRef<'a>, E> {
         let mut tokens = bytes.splitn(2, |b| *b == b'\t');
         if let (Some(mut first), Some(mut second)) = (tokens.next(), tokens.next()) {
             let (old, new, signature) = (

--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -66,7 +66,7 @@ impl Reference {
     }
 }
 
-fn parse(i: &mut &[u8]) -> PResult<MaybeUnsafeState> {
+fn parse(i: &mut &[u8]) -> ModalResult<MaybeUnsafeState> {
     if let Some(_ref_prefix) = opt(terminated("ref: ", take_while(0.., b' '))).parse_next(i)? {
         terminated(take_while(0.., |b| b != b'\r' && b != b'\n'), opt(newline))
             .map(|path| MaybeUnsafeState::UnvalidatedPath(path.into()))

--- a/gix-ref/src/store/packed/decode.rs
+++ b/gix-ref/src/store/packed/decode.rs
@@ -34,7 +34,7 @@ impl Default for Header {
     }
 }
 
-fn until_newline<'a, E>(input: &mut &'a [u8]) -> PResult<&'a BStr, E>
+fn until_newline<'a, E>(input: &mut &'a [u8]) -> ModalResult<&'a BStr, E>
 where
     E: ParserError<&'a [u8]>,
 {
@@ -43,7 +43,7 @@ where
         .parse_next(input)
 }
 
-pub fn header<'a, E>(input: &mut &'a [u8]) -> PResult<Header, E>
+pub fn header<'a, E>(input: &mut &'a [u8]) -> ModalResult<Header, E>
 where
     E: ParserError<&'a [u8]>,
 {
@@ -67,7 +67,7 @@ where
 
 pub fn reference<'a, E: ParserError<&'a [u8]> + FromExternalError<&'a [u8], crate::name::Error>>(
     input: &mut &'a [u8],
-) -> PResult<packed::Reference<'a>, E> {
+) -> ModalResult<packed::Reference<'a>, E> {
     (
         terminated(hex_hash, b" "),
         until_newline.try_map(TryInto::try_into),

--- a/gix-ref/src/store/packed/iter.rs
+++ b/gix-ref/src/store/packed/iter.rs
@@ -1,5 +1,5 @@
 use gix_object::bstr::{BString, ByteSlice};
-use winnow::{combinator::preceded, prelude::*, stream::Stream as _, token::rest};
+use winnow::{combinator::preceded, prelude::*, token::rest};
 
 use crate::store_impl::{packed, packed::decode};
 

--- a/gix-ref/src/store/packed/iter.rs
+++ b/gix-ref/src/store/packed/iter.rs
@@ -1,9 +1,5 @@
 use gix_object::bstr::{BString, ByteSlice};
-use winnow::{
-    combinator::{preceded, rest},
-    prelude::*,
-    stream::Stream as _,
-};
+use winnow::{combinator::preceded, prelude::*, stream::Stream as _, token::rest};
 
 use crate::store_impl::{packed, packed::decode};
 

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -31,7 +31,7 @@ gix-worktree = "0.34.0"
 gix-fs = "0.11"
 gix-tempfile = { version = "^14.0.0", default-features = false, features = ["signals"] }
 
-winnow = { version = "0.6.26", features = ["simd"] }
+winnow = { version = "0.7.0", features = ["simd"] }
 fastrand = "2.0.0"
 bstr = { version = "1.5.0", default-features = false }
 crc = "3.0.0"

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -31,7 +31,7 @@ gix-worktree = "0.34.0"
 gix-fs = "0.11"
 gix-tempfile = { version = "^14.0.0", default-features = false, features = ["signals"] }
 
-winnow = { version = "0.6.0", features = ["simd"] }
+winnow = { version = "0.6.26", features = ["simd"] }
 fastrand = "2.0.0"
 bstr = { version = "1.5.0", default-features = false }
 crc = "3.0.0"


### PR DESCRIPTION
FYI as this doesn't use `cut_err` or `Partial`, you could switch away from `ErrMode` for some potential simplification and performance improvements.

I think it should just be
1. Remove `ErrMode`
2. Switch from `ModalParser` to `Parser`
3. Switch from `ModalResult` to `winnow::Result`

However, it'd be harder to undo it (picking apart which `Result`s need to be `ModalResult`s) so I held off on it from this PR