### PR TITLE
Add test for commits not ordered chronologically

### DIFF
--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -236,6 +236,11 @@ mktest!(
 );
 mktest!(file_only_changed_in_branch, "file-only-changed-in-branch", 2);
 mktest!(file_changed_in_two_branches, "file-changed-in-two-branches", 3);
+mktest!(
+    file_topo_order_different_than_date_order,
+    "file-topo-order-different-than-date-order",
+    3
+);
 
 /// As of 2024-09-24, these tests are expected to fail.
 ///


### PR DESCRIPTION
This test covers a case that I came across working on #1743. Git doesn’t guarantee commits are ordered by commit date, so this adds a test for that specific case. In order to facilitate review, I decided to go with this small and targeted PR.

Since I keep adding tests to `make_blame_repo.sh`, I started wondering whether this was the best way of organizing the different test cases or whether it would be beneficial to spread them across multiple smaller files. What do you think?
