### PR TITLE
Replace `odb.find_commit` by `gix_traverse::commit::find`

### DIFF
--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -24,8 +24,6 @@ pub struct Outcome {
 pub struct Statistics {
     /// The amount of commits it traversed until the blame was complete.
     pub commits_traversed: usize,
-    /// The amount of commits whose trees were extracted.
-    pub commits_to_tree: usize,
     /// The amount of trees that were decoded to find the entry of the file to blame.
     pub trees_decoded: usize,
     /// The amount of tree-diffs to see if the filepath was added, deleted or modified. These diffs


### PR DESCRIPTION
This is another performance win. The speed-up varies greatly, depending on the specific case. As two examples, I compared `gix blame STABILITY.md` in `gitoxide` and `gix blame README` in `linux`.

```
gitoxide on  main [$?] is 📦 v0.41.0 via 🦀 v1.84.0 took 4s
❯ hyperfine "$HOME/github/Byron/gitoxide/target/release/gix blame STABILITY.md" "$HOME/worktrees/gitoxide/branch-1/target/release/gix blame STABILITY.md"
Benchmark 1: /home/christoph/github/Byron/gitoxide/target/release/gix blame STABILITY.md
  Time (mean ± σ):     111.6 ms ±   8.1 ms    [User: 91.9 ms, System: 12.5 ms]
  Range (min … max):   102.1 ms … 142.4 ms    28 runs

Benchmark 2: /home/christoph/worktrees/gitoxide/branch-1/target/release/gix blame STABILITY.md
  Time (mean ± σ):      69.8 ms ±   5.1 ms    [User: 51.7 ms, System: 11.2 ms]
  Range (min … max):    64.2 ms …  86.5 ms    44 runs

Summary
  '/home/christoph/worktrees/gitoxide/branch-1/target/release/gix blame STABILITY.md' ran
    1.60 ± 0.17 times faster than '/home/christoph/github/Byron/gitoxide/target/release/gix blame STABILITY.md'
```

```
linux on  master [⇣]
❯ hyperfine "$HOME/github/Byron/gitoxide/target/release/gix blame README" "$HOME/worktrees/gitoxide/branch-1/target/release/gix blame README"
Benchmark 1: /home/christoph/github/Byron/gitoxide/target/release/gix blame README
  Time (mean ± σ):     422.6 ms ±   3.4 ms    [User: 365.7 ms, System: 55.5 ms]
  Range (min … max):   419.4 ms … 429.6 ms    10 runs

Benchmark 2: /home/christoph/worktrees/gitoxide/branch-1/target/release/gix blame README
  Time (mean ± σ):     408.6 ms ±   3.1 ms    [User: 352.7 ms, System: 54.4 ms]
  Range (min … max):   403.9 ms … 414.1 ms    10 runs

Summary
  '/home/christoph/worktrees/gitoxide/branch-1/target/release/gix blame README' ran
    1.03 ± 0.01 times faster than '/home/christoph/github/Byron/gitoxide/target/release/gix blame README'
```
