### PR TITLE
Change test-32bit arm32v7 runner to ubuntu-22.04-arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
             toolchain: stable-i686-unknown-linux-gnu
           - container-arch: arm32v7
             runner-arch: arm64
-            runner-os: ubuntu-24.04-arm
+            runner-os: ubuntu-22.04-arm
             toolchain: stable-armv7-unknown-linux-gnueabihf
 
     runs-on: ${{ matrix.runner-os }}


### PR DESCRIPTION
Changed from ubuntu-24.04-arm, which seems to be having some problems in the test-32bit job (where it had still been in use), as discussed in #1828.

This can be viewed as a follow-up on #1802, which made the analogous change for the non-containerized test job only.

[This is the run](https://github.com/GitoxideLabs/gitoxide/actions/runs/13131588835/job/36637705370?pr=1830) of the changed job. It passes, though that does not demonstrate that this is better, since the failures before the change were nondeterministic and didn't happen most of the time.