### PR TITLE
build: upgrade to jiff 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,7 +1476,7 @@ dependencies = [
  "gix-testtools",
  "gix-worktree 0.39.0",
  "gix-worktree-stream",
- "jiff",
+ "jiff 0.2.0",
  "tar",
  "thiserror 2.0.3",
  "zip",
@@ -1705,7 +1705,7 @@ dependencies = [
  "gix-hash 0.16.0",
  "gix-testtools",
  "itoa",
- "jiff",
+ "jiff 0.2.0",
  "once_cell",
  "pretty_assertions",
  "serde",
@@ -3506,16 +3506,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-tzdb"
-version = "0.1.1"
+name = "jiff"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653"
+checksum = "ba926fdd8e5b5e7f9700355b0831d8c416afe94b014b1023424037a187c9c582"
+dependencies = [
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2cec2f5d266af45a071ece48b1fb89f3b00b2421ac3a5fe10285a6caaa60d3"
 
 [[package]]
 name = "jiff-tzdb-platform"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329"
+checksum = "a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e"
 dependencies = [
  "jiff-tzdb",
 ]
@@ -4146,6 +4160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4209,7 +4232,7 @@ dependencies = [
  "human_format",
  "humantime",
  "is-terminal",
- "jiff",
+ "jiff 0.1.14",
  "log",
  "parking_lot",
  "ratatui",

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -34,7 +34,7 @@ gix-date = { version = "^0.9.3", path = "../gix-date" }
 
 flate2 = { version = "1.0.33", optional = true }
 zip = { version = "2.1.0", optional = true, default-features = false, features = ["deflate"] }
-jiff = { version = "0.1.2", default-features = false, features = ["std"] }
+jiff = { version = "0.2.0", default-features = false, features = ["std"] }
 
 thiserror = "2.0.0"
 bstr = { version = "1.5.0", default-features = false }

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -22,7 +22,7 @@ serde = ["dep:serde", "bstr/serde"]
 bstr = { version = "1.3.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 itoa = "1.0.1"
-jiff = "0.1.1"
+jiff = "0.2.0"
 thiserror = "2.0.0"
 
 document-features = { version = "0.2.0", optional = true }

--- a/gix-date/src/parse.rs
+++ b/gix-date/src/parse.rs
@@ -167,7 +167,8 @@ mod relative {
 
         #[test]
         fn two_weeks_ago() {
-            assert_eq!(parse_inner("2 weeks ago").unwrap().unwrap(), Span::new().weeks(2));
+            let actual = parse_inner("2 weeks ago").unwrap().unwrap();
+            assert_eq!(actual.fieldwise(), Span::new().weeks(2));
         }
     }
 }


### PR DESCRIPTION
We should not be affected by all the breaking changes - https://github.com/BurntSushi/jiff/releases/tag/0.2.0

cc @BurntSushi as you contribute the original replacement to `time`.