### PR TITLE
Enable shell-related and env var tests Windows already supports

### DIFF
--- a/gix-command/tests/command.rs
+++ b/gix-command/tests/command.rs
@@ -459,10 +459,9 @@ mod spawn {
     }
 
     #[test]
-    #[cfg(unix)]
     fn disallow_shell() -> crate::Result {
         let out = gix_command::prepare("PATH= echo hi")
-            .command_may_be_shell_script()
+            .command_may_be_shell_script_disallow_manual_argument_splitting()
             .spawn()?
             .wait_with_output()?;
         assert_eq!(out.stdout.as_bstr(), "hi\n");

--- a/gix-command/tests/command.rs
+++ b/gix-command/tests/command.rs
@@ -446,7 +446,6 @@ mod spawn {
     use bstr::ByteSlice;
 
     #[test]
-    #[cfg(unix)]
     fn environment_variables_are_passed_one_by_one() -> crate::Result {
         let out = gix_command::prepare("echo $FIRST $SECOND")
             .env("FIRST", "first")


### PR DESCRIPTION
This enables two `gix-command` tests on Windows that had previously only run on Unix-like systems. One required a small change that didn't affect the robustness of the test, while the other required no change. Full details are in the commit messages.