### PR TITLE
Start blame from cache

### DIFF
--- a/gitoxide-core/src/repository/blame.rs
+++ b/gitoxide-core/src/repository/blame.rs
@@ -43,6 +43,7 @@ pub fn blame_file(
         suspect,
         cache,
         &mut resource_cache,
+        None,
         file.as_bstr(),
         range,
     )?;

--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -73,19 +73,11 @@ pub fn file(
 
     let mut stats = Statistics::default();
     let (mut buf, mut buf2, mut buf3) = (Vec::new(), Vec::new(), Vec::new());
-    let blamed_file_entry_id = find_path_entry_in_commit(
-        &odb,
-        &suspect,
-        file_path,
-        cache.as_ref(),
-        &mut buf,
-        &mut buf2,
-        &mut stats,
-    )?
-    .ok_or_else(|| Error::FileMissing {
+    let mut file_id = |commit, buf: &mut Vec<u8>, buf2: &mut Vec<u8>| find_path_entry_in_commit(&odb, commit, file_path, cache.as_ref(), buf, buf2, &mut stats)?.ok_or_else(|| Error::FileMissing {
         file_path: file_path.to_owned(),
         commit_id: suspect,
-    })?;
+    });
+    let blamed_file_entry_id = file_id(&suspect, &mut buf, &mut buf2)?;
     let blamed_file_blob = odb.find_blob(&blamed_file_entry_id, &mut buf)?.data.to_vec();
     let num_lines_in_blamed = tokens_for_diffing(&blamed_file_blob).tokenize().count() as u32;
 

--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -1,10 +1,11 @@
-use super::{process_changes, Change, UnblamedHunk};
+use super::{process_changes, update_blame_with_changes, Change, UnblamedHunk};
+use crate::types::BlameCacheObject;
 use crate::{BlameEntry, Error, Outcome, Statistics};
 use gix_diff::blob::intern::TokenSource;
 use gix_diff::tree::Visit;
 use gix_hash::ObjectId;
 use gix_object::{
-    bstr::{BStr, BString},
+    bstr::{BStr, BString, ByteSlice},
     FindExt,
 };
 use gix_traverse::commit::find as find_commit;
@@ -66,6 +67,7 @@ pub fn file(
     suspect: ObjectId,
     cache: Option<gix_commitgraph::Graph>,
     resource_cache: &mut gix_diff::blob::Platform,
+    blame_cache: Option<BlameCacheObject>,
     file_path: &BStr,
     range: Option<Range<u32>>,
 ) -> Result<Outcome, Error> {
@@ -73,10 +75,14 @@ pub fn file(
 
     let mut stats = Statistics::default();
     let (mut buf, mut buf2, mut buf3) = (Vec::new(), Vec::new(), Vec::new());
-    let mut file_id = |commit, buf: &mut Vec<u8>, buf2: &mut Vec<u8>| find_path_entry_in_commit(&odb, commit, file_path, cache.as_ref(), buf, buf2, &mut stats)?.ok_or_else(|| Error::FileMissing {
-        file_path: file_path.to_owned(),
-        commit_id: suspect,
-    });
+    let mut file_id = |commit, buf: &mut Vec<u8>, buf2: &mut Vec<u8>| {
+        find_path_entry_in_commit(&odb, commit, file_path, cache.as_ref(), buf, buf2, &mut stats)?.ok_or_else(|| {
+            Error::FileMissing {
+                file_path: file_path.to_owned(),
+                commit_id: suspect,
+            }
+        })
+    };
     let blamed_file_entry_id = file_id(&suspect, &mut buf, &mut buf2)?;
     let blamed_file_blob = odb.find_blob(&blamed_file_entry_id, &mut buf)?.data.to_vec();
     let num_lines_in_blamed = tokens_for_diffing(&blamed_file_blob).tokenize().count() as u32;
@@ -87,17 +93,56 @@ pub fn file(
     }
 
     let range_in_blamed_file = one_based_inclusive_to_zero_based_exclusive_range(range, num_lines_in_blamed)?;
-    let mut hunks_to_blame = vec![UnblamedHunk {
-        range_in_blamed_file: range_in_blamed_file.clone(),
-        suspects: [(suspect, range_in_blamed_file)].into(),
-    }];
+
+    let (blame_entries, mut hunks_to_blame) = match blame_cache {
+        Some(blame_cache) => {
+            // If there is a cache, we first get the diff between the current commit and the commit
+            // we passed as the cache.
+            let old_file_id = file_id(&blame_cache.cache_id, &mut buf, &mut buf2)?;
+            let changes = blob_changes(
+                &odb,
+                resource_cache,
+                blamed_file_entry_id,
+                old_file_id,
+                file_path.as_bstr(),
+                &mut stats,
+            )?;
+
+            // If there are no changes, we can return the cache as is immediately.
+            if changes.iter().all(|change| matches!(change, Change::Unchanged(_))) {
+                return Ok(Outcome {
+                    entries: blame_cache.entries.clone(),
+                    blob: blamed_file_blob,
+                    statistics: stats,
+                });
+            }
+            // Otherwise, we update the cache with the new changes.
+            let (blame_entries, hunks_to_blame) = update_blame_with_changes(blame_cache.entries, changes, suspect);
+            // If there are no more hunks to blame, we can return the result immediately.
+            if hunks_to_blame.is_empty() {
+                return Ok(Outcome {
+                    entries: blame_entries,
+                    blob: blamed_file_blob,
+                    statistics: stats,
+                });
+            }
+            (blame_entries, hunks_to_blame)
+        }
+        None => {
+            let hunks_to_blame = vec![UnblamedHunk {
+                range_in_blamed_file: range_in_blamed_file.clone(),
+                suspects: [(suspect, range_in_blamed_file)].into(),
+            }];
+            (Vec::new(), hunks_to_blame)
+        }
+    };
 
     let (mut buf, mut buf2) = (Vec::new(), Vec::new());
     let commit = find_commit(cache.as_ref(), &odb, &suspect, &mut buf)?;
     let mut queue: gix_revwalk::PriorityQueue<CommitTime, ObjectId> = gix_revwalk::PriorityQueue::new();
     queue.insert(commit_time(commit)?, suspect);
 
-    let mut out = Vec::new();
+    let mut out = blame_entries;
     let mut diff_state = gix_diff::tree::State::default();
     let mut previous_entry: Option<(ObjectId, ObjectId)> = None;
     'outer: while let Some(suspect) = queue.pop_value() {

--- a/gix-blame/src/file/mod.rs
+++ b/gix-blame/src/file/mod.rs
@@ -357,7 +357,7 @@ fn process_changes(
     new_hunks_to_blame
 }
 
-/// Consume `cached_blames` and `changes`. With the changes we update the cached blames. 
+/// Consume `cached_blames` and `changes`. With the changes we update the cached blames.
 /// This function returns the updated blames and the new hunks to blame.
 fn update_blame_with_changes(
     cached_blames: Vec<BlameEntry>,
@@ -453,7 +453,7 @@ fn update_blame_with_changes(
                         }
                         false => {
                             new_hunks_to_blame.push(new_unblamed_hunk(range, head_id));
-                            
+
                             blame_assigned
                                 .assigned
                                 .add_assigned(change_assigned.get_remaining(&change));

--- a/gix-blame/src/file/tests.rs
+++ b/gix-blame/src/file/tests.rs
@@ -27,6 +27,246 @@ fn one_sha() -> ObjectId {
     ObjectId::from_str("1111111111111111111111111111111111111111").unwrap()
 }
 
+fn two_sha() -> ObjectId {
+    use std::str::FromStr;
+
+    ObjectId::from_str("2222222222222222222222222222222222222222").unwrap()
+}
+
+mod blame_cache_to_hunks {
+    use super::*;
+    use crate::file::{update_blame_with_changes, BlameEntry, Change, UnblamedHunk};
+
+    fn single_blame_entry() -> Vec<BlameEntry> {
+        vec![BlameEntry::new(0..5, 0..5, zero_sha())]
+    }
+
+    fn multiple_blame_entries() -> Vec<BlameEntry> {
+        vec![
+            BlameEntry::new(0..5, 0..5, zero_sha()),
+            BlameEntry::new(5..10, 0..5, one_sha()),
+        ]
+    }
+
+    #[test]
+    fn no_changes() {
+        let cached_blames = single_blame_entry();
+        let changes = vec![Change::Unchanged(0..5)];
+
+        let expected_blame = single_blame_entry();
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, one_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert!(new_unblamed_hunks.is_empty());
+    }
+
+    #[test]
+    fn deleted_line_full_blame() {
+        let cached_blames = single_blame_entry();
+        let changes = vec![Change::Deleted(0, 5)];
+        let expected_blame = vec![];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, one_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert!(new_unblamed_hunks.is_empty());
+    }
+
+    #[test]
+    fn deleted_line_partial_first_delete() {
+        let cached_blames = single_blame_entry();
+        let changes = vec![Change::Deleted(0, 3), Change::Unchanged(0..2)];
+        let expected_blame = vec![BlameEntry::new(0..2, 3..5, zero_sha())];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, one_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert!(new_unblamed_hunks.is_empty());
+    }
+
+    #[test]
+    fn deleted_line_partial_first_unchanged() {
+        let cached_blames = single_blame_entry();
+        let changes = vec![Change::Unchanged(0..2), Change::Deleted(0, 3)];
+        let expected_blame = vec![BlameEntry::new(0..2, 0..2, zero_sha())];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, one_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert!(new_unblamed_hunks.is_empty());
+    }
+
+    #[test]
+    fn deleted_line_spanning() {
+        let cached_blames = single_blame_entry();
+        let changes = vec![Change::Unchanged(0..1), Change::Deleted(1, 3), Change::Unchanged(1..2)];
+        let expected_blame = vec![
+            BlameEntry::new(0..1, 0..1, zero_sha()),
+            BlameEntry::new(1..2, 4..5, zero_sha()),
+        ];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, one_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert!(new_unblamed_hunks.is_empty());
+    }
+
+    #[test]
+    fn add_or_replace_full_blame_delete() {
+        let cached_blames = single_blame_entry();
+        let changes = vec![Change::AddedOrReplaced(0..5, 5)];
+        let expected_blame = vec![];
+        let expected_unblamed_hunks = vec![UnblamedHunk {
+            range_in_blamed_file: 0..5,
+            suspects: [(two_sha(), 0..5)].into(),
+        }];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, two_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert_eq!(new_unblamed_hunks, expected_unblamed_hunks);
+    }
+
+    #[test]
+    fn add_or_replace_first_partial_blame_delete() {
+        let cached_blames = single_blame_entry();
+        let changes = vec![Change::AddedOrReplaced(0..5, 3), Change::Unchanged(5..7)];
+        let expected_blame = vec![BlameEntry::new(5..7, 3..5, zero_sha())];
+        let expected_unblamed_hunks = vec![UnblamedHunk {
+            range_in_blamed_file: 0..5,
+            suspects: [(two_sha(), 0..5)].into(),
+        }];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, two_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert_eq!(new_unblamed_hunks, expected_unblamed_hunks);
+    }
+
+    #[test]
+    fn add_or_replace_first_unchanged_partial_blame_delete() {
+        let cached_blames = single_blame_entry();
+        let changes = vec![Change::Unchanged(0..3), Change::AddedOrReplaced(0..5, 2)];
+        let expected_blame = vec![BlameEntry::new(0..3, 0..3, zero_sha())];
+        let expected_unblamed_hunks = vec![UnblamedHunk {
+            range_in_blamed_file: 0..5,
+            suspects: [(two_sha(), 0..5)].into(),
+        }];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, two_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert_eq!(new_unblamed_hunks, expected_unblamed_hunks);
+    }
+
+    #[test]
+    fn add_or_replace_unchanged_replace_unchanged() {
+        let cached_blames = single_blame_entry();
+        let changes = vec![
+            Change::Unchanged(0..2),
+            Change::AddedOrReplaced(0..5, 1),
+            Change::Unchanged(7..9),
+        ];
+        let expected_blame = vec![
+            BlameEntry::new(0..2, 0..2, zero_sha()),
+            BlameEntry::new(7..9, 3..5, zero_sha()),
+        ];
+        let expected_unblamed_hunks = vec![UnblamedHunk {
+            range_in_blamed_file: 0..5,
+            suspects: [(two_sha(), 0..5)].into(),
+        }];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, two_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert_eq!(new_unblamed_hunks, expected_unblamed_hunks);
+    }
+
+    #[test]
+    fn add_or_replace_no_deletion() {
+        let cached_blames = single_blame_entry();
+        let changes = vec![
+            Change::Unchanged(0..2),
+            Change::AddedOrReplaced(0..5, 0),
+            Change::Unchanged(6..9),
+        ];
+        let expected_blame = vec![
+            BlameEntry::new(0..2, 0..2, zero_sha()),
+            BlameEntry::new(6..9, 2..5, zero_sha()),
+        ];
+        let expected_unblamed_hunks = vec![UnblamedHunk {
+            range_in_blamed_file: 0..5,
+            suspects: [(two_sha(), 0..5)].into(),
+        }];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, two_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert_eq!(new_unblamed_hunks, expected_unblamed_hunks);
+    }
+
+    #[test]
+    fn multiple_blames_no_change() {
+        let cached_blames = multiple_blame_entries();
+        let changes = vec![Change::Unchanged(0..10)];
+        let expected_blame = vec![
+            BlameEntry::new(0..5, 0..5, zero_sha()),
+            BlameEntry::new(5..10, 0..5, one_sha()),
+        ];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, one_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert!(new_unblamed_hunks.is_empty());
+    }
+
+    #[test]
+    fn multiple_blames_change_spans_multiple_lines_first_unchanged() {
+        let cached_blames = multiple_blame_entries();
+        let changes = vec![Change::Unchanged(0..6), Change::Deleted(6, 4)];
+        let expected_blame = vec![
+            BlameEntry::new(0..5, 0..5, zero_sha()),
+            BlameEntry::new(5..6, 0..1, one_sha()),
+        ];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, one_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert!(new_unblamed_hunks.is_empty());
+    }
+
+    #[test]
+    fn multiple_blames_change_spans_multiple_lines_first_delete() {
+        let cached_blames = multiple_blame_entries();
+        let changes = vec![Change::Deleted(0, 4), Change::Unchanged(0..6)];
+        let expected_blame = vec![
+            BlameEntry::new(0..1, 4..5, zero_sha()),
+            BlameEntry::new(1..6, 0..5, one_sha()),
+        ];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, one_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert!(new_unblamed_hunks.is_empty());
+    }
+
+    #[test]
+    fn multiple_blames_change_spans_delete_spanning() {
+        let cached_blames = multiple_blame_entries();
+        let changes = vec![Change::Unchanged(0..4), Change::Deleted(4, 4), Change::Unchanged(4..6)];
+        let expected_blame = vec![
+            BlameEntry::new(0..4, 0..4, zero_sha()),
+            BlameEntry::new(4..6, 3..5, one_sha()),
+        ];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, one_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert!(new_unblamed_hunks.is_empty());
+    }
+
+    #[test]
+    fn multiple_blames_add_or_replace_blame_delete_spanning() {
+        let cached_blames = multiple_blame_entries();
+        let changes = vec![
+            Change::Unchanged(0..4),
+            Change::AddedOrReplaced(4..9, 3),
+            Change::Unchanged(9..10),
+            Change::AddedOrReplaced(10..12, 2),
+        ];
+        let expected_blame = vec![
+            BlameEntry::new(0..4, 0..4, zero_sha()),
+            BlameEntry::new(9..10, 2..3, one_sha()),
+        ];
+        let expected_unblamed_hunks = vec![
+            UnblamedHunk {
+                range_in_blamed_file: 4..9,
+                suspects: [(two_sha(), 4..9)].into(),
+            },
+            UnblamedHunk {
+                range_in_blamed_file: 10..12,
+                suspects: [(two_sha(), 10..12)].into(),
+            },
+        ];
+        let (updated_blame_entries, new_unblamed_hunks) = update_blame_with_changes(cached_blames, changes, two_sha());
+        assert_eq!(updated_blame_entries, expected_blame);
+        assert_eq!(new_unblamed_hunks, expected_unblamed_hunks);
+    }
+}
+
 mod process_change {
     use super::*;
     use crate::file::{process_change, Change, Offset, UnblamedHunk};

--- a/gix-blame/src/lib.rs
+++ b/gix-blame/src/lib.rs
@@ -17,7 +17,7 @@
 mod error;
 pub use error::Error;
 mod types;
-pub use types::{BlameEntry, Outcome, Statistics};
+pub use types::{BlameCacheObject, BlameEntry, Outcome, Statistics};
 
 mod file;
 pub use file::function::file;

--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -117,6 +117,15 @@ impl SubAssign<u32> for Offset {
     }
 }
 
+#[derive(Debug, PartialEq)]
+/// A cache of blame entries that can be used to speed up subsequent blames.
+pub struct BlameCacheObject {
+    /// The entries of the cache.
+    pub entries: Vec<BlameEntry>,
+    /// The commit that was blamed to produce these entries.
+    pub cache_id: ObjectId,
+}
+
 /// A mapping of a section of the *Blamed File* to the section in a *Source File* that introduced it.
 ///
 /// Both ranges are of the same size, but may use different [starting points](Range::start). Naturally,

--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -170,6 +170,15 @@ impl BlameEntry {
     }
 }
 
+impl BlameEntry {
+    /// Update the `start_in_blamed_file` and `start_in_source_file` fields by the lines that are already assigned.
+    pub(crate) fn update_blame(&mut self, offset: &LinesAssigned) {
+        self.start_in_blamed_file += offset.get_assigned();
+        self.start_in_source_file += offset.get_assigned();
+        self.len = NonZeroU32::new(u32::from(self.len) - offset.get_assigned()).unwrap();
+    }
+}
+
 pub(crate) trait LineRange {
     fn shift_by(&self, offset: Offset) -> Self;
 }
@@ -204,4 +213,53 @@ pub enum Change {
     AddedOrReplaced(Range<u32>, u32),
     /// `(line_to_start_deletion_at, num_deleted_in_before)`
     Deleted(u32, u32),
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct LinesAssigned {
+    lines_assigned: u32,
+}
+
+impl LinesAssigned {
+    pub(crate) fn add_assigned(&mut self, lines: u32) {
+        self.lines_assigned += lines;
+    }
+
+    pub(crate) fn get_assigned(&self) -> u32 {
+        self.lines_assigned
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct BlameLines {
+    pub(crate) assigned: LinesAssigned,
+}
+
+impl BlameLines {
+    pub(crate) fn get_remaining(&self, blame: &BlameEntry) -> u32 {
+        blame.len.get() - self.assigned.get_assigned()
+    }
+
+    pub(crate) fn has_remaining(&self, blame: &BlameEntry) -> bool {
+        self.get_remaining(blame) > 0
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ChangeLines {
+    pub(crate) assigned: LinesAssigned,
+}
+
+impl ChangeLines {
+    pub(crate) fn get_remaining(&self, change: &Change) -> u32 {
+        match &change {
+            Change::Unchanged(range) => range.len() as u32 - self.assigned.get_assigned(),
+            Change::AddedOrReplaced(_, deleted_in_before) => *deleted_in_before - self.assigned.get_assigned(),
+            Change::Deleted(_, deleted_in_before) => *deleted_in_before - self.assigned.get_assigned(),
+        }
+    }
+
+    pub(crate) fn has_remaining(&self, change: &Change) -> bool {
+        self.get_remaining(change) > 0
+    }
 }

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -190,6 +190,7 @@ macro_rules! mktest {
                 suspect,
                 None,
                 &mut resource_cache,
+                None,
                 format!("{}.txt", $case).as_str().into(),
                 None,
             )?
@@ -257,6 +258,7 @@ fn diff_disparity() {
             suspect,
             None,
             &mut resource_cache,
+            None,
             format!("{case}.txt").as_str().into(),
             None,
         )
@@ -285,6 +287,7 @@ fn line_range() {
         suspect,
         None,
         &mut resource_cache,
+        None,
         "simple.txt".into(),
         Some(1..2),
     )


### PR DESCRIPTION
As discussed in #1848, @jtwaleson and I have been working on a way to speed up git blame by introducing a caching mechanism. This allows us to start a blame operation from a checkpoint instead of computing it from scratch, significantly reducing computation time.

**Proposed Changes**
1. **Introduce BlameCacheObject**
The function `function::file` now accepts a `BlameCacheObject`, which stores:
    Commit ID at which the blame was previously computed.
    Blame entries corresponding to that commit.
2. **Detect and Process Changes**
    Using the cached data, we compute the differences between the cached blob and the new target blob at the suspect commit.
    If the file has been rewritten, this will probably error, so the BlameCacheObject might need to store the file path as well.
3. **Efficiently Update Blame Entries**
    Cached blame entries are updated based on detected changes.
    Only `UnblamedHunks` (caused by `AddedOrReplace` changes) are recomputed using the standard blame algorithm.
    Previously, the entire file or a range was marked as `UnblamedHunk`, but now this only happens when necessary.

So far the results show significant speed-ups. These are results for the README file in the linux repo starting with a blame at commit `bf4401f3ec700e1a7376a4cbf05ef40c7ffce064`.
```
Performing blame operations
Elapsed time for blame on bf4401f3ec700e1a7376a4cbf05ef40c7ffce064: 6604ms
Statistics: Statistics { commits_traversed: 18008, trees_decoded: 18030, trees_diffed: 6, blobs_diffed: 5 }

Performing blame with cache
Elapsed time for blame on 8c93d454027ffceea663ce6ea5b87557b8aaeb8a: 4ms
Statistics: Statistics { commits_traversed: 0, trees_decoded: 2, trees_diffed: 0, blobs_diffed: 1 }

Performing blame without cache
Elapsed time for blame on 8c93d454027ffceea663ce6ea5b87557b8aaeb8a: 313ms
Statistics: Statistics { commits_traversed: 20592, trees_decoded: 20620, trees_diffed: 8, blobs_diffed: 7 } 

time git blame README >/dev/null
Blaming lines: 100% (14/14), done.
git blame README > /dev/null  0.26s user 0.21s system 33% cpu 1.382 total
```

Next Step's
- [ ] Add tests that compare the outcome of a blame with and without cache
- [ ] Add filepath to `BlameCacheObject`

Curious to hear what you think!

 