### PR TITLE
Add `gix blame --since`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,6 +1545,7 @@ name = "gix-blame"
 version = "0.0.0"
 dependencies = [
  "gix-commitgraph 0.26.0",
+ "gix-date 0.9.3",
  "gix-diff",
  "gix-filter",
  "gix-fs 0.13.0",

--- a/gitoxide-core/src/repository/blame.rs
+++ b/gitoxide-core/src/repository/blame.rs
@@ -5,7 +5,7 @@ use std::ffi::OsStr;
 pub fn blame_file(
     mut repo: gix::Repository,
     file: &OsStr,
-    range: Option<std::ops::Range<u32>>,
+    options: gix::blame::Options,
     out: impl std::io::Write,
     err: Option<&mut dyn std::io::Write>,
 ) -> anyhow::Result<()> {
@@ -44,7 +44,7 @@ pub fn blame_file(
         cache,
         &mut resource_cache,
         file.as_bstr(),
-        range,
+        options,
     )?;
     let statistics = outcome.statistics;
     write_blame_entries(out, outcome)?;

--- a/gix-blame/Cargo.toml
+++ b/gix-blame/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 gix-commitgraph = { version = "^0.26.0", path = "../gix-commitgraph" }
 gix-revwalk = { version = "^0.18.0", path = "../gix-revwalk" }
 gix-trace = { version = "^0.1.12", path = "../gix-trace" }
+gix-date = { version = "^0.9.3", path = "../gix-date" }
 gix-diff = { version = "^0.50.0", path = "../gix-diff", default-features = false, features = ["blob"] }
 gix-object = { version = "^0.47.0", path = "../gix-object" }
 gix-hash = { version = "^0.16.0", path = "../gix-hash" }

--- a/gix-blame/src/lib.rs
+++ b/gix-blame/src/lib.rs
@@ -17,7 +17,7 @@
 mod error;
 pub use error::Error;
 mod types;
-pub use types::{BlameEntry, Outcome, Statistics};
+pub use types::{BlameEntry, Options, Outcome, Statistics};
 
 mod file;
 pub use file::function::file;

--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -7,6 +7,17 @@ use std::{
     ops::{AddAssign, Range, SubAssign},
 };
 
+/// Options to be passed to [`file()`](crate::file()).
+#[derive(Default, Debug, Clone)]
+pub struct Options {
+    /// A 1-based inclusive range, in order to mirror `git`’s behaviour. `Some(20..40)` represents
+    /// 21 lines, spanning from line 20 up to and including line 40. This will be converted to
+    /// `19..40` internally as the algorithm uses 0-based ranges that are exclusive at the end.
+    pub range: Option<std::ops::Range<u32>>,
+    /// Don't consider commits before the given date.
+    pub since: Option<gix_date::Time>,
+}
+
 /// The outcome of [`file()`](crate::file()).
 #[derive(Debug, Default, Clone)]
 pub struct Outcome {

--- a/gix-blame/tests/fixtures/make_blame_repo.sh
+++ b/gix-blame/tests/fixtures/make_blame_repo.sh
@@ -227,6 +227,7 @@ git merge branch-that-has-earlier-commit || true
 
 git blame --porcelain simple.txt > .git/simple.baseline
 git blame --porcelain -L 1,2 simple.txt > .git/simple-lines-1-2.baseline
+git blame --porcelain --since 2025-01-31 simple.txt > .git/simple-since.baseline
 git blame --porcelain multiline-hunks.txt > .git/multiline-hunks.baseline
 git blame --porcelain deleted-lines.txt > .git/deleted-lines.baseline
 git blame --porcelain deleted-lines-multiple-hunks.txt > .git/deleted-lines-multiple-hunks.baseline

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -1546,6 +1546,7 @@ pub fn main() -> Result<()> {
             statistics,
             file,
             range,
+            since,
         } => prepare_and_run(
             "blame",
             trace,
@@ -1557,7 +1558,7 @@ pub fn main() -> Result<()> {
                 core::repository::blame::blame_file(
                     repository(Mode::Lenient)?,
                     &file,
-                    range,
+                    gix::blame::Options { range, since },
                     out,
                     statistics.then_some(err),
                 )

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -4,7 +4,7 @@ use clap_complete::Shell;
 use gitoxide_core as core;
 use gix::bstr::BString;
 
-use crate::shared::AsRange;
+use crate::shared::{AsRange, AsTime};
 
 #[derive(Debug, clap::Parser)]
 #[clap(name = "gix", about = "The git underworld", version = option_env!("GIX_VERSION"))]
@@ -167,6 +167,9 @@ pub enum Subcommands {
         /// Only blame lines in the given 1-based inclusive range '<start>,<end>', e.g. '20,40'.
         #[clap(short='L', value_parser=AsRange)]
         range: Option<std::ops::Range<u32>>,
+        /// Don't consider commits before the given date.
+        #[clap(long,  value_parser=AsTime, value_name = "DATE")]
+        since: Option<gix::date::Time>,
     },
     /// Generate shell completions to stdout or a directory.
     #[clap(visible_alias = "generate-completions", visible_alias = "shell-completions")]


### PR DESCRIPTION
This PR adds support for `--since=<date>` to `gix blame`. I’ve run a couple of manual tests on my machine and the results seem to match `git`’s results (apart from differences due to the slider problem as far as I can see).
