### PR TITLE
Add test for `--since`

### DIFF
--- a/src/shared.rs
+++ b/src/shared.rs
@@ -441,7 +441,7 @@ pub use self::clap::{
 
 #[cfg(test)]
 mod value_parser_tests {
-    use super::{AsRange, ParseRenameFraction};
+    use super::{AsRange, AsTime, ParseRenameFraction};
     use clap::Parser;
 
     #[test]
@@ -478,5 +478,17 @@ mod value_parser_tests {
 
         let c = Cmd::parse_from(["cmd", "-l=1,10"]);
         assert_eq!(c.arg, Some(1..10));
+    }
+
+    #[test]
+    fn since() {
+        #[derive(Debug, clap::Parser)]
+        pub struct Cmd {
+            #[clap(long, long="since", value_parser = AsTime)]
+            pub arg: Option<gix::date::Time>,
+        }
+
+        let c = Cmd::parse_from(["cmd", "--since", "2 weeks ago"]);
+        assert!(matches!(c.arg, Some(gix::date::Time { .. })));
     }
 }


### PR DESCRIPTION
I wanted to add the following test for `AsTime`, but it fails with the following message:

```
error: invalid value ''2 weeks ago'' for '--since <ARG>': Date string can not be parsed
```

Am I using `AsTime` incorrectly or is there an issue with the way the test is written?

I initially created the test to be part of #1858.
