### PR TITLE
use MSRV more consistently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 version = "0.41.0"
+rust-version = "1.74"
 default-run = "gix"
 include = ["src/**/*", "/build.rs", "LICENSE-*", "README.md"]
 resolver = "2"

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -327,7 +327,7 @@ mod clap {
     #[derive(Clone)]
     pub struct AsPathSpec;
 
-    static PATHSPEC_DEFAULTS: std::sync::LazyLock<gix::pathspec::Defaults> = std::sync::LazyLock::new(|| {
+    static PATHSPEC_DEFAULTS: once_cell::sync::Lazy<gix::pathspec::Defaults> = once_cell::sync::Lazy::new(|| {
         gix::pathspec::Defaults::from_environment(&mut |n| std::env::var_os(n)).unwrap_or_default()
     });
 

--- a/tests/it/Cargo.toml
+++ b/tests/it/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
+rust-version = "1.74.0"
 
 [[bin]]
 name = "it"

--- a/tests/it/src/commands/check_mode.rs
+++ b/tests/it/src/commands/check_mode.rs
@@ -1,7 +1,7 @@
 pub(super) mod function {
     use anyhow::{bail, Context};
     use gix::bstr::ByteSlice;
-
+    use once_cell::sync::Lazy;
     use regex::bytes::Regex;
     use std::ffi::{OsStr, OsString};
     use std::io::{BufRead, BufReader, Read};
@@ -66,7 +66,7 @@ pub(super) mod function {
 
     /// On mismatch, report it and return `Some(true)`.
     fn check_for_mismatch(root: &OsStr, record: &[u8]) -> anyhow::Result<bool> {
-        static RECORD_REGEX: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+        static RECORD_REGEX: Lazy<Regex> = Lazy::new(|| {
             let pattern = r"(?-u)\A([0-7]+) ([[:xdigit:]]+) [[:digit:]]+\t(.+)\z";
             Regex::new(pattern).expect("regex should be valid")
         });


### PR DESCRIPTION
To prevent this from happening again, also set `rust-version` on the top-level.
