### PR TITLE
Make `gix_path::env:shell()` more robust and use it in `gix-command`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,6 +1589,7 @@ dependencies = [
  "gix-quote 0.4.15",
  "gix-testtools",
  "gix-trace 0.1.12",
+ "once_cell",
  "shell-words",
 ]
 

--- a/gix-command/Cargo.toml
+++ b/gix-command/Cargo.toml
@@ -24,3 +24,4 @@ shell-words = "1.0"
 
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }
+once_cell = "1.17.1"

--- a/gix-command/src/lib.rs
+++ b/gix-command/src/lib.rs
@@ -280,10 +280,8 @@ mod prepare {
                         cmd
                     }
                     None => {
-                        let mut cmd = Command::new(
-                            prep.shell_program
-                                .unwrap_or(if cfg!(windows) { "sh" } else { "/bin/sh" }.into()),
-                        );
+                        let shell = prep.shell_program.unwrap_or_else(|| gix_path::env::shell().into());
+                        let mut cmd = Command::new(shell);
                         cmd.arg("-c");
                         if !prep.args.is_empty() {
                             if prep.command.to_str().map_or(true, |cmd| !cmd.contains("$@")) {

--- a/gix-credentials/tests/program/from_custom_definition.rs
+++ b/gix-credentials/tests/program/from_custom_definition.rs
@@ -1,12 +1,17 @@
 use gix_credentials::{helper, program::Kind, Program};
+use once_cell::sync::Lazy;
 
-static GIT: once_cell::sync::Lazy<&'static str> =
-    once_cell::sync::Lazy::new(|| gix_path::env::exe_invocation().to_str().expect("not illformed"));
+static GIT: once_cell::sync::Lazy<&'static str> = once_cell::sync::Lazy::new(|| {
+    gix_path::env::exe_invocation()
+        .to_str()
+        .expect("some `from_custom_definition` tests must be run where 'git' path is valid Unicode")
+});
 
-#[cfg(windows)]
-const SH: &str = "sh";
-#[cfg(not(windows))]
-const SH: &str = "/bin/sh";
+static SH: Lazy<&'static str> = Lazy::new(|| {
+    gix_path::env::shell()
+        .to_str()
+        .expect("some `from_custom_definition` tests must be run where 'sh' path is valid Unicode")
+});
 
 #[test]
 fn empty() {
@@ -47,11 +52,12 @@ fn name_with_args() {
 fn name_with_special_args() {
     let input = "name --arg --bar=~/folder/in/home";
     let prog = Program::from_custom_definition(input);
+    let sh = *SH;
     let git = *GIT;
     assert!(matches!(&prog.kind, Kind::ExternalName{name_and_args} if name_and_args == input));
     assert_eq!(
         format!("{:?}", prog.to_command(&helper::Action::Store("egal".into()))),
-        format!(r#""{SH}" "-c" "{git} credential-name --arg --bar=~/folder/in/home \"$@\"" "--" "store""#)
+        format!(r#""{sh}" "-c" "{git} credential-name --arg --bar=~/folder/in/home \"$@\"" "--" "store""#)
     );
 }
 
@@ -73,12 +79,13 @@ fn path_with_args_that_definitely_need_shell() {
     let input = "/abs/name --arg --bar=\"a b\"";
     let prog = Program::from_custom_definition(input);
     assert!(matches!(&prog.kind, Kind::ExternalPath{path_and_args} if path_and_args == input));
+    let sh = *SH;
     assert_eq!(
         format!("{:?}", prog.to_command(&helper::Action::Store("egal".into()))),
         if cfg!(windows) {
             r#""/abs/name" "--arg" "--bar=a b" "store""#.to_owned()
         } else {
-            format!(r#""{SH}" "-c" "/abs/name --arg --bar=\"a b\" \"$@\"" "--" "store""#)
+            format!(r#""{sh}" "-c" "/abs/name --arg --bar=\"a b\" \"$@\"" "--" "store""#)
         }
     );
 }
@@ -100,12 +107,13 @@ fn path_with_simple_args() {
     let input = "/abs/name a b";
     let prog = Program::from_custom_definition(input);
     assert!(matches!(&prog.kind, Kind::ExternalPath{path_and_args} if path_and_args == input));
+    let sh = *SH;
     assert_eq!(
         format!("{:?}", prog.to_command(&helper::Action::Store("egal".into()))),
         if cfg!(windows) {
             r#""/abs/name" "a" "b" "store""#.to_owned()
         } else {
-            format!(r#""{SH}" "-c" "/abs/name a b \"$@\"" "--" "store""#)
+            format!(r#""{sh}" "-c" "/abs/name a b \"$@\"" "--" "store""#)
         },
         "a shell is used as there are arguments, and it's generally more flexible, but on windows we split ourselves"
     );

--- a/gix-path/src/env/auxiliary.rs
+++ b/gix-path/src/env/auxiliary.rs
@@ -44,16 +44,7 @@ const MSYS_USR_VARIANTS: &[&str] = &["mingw64", "mingw32", "clangarm64", "clang6
 /// Find a Git for Windows installation directory based on `git --exec-path` output.
 ///
 /// Currently this is used only for finding the path to an `sh.exe` associated with Git. This is
-/// separate from `installation_config()` and `installation_config_prefix()` in `gix_path::env`,
-/// which guess where `etc/gitconfig` is based on `EXEPATH` or the location of the highest-scope
-/// config file.
-///
-/// The techniques might be combined or unified in some way in the future. The techniques those
-/// functions currently use shouldn't be used to find `sh.exe`, because `EXEPATH` can take on other
-/// values in some environments, and the highest scope config file may be unavailable or in another
-/// location if `GIT_CONFIG_SYSTEM` or `GIT_CONFIG_NOSYSTEM` are set or if there are no variables
-/// of system scope. Then paths found relative to it could be different. In contrast, the technique
-/// used here may be usable for those functions, though may need to cover more directory layouts.
+/// separate from `installation_config()` and `installation_config_prefix()` in `gix_path::env`.
 fn git_for_windows_root() -> Option<&'static Path> {
     static GIT_ROOT: Lazy<Option<PathBuf>> = Lazy::new(|| {
         super::core_dir()

--- a/gix-path/src/env/auxiliary.rs
+++ b/gix-path/src/env/auxiliary.rs
@@ -114,7 +114,7 @@ pub(super) fn find_git_associated_windows_executable_with_fallback(stem: &str) -
     })
 }
 
-#[cfg(all(windows, test))]
+#[cfg(test)]
 mod tests {
     use std::path::Path;
 
@@ -139,6 +139,7 @@ mod tests {
     ];
 
     #[test]
+    #[cfg_attr(not(windows), ignore)]
     fn find_git_associated_windows_executable() {
         for stem in SHOULD_FIND {
             let path = super::find_git_associated_windows_executable(stem);
@@ -147,6 +148,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(windows), ignore)]
     fn find_git_associated_windows_executable_no_extra() {
         for stem in SHOULD_NOT_FIND {
             let path = super::find_git_associated_windows_executable(stem);
@@ -155,6 +157,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(windows), ignore)]
     fn find_git_associated_windows_executable_with_fallback() {
         for stem in SHOULD_FIND {
             let path = super::find_git_associated_windows_executable_with_fallback(stem);
@@ -163,6 +166,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(windows), ignore)]
     fn find_git_associated_windows_executable_with_fallback_falls_back() {
         for stem in SHOULD_NOT_FIND {
             let path = super::find_git_associated_windows_executable_with_fallback(stem)

--- a/gix-path/src/env/auxiliary.rs
+++ b/gix-path/src/env/auxiliary.rs
@@ -70,9 +70,9 @@ const BIN_DIR_FRAGMENTS: &[&str] = &["bin", "usr/bin"];
 /// The resulting path uses only `/` separators so long as the path obtained from `git --exec-path`
 /// does, which is the case unless it is overridden by setting `GIT_EXEC_PATH` to an unusual value.
 ///
-/// This is currently only used (and only exercised in tests) for finding `sh.exe`. It may be used
-/// to find other executables in the future, but may require adjustment. In particular, depending
-/// on the desired semantics, it should possibly also check inside a `cmd` directory; directories
+/// This is currently only used (and only heavily exercised in tests) for finding `sh.exe`. It may
+/// be used to find other executables in the future, but may need adjustment. In particular,
+/// depending on desired semantics, it should possibly also check a `cmd` directory; directories
 /// like `<platform>/bin`, for any applicable variants (such as `mingw64`); and `super::core_dir()`
 /// itself, which it could safely check even if its value is not safe for inferring other paths.
 fn find_git_associated_windows_executable(stem: &str) -> Option<OsString> {
@@ -100,4 +100,64 @@ pub(super) fn find_git_associated_windows_executable_with_fallback(stem: &str) -
         raw_path.push(".exe");
         raw_path
     })
+}
+
+#[cfg(all(windows, test))]
+mod tests {
+    use std::path::Path;
+
+    /// Some commands with `.exe` files in `bin` and `usr/bin` that should be found.
+    ///
+    /// Tests are expected to run with a full Git for Windows installation (not MinGit).
+    const SHOULD_FIND: &[&str] = &[
+        "sh", "bash", "dash", "diff", "tar", "less", "sed", "awk", "perl", "cygpath",
+    ];
+
+    /// Shouldn't find anything nonexistent, or only in PATH or in `bin`s we don't mean to search.
+    ///
+    /// If dirs like `mingsw64/bin` are added, `git-credential-manager` should be moved to `SHOULD_FIND`.
+    /// Likewise, if `super::core_dir()` is added, `git-daemon` should be moved to `SHOULD_FIND`.
+    const SHOULD_NOT_FIND: &[&str] = &[
+        "nonexistent-command",
+        "cmd",
+        "powershell",
+        "explorer",
+        "git-credential-manager",
+        "git-daemon",
+    ];
+
+    #[test]
+    fn find_git_associated_windows_executable() {
+        for stem in SHOULD_FIND {
+            let path = super::find_git_associated_windows_executable(stem);
+            assert!(path.is_some(), "should find {stem:?}");
+        }
+    }
+
+    #[test]
+    fn find_git_associated_windows_executable_no_extra() {
+        for stem in SHOULD_NOT_FIND {
+            let path = super::find_git_associated_windows_executable(stem);
+            assert_eq!(path, None, "should not find {stem:?}");
+        }
+    }
+
+    #[test]
+    fn find_git_associated_windows_executable_with_fallback() {
+        for stem in SHOULD_FIND {
+            let path = super::find_git_associated_windows_executable_with_fallback(stem);
+            assert!(Path::new(&path).is_absolute(), "should find {stem:?}");
+        }
+    }
+
+    #[test]
+    fn find_git_associated_windows_executable_with_fallback_falls_back() {
+        for stem in SHOULD_NOT_FIND {
+            let path = super::find_git_associated_windows_executable_with_fallback(stem)
+                .to_str()
+                .expect("valid Unicode")
+                .to_owned();
+            assert_eq!(path, format!("{stem}.exe"), "should fall back for {stem:?}");
+        }
+    }
 }

--- a/gix-path/src/env/auxiliary.rs
+++ b/gix-path/src/env/auxiliary.rs
@@ -1,0 +1,80 @@
+use std::ffi::OsString;
+use std::path::Path;
+
+/// `usr`-like directory component names that MSYS2 may provide, other than for `/usr` itself.
+///
+/// These are the values of the "Prefix" column of the "Environments" and "Legacy Environments"
+/// tables in the [MSYS2 Environments](https://www.msys2.org/docs/environments/) documentation,
+/// with the leading `/` separator removed, except that this does not list `usr` itself.
+///
+/// On Windows, we prefer to use `sh` as provided by Git for Windows, when present. To find it, we
+/// run `git --exec-path` to get a path that is usually `<platform>/libexec/git-core` in the Git
+/// for Windows installation, where `<platform>` is something like `mingw64`. It is also acceptable
+/// to find `sh` in an environment not provided by Git for Windows, such as an independent MSYS2
+/// environment in which a `git` package has been installed. However, in an unusual installation,
+/// or if the user has set a custom value of `GIT_EXEC_PATH`, the output of `git --exec-path` may
+/// take a form other than `<platform>/libexec/git-core`, such that finding shell at a location
+/// like `../../../bin/sh.exe` relative to it should not be attempted. We lower the risk by
+/// checking that `<platform>` is a plausible value that is not likely to have any other meaning.
+///
+/// This involves two tradeoffs. First, it may be reasonable to find `sh.exe` in an environment
+/// that is not MSYS2 at all, for which in principle the prefix could be different. But listing
+/// more prefixes or matching a broad pattern of platform-like strings might be too broad. So only
+/// prefixes that have been used in MSYS2 are considered.
+///
+/// Second, we don't recognize `usr` itself here, even though is a plausible prefix. In MSYS2, it
+/// is the prefix for MSYS2 non-native programs, i.e. those that use `msys-2.0.dll`. But unlike the
+/// `<platform>` names we recognize, `usr` also has an effectively unbounded range of plausible
+/// meanings on non-Unix systems, which may occasionally relate to subdirectories whose contents
+/// are controlled by different user accounts.
+///
+/// If we start with a `libexec/git-core` directory that we already use and trust, and it is in a
+/// directory with a name like `mingw64`, we infer that this `mingw64` directory has the expected
+/// meaning and that its `usr` sibling, if present, is acceptable to treat as though it is a
+/// first-level directory inside an MSYS2-like tree. So we are willing to traverse down to
+/// `usr/sh.exe` and attempt to use it. But if the `libexec/git-core` we use and trust is inside a
+/// directory named `usr`, that `usr` directory may still not have the meaning we expect of `usr`.
+///
+/// The conditions for a privilege escalation attack or other serious malfunction seem unlikely. If
+/// research indicates the risk is low enough, `usr` may be added. But for now it is omitted.
+const MSYS_USR_VARIANTS: &[&str] = &["mingw64", "mingw32", "clangarm64", "clang64", "clang32", "ucrt64"];
+
+/// Shell path fragments to concatenate to the root of a Git for Windows or MSYS2 installation.
+///
+/// These look like absolute Unix-style paths, but the leading `/` separators are present because
+/// they simplify forming paths like `C:/Program Files/Git` obtained by removing trailing
+/// components from the output of `git --exec-path`.
+const RAW_SH_EXE_PATH_SUFFIXES: &[&str] = &[
+    "/bin/sh.exe", // Usually a shim, which currently we prefer, if available.
+    "/usr/bin/sh.exe",
+];
+
+///
+fn raw_join(path: &Path, raw_suffix: &str) -> OsString {
+    let mut raw_path = OsString::from(path);
+    raw_path.push(raw_suffix);
+    raw_path
+}
+
+///
+pub(super) fn find_sh_on_windows() -> Option<OsString> {
+    super::core_dir()
+        .filter(|core| core.is_absolute() && core.ends_with("libexec/git-core"))
+        .and_then(|core| core.ancestors().nth(2))
+        .filter(|prefix| {
+            // Only use `libexec/git-core` from inside something `usr`-like, such as `mingw64`.
+            MSYS_USR_VARIANTS.iter().any(|name| prefix.ends_with(name))
+        })
+        .and_then(|prefix| prefix.parent())
+        .into_iter()
+        .flat_map(|git_root| {
+            // Enumerate locations where `sh.exe` usually is. To avoid breaking scripts that assume the
+            // shell's own path contains no `\`, and so messages are more readable, append literally
+            // with `/` separators. The path from `git --exec-path` already uses `/` separators (and no
+            // trailing `/`) unless explicitly overridden to an unusual value via `GIT_EXEC_PATH`.
+            RAW_SH_EXE_PATH_SUFFIXES
+                .iter()
+                .map(|raw_suffix| raw_join(git_root, raw_suffix))
+        })
+        .find(|raw_path| Path::new(raw_path).is_file())
+}

--- a/gix-path/src/env/auxiliary.rs
+++ b/gix-path/src/env/auxiliary.rs
@@ -71,10 +71,10 @@ const BIN_DIR_FRAGMENTS: &[&str] = &["bin", "usr/bin"];
 /// does, which is the case unless it is overridden by setting `GIT_EXEC_PATH` to an unusual value.
 ///
 /// This is currently only used (and only exercised in tests) for finding `sh.exe`. It may be used
-/// to find other executables in the future, but may require adjustment. (In particular, depending
-/// on the desired semantics, it should possibly also check inside a `cmd` directory, possibly also
-/// check inside `super::core_dir()` itself, and could safely check the latter location even if its
-/// value is not suitable to use in inferring any other paths.)
+/// to find other executables in the future, but may require adjustment. In particular, depending
+/// on the desired semantics, it should possibly also check inside a `cmd` directory; directories
+/// like `<platform>/bin`, for any applicable variants (such as `mingw64`); and `super::core_dir()`
+/// itself, which it could safely check even if its value is not safe for inferring other paths.
 fn find_git_associated_windows_executable(stem: &str) -> Option<OsString> {
     let git_root = git_for_windows_root()?;
 

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -6,6 +6,7 @@ use once_cell::sync::Lazy;
 
 use crate::env::git::EXE_NAME;
 
+mod auxiliary;
 mod git;
 
 /// Return the location at which installation specific git configuration file can be found, or `None`
@@ -28,84 +29,6 @@ pub fn installation_config_prefix() -> Option<&'static Path> {
     installation_config().map(git::config_to_base_path)
 }
 
-/// `usr`-like directory component names that MSYS2 may provide, other than for `/usr` itself.
-///
-/// These are the values of the "Prefix" column of the "Environments" and "Legacy Environments"
-/// tables in the [MSYS2 Environments](https://www.msys2.org/docs/environments/) documentation,
-/// with the leading `/` separator removed, except that this does not list `usr` itself.
-///
-/// On Windows, we prefer to use `sh` as provided by Git for Windows, when present. To find it, we
-/// run `git --exec-path` to get a path that is usually `<platform>/libexec/git-core` in the Git
-/// for Windows installation, where `<platform>` is something like `mingw64`. It is also acceptable
-/// to find `sh` in an environment not provided by Git for Windows, such as an independent MSYS2
-/// environment in which a `git` package has been installed. However, in an unusual installation,
-/// or if the user has set a custom value of `GIT_EXEC_PATH`, the output of `git --exec-path` may
-/// take a form other than `<platform>/libexec/git-core`, such that finding shell at a location
-/// like `../../../bin/sh.exe` relative to it should not be attempted. We lower the risk by
-/// checking that `<platform>` is a plausible value that is not likely to have any other meaning.
-///
-/// This involves two tradeoffs. First, it may be reasonable to find `sh.exe` in an environment
-/// that is not MSYS2 at all, for which in principle the prefix could be different. But listing
-/// more prefixes or matching a broad pattern of platform-like strings might be too broad. So only
-/// prefixes that have been used in MSYS2 are considered.
-///
-/// Second, we don't recognize `usr` itself here, even though is a plausible prefix. In MSYS2, it
-/// is the prefix for MSYS2 non-native programs, i.e. those that use `msys-2.0.dll`. But unlike the
-/// `<platform>` names we recognize, `usr` also has an effectively unbounded range of plausible
-/// meanings on non-Unix systems, which may occasionally relate to subdirectories whose contents
-/// are controlled by different user accounts.
-///
-/// If we start with a `libexec/git-core` directory that we already use and trust, and it is in a
-/// directory with a name like `mingw64`, we infer that this `mingw64` directory has the expected
-/// meaning and that its `usr` sibling, if present, is acceptable to treat as though it is a
-/// first-level directory inside an MSYS2-like tree. So we are willing to traverse down to
-/// `usr/sh.exe` and attempt to use it. But if the `libexec/git-core` we use and trust is inside a
-/// directory named `usr`, that `usr` directory may still not have the meaning we expect of `usr`.
-///
-/// The conditions for a privilege escalation attack or other serious malfunction seem unlikely. If
-/// research indicates the risk is low enough, `usr` may be added. But for now it is omitted.
-const MSYS_USR_VARIANTS: &[&str] = &["mingw64", "mingw32", "clangarm64", "clang64", "clang32", "ucrt64"];
-
-/// Shell path fragments to concatenate to the root of a Git for Windows or MSYS2 installation.
-///
-/// These look like absolute Unix-style paths, but the leading `/` separators are present because
-/// they simplify forming paths like `C:/Program Files/Git` obtained by removing trailing
-/// components from the output of `git --exec-path`.
-const RAW_SH_EXE_PATH_SUFFIXES: &[&str] = &[
-    "/bin/sh.exe", // Usually a shim, which currently we prefer, if available.
-    "/usr/bin/sh.exe",
-];
-
-///
-fn raw_join(path: &Path, raw_suffix: &str) -> OsString {
-    let mut raw_path = OsString::from(path);
-    raw_path.push(raw_suffix);
-    raw_path
-}
-
-///
-fn find_sh_on_windows() -> Option<OsString> {
-    core_dir()
-        .filter(|core| core.is_absolute() && core.ends_with("libexec/git-core"))
-        .and_then(|core| core.ancestors().nth(2))
-        .filter(|prefix| {
-            // Only use `libexec/git-core` from inside something `usr`-like, such as `mingw64`.
-            MSYS_USR_VARIANTS.iter().any(|name| prefix.ends_with(name))
-        })
-        .and_then(|prefix| prefix.parent())
-        .into_iter()
-        .flat_map(|git_root| {
-            // Enumerate locations where `sh.exe` usually is. To avoid breaking scripts that assume the
-            // shell's own path contains no `\`, and so messages are more readable, append literally
-            // with `/` separators. The path from `git --exec-path` already uses `/` separators (and no
-            // trailing `/`) unless explicitly overridden to an unusual value via `GIT_EXEC_PATH`.
-            RAW_SH_EXE_PATH_SUFFIXES
-                .iter()
-                .map(|raw_suffix| raw_join(git_root, raw_suffix))
-        })
-        .find(|raw_path| Path::new(raw_path).is_file())
-}
-
 /// Return the shell that Git would use, the shell to execute commands from.
 ///
 /// On Windows, this is the full path to `sh.exe` bundled with Git for Windows if we can find it.
@@ -117,7 +40,7 @@ fn find_sh_on_windows() -> Option<OsString> {
 pub fn shell() -> &'static OsStr {
     static PATH: Lazy<OsString> = Lazy::new(|| {
         if cfg!(windows) {
-            find_sh_on_windows().unwrap_or_else(|| "sh.exe".into())
+            auxiliary::find_sh_on_windows().unwrap_or_else(|| "sh.exe".into())
         } else {
             "/bin/sh".into()
         }

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -67,14 +67,16 @@ pub fn shell() -> &'static OsStr {
 }
 
 /// Return the name of the Git executable to invoke it.
+///
 /// If it's in the `PATH`, it will always be a short name.
 ///
 /// Note that on Windows, we will find the executable in the `PATH` if it exists there, or search it
 /// in alternative locations which when found yields the full path to it.
 pub fn exe_invocation() -> &'static Path {
     if cfg!(windows) {
-        /// The path to the Git executable as located in the `PATH` or in other locations that it's known to be installed to.
-        /// It's `None` if environment variables couldn't be read or if no executable could be found.
+        /// The path to the Git executable as located in the `PATH` or in other locations that it's
+        /// known to be installed to. It's `None` if environment variables couldn't be read or if
+        /// no executable could be found.
         static EXECUTABLE_PATH: Lazy<Option<PathBuf>> = Lazy::new(|| {
             std::env::split_paths(&std::env::var_os("PATH")?)
                 .chain(git::ALTERNATIVE_LOCATIONS.iter().map(Into::into))
@@ -99,11 +101,11 @@ pub fn exe_invocation() -> &'static Path {
     }
 }
 
-/// Returns the fully qualified path in the *xdg-home* directory (or equivalent in the home dir) to `file`,
-/// accessing `env_var(<name>)` to learn where these bases are.
+/// Returns the fully qualified path in the *xdg-home* directory (or equivalent in the home dir) to
+/// `file`, accessing `env_var(<name>)` to learn where these bases are.
 ///
-/// Note that the `HOME` directory should ultimately come from [`home_dir()`] as it handles windows correctly.
-/// The same can be achieved by using [`var()`] as `env_var`.
+/// Note that the `HOME` directory should ultimately come from [`home_dir()`] as it handles Windows
+/// correctly. The same can be achieved by using [`var()`] as `env_var`.
 pub fn xdg_config(file: &str, env_var: &mut dyn FnMut(&str) -> Option<OsString>) -> Option<PathBuf> {
     env_var("XDG_CONFIG_HOME")
         .map(|home| {
@@ -153,17 +155,17 @@ pub fn core_dir() -> Option<&'static Path> {
     GIT_CORE_DIR.as_deref()
 }
 
-/// Returns the platform dependent system prefix or `None` if it cannot be found (right now only on windows).
+/// Returns the platform dependent system prefix or `None` if it cannot be found (right now only on Windows).
 ///
 /// ### Performance
 ///
-/// On windows, the slowest part is the launch of the Git executable in the PATH, which only happens when launched
-/// from outside of the `msys2` shell.
+/// On Windows, the slowest part is the launch of the Git executable in the PATH. This is often
+/// avoided by inspecting the environment, when launched from inside a Git Bash MSYS2 shell.
 ///
 /// ### When `None` is returned
 ///
-/// This happens only windows if the git binary can't be found at all for obtaining its executable path, or if the git binary
-/// wasn't built with a well-known directory structure or environment.
+/// This happens only Windows if the git binary can't be found at all for obtaining its executable
+/// path, or if the git binary wasn't built with a well-known directory structure or environment.
 pub fn system_prefix() -> Option<&'static Path> {
     if cfg!(windows) {
         static PREFIX: Lazy<Option<PathBuf>> = Lazy::new(|| {
@@ -194,19 +196,20 @@ pub fn home_dir() -> Option<PathBuf> {
     std::env::var("HOME").map(PathBuf::from).ok()
 }
 
-/// Tries to obtain the home directory from `HOME` on all platforms, but falls back to [`home::home_dir()`] for
-/// more complex ways of obtaining a home directory, particularly useful on Windows.
+/// Tries to obtain the home directory from `HOME` on all platforms, but falls back to
+/// [`home::home_dir()`] for more complex ways of obtaining a home directory, particularly useful
+/// on Windows.
 ///
-/// The reason `HOME` is tried first is to allow Windows users to have a custom location for their linux-style
-/// home, as otherwise they would have to accumulate dot files in a directory these are inconvenient and perceived
-/// as clutter.
+/// The reason `HOME` is tried first is to allow Windows users to have a custom location for their
+/// linux-style home, as otherwise they would have to accumulate dot files in a directory these are
+/// inconvenient and perceived as clutter.
 #[cfg(not(target_family = "wasm"))]
 pub fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME").map(Into::into).or_else(home::home_dir)
 }
 
-/// Returns the contents of an environment variable of `name` with some special handling
-/// for certain environment variables (like `HOME`) for platform compatibility.
+/// Returns the contents of an environment variable of `name` with some special handling for
+/// certain environment variables (like `HOME`) for platform compatibility.
 pub fn var(name: &str) -> Option<OsString> {
     if name == "HOME" {
         home_dir().map(PathBuf::into_os_string)

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -40,7 +40,7 @@ pub fn installation_config_prefix() -> Option<&'static Path> {
 pub fn shell() -> &'static OsStr {
     static PATH: Lazy<OsString> = Lazy::new(|| {
         if cfg!(windows) {
-            auxiliary::find_sh_on_windows().unwrap_or_else(|| "sh.exe".into())
+            auxiliary::find_git_associated_windows_executable_with_fallback("sh")
         } else {
             "/bin/sh".into()
         }

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -28,6 +28,84 @@ pub fn installation_config_prefix() -> Option<&'static Path> {
     installation_config().map(git::config_to_base_path)
 }
 
+/// `usr`-like directory component names that MSYS2 may provide, other than for `/usr` itself.
+///
+/// These are the values of the "Prefix" column of the "Environments" and "Legacy Environments"
+/// tables in the [MSYS2 Environments](https://www.msys2.org/docs/environments/) documentation,
+/// with the leading `/` separator removed, except that this does not list `usr` itself.
+///
+/// On Windows, we prefer to use `sh` as provided by Git for Windows, when present. To find it, we
+/// run `git --exec-path` to get a path that is usually `<platform>/libexec/git-core` in the Git
+/// for Windows installation, where `<platform>` is something like `mingw64`. It is also acceptable
+/// to find `sh` in an environment not provided by Git for Windows, such as an independent MSYS2
+/// environment in which a `git` package has been installed. However, in an unusual installation,
+/// or if the user has set a custom value of `GIT_EXEC_PATH`, the output of `git --exec-path` may
+/// take a form other than `<platform>/libexec/git-core`, such that finding shell at a location
+/// like `../../../bin/sh.exe` relative to it should not be attempted. We lower the risk by
+/// checking that `<platform>` is a plausible value that is not likely to have any other meaning.
+///
+/// This involves two tradeoffs. First, it may be reasonable to find `sh.exe` in an environment
+/// that is not MSYS2 at all, for which in principle the prefix could be different. But listing
+/// more prefixes or matching a broad pattern of platform-like strings might be too broad. So only
+/// prefixes that have been used in MSYS2 are considered.
+///
+/// Second, we don't recognize `usr` itself here, even though is a plausible prefix. In MSYS2, it
+/// is the prefix for MSYS2 non-native programs, i.e. those that use `msys-2.0.dll`. But unlike the
+/// `<platform>` names we recognize, `usr` also has an effectively unbounded range of plausible
+/// meanings on non-Unix systems, which may occasionally relate to subdirectories whose contents
+/// are controlled by different user accounts.
+///
+/// If we start with a `libexec/git-core` directory that we already use and trust, and it is in a
+/// directory with a name like `mingw64`, we infer that this `mingw64` directory has the expected
+/// meaning and that its `usr` sibling, if present, is acceptable to treat as though it is a
+/// first-level directory inside an MSYS2-like tree. So we are willing to traverse down to
+/// `usr/sh.exe` and attempt to use it. But if the `libexec/git-core` we use and trust is inside a
+/// directory named `usr`, that `usr` directory may still not have the meaning we expect of `usr`.
+///
+/// The conditions for a privilege escalation attack or other serious malfunction seem unlikely. If
+/// research indicates the risk is low enough, `usr` may be added. But for now it is omitted.
+const MSYS_USR_VARIANTS: &[&str] = &["mingw64", "mingw32", "clangarm64", "clang64", "clang32", "ucrt64"];
+
+/// Shell path fragments to concatenate to the root of a Git for Windows or MSYS2 installation.
+///
+/// These look like absolute Unix-style paths, but the leading `/` separators are present because
+/// they simplify forming paths like `C:/Program Files/Git` obtained by removing trailing
+/// components from the output of `git --exec-path`.
+const RAW_SH_EXE_PATH_SUFFIXES: &[&str] = &[
+    "/bin/sh.exe", // Usually a shim, which currently we prefer, if available.
+    "/usr/bin/sh.exe",
+];
+
+///
+fn raw_join(path: &Path, raw_suffix: &str) -> OsString {
+    let mut raw_path = OsString::from(path);
+    raw_path.push(raw_suffix);
+    raw_path
+}
+
+///
+fn find_sh_on_windows() -> Option<OsString> {
+    core_dir()
+        .filter(|core| core.is_absolute() && core.ends_with("libexec/git-core"))
+        .and_then(|core| core.ancestors().nth(2))
+        .filter(|prefix| {
+            // Only use `libexec/git-core` from inside something `usr`-like, such as `mingw64`.
+            MSYS_USR_VARIANTS.iter().any(|name| prefix.ends_with(name))
+        })
+        .and_then(|prefix| prefix.parent())
+        .into_iter()
+        .flat_map(|git_root| {
+            // Enumerate locations where `sh.exe` usually is. To avoid breaking scripts that assume the
+            // shell's own path contains no `\`, and so messages are more readable, append literally
+            // with `/` separators. The path from `git --exec-path` already uses `/` separators (and no
+            // trailing `/`) unless explicitly overridden to an unusual value via `GIT_EXEC_PATH`.
+            RAW_SH_EXE_PATH_SUFFIXES
+                .iter()
+                .map(|raw_suffix| raw_join(git_root, raw_suffix))
+        })
+        .find(|raw_path| Path::new(raw_path).is_file())
+}
+
 /// Return the shell that Git would use, the shell to execute commands from.
 ///
 /// On Windows, this is the full path to `sh.exe` bundled with Git for Windows if we can find it.
@@ -39,43 +117,7 @@ pub fn installation_config_prefix() -> Option<&'static Path> {
 pub fn shell() -> &'static OsStr {
     static PATH: Lazy<OsString> = Lazy::new(|| {
         if cfg!(windows) {
-            const MSYS_PREFIX_NAMES: &[&str] = &[
-                "mingw64",
-                "mingw32",
-                "clangarm64",
-                "clang64",
-                "clang32",
-                "ucrt64",
-                "usr",
-            ];
-            const RAW_SUFFIXES: &[&str] = &[
-                "/bin/sh.exe", // Usually a shim, which currently we prefer, if available.
-                "/usr/bin/sh.exe",
-            ];
-            fn raw_join(path: &Path, raw_suffix: &str) -> OsString {
-                let mut raw_path = OsString::from(path);
-                raw_path.push(raw_suffix);
-                raw_path
-            }
-            core_dir()
-                .filter(|core| core.is_absolute() && core.ends_with("libexec/git-core"))
-                .and_then(|core| core.ancestors().nth(2))
-                .filter(|prefix| {
-                    // Only use `libexec/git-core` from inside something `usr`-like, such as `mingw64`.
-                    MSYS_PREFIX_NAMES.iter().any(|name| prefix.ends_with(name))
-                })
-                .and_then(|prefix| prefix.parent())
-                .into_iter()
-                .flat_map(|git_root| {
-                    // Enumerate the locations where `sh.exe` usually is. To avoid breaking shell
-                    // scripts that assume the shell's own path contains no `\`, and to produce
-                    // more readable messages, append literally with `/` separators. The path from
-                    // `git --exec-path` will already have all `/` separators (and no trailing `/`)
-                    // unless it was explicitly overridden to an unusual value via `GIT_EXEC_PATH`.
-                    RAW_SUFFIXES.iter().map(|raw_suffix| raw_join(git_root, raw_suffix))
-                })
-                .find(|raw_path| Path::new(raw_path).is_file())
-                .unwrap_or_else(|| "sh.exe".into())
+            find_sh_on_windows().unwrap_or_else(|| "sh.exe".into())
         } else {
             "/bin/sh".into()
         }

--- a/gix-path/tests/path/env.rs
+++ b/gix-path/tests/path/env.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 #[test]
 fn exe_invocation() {
     let actual = gix_path::env::exe_invocation();
@@ -10,8 +12,27 @@ fn exe_invocation() {
 #[test]
 fn shell() {
     assert!(
-        std::path::Path::new(gix_path::env::shell()).exists(),
-        "On CI and on Unix we'd expect a full path to the shell that exists on disk"
+        Path::new(gix_path::env::shell()).exists(),
+        "On CI and on Unix we expect a usable path to the shell that exists on disk"
+    );
+}
+
+#[test]
+fn shell_absolute() {
+    assert!(
+        Path::new(gix_path::env::shell()).is_absolute(),
+        "On CI and on Unix we currently expect the path to the shell always to be absolute"
+    );
+}
+
+#[test]
+fn shell_unix_path() {
+    let shell = gix_path::env::shell()
+        .to_str()
+        .expect("This test depends on the shell path being valid Unicode");
+    assert!(
+        !shell.contains('\\'),
+        "The path to the shell should have no backslashes, barring strange `GIT_EXEC_PATH` values"
     );
 }
 


### PR DESCRIPTION
Tasks since https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831:

- [x] Use the shim `sh.exe` when available
- [x] Fall back to the non-shim `sh.exe`
- [x] Test locally to ensure the failures still go away with the shim
- [x] Only use inferred `(git root)` if it looks like Git for Windows and looks safe
- [x] Fix unrelated `test-fixtures-windows` breakage ([#1849](https://github.com/GitoxideLabs/gitoxide/issues/1849), [#1870](https://github.com/GitoxideLabs/gitoxide/pull/1870)) and rebase
- [x] Fix unrelated `test-32bit` breakage ([#1874](https://github.com/GitoxideLabs/gitoxide/pull/1874)) and rebase
- [x] Retest locally after all nontrivial rebasing
- [x] Investigate [local failures](https://github.com/GitoxideLabs/gitoxide/pull/1864#issuecomment-2724464883) in [#1864](https://github.com/GitoxideLabs/gitoxide/pull/1864) with non-shim, in case relevant here

Outscoped:

- Report the observed `>>` problem as a bug to MSYS2 or a related project
- https://github.com/GitoxideLabs/gitoxide/issues/1868

(On all the above, see "What it means for this PR" in https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831.)

The original PR description follows.

---

This makes `git_path::env::shell()` more likely to work correctly on Windows, then attempts to use it in `gix_command::Prepare` when running a command with a shell due to `use_shell` being set to `true`. Full details are in the commit messages, though the changes are also summarized here.

I think this is not ready to merge yet, due to failures that happen when running the tests locally from PowerShell, but that I cannot produce otherwise. I do not know what causes these failures, and I expect I may have difficulty getting this to a point where it would be ready to merge without input. Since the failures happen in a test that was fairly recently added, I figured you might just know what is going on.

I think `shell()` can and should be used for `gix-command`. But if not then the reason will be relevant to other potential uses of `shell()`. In that case, assuming they leave enough good uses for `shell()` that it is kept, I hope to discover and articulate those reasons in the documentation for `shell()`. But I think most likely there is a bug or wrong test expectation somewhere that accounts for the local test failure, and that either the current implementation of `shell()` with the modifications included here, or something much like it, is suitable for broad use.

#### Making `gix_path::env::shell()` more robust

This makes `gix_path::env::shell()` more likely to work correctly on Windows by:

- Checking that the path to a `sh.exe` associated with Git for Windows actually exists (and is either a regular file or a symbolic link that, when fully dereferenced, gives a file), because if that is not the case, then the fallback of just looking up `sh.exe` using a `PATH` search is more likely to succeed.

  This change is needed to use `shell()` more widely without breaking things on systems where `sh.exe` is available and usable but cannot be found in the usual location where Git for Windows supplies it.

- Using `/` rather than `\` directory separators when appending `usr`, `bin`, and `sh.exe` components to the Git for Windows installation directory path obtained via `git --exec-path` and going up three components. This causes the path through `sh.exe` is run to use all `/` separators except in the unusual situation that `GIT_EXEC_PATH` has been set to a path with `\` separator. (This is unusual because people don't usually set `GIT_EXEC_PATH`. It would probably be best, when setting it on Windows, to use `/` separators, but I do not actually know how often people do that.)

  I believe this is only a minor improvement, in view of this path not being automatically passed through to the shell, as described in [#1840 (reply in thread)](https://github.com/GitoxideLabs/gitoxide/discussions/1840#discussioncomment-12294328). But this change also makes tests in `gix-command` and `gix-credentials` pass that would otherwise require more extensive modification related to `\` escaping, when modifying `gix-command` to use `shell()`.

#### Using `gix_path::env::shell()` in `gix-command`

Before the changes in this PR, `gix-command` uses the relative path `sh.exe` on Windows. This works a significant fraction of the time already. In particular, the problems with the relative path `bash.exe` that make it frequently unusable to find a non-WSL `bash` on Windows, described in https://github.com/GitoxideLabs/gitoxide/issues/1359#issuecomment-2316614616, do not apply to `sh.exe`, since there is no Microsoft-provided `sh.exe` related to WSL. However:

- Such an `sh.exe` is not always the best choice when present.
- There may be no `sh.exe` that can be found in `PATH`. For example, if the only `sh.exe` is supplied by Git for Windows, and neither of the Git for Windows directories that contain an `sh.exe` binary are in `PATH`, then before the changes in this PR, a shell will not be found unless `shell_program()` is called (every time a command with `use_shell` is run).

Therefore, this uses `shell()`, with the improvements described above, in `gix-command`.

---

As alluded to above, I think this is not ready yet. All tests pass on CI, as well a when run locally from Git Bash. But when running them locally in PowerShell, `gix-merge::merge blob::platform::merge::with_external` fails. The failure does not require `GIX_TEST_IGNORE_ARCHIVES` to be set, and this PR does not currently modify any test fixture scripts.

Windows failures that occur when tests are run from PowerShell but not from Git Bash have usually been due to #1359 and are thus not expected since #1712, where `gix-testtools` finds `bash.exe` associated with Git for Windows and uses it to run fixtures. But that fix didn't affect the way `gix-command` uses a shell, so it does not provide for the kind of shell invocations occurring here.

Still, it doesn't make sense to me why the failure happens, and why it happens only when I run the tests locally from PowerShell. On this system, in the `PATH`, including when accessed from PowerShell, the command `sh` finds is a shim for the same shell that, as of this PR, `gix-path` finds and `gix-command` uses. Furthermore, the change here makes `gix-path` find `sh.exe` *more like* the way `gix-testtools` finds `bash.exe`, both of which are Bash when provided by Git for Windows.

Furthermore, while most of my local testing has been with Git for Windows 2.48.1, I have verified that the test fails the same way on the same system with Git for Windows 2.47.1(2), and that the experiment described below to examine the details of the failure also gives the same results with that version. This is to say that it seems like this failure is *not* related, even conceptually, to #1849.

```text
C:\Users\ek\source\repos\gitoxide [run-ci/consistent-sh ≡]> cargo nextest run -p gix-merge --no-fail-fast
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.48s
────────────
 Nextest run ID 5771b786-7fff-43d7-9721-b20970cbb558 with nextest profile: default
    Starting 20 tests across 2 binaries
     Running [ 00:00:00] 0/20: 0 running, 0 passed, 0 skipped
        PASS [   0.018s] gix-merge::merge blob::builtin_driver::text::fuzzed
        PASS [   0.022s] gix-merge::merge blob::builtin_driver::text::both_sides_same_changes_are_conflict_free
        PASS [   0.025s] gix-merge::merge blob::pipeline::without_transformation
        PASS [   0.031s] gix-merge::merge blob::pipeline::non_existing
        PASS [   0.035s] gix-merge::merge blob::pipeline::binary_below_large_file_threshold
        PASS [   0.038s] gix-merge::merge blob::builtin_driver::text::both_differ_partially_resolution_is_conflicting
        PASS [   0.040s] gix-merge::merge blob::builtin_driver::binary
        PASS [   0.047s] gix-merge::merge blob::pipeline::worktree_filter
        PASS [   0.054s] gix-merge::merge blob::pipeline::above_large_file_threshold
        PASS [   0.052s] gix-merge::merge blob::platform::merge::builtin_with_conflict
        PASS [   0.054s] gix-merge::merge blob::platform::merge::builtin_text_uses_binary_if_needed
        PASS [   0.058s] gix-merge::merge blob::platform::merge::one_buffer_too_large
        PASS [   0.070s] gix-merge::merge blob::platform::merge::same_binaries_do_not_count_as_conflicted
        PASS [   0.067s] gix-merge::merge blob::platform::prepare_merge::ancestor_and_current_and_other_do_not_exist
        PASS [   0.067s] gix-merge::merge blob::platform::prepare_merge::driver_selection
        PASS [   0.059s] gix-merge::merge blob::platform::set_resource::invalid_resource_types
        PASS [   0.200s] gix-merge::merge blob::platform::merge::missing_buffers_are_empty_buffers
        FAIL [   0.245s] gix-merge::merge blob::platform::merge::with_external
──── STDOUT:             gix-merge::merge blob::platform::merge::with_external

running 1 test
test blob::platform::merge::with_external ... FAILED

failures:

failures:
    blob::platform::merge::with_external

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.18s

──── STDERR:             gix-merge::merge blob::platform::merge::with_external
thread 'blob::platform::merge::with_external' panicked at gix-merge\tests\merge\blob\platform.rs:297:13:
b
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

        PASS [   0.330s] gix-merge::merge blob::builtin_driver::text::run_baseline
        PASS [   0.998s] gix-merge::merge tree::run_baseline
────────────
     Summary [   1.036s] 20 tests run: 19 passed, 1 failed, 0 skipped
        FAIL [   0.245s] gix-merge::merge blob::platform::merge::with_external
error: test run failed
```

The failing assertion is the first of the assertions in this fragment of the failing test:

https://github.com/GitoxideLabs/gitoxide/blob/2efce72ada61149ef3823f4e15fdbc75157745ec/gix-merge/tests/merge/blob/platform.rs#L291-L314

The first three of the cleaned driver lines are supposed to contain `.tmp`, but the first one is just `b`, which is expected to apper later. This somehow varies based on how the tests are run, and there are at least three environments for figuring out what's going on: CI, local in Git Bash, and local in PowerShell. It seems like they shouldn't differ, but they do.

Locally, it is possible to inspect things in a debugger, but this is harder on CI because while [action-tmate](https://github.com/mxschmitt/action-tmate) can be used to get a reverse shell, on Windows runners the reverse shell's environment differs from the noninteractive environment in which the tests run. Fortunately, I can break the tests in a way that makes them always fail by panicking and printing all the lines:

```diff
diff --git a/gix-merge/tests/merge/blob/platform.rs b/gix-merge/tests/merge/blob/platform.rs
index 6230377b8..62882cc69 100644
--- a/gix-merge/tests/merge/blob/platform.rs
+++ b/gix-merge/tests/merge/blob/platform.rs
@@ -293,6 +293,11 @@ theirs
         let res = platform_ref.merge(&mut buf, default_labels(), &Default::default())?;
         assert_eq!(res, (Pick::Buffer, Resolution::Complete), "merge drivers always merge ");
         let mut lines = cleaned_driver_lines(&buf)?;
+        panic!(
+            "original: {:#?}\ncleaned: {:#?}",
+            buf.lines().map(|s| s.as_bstr()).collect::<Vec<_>>(),
+            lines.collect::<Vec<_>>()
+        );
         for tmp_file in lines.by_ref().take(3) {
             assert!(tmp_file.contains_str(&b".tmp"[..]), "{tmp_file}");
         }
```

To be clear, while all of the following are from messages printed in failing tests, the tests fail *because* of that change. All of them would otherwise pass, except the local run, in Windows, from PowerShell, shown last. Also, I do not know why this is happening. I am hoping you may have some insight into it.

#### Based off the main branch, on CI, in Ubuntu (would pass)

In the [test-fast (ubuntu-latest)](https://github.com/EliahKagan/gitoxide/actions/runs/13406804999/job/37448117443#step:8:1508) run, for comparison:

```text
original: [
    "ours/home/runner/work/gitoxide/gitoxide/gix-merge/.tmpmK4t1a",
    "/home/runner/work/gitoxide/gitoxide/gix-merge/.tmpNFsS5l",
    "/home/runner/work/gitoxide/gitoxide/gix-merge/.tmp8rvAjw",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
cleaned: [
    "ours/home/runner/work/gitoxide/gitoxide/gix-merge/.tmpmK4t1a",
    "/.tmpNFsS5l",
    "/.tmp8rvAjw",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
```

#### Based off the main branch, on CI, in Windows (would pass)

In the [test-fast (windows-latest)](https://github.com/EliahKagan/gitoxide/actions/runs/13406804999/job/37448116375#step:8:1694) run:

```text
original: [
    "oursD:agitoxidegitoxidegix-merge.tmpDYZgPn",
    "D:agitoxidegitoxidegix-merge.tmpOKiCuJ",
    "D:agitoxidegitoxidegix-merge.tmpOahQgz",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
cleaned: [
    "oursD:agitoxidegitoxidegix-merge.tmpDYZgPn",
    "D:agitoxidegitoxidegix-merge.tmpOKiCuJ",
    "D:agitoxidegitoxidegix-merge.tmpOahQgz",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
```

Note how backslashes are being treated as escape characters and removed, which seems like it is not intended, but this does not in and of itself cause a problem with this test: it happens even on the main branch, and even without the changes from this PR.

#### Based off the main branch, locally, in Windows, from Git Bash (would pass)

Via [`cargo nextest run -p gix-merge --no-fail-fast`](https://gist.github.com/EliahKagan/5ea1be801f9770d48826dd1a4df3a3c7):

```text
original: [
    "oursC:Userseksourcereposgitoxidegix-merge.tmpORUoAj",
    "C:Userseksourcereposgitoxidegix-merge.tmpuUGgiZ",
    "C:Userseksourcereposgitoxidegix-merge.tmpsYzC12",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
cleaned: [
    "oursC:Userseksourcereposgitoxidegix-merge.tmpORUoAj",
    "C:Userseksourcereposgitoxidegix-merge.tmpuUGgiZ",
    "C:Userseksourcereposgitoxidegix-merge.tmpsYzC12",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
```

#### Based off the main branch, locally, in Windows, from PowerShell (would pass)

Via [`cargo nextest run -p gix-merge --no-fail-fast`](https://gist.github.com/EliahKagan/a6b8584526b5153c7bedf588e2e0fdfd):

```text
original: [
    "oursC:Userseksourcereposgitoxidegix-merge.tmpPNy4Pa",
    "C:Userseksourcereposgitoxidegix-merge.tmp5Fkmzy",
    "C:Userseksourcereposgitoxidegix-merge.tmp9aFhwO",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
cleaned: [
    "oursC:Userseksourcereposgitoxidegix-merge.tmpPNy4Pa",
    "C:Userseksourcereposgitoxidegix-merge.tmp5Fkmzy",
    "C:Userseksourcereposgitoxidegix-merge.tmp9aFhwO",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
```

#### Based off this feature branch, on CI, in Ubuntu (would pass)

In the [test-fast (ubuntu-latest)](https://github.com/EliahKagan/gitoxide/actions/runs/13406769468/job/37448018317#step:8:1508) run, for comparison:

```text
original: [
    "ours/home/runner/work/gitoxide/gitoxide/gix-merge/.tmpvKkoxy",
    "/home/runner/work/gitoxide/gitoxide/gix-merge/.tmpr402lE",
    "/home/runner/work/gitoxide/gitoxide/gix-merge/.tmp8bJjIe",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
cleaned: [
    "ours/home/runner/work/gitoxide/gitoxide/gix-merge/.tmpvKkoxy",
    "/.tmpr402lE",
    "/.tmp8bJjIe",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
```

That is the same as based off the main branch, which is very much as expected, because the changes on this feature branch do not produce a different value for `gix_path::env::shell()` on systems other than Windows.

#### Based off this feature branch, on CI, on Windows (would pass)

In the [test-fast (windows-latest)](https://github.com/EliahKagan/gitoxide/actions/runs/13406769468/job/37448017722#step:8:1559) run:

```text
original: [
    "oursD:agitoxidegitoxidegix-merge.tmpyuHJtT",
    "D:agitoxidegitoxidegix-merge.tmpC2s55H",
    "D:agitoxidegitoxidegix-merge.tmp06rraO",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
cleaned: [
    "oursD:agitoxidegitoxidegix-merge.tmpyuHJtT",
    "D:agitoxidegitoxidegix-merge.tmpC2s55H",
    "D:agitoxidegitoxidegix-merge.tmp06rraO",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
```

This is similar to the main branch CI and local Git Bash runs shown above.

#### Based off this feature branch, locally, in Windows, from Git Bash (would pass)

Via [`cargo nextest run -p gix-merge --no-fail-fast`](https://gist.github.com/EliahKagan/3dbe97b9e291ee5ec66538379fb2503b):

```text
original: [
    "oursC:Userseksourcereposgitoxidegix-merge.tmpUfxnE8",
    "C:Userseksourcereposgitoxidegix-merge.tmpiUdSfX",
    "C:Userseksourcereposgitoxidegix-merge.tmpmkVmRq",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
cleaned: [
    "oursC:Userseksourcereposgitoxidegix-merge.tmpUfxnE8",
    "C:Userseksourcereposgitoxidegix-merge.tmpiUdSfX",
    "C:Userseksourcereposgitoxidegix-merge.tmpmkVmRq",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
    "b",
    "theirs",
]
```

#### Based off this feature branch, locally, in Windows, from PowerShell (would fail)

Via [`cargo nextest run -p gix-merge --no-fail-fast`](https://gist.github.com/EliahKagan/1597402f5e78a0056b76f903a477ce35):

```text
original: [
    "b",
    "theirserseksourcereposgitoxidegix-merge.tmpTDKDff",
    "C:Userseksourcereposgitoxidegix-merge.tmp5WJaSb",
    "C:Userseksourcereposgitoxidegix-merge.tmpyQDnZt",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
]
cleaned: [
    "b",
    "theirserseksourcereposgitoxidegix-merge.tmpTDKDff",
    "C:Userseksourcereposgitoxidegix-merge.tmp5WJaSb",
    "C:Userseksourcereposgitoxidegix-merge.tmpyQDnZt",
    "7",
    "b",
    "ancestor label",
    "current label",
    "other label",
    "%F",
]
```

Note how `b` comes first, and the three lines with paths to files named containing `.tmp` follow it. This causes this assertion, which is run for the first three lines, to fail in the first iteration (i.e. for the first line):

https://github.com/GitoxideLabs/gitoxide/blob/2efce72ada61149ef3823f4e15fdbc75157745ec/gix-merge/tests/merge/blob/platform.rs#L297

But I do not understand why. I'm not very familiar with the details of `gix-merge`. I'm also not entirely clear on which kinds of shell transformations (from parsing `%` items into fields, from shell expansions on unquoted parameter expansion, and from the implicit effect of joining on spaces when passing multiple arguments arising from an unquoted expansion to `echo`) are intended to occur in the test command, and with what effects.

Is this likely to be caused by different environments across shells run in different ways? Or is it somehow due to the name the shell is called with, even though that does not become its `$0` here and, furthermore, its `$0` does not seem to be expanded? What could be going on?