### PR TITLE
cargo-deny maintenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4652,9 +4652,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.2.5"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b202022bb57c049555430e11fc22fea12909276a80a4c3d368da36ac1d88ed"
+checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
 dependencies = [
  "sdd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4676,9 +4676,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "3.0.4"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
+checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
 
 [[package]]
 name = "security-framework"

--- a/deny.toml
+++ b/deny.toml
@@ -28,7 +28,6 @@ allow = [
     "ISC",
     "LicenseRef-ring",
     "OpenSSL",
-    "Unicode-DFS-2016",
     "Zlib",
     "MPL-2.0",
     "Unicode-3.0"

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,7 @@
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-ignore = ['RUSTSEC-2025-0007']
+ignore = []
 
 
 


### PR DESCRIPTION
This removes [RUSTSEC-2025-0007](https://rustsec.org/advisories/RUSTSEC-2025-0007.html) as an allowed advisory since it has been withdrawn and therefore need no longer be listed, updates the versions of two `Cargo.lock` dependencies that have been yanked and whose updated versions fix what seem to be soundness bugs, and removes the old Unicode license from the allow list now that no dependencies use it. See commit messages for full details.