### PR TITLE
Make the `bash_program()` helper in `gix-testtools` a little more robust

### DIFF
--- a/gix/tests/fixtures/make_remote_repos.sh
+++ b/gix/tests/fixtures/make_remote_repos.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu -o pipefail
+set -eux -o pipefail
 
 function tick () {
   if test -z "${tick+set}"
@@ -190,6 +190,7 @@ git init --bare bad-url-rewriting
 (cd bad-url-rewriting
 
   git remote add origin https://github.com/foobar/gitoxide
+  nl -ba config >&2
   cat <<EOF >> config
 
 [remote "origin"]
@@ -201,6 +202,7 @@ git init --bare bad-url-rewriting
 [url "https://github.com/byron/"]
   insteadOf = https://github.com/foobar/
 EOF
+  nl -ba config >&2
 
   {
     git remote get-url origin

--- a/gix/tests/fixtures/make_remote_repos.sh
+++ b/gix/tests/fixtures/make_remote_repos.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eux -o pipefail
+set -eu -o pipefail
 
 function tick () {
   if test -z "${tick+set}"
@@ -190,7 +190,6 @@ git init --bare bad-url-rewriting
 (cd bad-url-rewriting
 
   git remote add origin https://github.com/foobar/gitoxide
-  nl -ba config >&2
   cat <<EOF >> config
 
 [remote "origin"]
@@ -202,7 +201,6 @@ git init --bare bad-url-rewriting
 [url "https://github.com/byron/"]
   insteadOf = https://github.com/foobar/
 EOF
-  nl -ba config >&2
 
   {
     git remote get-url origin

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -663,7 +663,7 @@ fn bash_program() -> &'static Path {
                 .map(OsString::from)
                 .map(|mut raw_path| {
                     // Go down to where `bash.exe` usually is. Keep using `/` separators (not `\`).
-                    raw_path.push("/bin/bash.exe");
+                    raw_path.push("/usr/bin/bash.exe");
                     raw_path
                 })
                 .map(PathBuf::from)

--- a/tests/tools/src/main.rs
+++ b/tests/tools/src/main.rs
@@ -1,5 +1,14 @@
 use std::{fs, io, io::prelude::*, path::PathBuf};
 
+fn bash_program() -> io::Result<()> {
+    use std::io::IsTerminal;
+    if !std::io::stdout().is_terminal() {
+        eprintln!("warning: `bash-program` subcommand not meant for scripting, format may change");
+    }
+    println!("{:?}", gix_testtools::bash_program());
+    Ok(())
+}
+
 fn mess_in_the_middle(path: PathBuf) -> io::Result<()> {
     let mut file = fs::OpenOptions::new().read(false).write(true).open(path)?;
     file.seek(io::SeekFrom::Start(file.metadata()?.len() / 2))?;
@@ -17,6 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut args = std::env::args().skip(1);
     let scmd = args.next().expect("sub command");
     match &*scmd {
+        "bash-program" | "bp" => bash_program()?,
         "mess-in-the-middle" => mess_in_the_middle(PathBuf::from(args.next().expect("path to file to mess with")))?,
         #[cfg(unix)]
         "umask" => umask()?,


### PR DESCRIPTION
Tasks:

- [x] Change it to prefer the shim (drop/rewind or undo 7c0af6a)
- [x] Figure out if and how is currently best to fall back to a non-shim (see outscoped)
- [x] Retest locally
- [x] Retest locally along with changes from [#1862](https://github.com/GitoxideLabs/gitoxide/pull/1862) (though they should be independent)
- [ ] If [#1862](https://github.com/GitoxideLabs/gitoxide/pull/1862) comes in first, rebase for clearer history (optional, should not be needed)

Outscoped:

- https://github.com/GitoxideLabs/gitoxide/issues/1886
- Investigate local failures with non-shim (outscoped to [#1862](https://github.com/GitoxideLabs/gitoxide/pull/1862))\*

\* The stakes here are low enough that I think that doesn't have to be investigated in detail. But the stakes in #1862 are higher, the shim vs. non-shim situation is similar, and we only surfaced one error case there, so I am going to examine the failures from *here* to become more confident in the improved solution *there*.

---

On Windows, since #1712, `gix-testtools` looks for a `bash` shell associated with Git for Windows, to run fixture scripts. This logic is broadly similar to `gix_path::env::shell()` (#1758), which it influenced (https://github.com/GitoxideLabs/gitoxide/pull/1752#discussion_r1909401210). But there are some differences, even beyond `shell()` in `gix-path` being for `sh` and `bash_program()` in `gix-testtools` being for `bash`. Some differences are stylistic, while others are behavioral.

It seems to me that they should be more similar than they are, and that there are also some improvements that should be applied to both in the same way. The changes proposed for `shell()` in #1862 include some that make it more similar to `bash_program()`, such as checking if the shell exists, as well as others such as preferring `/`, which neither `shell()` nor `bash_program()` yet do but which makes sense in both.

This PR is the `gix-testtools` counterpart to the `gix-path` changes in #1862. The topical similarity could justify including both in the same PR, but having separate feature branches is more flexible, and I think the effects are also independent. In addition, neither is ready, it is possible that one will be ready before the other, and I do not know which. Currently the changes in this PR are:

- Refactor for clarity and to reduce unnecessary dissimilarity to `gix_path::env::shell()`.
- Prefer `/` over `\` in building the path to `bash.exe`.
- Add some more tests.
- Look for the non-shim `bash.exe` in `(git root)/usr/bin` instead of the shim in `(git root)/bin`.

All but the last of those changes are done together, while the last is in its own commit. See commit messages for more details and rationale. Some code is analogous to code proposed for `gix-path` in #1862 but less commented. More comments could be added, especially if this PR ends up being merged without #1862 being merged or looking like it would be merged soon after.

All but the last of these changes also appear to be working fine on all tested systems. In contrast, using the non-shim `bash.exe` breaks at least one fixture and many tests when run locally on my Windows 10 development machine from PowerShell. The failing tests are not the ones introduced here, but preexisting tests that passed before, including when run in that environment. The failures appear to be due to errors in test fixture scripts. This situation is similar to the local failures currently blocking #1862 and I suspect the cause is the same. This is what I was referring to in https://github.com/GitoxideLabs/gitoxide/pull/1758#discussion_r1968403527, and I'll try to give details of the failures (as an edit or comment here) soon.

I suspect that, for the `sh.exe` and `bash.exe` provided by Git for Windows, the shim behavior of adding `bin` directories associated with Git for Windows to the front of `PATH` is necessary to prevent scripts run in those shells from invoking the wrong implementations of commands, where multiple implementations are available. But I have not determined for sure that this is the case, so this PR is not ready yet.

*If* that is the case, then a possible solution could be to prefer the shims (both here and in #1862), though if the additional subprocess invocations inherent in doing so cause a performance problem, then the existing customization of the environment in both `gix-command` and `gix-testtools` could potentially be extended. If that performance degradation is not excessive, then the ideal solution may be to prefer the shims but fall back to the non-shim versions, which would preserve compatibility with the Git for Windows SDK in scenarios where it currently works (the SDK does not have the shims, noted in https://github.com/GitoxideLabs/gitoxide/issues/1761#issue-2782287034, as observed in https://github.com/GitoxideLabs/gitoxide/pull/1758#discussion_r1912385953 and rechecked in https://github.com/GitoxideLabs/gitoxide/pull/1758#discussion_r1966873897).