### PR TITLE
Minor clarity fixes in `gix-commitgraph`

### DIFF
--- a/gix-commitgraph/Cargo.toml
+++ b/gix-commitgraph/Cargo.toml
@@ -4,7 +4,7 @@ lints.workspace = true
 name = "gix-commitgraph"
 version = "0.26.0"
 repository = "https://github.com/GitoxideLabs/gitoxide"
-documentation = "https://git-scm.com/docs/commit-graph#:~:text=The%20commit-graph%20file%20is%20a%20supplemental%20data%20structure,or%20in%20the%20info%20directory%20of%20an%20alternate."
+documentation = "https://git-scm.com/docs/commit-graph"
 license = "MIT OR Apache-2.0"
 description = "Read-only access to the git commitgraph file format"
 authors = ["Conor Davis <gitoxide@conor.fastmail.fm>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]

--- a/gix-commitgraph/tests/access/mod.rs
+++ b/gix-commitgraph/tests/access/mod.rs
@@ -70,7 +70,7 @@ fn generation_numbers_overflow_is_handled_in_chained_graph() {
 }
 
 #[test]
-fn octupus_merges() {
+fn octopus_merges() {
     let (cg, refs) = graph_and_expected(
         "octopus_merges.sh",
         &[


### PR DESCRIPTION
This fixes a misspelled test name, and simplifies a documentation URL that had a long `#:~:text` anchor that no longer worked even in browsers that support them and that (fortunately) is not needed for the page to be useful.

This is pretty minor, but it doesn't seem to naturally go together with any other PRs I have open or plan to open anytime soon. So it is its own PR.

(As elsewhere, the `test-fixtures-windows` failure here is unrelated to this PR; see #1849 and #1870. The `test-32bit` failure is likewise unrelated; see #1874.) 