### PR TITLE
Allow `paste` even though unmaintained, for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -3641,7 +3641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4471,15 +4471,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -4899,12 +4898,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stability"

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,7 @@
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-ignore = []
+ignore = ["RUSTSEC-2024-0436"]
 
 
 


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2024-0436.html now causes the `cargo deny advisories` check to fail (even if the separate and more important failure from `ring` is fixed by bumping the `ring` version, as in #1878).

`paste` is mature and would be hard to remove as a transitive dependency at this time:

    > cargo tree --invert paste --no-dedupe --depth 3
    paste v1.0.15 (proc-macro)
    └── ratatui v0.26.3
        ├── crosstermion v0.14.0
        │   ├── gitoxide v0.41.0 (C:\Users\ek\source\repos\gitoxide)
        │   └── prodash v29.0.0
        ├── prodash v29.0.0
        │   ├── gitoxide v0.41.0 (C:\Users\ek\source\repos\gitoxide)
        │   ├── gix v0.70.0 (C:\Users\ek\source\repos\gitoxide\gix)
        │   └── gix-features v0.40.0 (C:\Users\ek\source\repos\gitoxide\gix-features)
        └── tui-react v0.23.2
            ├── crosstermion v0.14.0
            └── prodash v29.0.0

As discussed in https://github.com/rustsec/advisory-db/pull/2215 and https://github.com/leptos-rs/leptos/issues/3685, `paste` is widely used and there is community interest in maintaining it.

When the status changes or more information about the future of `paste` or its alternatives is available, `deny.toml` could be updated again (even if only with a comment).

---

This PR adds a commit atop #1878. It would be reasonable to include this change there, but I [cannot use](https://github.com/orgs/community/discussions/9099) a review comment to propose an automatically appliable patch to code in a PR that is not changed or right next to lines that are changed. I considered opening this against the Dependabot branch for #1878 rather than against main, but in this case it seems like that might be more complicated to handle; but I'd be pleased to change the base branch on request.

If #1878 is merged first, then this can be merged and the history should be okay and still free of duplicate commits. Or this could be rebased after that for a slightly clearer history. Or if this is merged before #1878, it will bring in the changes from there, and I believe #1878 will be closed automatically. Another option is to merge this commit into the branch for #1878 (`git merge 1d9f7cd` when on that branch) and then merge #1878.

This causes the `cargo deny advisories` check to pass. The remaining failures here are unrelated to the changes. They are the same as the other failures occurring on main: `test-fixtures-windows` (due to #1849, #1870 would fix) and `test-32bit` ([due to](https://github.com/GitoxideLabs/gitoxide/pull/1874#issuecomment-2696799485) rustup [changes](https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html), #1874 would fix).