### PR TITLE
Respect `diff.algorithm` in `gix blame`

### DIFF
--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -269,7 +269,15 @@ pub fn file(
                     unreachable!("We already found file_path in suspect^{{tree}}, so it can't be deleted")
                 }
                 gix_diff::tree::recorder::Change::Modification { previous_oid, oid, .. } => {
-                    let changes = blob_changes(&odb, resource_cache, oid, previous_oid, file_path, &mut stats)?;
+                    let changes = blob_changes(
+                        &odb,
+                        resource_cache,
+                        oid,
+                        previous_oid,
+                        file_path,
+                        options.diff_algorithm,
+                        &mut stats,
+                    )?;
                     hunks_to_blame = process_changes(hunks_to_blame, changes, suspect, parent_id);
                 }
             }
@@ -553,6 +561,7 @@ fn blob_changes(
     oid: ObjectId,
     previous_oid: ObjectId,
     file_path: &BStr,
+    diff_algorithm: gix_diff::blob::Algorithm,
     stats: &mut Statistics,
 ) -> Result<Vec<Change>, Error> {
     /// Record all [`Change`]s to learn about additions, deletions and unchanged portions of a *Source File*.
@@ -631,7 +640,7 @@ fn blob_changes(
     let number_of_lines_in_destination = input.after.len();
     let change_recorder = ChangeRecorder::new(number_of_lines_in_destination as u32);
 
-    let res = gix_diff::blob::diff(gix_diff::blob::Algorithm::Histogram, &input, change_recorder);
+    let res = gix_diff::blob::diff(diff_algorithm, &input, change_recorder);
     stats.blobs_diffed += 1;
     Ok(res)
 }

--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -10,6 +10,8 @@ use std::{
 /// Options to be passed to [`file()`](crate::file()).
 #[derive(Default, Debug, Clone)]
 pub struct Options {
+    /// The algorithm to use for diffing.
+    pub diff_algorithm: gix_diff::blob::Algorithm,
     /// A 1-based inclusive range, in order to mirror `git`’s behaviour. `Some(20..40)` represents
     /// 21 lines, spanning from line 20 up to and including line 40. This will be converted to
     /// `19..40` internally as the algorithm uses 0-based ranges that are exclusive at the end.

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -192,6 +192,7 @@ macro_rules! mktest {
                 &mut resource_cache,
                 format!("{}.txt", $case).as_str().into(),
                 gix_blame::Options {
+                    diff_algorithm: gix_diff::blob::Algorithm::Histogram,
                     range: None,
                     since: None,
                 },
@@ -262,6 +263,7 @@ fn diff_disparity() {
             &mut resource_cache,
             format!("{case}.txt").as_str().into(),
             gix_blame::Options {
+                diff_algorithm: gix_diff::blob::Algorithm::Histogram,
                 range: None,
                 since: None,
             },
@@ -293,6 +295,7 @@ fn line_range() {
         &mut resource_cache,
         "simple.txt".into(),
         gix_blame::Options {
+            diff_algorithm: gix_diff::blob::Algorithm::Histogram,
             range: Some(1..2),
             since: None,
         },
@@ -323,6 +326,7 @@ fn since() {
         &mut resource_cache,
         "simple.txt".into(),
         gix_blame::Options {
+            diff_algorithm: gix_diff::blob::Algorithm::Histogram,
             range: None,
             since: Some(gix_date::parse("2025-01-31", None).unwrap()),
         },

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -1555,10 +1555,17 @@ pub fn main() -> Result<()> {
             progress_keep_open,
             None,
             move |_progress, out, err| {
+                let repo = repository(Mode::Lenient)?;
+                let diff_algorithm = repo.diff_algorithm()?;
+
                 core::repository::blame::blame_file(
-                    repository(Mode::Lenient)?,
+                    repo,
                     &file,
-                    gix::blame::Options { range, since },
+                    gix::blame::Options {
+                        diff_algorithm,
+                        range,
+                        since,
+                    },
                     out,
                     statistics.then_some(err),
                 )


### PR DESCRIPTION
Currently, the diff algorithm used for diffing while running blame is hard-coded to `Histogram` in `blame::file()` (or, more specifically, in `blob_changes()`). With this PR, `diff_algorithm` becomes an option to be provided to `blame::file()`. For `gix blame`, the value of `diff.algorithm` as returned by `Repository::diff_algorithm()` is used.

- feat!: add `diff_algorithm` to `blame::file()`
- Adapt to changes in `gix-blame`
