### PR TITLE
Delist withdrawn RUSTSEC-2025-0014

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,8 +9,6 @@
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 ignore = [
-    # human-time in env-logger
-    "RUSTSEC-2025-0014",
     # `paste` - macro crate without replacement
     "RUSTSEC-2024-0436"
 ]


### PR DESCRIPTION
The `humantime` crate briefly had unmaintained status, for which RUSTSEC-2025-0014 was issued. It has since become maintained again, and that advisory has been withdrawn. So this removes it from the list of advisores we allow `cargo deny` to ignore.

Background:

- https://rustsec.org/advisories/RUSTSEC-2025-0014.html (advisory)
- https://github.com/rustsec/advisory-db/pull/2249
- https://github.com/rustsec/advisory-db/pull/2252
- cf7f34d in [#1882](https://github.com/GitoxideLabs/gitoxide/pull/1882) (commit that ignored it, among other changes)