### PR TITLE
Improve filesystem timestamp granularity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - ubuntu-24.04-arm
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
 
@@ -265,6 +266,7 @@ jobs:
             runner-arch: arm64
             runner-os: ubuntu-24.04-arm
             host-triple: armv7-unknown-linux-gnueabihf
+      fail-fast: false
 
     runs-on: ${{ matrix.runner-os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,6 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - ubuntu-24.04-arm
-      fail-fast: false
 
     runs-on: ${{ matrix.os }}
 
@@ -266,7 +265,6 @@ jobs:
             runner-arch: arm64
             runner-os: ubuntu-24.04-arm
             host-triple: armv7-unknown-linux-gnueabihf
-      fail-fast: false
 
     runs-on: ${{ matrix.runner-os }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,6 +1903,7 @@ dependencies = [
  "fastrand",
  "gix-features 0.40.0",
  "gix-utils 0.1.14",
+ "is_ci",
  "serde",
  "tempfile",
 ]

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -27,5 +27,6 @@ serde = { version = "1.0.114", optional = true, default-features = false, featur
 fastrand = { version = "2.1.0", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-tempfile = "3.5.0"
 crossbeam-channel = "0.5.0"
+is_ci = "1.1.1"
+tempfile = "3.5.0"

--- a/gix-fs/tests/fs/snapshot.rs
+++ b/gix-fs/tests/fs/snapshot.rs
@@ -3,13 +3,6 @@ use std::path::Path;
 
 #[test]
 fn journey() -> Result<(), Box<dyn std::error::Error>> {
-    for _ in 0..250 {
-        do_journey()?;
-    }
-    Ok(())
-}
-
-fn do_journey() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir().unwrap();
     if !has_granular_times(tmp.path())? {
         return Ok(());

--- a/gix-fs/tests/fs/snapshot.rs
+++ b/gix-fs/tests/fs/snapshot.rs
@@ -64,5 +64,9 @@ fn has_granular_times(root: &Path) -> std::io::Result<bool> {
 
     // This could be wrongly false if a filesystem has very precise timings yet is ridiculously
     // fast. Then the `journey` test wouldn't run, though it could. But that's OK, and unlikely.
+    // However, for now, on CI, on macOS only, we assert the expectation of high granularity.
+    if cfg!(target_os = "macos") && is_ci::cached() {
+        assert_eq!(times.len(), n);
+    }
     Ok(times.len() == n)
 }

--- a/gix-fs/tests/fs/snapshot.rs
+++ b/gix-fs/tests/fs/snapshot.rs
@@ -49,11 +49,11 @@ fn do_journey() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn has_granular_times(root: &Path) -> std::io::Result<bool> {
-    let n = 100;
+    let n = 50;
 
-    let names: Vec<_> = (0..n).map(|i| format!("{i:03}")).collect();
-    for name in &names {
-        std::fs::write(root.join(name), name)?;
+    let names = (0..n).map(|i| format!("{i:03}"));
+    for name in names.clone() {
+        std::fs::write(root.join(&name), name)?;
     }
     let mut times = Vec::new();
     for name in names {
@@ -64,9 +64,12 @@ fn has_granular_times(root: &Path) -> std::io::Result<bool> {
 
     // This could be wrongly false if a filesystem has very precise timings yet is ridiculously
     // fast. Then the `journey` test wouldn't run, though it could. But that's OK, and unlikely.
-    // However, for now, on CI, on macOS only, we assert the expectation of high granularity.
     if cfg!(target_os = "macos") && is_ci::cached() {
-        assert_eq!(times.len(), n);
+        assert_eq!(
+            times.len(),
+            n,
+            "should have very granular timestamps at least on macOS on CI"
+        );
     }
     Ok(times.len() == n)
 }

--- a/gix-fs/tests/fs/snapshot.rs
+++ b/gix-fs/tests/fs/snapshot.rs
@@ -3,6 +3,13 @@ use std::path::Path;
 
 #[test]
 fn journey() -> Result<(), Box<dyn std::error::Error>> {
+    for _ in 0..250 {
+        do_journey()?;
+    }
+    Ok(())
+}
+
+fn do_journey() -> Result<(), Box<dyn std::error::Error>> {
     let tmp = tempfile::tempdir().unwrap();
     if !has_nanosecond_times(tmp.path())? {
         return Ok(());

--- a/gix-fs/tests/fs/snapshot.rs
+++ b/gix-fs/tests/fs/snapshot.rs
@@ -51,13 +51,13 @@ fn do_journey() -> Result<(), Box<dyn std::error::Error>> {
 fn has_granular_times(root: &Path) -> std::io::Result<bool> {
     let n = 50;
 
-    let names = (0..n).map(|i| format!("{i:03}"));
-    for name in names.clone() {
-        std::fs::write(root.join(&name), name)?;
+    let paths = (0..n).map(|i| root.join(format!("{i:03}")));
+    for (index, path) in paths.clone().enumerate() {
+        std::fs::write(&path, index.to_string().as_bytes())?;
     }
     let mut times = Vec::new();
-    for name in names {
-        times.push(root.join(name).symlink_metadata()?.modified()?);
+    for path in paths {
+        times.push(path.symlink_metadata()?.modified()?);
     }
     times.sort();
     times.dedup();


### PR DESCRIPTION
Fixes #1896

This avoids false positives for the check of whether we can proceed to run the filesystem snapshot `journey` test, by making a hundred files about as fast as we can using ordinary non-parallelized techniques, then checking if all their timestamps are distinct.

This carries a small risk of false negatives, but experiments on macOS, where the `journey` test is typically able to run, suggest that the rate of false negatives will be low. (False positives are also, in theory, possible, but should be extremely rare or never happen.)

#### Distinct timestamp experiment

First, I experimented outside of CI on Ubuntu, Windows, and macOS, initially with the code shown in https://github.com/GitoxideLabs/gitoxide/pull/1897#pullrequestreview-2699690027, but after that with this test program:

```rust
use std::io::Result;
use std::path::Path;
use std::time::{Instant, SystemTime};

fn main() -> Result<()> {
    let reps = 50;
    let n = 100;

    let mut uniques = Vec::new();
    for _ in 0..reps {
        uniques.push(run_experiment(n)?);
    }
    println!("{:?}", uniques);
    println!("{}, {}", uniques.contains(&1), uniques.contains(&n));
    Ok(())
}

fn run_experiment(n: u32) -> Result<u32> {
    let start = Instant::now();
    let tmp = tempfile::tempdir().unwrap();
    let times = unique_times(n, tmp.path())?;
    let finish = Instant::now();
    println!("{} / {}", times.len(), n);
    println!("{times:?}");
    println!("Experiment took {:?}.", finish - start);
    Ok(times.len().try_into().expect("it's out of n, which is u32"))
}

fn unique_times(n: u32, root: &Path) -> Result<Vec<SystemTime>> {
    let names: Vec<_> = (0..n).map(|i| format!("{i:03}")).collect();
    for name in &names {
        std::fs::write(root.join(name), name)?;
    }
    let mut times = Vec::new();
    for name in names {
        times.push(root.join(name).symlink_metadata()?.modified()?);
    }
    times.sort();
    times.dedup();
    Ok(times)
}
```

Running that locally, the last two lines of output on Ubuntu were:

```text
[4, 4, 4, 3, 3, 3, 3, 3, 4, 4, 3, 3, 3, 3, 3, 4, 4, 5, 4, 3, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 3, 3, 3, 4, 3, 4, 4, 3, 3, 4, 4, 3, 3, 4, 4, 4, 4, 4, 3]
false, false
```

And on Windows (which has 100 ns representation granularity, and which uses a temporary directory that is not on a separate `tmpfs`-like filesystem):

```text
[25, 25, 25, 24, 24, 25, 26, 25, 24, 24, 25, 26, 26, 24, 26, 25, 25, 24, 24, 23, 25, 25, 24, 23, 23, 24, 24, 26, 28, 26, 24, 23, 24, 23, 23, 23, 24, 23, 24, 25, 23, 23, 24, 24, 24, 30, 25, 26, 24, 23]                                        false, false
```

And on macOS, which has 1 ns granularity at least on the current default filesystem:

```text
[100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100]                                                                                                              false, true
```

For full details, including full output, see [this repository](https://github.com/EliahKagan/granularity).

This is not guaranteed to be that way on all such systems. The use of a different filesystem type or device type could potentially confer high granularity on a system that ordinarily doesn't have it, or result in diminished granularity on a system where it ordinarily is high. If it were guaranteed, then actually checking this would be overkill because it would be sufficient to enable the test on macOS but not other operating systems. That is expected to be what happens on CI as it is currently set up, as well as in most local environments, but not necessarily in all local environments. Therefore:

- I think this is better than assuming which platforms work, though it might make sense to have CI fail if the check returns `false` on macOS.

- Before considering this ready, I'm going to do that at least temporarily, to check that my non-CI macOS experiments are similar to CI (i.e. to make sure the test it least sometimes actually running). That's why this is still a draft.

  *Edit:* I've done that. The passing test with this macOS+CI specific assertion when repeating the whole test 250 times can be seen [in this run](https://github.com/EliahKagan/gitoxide/actions/runs/13959179656/job/39077179279).

- Although I've marked this as fixing the issue, it might be better--even if merging this--to view it as a workaround in the hope of developing a better fix later, more along the lines of what you suggested in [#1897 (comment)](https://github.com/GitoxideLabs/gitoxide/pull/1897#discussion_r2004448543). That way, the test could run on all platforms we test on CI, and most other platforms anyone would want to run it on, too.

  On the other hand, even then, it might be considered valuable to avoid sleeping during the test if the granularity is high enough that it isn't necessary. (I don't mean to avoid the delay, but rather with the idea that the test might be slightly more robust.) Also, the technique used here should be possible to adapt to infer the timestamp granularity.

#### CI experiment

The actual fix here is in d4a8d79, but I also changed the test so it runs 250 times instead of once (including separate calls to the helper function each time) before that commit, and changed it back afterwards. This was to make sure that the reason I didn't see failures was that this really does eliminate the failures (or at least make them extremely rare), rather than by chance, since the failures did not always happen before.

[This workflow output on my fork](https://github.com/EliahKagan/gitoxide/actions/runs/13958357773/job/39074728541) shows that the tests passed even before it was changed back from running 250 times to one time. Please note also that this 250-times repetition is of the whole test--it is not related to the "inner" repetition of creating 100 files.