### PR TITLE
Derive Clone and Copy for Either

### DIFF
--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -103,7 +103,7 @@ pub fn file(
     let (mut buf, mut buf2) = (Vec::new(), Vec::new());
     let commit = find_commit(cache.as_ref(), &odb, &suspect, &mut buf)?;
     let mut queue: gix_revwalk::PriorityQueue<CommitTime, ObjectId> = gix_revwalk::PriorityQueue::new();
-    queue.insert(commit_time(&commit)?, suspect);
+    queue.insert(commit_time(commit)?, suspect);
 
     let mut out = Vec::new();
     let mut diff_state = gix_diff::tree::State::default();
@@ -122,7 +122,7 @@ pub fn file(
         }
 
         let commit = find_commit(cache.as_ref(), &odb, &suspect, &mut buf)?;
-        let commit_time = commit_time(&commit)?;
+        let commit_time = commit_time(commit)?;
 
         if let Some(since) = options.since {
             if commit_time < since.seconds {
@@ -669,7 +669,7 @@ fn find_path_entry_in_commit(
 
 type CommitTime = i64;
 
-fn commit_time(commit: &gix_traverse::commit::Either<'_, '_>) -> Result<CommitTime, gix_object::decode::Error> {
+fn commit_time(commit: gix_traverse::commit::Either<'_, '_>) -> Result<CommitTime, gix_object::decode::Error> {
     match commit {
         gix_traverse::commit::Either::CommitRefIter(commit_ref_iter) => {
             commit_ref_iter.committer().map(|c| c.time.seconds)

--- a/gix-traverse/src/commit/mod.rs
+++ b/gix-traverse/src/commit/mod.rs
@@ -69,6 +69,7 @@ pub struct Info {
 
 /// Information about a commit that can be obtained either from a [`gix_object::CommitRefIter`] or
 /// a [`gix_commitgraph::file::Commit`].
+#[derive(Clone, Copy)]
 pub enum Either<'buf, 'cache> {
     /// See [`gix_object::CommitRefIter`].
     CommitRefIter(gix_object::CommitRefIter<'buf>),


### PR DESCRIPTION
This is a small PR that adds `#[derive(Clone, Copy)]` to `Either`. `std::mem::size_of::<Either<'_, '_>>()` is 56, but I don’t know whether that qualifies as “a bit large”. :-) If you think it does, I would adapt this PR accordingly.
