### PR TITLE
Make the justfile more portable and slightly more resilient

### DIFF
--- a/justfile
+++ b/justfile
@@ -243,7 +243,9 @@ audit:
 nextest *FLAGS='--workspace':
     cargo nextest run {{ FLAGS }}
 
-summarize EXPRESSION='all()': (nextest '--workspace --run-ignored all --no-fail-fast --status-level none --final-status-level none -E' quote(EXPRESSION))
+summarize EXPRESSION='all()':
+    cargo nextest run --workspace --run-ignored all --no-fail-fast \
+        --status-level none --final-status-level none -E {{ quote(EXPRESSION) }}
 
 # run nightly rustfmt for its extra features, but check that it won't upset stable rustfmt
 fmt:

--- a/justfile
+++ b/justfile
@@ -144,7 +144,7 @@ check:
     cargo check --no-default-features --features max-control
 
 # Run cargo doc on all crates
-doc $RUSTDOCFLAGS="-D warnings":
+doc $RUSTDOCFLAGS='-D warnings':
     cargo doc --workspace --no-deps --features need-more-recent-msrv
     cargo doc --features=max,lean,small --workspace --no-deps --features need-more-recent-msrv
 
@@ -158,9 +158,9 @@ unit-tests:
     cargo nextest run -p gix-archive --features tar
     cargo nextest run -p gix-archive --features tar_gz
     cargo nextest run -p gix-archive --features zip
-    cargo nextest run -p gix-status-tests --features "gix-features-parallel"
-    cargo nextest run -p gix-worktree-state-tests --features "gix-features-parallel"
-    cargo nextest run -p gix-worktree-tests --features "gix-features-parallel"
+    cargo nextest run -p gix-status-tests --features gix-features-parallel
+    cargo nextest run -p gix-worktree-state-tests --features gix-features-parallel
+    cargo nextest run -p gix-worktree-tests --features gix-features-parallel
     cd gix-object; \
         set -ex; \
         cargo nextest run; \
@@ -172,10 +172,10 @@ unit-tests:
     cargo nextest run -p gix-odb-tests --features gix-features-parallel
     cargo nextest run -p gix-pack --all-features
     cargo nextest run -p gix-pack-tests --features all-features
-    cargo nextest run -p gix-pack-tests --features "gix-features-parallel"
-    cargo nextest run -p gix-index-tests --features "gix-features-parallel"
+    cargo nextest run -p gix-pack-tests --features gix-features-parallel
+    cargo nextest run -p gix-index-tests --features gix-features-parallel
     cargo nextest run -p gix-packetline --features blocking-io,maybe-async/is_sync --test blocking-packetline
-    cargo nextest run -p gix-packetline --features "async-io" --test async-packetline
+    cargo nextest run -p gix-packetline --features async-io --test async-packetline
     cargo nextest run -p gix-transport --features http-client-curl,maybe-async/is_sync
     cargo nextest run -p gix-transport --features http-client-reqwest,maybe-async/is_sync
     cargo nextest run -p gix-transport --features async-client
@@ -192,10 +192,10 @@ unit-tests-flaky:
     cargo test -p gix --features async-network-client-async-std
 
 target_dir := `cargo metadata --format-version 1 | jq -r .target_directory`
-ein := quote(target_dir / "debug/ein")
-gix := quote(target_dir / "debug/gix")
-jtt := quote(target_dir / "debug/jtt")
-it := quote(target_dir / "debug/it")
+ein := quote(target_dir / 'debug/ein')
+gix := quote(target_dir / 'debug/gix')
+jtt := quote(target_dir / 'debug/jtt')
+it := quote(target_dir / 'debug/it')
 
 # run journey tests (max)
 journey-tests:
@@ -240,10 +240,10 @@ audit:
     cargo deny check advisories bans licenses sources
 
 # run tests with `cargo nextest` (all unit-tests, no doc-tests, faster)
-nextest *FLAGS="--workspace":
+nextest *FLAGS='--workspace':
     cargo nextest run {{ FLAGS }}
 
-summarize EXPRESSION="all()": (nextest "--workspace --run-ignored all --no-fail-fast --status-level none --final-status-level none -E" quote(EXPRESSION))
+summarize EXPRESSION='all()': (nextest '--workspace --run-ignored all --no-fail-fast --status-level none --final-status-level none -E' quote(EXPRESSION))
 
 # run nightly rustfmt for its extra features, but check that it won't upset stable rustfmt
 fmt:

--- a/justfile
+++ b/justfile
@@ -255,7 +255,7 @@ summarize EXPRESSION='all()':
 fmt:
     cargo +nightly fmt --all -- --config-path rustfmt-nightly.toml
     cargo +stable fmt --all -- --check
-    just --fmt --unstable
+    {{ j }} --fmt --unstable
 
 # Cancel this after the first few seconds, as yanked crates will appear in warnings.
 find-yanked:

--- a/justfile
+++ b/justfile
@@ -201,29 +201,29 @@ it := quote(target_dir / 'debug/it')
 journey-tests:
     cargo build --features http-client-curl-rustls
     cargo build -p gix-testtools --bin jtt
-    ./tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} max
+    tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} max
 
 # run journey tests (max-pure)
 journey-tests-pure:
     cargo build --no-default-features --features max-pure
     cargo build -p gix-testtools --bin jtt
-    ./tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} max-pure
+    tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} max-pure
 
 # run journey tests (small)
 journey-tests-small:
     cargo build --no-default-features --features small
     cargo build -p gix-testtools
-    ./tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} small
+    tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} small
 
 # run journey tests (lean-async)
 journey-tests-async:
     cargo build --no-default-features --features lean-async
     cargo build -p gix-testtools
-    ./tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} async
+    tests/journey.sh {{ ein }} {{ gix }} {{ jtt }} async
 
 # Run cargo-diet on all crates to see that they are still in bound
 check-size:
-    ./etc/check-package-size.sh
+    etc/check-package-size.sh
 
 # Check the minimal support rust version for currently installed Rust version
 ci-check-msrv:
@@ -264,4 +264,4 @@ check-mode:
 
 # Delete gix-packetline-blocking/src and regenerate from gix-packetline/src
 copy-packetline:
-    ./etc/copy-packetline.sh
+    etc/copy-packetline.sh

--- a/justfile
+++ b/justfile
@@ -243,7 +243,7 @@ audit:
 nextest *FLAGS="--workspace":
     cargo nextest run {{ FLAGS }}
 
-summarize EXPRESSION="all()": (nextest "--workspace --run-ignored all --no-fail-fast --status-level none --final-status-level none -E '" EXPRESSION "'")
+summarize EXPRESSION="all()": (nextest "--workspace --run-ignored all --no-fail-fast --status-level none --final-status-level none -E" quote(EXPRESSION))
 
 # run nightly rustfmt for its extra features, but check that it won't upset stable rustfmt
 fmt:

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@
 #   like a script, with `./justfile test`, for example.
 
 default:
-    {{ just_executable() }} --list
+    {{ quote(just_executable()) }} --list
 
 alias t := test
 alias c := check
@@ -192,10 +192,10 @@ unit-tests-flaky:
     cargo test -p gix --features async-network-client-async-std
 
 target_dir := `cargo metadata --format-version 1 | jq -r .target_directory`
-ein := target_dir / "debug/ein"
-gix := target_dir / "debug/gix"
-jtt := target_dir / "debug/jtt"
-it := target_dir / "debug/it"
+ein := quote(target_dir / "debug/ein")
+gix := quote(target_dir / "debug/gix")
+jtt := quote(target_dir / "debug/jtt")
+it := quote(target_dir / "debug/it")
 
 # run journey tests (max)
 journey-tests:
@@ -258,7 +258,7 @@ find-yanked:
 # Find shell scripts whose +x/-x bits and magic bytes (e.g. `#!`) disagree
 check-mode:
     cargo build -p internal-tools
-    "{{ it }}" check-mode
+    {{ it }} check-mode
 
 # Delete gix-packetline-blocking/src and regenerate from gix-packetline/src
 copy-packetline:

--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@
 
 j := quote(just_executable())
 
+# List available recipes
 default:
     {{ j }} --list
 
@@ -11,26 +12,27 @@ alias t := test
 alias c := check
 alias nt := nextest
 
-# run all tests, clippy, including journey tests, try building docs
+# Run all tests, clippy, including journey tests, try building docs
 test: clippy check doc unit-tests journey-tests-pure journey-tests-small journey-tests-async journey-tests check-mode
 
-# run all tests, without clippy, and try building docs
+# Run all tests, without clippy, and try building docs
 ci-test: check doc unit-tests check-mode
 
-# run all journey tests - should be run in a fresh clone or after `cargo clean`
+# Run all journey tests - should be run in a fresh clone or after `cargo clean`
 ci-journey-tests: journey-tests-pure journey-tests-small journey-tests-async journey-tests
 
+# Clean the `target` directory
 clear-target:
     cargo clean
 
-# Run cargo clippy on all crates
+# Run `cargo clippy` on all crates
 clippy *clippy-args:
     cargo clippy --workspace --all-targets -- {{ clippy-args }}
     cargo clippy --workspace --no-default-features --features small -- {{ clippy-args }}
     cargo clippy --workspace --no-default-features --features max-pure -- {{ clippy-args }}
     cargo clippy --workspace --no-default-features --features lean-async --tests -- {{ clippy-args }}
 
-# Run cargo clippy on all crates, fixing what can be fixed, and format all code
+# Run `cargo clippy` on all crates, fixing what can be fixed, and format all code
 clippy-fix:
     cargo clippy --fix --workspace --all-targets
     cargo clippy --fix --allow-dirty --workspace --no-default-features --features small
@@ -145,12 +147,12 @@ check:
     cargo check -p gix-odb --features serde
     cargo check --no-default-features --features max-control
 
-# Run cargo doc on all crates
+# Run `cargo doc` on all crates
 doc $RUSTDOCFLAGS='-D warnings':
     cargo doc --workspace --no-deps --features need-more-recent-msrv
     cargo doc --features=max,lean,small --workspace --no-deps --features need-more-recent-msrv
 
-# run all unit tests
+# Run all unit tests
 unit-tests:
     cargo nextest run
     cargo test --doc
@@ -193,7 +195,7 @@ unit-tests:
 unit-tests-flaky:
     cargo test -p gix --features async-network-client-async-std
 
-# depend on this to pre-generate metadata, and/or use it inside a recipe as `"$({{ j }} dbg)"`
+# Depend on this to pre-generate metadata, and/or use it inside a recipe as `"$({{ j }} dbg)"`
 [private]
 dbg:
     set -eu; \
@@ -201,63 +203,64 @@ dbg:
         test -n "$target_dir"; \
         echo "$target_dir/debug"
 
-# run journey tests (max)
+# Run journey tests (`max`)
 journey-tests: dbg
     cargo build --features http-client-curl-rustls
     cargo build -p gix-testtools --bin jtt
     dbg="$({{ j }} dbg)" && tests/journey.sh "$dbg/ein" "$dbg/gix" "$dbg/jtt" max
 
-# run journey tests (max-pure)
+# Run journey tests (`max-pure`)
 journey-tests-pure: dbg
     cargo build --no-default-features --features max-pure
     cargo build -p gix-testtools --bin jtt
     dbg="$({{ j }} dbg)" && tests/journey.sh "$dbg/ein" "$dbg/gix" "$dbg/jtt" max-pure
 
-# run journey tests (small)
+# Run journey tests (`small`)
 journey-tests-small: dbg
     cargo build --no-default-features --features small
     cargo build -p gix-testtools
     dbg="$({{ j }} dbg)" && tests/journey.sh "$dbg/ein" "$dbg/gix" "$dbg/jtt" small
 
-# run journey tests (lean-async)
+# Run journey tests (`lean-async`)
 journey-tests-async: dbg
     cargo build --no-default-features --features lean-async
     cargo build -p gix-testtools
     dbg="$({{ j }} dbg)" && tests/journey.sh "$dbg/ein" "$dbg/gix" "$dbg/jtt" async
 
-# Run cargo-diet on all crates to see that they are still in bound
+# Run `cargo diet` on all crates to see that they are still in bounds
 check-size:
     etc/check-package-size.sh
 
-# Check the minimal support rust version for currently installed Rust version
+# Check the minimal support Rust version, with the currently installed Rust version
 ci-check-msrv:
     rustc --version
     cargo check -p gix
     cargo check -p gix --no-default-features --features async-network-client,max-performance
 
-# Enter a nix-shell able to build on macos
+# Enter a nix-shell able to build on macOS
 nix-shell-macos:
     nix-shell -p pkg-config openssl libiconv darwin.apple_sdk.frameworks.Security darwin.apple_sdk.frameworks.SystemConfiguration
 
-# run various auditing tools to assure we are legal and safe
+# Run various auditing tools to help us stay legal and safe
 audit:
     cargo deny check advisories bans licenses sources
 
-# run tests with `cargo nextest` (all unit-tests, no doc-tests, faster)
+# Run tests with `cargo nextest` (all unit-tests, no doc-tests, faster)
 nextest *FLAGS='--workspace':
     cargo nextest run {{ FLAGS }}
 
+# Run tests with `cargo nextest`, skipping none except as filtered, omitting status reports
 summarize EXPRESSION='all()':
     cargo nextest run --workspace --run-ignored all --no-fail-fast \
         --status-level none --final-status-level none -E {{ quote(EXPRESSION) }}
 
-# run nightly rustfmt for its extra features, but check that it won't upset stable rustfmt
+# Run nightly `rustfmt` for its extra features, but check that it won't upset stable `rustfmt`
 fmt:
     cargo +nightly fmt --all -- --config-path rustfmt-nightly.toml
     cargo +stable fmt --all -- --check
     {{ j }} --fmt --unstable
 
-# Cancel this after the first few seconds, as yanked crates will appear in warnings.
+# Cancel this after the first few seconds, as yanked crates will appear in warnings
 find-yanked:
     cargo install --debug --locked --no-default-features --features max-pure --path .
 
@@ -266,6 +269,6 @@ check-mode:
     cargo build -p internal-tools
     cargo run -p internal-tools -- check-mode
 
-# Delete gix-packetline-blocking/src and regenerate from gix-packetline/src
+# Delete `gix-packetline-blocking/src` and regenerate from `gix-packetline/src`
 copy-packetline:
     etc/copy-packetline.sh

--- a/justfile
+++ b/justfile
@@ -196,7 +196,7 @@ unit-tests-flaky:
 # depend on this to pre-generate metadata, and/or use it inside a recipe as `"$({{ j }} dbg)"`
 [private]
 dbg:
-    set -eux; \
+    set -eu; \
         target_dir="$(cargo metadata --format-version 1 | jq -r .target_directory)"; \
         test -n "$target_dir"; \
         echo "$target_dir/debug"


### PR DESCRIPTION
See the commit messages (and diff) for full details. Some highlights are described below.

#### When `cargo metadata` fails and it's not a problem

Before these changes:

```text
ek in 🌐 catenary in gitoxide on  main is 📦 v0.41.0 via 🦀 v1.85.1
❯ rm -r gix-packetline-blocking/src

ek in 🌐 catenary in gitoxide on  main [✘] is 📦 v0.41.0 via 🦀 v1.85.1
❯ just copy-packetline
error: failed to load manifest for workspace member `/home/ek/repos/gitoxide/gix-ref`
referenced by workspace at `/home/ek/repos/gitoxide/Cargo.toml`

Caused by:
  failed to load manifest for dependency `gix-object`

Caused by:
  failed to load manifest for dependency `gix-odb`

Caused by:
  failed to load manifest for dependency `gix-pack`

Caused by:
  failed to load manifest for dependency `gix-diff`

Caused by:
  failed to load manifest for dependency `gix-filter`

Caused by:
  failed to load manifest for dependency `gix-packetline-blocking`

Caused by:
  failed to parse manifest at `/home/ek/repos/gitoxide/gix-packetline-blocking/Cargo.toml`

Caused by:
  can't find library `gix_packetline_blocking`, rename file to `src/lib.rs` or specify lib.path
./etc/copy-packetline.sh
```

The `copy-packetline.sh` script actually succeeded, because it didn't need the `cargo manifest` output. But `cargo manifest` was called anytime `just` was used to run any recipe, or even just to list the recipes. Besides occasionally making the first invocation take noticeably longer, this is misleading, because it looks like something relevant to the requested operation failed. (See also https://github.com/GitoxideLabs/gitoxide/issues/1310#issuecomment-2040299934.)

After these changes:

```text
ek in 🌐 catenary in gitoxide on  run-ci/just is 📦 v0.41.0 via 🦀 v1.85.1
❯ rm -r gix-packetline-blocking/src

ek in 🌐 catenary in gitoxide on  run-ci/just [✘] is 📦 v0.41.0 via 🦀 v1.85.1
❯ just copy-packetline
etc/copy-packetline.sh
```

#### Making future additions more discoverable

Related to the above, there are various approaches we can use to have Rust code that builds and runs even when the workspace is broken. This is relevant if we decide to introduce Rust code that generates Rust code that, if absent, may cause the workspace to be considered broken. One of the approaches for this, which requires no extra tools, is to have a project that opts out of being in any workspace by having an empty `[workspace]` section in its `Cargo.toml`.

Such a project is then less discoverable. But it can be made discoverable by including commands that use it in the `justfile`. That is only feasible if the `justfile` avoids eagerly failing when the workspace is broken.

That's actually may main motivation for doing this PR: to open up the ability to do things like `copy-packetline.sh` in Rust, as I fear may be needed for #1886 (depending on what the answer to https://github.com/GitoxideLabs/gitoxide/issues/1886#issuecomment-2727490062 turns out to be).

#### When `cargo metadata` fails and it *is* a problem

Recipes that actually use the output of `cargo metadata`, such as `journey-tests`, showed the same errors twice. In principle, they could in the future come to have been written in a way that would cause them to behave even more strangely, if they did something first that did not use `cargo`. Now that we only use `cargo metadata` when we need the output, this is made into a hard error, and thus is only run once.

It may be that this was originally intended--though then, since it was run eagerly before all recipes, it would have kept anything from working even when failures was not a problem. The reason it was not a hard error before is that the failing command is on the left side of a pipe, where it does not cause the whole pipeline to fail, and the `jq` parsing command on the right side of the pipe produced empty output but still reported success even when its input was empty.

#### Quoting

Before these changes, on Windows:

```text
C:\Users\ek\source\repos\gitoxide [main ≡]> just
C:\Users\ek\.cargo\bin\just.exe --list
/usr/bin/bash: line 1: C:Usersek.cargobinjust.exe: command not found
error: Recipe `default` failed on line 6 with exit code 127
```

After these changes, on Windows:

```text
C:\Users\ek\source\repos\gitoxide [run-ci/just ≡]> just
'C:\Users\ek\.cargo\bin\just.exe' --list
Available recipes:
    audit                           # Run various auditing tools to help us stay legal and safe
    check                           # Build all code in suitable configurations [alias: c]
    check-mode                      # Find shell scripts whose +x/-x bits and magic bytes (e.g. `#!`) disagree
    check-size                      # Run `cargo diet` on all crates to see that they are still in bounds
    ci-check-msrv                   # Check the minimal support Rust version, with the currently installed Rust version
    ci-journey-tests                # Run all journey tests - should be run in a fresh clone or after `cargo clean`
    ci-test                         # Run all tests, without clippy, and try building docs
    clear-target                    # Clean the `target` directory
    clippy *clippy-args             # Run `cargo clippy` on all crates
    clippy-fix                      # Run `cargo clippy` on all crates, fixing what can be fixed, and format all code
    copy-packetline                 # Delete `gix-packetline-blocking/src` and regenerate from `gix-packetline/src`
    default                         # List available recipes
    doc $RUSTDOCFLAGS='-D warnings' # Run `cargo doc` on all crates
    find-yanked                     # Cancel this after the first few seconds, as yanked crates will appear in warnings
    fmt                             # Run nightly `rustfmt` for its extra features, but check that it won't upset stable `rustfmt`
    journey-tests                   # Run journey tests (`max`)
    journey-tests-async             # Run journey tests (`lean-async`)
    journey-tests-pure              # Run journey tests (`max-pure`)
    journey-tests-small             # Run journey tests (`small`)
    nextest *FLAGS='--workspace'    # Run tests with `cargo nextest` (all unit-tests, no doc-tests, faster) [alias: nt]
    nix-shell-macos                 # Enter a nix-shell able to build on macOS
    summarize EXPRESSION='all()'    # Run tests with `cargo nextest`, skipping none except as filtered, omitting status reports
    test                            # Run all tests, clippy, including journey tests, try building docs [alias: t]
    unit-tests                      # Run all unit tests
    unit-tests-flaky                # These tests aren't run by default as they are flaky (even locally)
```

Some other quoting improvements are included. For example, `summarize` no longer pastes single quotes around the expression, but instead quotes it robustly.

Although this mainly benefits Windows, in principle it can be needed on any platform, such as when a path used in a shell has spaces in one of its components.

#### Using the same `just` implementation

`just_executable()` was already used in the default recipe to make sure we run the same `just` for `just --list` rather than a different `just`. (It was used in a shell without quoting, but that is fixed here as described above.) But one recipe had previously hard-coded `just` and used it for formatting. This fixes that.

#### Descriptions

All recipes have `#` descriptions that show when the recipes are listed, and they are revised to slightly improve clarity and to eliminate unnecessary stylistic differences. (As shown above.)

---

For some of the changes here, there is more than one way they could be done, and whether this way is clearer or less clear than alternatives is subjective. Accordingly, even though this is kind of thing that, along the lines of the discussion in #1883, I might consider merging myself without a review, in this case I think it's better that I check.