### PR TITLE
fix: use platform path separator instead of `/`

### DIFF
--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -661,7 +661,16 @@ fn find_path_entry_in_commit(
     let res = tree_iter.lookup_entry(
         odb,
         buf2,
-        file_path.split(|b| *b == b'/').inspect(|_| stats.trees_decoded += 1),
+        file_path
+            .split(|b| {
+                b == const {
+                    std::path::MAIN_SEPARATOR_STR
+                        .as_bytes()
+                        .first()
+                        .expect("platform path separator not to be empty")
+                }
+            })
+            .inspect(|_| stats.trees_decoded += 1),
     )?;
     stats.trees_decoded -= 1;
     Ok(res.map(|e| e.oid))


### PR DESCRIPTION
I'm working on Git Blame for Helix and some people on Windows experienced issues where they don't see the blame (https://github.com/helix-editor/helix/pull/13133?notification_referrer_id=NT_kwDOCTrtqLUxNTM1OTU2ODI4OToxNTQ4NTY4NzI#issuecomment-2744734878)

I found the reason is because Gix uses `/` for path separator always, instead of using the platform's separator. This PR fixes that

note: the way I'm turning `MAIN_SEPARATOR_STR` into a byte is a bit awkward here, I wish there was some kind of `MAIN_SEPARATOR_BYTE`