### PR TITLE
Accept `ToComponents` in `gix_fs::Stack`

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       # dictated by `firefox` to support the `helix` editor, but now probably effectively be controlled by `jiff`, which also aligns with `regex`.
       # IMPORTANT: adjust etc/msrv-badge.svg as well
-      rust_version: 1.74.0
+      rust_version: 1.75.0
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,7 @@ dependencies = [
  "is_ci",
  "serde",
  "tempfile",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,9 +1901,11 @@ dependencies = [
 name = "gix-fs"
 version = "0.13.0"
 dependencies = [
+ "bstr",
  "crossbeam-channel",
  "fastrand",
  "gix-features 0.40.0",
+ "gix-path 0.10.14",
  "gix-utils 0.1.14",
  "is_ci",
  "serde",

--- a/etc/msrv-badge.svg
+++ b/etc/msrv-badge.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="92" height="20" role="img" aria-label="rustc: 1.70.0+">
-    <title>rustc: 1.74.0+</title>
+    <title>rustc: 1.75.0+</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         <text aria-hidden="true" x="195" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">rustc</text>
         <text x="195" y="140" transform="scale(.1)" fill="#fff" textLength="270">rustc</text>
-        <text aria-hidden="true" x="635" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">1.74.0+</text>
-        <text x="635" y="140" transform="scale(.1)" fill="#fff" textLength="450">1.74.0+</text>
+        <text aria-hidden="true" x="635" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">1.75.0+</text>
+        <text x="635" y="140" transform="scale(.1)" fill="#fff" textLength="450">1.75.0+</text>
     </g>
 </svg>

--- a/gitoxide-core/src/repository/attributes/query.rs
+++ b/gitoxide-core/src/repository/attributes/query.rs
@@ -8,10 +8,10 @@ pub struct Options {
 }
 
 pub(crate) mod function {
-    use std::{borrow::Cow, io, path::Path};
-
     use anyhow::bail;
     use gix::bstr::BStr;
+    use std::borrow::Cow;
+    use std::{io, path::Path};
 
     use crate::{
         is_dir_to_mode,
@@ -44,7 +44,7 @@ pub(crate) mod function {
                         .ok()
                         .map(|m| is_dir_to_mode(m.is_dir()));
 
-                    let entry = cache.at_entry(path.as_slice(), mode)?;
+                    let entry = cache.at_entry(&path, mode)?;
                     if !entry.matching_attributes(&mut matches) {
                         continue;
                     }

--- a/gitoxide-core/src/repository/exclude.rs
+++ b/gitoxide-core/src/repository/exclude.rs
@@ -48,7 +48,7 @@ pub fn query(
                     .metadata()
                     .ok()
                     .map(|m| is_dir_to_mode(m.is_dir()));
-                let entry = cache.at_entry(path.as_slice(), mode)?;
+                let entry = cache.at_entry(&path, mode)?;
                 let match_ = entry
                     .matching_exclude_pattern()
                     .and_then(|m| (show_ignore_patterns || !m.pattern.is_negative()).then_some(m));

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate providing file system specific utilities to `gitoxide`"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.75"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate providing file system specific utilities to `gitoxide`"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.74"
 include = ["src/**/*", "LICENSE-*"]
 
 [lib]
@@ -21,6 +21,7 @@ serde = ["dep:serde"]
 [dependencies]
 gix-features = { version = "^0.40.0", path = "../gix-features", features = ["fs-read-dir"] }
 gix-utils = { version = "^0.1.14", path = "../gix-utils" }
+thiserror = "2.0.0"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }
 
 # For `Capabilities` to assure parallel operation works.

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -19,6 +19,8 @@ doctest = false
 serde = ["dep:serde"]
 
 [dependencies]
+bstr = "1.5.0"
+gix-path = { version = "^0.10.14", path = "../gix-path" }
 gix-features = { version = "^0.40.0", path = "../gix-features", features = ["fs-read-dir"] }
 gix-utils = { version = "^0.1.14", path = "../gix-utils" }
 thiserror = "2.0.0"

--- a/gix-fs/src/stack.rs
+++ b/gix-fs/src/stack.rs
@@ -1,6 +1,42 @@
+use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
 
 use crate::Stack;
+
+///
+pub mod to_normal_path_components {
+    use std::ffi::OsString;
+
+    /// The error used in [`ToNormalPathComponents::to_normal_path_components()`](super::ToNormalPathComponents::to_normal_path_components()).
+    #[derive(Debug, thiserror::Error)]
+    #[allow(missing_docs)]
+    pub enum Error {
+        #[error("Input path \"{path}\" contains relative or absolute components", path = std::path::Path::new(.0.as_os_str()).display())]
+        NotANormalComponent(OsString),
+    }
+}
+
+/// Obtain an iterator over `OsStr`-components which are normal, none-relative and not absolute.
+pub trait ToNormalPathComponents {
+    /// Return an iterator over the normal components of a path, without the separator.
+    // TODO(MSRV): turn this into `impl Iterator` once MSRV is 1.75 or higher
+    fn to_normal_path_components(
+        &self,
+    ) -> Box<dyn Iterator<Item = Result<&OsStr, to_normal_path_components::Error>> + '_>;
+}
+
+impl ToNormalPathComponents for &Path {
+    fn to_normal_path_components(
+        &self,
+    ) -> Box<dyn Iterator<Item = Result<&OsStr, to_normal_path_components::Error>> + '_> {
+        Box::new(self.components().map(|component| match component {
+            Component::Normal(os_str) => Ok(os_str),
+            _ => Err(to_normal_path_components::Error::NotANormalComponent(
+                self.as_os_str().to_owned(),
+            )),
+        }))
+    }
+}
 
 /// Access
 impl Stack {
@@ -62,8 +98,13 @@ impl Stack {
     /// `relative` paths are terminal, so point to their designated file or directory.
     /// The path is also expected to be normalized, and should not contain extra separators, and must not contain `..`
     /// or have leading or trailing slashes (or additionally backslashes on Windows).
-    pub fn make_relative_path_current(&mut self, relative: &Path, delegate: &mut dyn Delegate) -> std::io::Result<()> {
-        if self.valid_components != 0 && relative.as_os_str().is_empty() {
+    pub fn make_relative_path_current(
+        &mut self,
+        relative: impl ToNormalPathComponents,
+        delegate: &mut dyn Delegate,
+    ) -> std::io::Result<()> {
+        let mut components = relative.to_normal_path_components().peekable();
+        if self.valid_components != 0 && components.peek().is_none() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "empty inputs are not allowed",
@@ -73,15 +114,19 @@ impl Stack {
             delegate.push_directory(self)?;
         }
 
-        let mut components = relative.components().peekable();
         let mut existing_components = self.current_relative.components();
         let mut matching_components = 0;
         while let (Some(existing_comp), Some(new_comp)) = (existing_components.next(), components.peek()) {
-            if existing_comp == *new_comp {
-                components.next();
-                matching_components += 1;
-            } else {
-                break;
+            match new_comp {
+                Ok(new_comp) => {
+                    if existing_comp.as_os_str() == *new_comp {
+                        components.next();
+                        matching_components += 1;
+                    } else {
+                        break;
+                    }
+                }
+                Err(err) => return Err(std::io::Error::other(format!("{err}"))),
             }
         }
 
@@ -100,15 +145,7 @@ impl Stack {
         }
 
         while let Some(comp) = components.next() {
-            if !matches!(comp, Component::Normal(_)) {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!(
-                        "Input path \"{}\" contains relative or absolute components",
-                        relative.display()
-                    ),
-                ));
-            }
+            let comp = comp.map_err(std::io::Error::other)?;
             let is_last_component = components.peek().is_none();
             self.current_is_directory = !is_last_component;
             self.current.push(comp);

--- a/gix-fs/src/stack.rs
+++ b/gix-fs/src/stack.rs
@@ -19,22 +19,17 @@ pub mod to_normal_path_components {
 /// Obtain an iterator over `OsStr`-components which are normal, none-relative and not absolute.
 pub trait ToNormalPathComponents {
     /// Return an iterator over the normal components of a path, without the separator.
-    // TODO(MSRV): turn this into `impl Iterator` once MSRV is 1.75 or higher
-    fn to_normal_path_components(
-        &self,
-    ) -> Box<dyn Iterator<Item = Result<&OsStr, to_normal_path_components::Error>> + '_>;
+    fn to_normal_path_components(&self) -> impl Iterator<Item = Result<&OsStr, to_normal_path_components::Error>>;
 }
 
 impl ToNormalPathComponents for &Path {
-    fn to_normal_path_components(
-        &self,
-    ) -> Box<dyn Iterator<Item = Result<&OsStr, to_normal_path_components::Error>> + '_> {
-        Box::new(self.components().map(|component| match component {
+    fn to_normal_path_components(&self) -> impl Iterator<Item = Result<&OsStr, to_normal_path_components::Error>> {
+        self.components().map(|component| match component {
             Component::Normal(os_str) => Ok(os_str),
             _ => Err(to_normal_path_components::Error::NotANormalComponent(
                 self.as_os_str().to_owned(),
             )),
-        }))
+        })
     }
 }
 

--- a/gix-protocol/src/fetch/response/async_io.rs
+++ b/gix-protocol/src/fetch/response/async_io.rs
@@ -124,7 +124,7 @@ impl Response {
                             io::ErrorKind::UnexpectedEof,
                             "Could not read message headline",
                         )));
-                    };
+                    }
 
                     match line.trim_end() {
                         "acknowledgments" => {

--- a/gix-status/tests/status/stack.rs
+++ b/gix-status/tests/status/stack.rs
@@ -25,7 +25,7 @@ fn paths_not_going_through_symlink_directories_are_ok_and_point_to_correct_item(
             ("dir/dirlink", is_symlinked_dir),
         ] {
             assert!(
-                expectation(&stack.verified_path(rela_path.as_ref())?.symlink_metadata()?),
+                expectation(&stack.verified_path(rela_path)?.symlink_metadata()?),
                 "{rela_path:?} expectation failed"
             );
         }
@@ -35,7 +35,7 @@ fn paths_not_going_through_symlink_directories_are_ok_and_point_to_correct_item(
 
 #[test]
 fn leaf_file_does_not_have_to_exist() -> crate::Result {
-    assert!(!stack().verified_path("dir/does-not-exist".as_ref())?.exists());
+    assert!(!stack().verified_path("dir/does-not-exist")?.exists());
     Ok(())
 }
 
@@ -43,10 +43,7 @@ fn leaf_file_does_not_have_to_exist() -> crate::Result {
 #[cfg(not(windows))]
 fn intermediate_directories_have_to_exist_or_not_found_error() -> crate::Result {
     assert_eq!(
-        stack()
-            .verified_path("nonexisting-dir/file".as_ref())
-            .unwrap_err()
-            .kind(),
+        stack().verified_path("nonexisting-dir/file").unwrap_err().kind(),
         std::io::ErrorKind::NotFound
     );
     Ok(())
@@ -55,7 +52,7 @@ fn intermediate_directories_have_to_exist_or_not_found_error() -> crate::Result 
 #[test]
 #[cfg(windows)]
 fn intermediate_directories_do_not_have_exist_for_success() -> crate::Result {
-    assert!(stack().verified_path("nonexisting-dir/file".as_ref()).is_ok());
+    assert!(stack().verified_path("nonexisting-dir/file").is_ok());
     Ok(())
 }
 
@@ -67,16 +64,13 @@ fn intermediate_directories_do_not_have_exist_for_success() -> crate::Result {
 fn paths_leading_through_symlinks_are_rejected() {
     let mut stack = stack();
     assert_eq!(
-        stack
-            .verified_path("root-dirlink/file-in-dir".as_ref())
-            .unwrap_err()
-            .kind(),
+        stack.verified_path("root-dirlink/file-in-dir").unwrap_err().kind(),
         std::io::ErrorKind::Other,
         "root-dirlink is a symlink to a directory"
     );
 
     assert_eq!(
-        stack.verified_path("dir/dirlink/nothing".as_ref()).unwrap_err().kind(),
+        stack.verified_path("dir/dirlink/nothing").unwrap_err().kind(),
         std::io::ErrorKind::Other,
         "root-dirlink is a symlink to a directory"
     );

--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -80,7 +80,7 @@ where
     let dest_relative = gix_path::try_from_bstr(entry_path).map_err(|_| crate::checkout::Error::IllformedUtf8 {
         path: entry_path.to_owned(),
     })?;
-    let path_cache = path_cache.at_path(dest_relative, Some(entry.mode), &*objects)?;
+    let path_cache = path_cache.at_path(dest_relative.as_ref(), Some(entry.mode), &*objects)?;
     let dest = path_cache.path();
 
     let object_size = match entry.mode {

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project for shared worktree related types
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.74"
 autotests = false
 
 [lib]

--- a/gix-worktree/src/stack/mod.rs
+++ b/gix-worktree/src/stack/mod.rs
@@ -113,7 +113,7 @@ impl Stack {
     /// Provide access to cached information for that `relative` path via the returned platform.
     pub fn at_path(
         &mut self,
-        relative: impl AsRef<Path>,
+        relative: impl ToNormalPathComponents,
         mode: Option<gix_index::entry::Mode>,
         objects: &dyn gix_object::Find,
     ) -> std::io::Result<Platform<'_>> {
@@ -127,8 +127,7 @@ impl Stack {
             case: self.case,
             statistics: &mut self.statistics,
         };
-        self.stack
-            .make_relative_path_current(relative.as_ref(), &mut delegate)?;
+        self.stack.make_relative_path_current(relative, &mut delegate)?;
         Ok(Platform {
             parent: self,
             is_dir: mode_is_dir(mode),
@@ -148,15 +147,8 @@ impl Stack {
         objects: &dyn gix_object::Find,
     ) -> std::io::Result<Platform<'_>> {
         let relative = relative.into();
-        let relative_path = gix_path::try_from_bstr(relative).map_err(|_err| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("The path \"{relative}\" contained invalid UTF-8 and could not be turned into a path"),
-            )
-        })?;
-
         self.at_path(
-            relative_path,
+            relative,
             mode.or_else(|| relative.ends_with_str("/").then_some(gix_index::entry::Mode::DIR)),
             objects,
         )
@@ -210,6 +202,7 @@ impl Stack {
 ///
 pub mod delegate;
 use delegate::StackDelegate;
+use gix_fs::stack::ToNormalPathComponents;
 
 mod platform;
 ///

--- a/gix-worktree/tests/worktree/stack/create_directory.rs
+++ b/gix-worktree/tests/worktree/stack/create_directory.rs
@@ -92,7 +92,7 @@ fn symlinks_or_files_in_path_are_forbidden_or_unlinked_when_forced() -> crate::R
         let relative_path = format!("{dirname}/file");
         assert_eq!(
             cache
-                .at_path(&relative_path, IS_FILE, &gix_object::find::Never)
+                .at_path(&*relative_path, IS_FILE, &gix_object::find::Never)
                 .unwrap_err()
                 .kind(),
             std::io::ErrorKind::AlreadyExists
@@ -112,7 +112,9 @@ fn symlinks_or_files_in_path_are_forbidden_or_unlinked_when_forced() -> crate::R
             *unlink_on_collision = true;
         }
         let relative_path = format!("{dirname}/file");
-        let path = cache.at_path(&relative_path, IS_FILE, &gix_object::find::Never)?.path();
+        let path = cache
+            .at_path(&*relative_path, IS_FILE, &gix_object::find::Never)?
+            .path();
         assert!(path.parent().unwrap().is_dir(), "directory was forcefully created");
         assert!(!path.exists());
     }

--- a/gix-worktree/tests/worktree/stack/ignore.rs
+++ b/gix-worktree/tests/worktree/stack/ignore.rs
@@ -1,9 +1,9 @@
+use crate::{hex_to_id, worktree::stack::probe_case};
 use bstr::{BStr, ByteSlice};
+use gix_fs::stack::ToNormalPathComponents;
 use gix_index::entry::Mode;
 use gix_worktree::{stack::state::ignore::Source, Stack};
 use std::fs::Metadata;
-
-use crate::{hex_to_id, worktree::stack::probe_case};
 
 struct IgnoreExpectations<'a> {
     lines: bstr::Lines<'a>,
@@ -170,7 +170,10 @@ fn check_against_baseline() -> crate::Result {
                 // OK: we provide negative patterns that matched on paths if there was no other match, while git doesn't.
             }
             (actual, expected) => {
-                panic!("actual {actual:?} didn't match {expected:?} at '{relative_entry}'");
+                panic!(
+                    "actual {actual:?} didn't match {expected:?} at '{relative_entry}': {components:?}",
+                    components = relative_entry.to_normal_path_components().collect::<Vec<_>>()
+                );
             }
         }
     }

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.70.0"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
-rust-version = "1.70"
+rust-version = "1.75"
 
 [lib]
 doctest = false

--- a/gix/src/attribute_stack.rs
+++ b/gix/src/attribute_stack.rs
@@ -1,6 +1,6 @@
+use crate::{types::AttributeStack, Repository};
+use gix_fs::stack::ToNormalPathComponents;
 use std::ops::{Deref, DerefMut};
-
-use crate::{bstr::BStr, types::AttributeStack, Repository};
 
 /// Lifecycle
 impl<'repo> AttributeStack<'repo> {
@@ -44,18 +44,18 @@ impl AttributeStack<'_> {
         relative: impl AsRef<std::path::Path>,
         mode: Option<gix_index::entry::Mode>,
     ) -> std::io::Result<gix_worktree::stack::Platform<'_>> {
-        self.inner.at_path(relative, mode, &self.repo.objects)
+        self.inner.at_path(relative.as_ref(), mode, &self.repo.objects)
     }
 
     /// Obtain a platform for attribute or ignore lookups from a repo-`relative` path, typically obtained from an index entry.
     /// `mode` should reflect whether it's a directory or not, or left at `None` if unknown.
     ///
     /// If `relative` ends with `/` and `mode` is `None`, it is automatically assumed to be a directory.
-    pub fn at_entry<'r>(
+    pub fn at_entry(
         &mut self,
-        relative: impl Into<&'r BStr>,
+        relative: impl ToNormalPathComponents,
         mode: Option<gix_index::entry::Mode>,
     ) -> std::io::Result<gix_worktree::stack::Platform<'_>> {
-        self.inner.at_entry(relative, mode, &self.repo.objects)
+        self.inner.at_path(relative, mode, &self.repo.objects)
     }
 }

--- a/gix/src/id.rs
+++ b/gix/src/id.rs
@@ -64,7 +64,7 @@ impl<'repo> Id<'repo> {
 
 fn calculate_auto_hex_len(num_packed_objects: u64) -> usize {
     let mut len = 64 - num_packed_objects.leading_zeros();
-    len = (len + 1) / 2;
+    len = len.div_ceil(2);
     len.max(7) as usize
 }
 

--- a/tests/it/src/commands/copy_royal.rs
+++ b/tests/it/src/commands/copy_royal.rs
@@ -29,7 +29,7 @@ pub(super) mod function {
         {
             let rela_path = gix::path::from_bstr(rela_path);
             let src = worktree_dir.join(&rela_path);
-            stack.make_relative_path_current(&rela_path, &mut create_dir)?;
+            stack.make_relative_path_current(&*rela_path, &mut create_dir)?;
             let dst = stack.current();
 
             eprintln!(


### PR DESCRIPTION
This is a draft PR, intended to make sure I got the task right before making any larger changes that I would need to make now that I’ve changed `gix_fs::Stack`’s API. It is expected that it does not even compile at this stage.

A few observations:

- There’s places that currently call `Stack::new` with a `PathBuf`. Would it make sense to `impl ToComponents for PathBuf`?
- Having to add `bstr` as a dependency made me wonder: is `gix-fs` the right crate for `ToComponents` to live in or should it be moved somewhere else, e. g. into `gix-path`? `gix-path` also has `os_string_into_bstring` which should probably replace the chain `.as_os_str().as_bytes().into()` that I had to resort to on one line because `gix-fs` does not depend on `gix-path` currently.

Let me know what you think!
