### PR TITLE
Fix clippy

### DIFF
--- a/gix-packetline-blocking/src/read/sidebands/async_io.rs
+++ b/gix-packetline-blocking/src/read/sidebands/async_io.rs
@@ -302,7 +302,7 @@ where
                                                         "interrupted by user",
                                                     )))
                                                 }
-                                            };
+                                            }
                                         }
                                         BandRef::Error(d) => {
                                             let text = TextRef::from(d).0;
@@ -314,9 +314,9 @@ where
                                                         "interrupted by user",
                                                     )))
                                                 }
-                                            };
+                                            }
                                         }
-                                    };
+                                    }
                                 }
                                 None => {
                                     break match line.as_slice() {

--- a/gix-packetline/src/read/sidebands/async_io.rs
+++ b/gix-packetline/src/read/sidebands/async_io.rs
@@ -300,7 +300,7 @@ where
                                                         "interrupted by user",
                                                     )))
                                                 }
-                                            };
+                                            }
                                         }
                                         BandRef::Error(d) => {
                                             let text = TextRef::from(d).0;
@@ -312,9 +312,9 @@ where
                                                         "interrupted by user",
                                                     )))
                                                 }
-                                            };
+                                            }
                                         }
-                                    };
+                                    }
                                 }
                                 None => {
                                     break match line.as_slice() {

--- a/gix-transport/src/client/blocking_io/http/traits.rs
+++ b/gix-transport/src/client/blocking_io/http/traits.rs
@@ -27,7 +27,7 @@ impl crate::IsSpuriousError for Error {
                 #[cfg(feature = "http-client-reqwest")]
                 if let Some(err) = source.downcast_ref::<crate::client::http::reqwest::remote::Error>() {
                     return err.is_spurious();
-                };
+                }
                 false
             }
             _ => false,


### PR DESCRIPTION
`clippy` has recently begun to fail with:

    error: unnecessary semicolon
      --> gix-transport/src/client/blocking_io/http/traits.rs:30:18
       |
    30 |                 };
       |                  ^ help: remove
       |
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_semicolon
       = note: `-D clippy::unnecessary-semicolon` implied by `-D warnings`
       = help: to override `-D warnings` add `#[allow(clippy::unnecessary_semicolon)]`

While it looks like this might first have been observed in #1917, it is unrelated to any change there. It happens when the current tip of main (4660f7a) is rerun, as observed in:
https://github.com/EliahKagan/gitoxide/actions/runs/14254079128/job/39958292846

---

This is initially empty as I'm double checking that it does happen. I'll amend with a fix shortly.

*Edit:* Yes, [it reproduces here](https://github.com/GitoxideLabs/gitoxide/actions/runs/14255961692/job/39958584453?pr=1918#step:5:1066). I've amended to add the fix.