### PR TITLE
Use runner-provided Git for Windows now that it's 2.49.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,35 +193,6 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Upgrade Git for Windows to latest stable release
-        # This upgrades Git to work around https://github.com/GitoxideLabs/gitoxide/issues/1849.
-        # TODO: Remove this step once the runner image has Git 2.49.0 or higher.
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          $workingDir = '~/git-dl'
-          $repo = 'git-for-windows/git'
-          $pattern = 'Git-*-64-bit.exe'
-          $log = 'setup-log.txt'
-          # Inno Setup args reference: https://jrsoftware.org/ishelp/index.php?topic=setupcmdline
-          $arguments = @(
-            '/VERYSILENT',
-            '/SUPPRESSMSGBOXES',
-            '/ALLUSERS',
-            "/LOG=$log",
-            '/NORESTART',
-            '/CLOSEAPPLICATIONS',
-            '/FORCECLOSEAPPLICATIONS'
-          )
-
-          mkdir $workingDir | Out-Null
-          cd $workingDir
-          gh release download --repo $repo --pattern $pattern
-          $installer = Get-Item $pattern
-          Start-Process -FilePath $installer -ArgumentList $arguments -NoNewWindow -Wait
-
-          Get-Content -Path $log -Tail 50
-          git version
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Closes #1849

Because #1849 (https://github.com/git-for-windows/git/issues/5436) caused some incorrect test failures in `test-fixtures-windows`, we have been upgrading Git for Windows on the runner for that job:

- We starting doing that in of 4237e5a ([#1870](https://github.com/GitoxideLabs/gitoxide/pull/1870)). At that time, we upgraded it to the most recent tag, to select the latest release even though it was a release candiate, because Git for Windows 2.49.0 had not yet had a stable release.

- Then Git for Windows 2.49.0 got a stable release, and starting in ddef6d3 ([#1892](https://github.com/GitoxideLabs/gitoxide/pull/1892)) we have upgraded to the release marked "latest" (which in Git for Windows is always the latest stable release).

More recently, the Windows Server 2022 runner image (which the `windows-latest` label we use currently selects) has upgraded its Git for Windows installation from 2.48.1 to 2.49.0: https://github.com/actions/runner-images/releases/tag/win22%2F20250330.1

It is therefore no longer necessary for the `test-fixtures-windows` job to upgrade Git for Windows on the runner. This removes the step that did that. (Either version of the step could be brought back from the history if ever needed again.)

This is as planned in https://github.com/GitoxideLabs/gitoxide/issues/1849#issuecomment-2724513361.