### PR TITLE
Add `gix_path::relative_path::RelativePath`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,7 @@ dependencies = [
  "bstr",
  "gix-testtools",
  "gix-trace 0.1.12",
+ "gix-validate 0.9.4",
  "home",
  "known-folders",
  "once_cell",

--- a/gix-fs/tests/fs/stack.rs
+++ b/gix-fs/tests/fs/stack.rs
@@ -246,6 +246,19 @@ fn absolute_paths_are_invalid() -> crate::Result {
         r#"Input path "/" contains relative or absolute components"#,
         "a leading slash is always considered absolute"
     );
+    s.make_relative_path_current("/", &mut r)?;
+    assert_eq!(
+        s.current(),
+        s.root(),
+        "as string this is a no-op as it's just split by /"
+    );
+
+    let err = s.make_relative_path_current("../breakout", &mut r).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        r#"Input path "../breakout" contains relative or absolute components"#,
+        "otherwise breakout attempts are detected"
+    );
     s.make_relative_path_current(p("a/"), &mut r)?;
     assert_eq!(
         s.current(),

--- a/gix-negotiate/tests/baseline/mod.rs
+++ b/gix-negotiate/tests/baseline/mod.rs
@@ -71,7 +71,7 @@ fn run() -> crate::Result {
                 // }
                 for tip in lookup_names(&["HEAD"]).into_iter().chain(
                     refs.iter()?
-                        .prefixed(b"refs/heads")?
+                        .prefixed(b"refs/heads".try_into().unwrap())?
                         .filter_map(Result::ok)
                         .map(|r| r.target.into_id()),
                 ) {

--- a/gix-path/Cargo.toml
+++ b/gix-path/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 
 [dependencies]
 gix-trace = { version = "^0.1.12", path = "../gix-trace" }
+gix-validate = { version = "^0.9.4", path = "../gix-validate" }
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 thiserror = "2.0.0"
 once_cell = "1.21.3"

--- a/gix-path/src/lib.rs
+++ b/gix-path/src/lib.rs
@@ -65,3 +65,4 @@ pub mod env;
 
 ///
 pub mod relative_path;
+pub use relative_path::types::RelativePath;

--- a/gix-path/src/lib.rs
+++ b/gix-path/src/lib.rs
@@ -47,7 +47,7 @@
 //! ever get into a code-path which does panic though.
 //! </details>
 #![deny(missing_docs, rust_2018_idioms)]
-#![cfg_attr(not(test), forbid(unsafe_code))]
+#![cfg_attr(not(test), deny(unsafe_code))]
 
 /// A dummy type to represent path specs and help finding all spots that take path specs once it is implemented.
 mod convert;
@@ -62,3 +62,6 @@ pub use realpath::function::{realpath, realpath_opts};
 
 /// Information about the environment in terms of locations of resources.
 pub mod env;
+
+///
+pub mod relative_path;

--- a/gix-path/src/relative_path.rs
+++ b/gix-path/src/relative_path.rs
@@ -2,21 +2,32 @@ use bstr::BStr;
 use bstr::BString;
 use bstr::ByteSlice;
 use gix_validate::path::component::Options;
-use std::borrow::Cow;
+use std::path::Path;
 
 use crate::os_str_into_bstr;
 use crate::try_from_bstr;
 use crate::try_from_byte_slice;
 
-/// A wrapper for `BStr`. It is used to enforce the following constraints:
-///
-/// - The path separator always is `/`, independent of the platform.
-/// - Only normal components are allowed.
-/// - It is always represented as a bunch of bytes.
-#[derive()]
-pub struct RelativePath {
-    inner: BStr,
+pub(super) mod types {
+    use bstr::{BStr, ByteSlice};
+    /// A wrapper for `BStr`. It is used to enforce the following constraints:
+    ///
+    /// - The path separator always is `/`, independent of the platform.
+    /// - Only normal components are allowed.
+    /// - It is always represented as a bunch of bytes.
+    #[derive()]
+    pub struct RelativePath {
+        inner: BStr,
+    }
+
+    impl AsRef<[u8]> for RelativePath {
+        #[inline]
+        fn as_ref(&self) -> &[u8] {
+            self.inner.as_bytes()
+        }
+    }
 }
+use types::RelativePath;
 
 impl RelativePath {
     fn new_unchecked(value: &BStr) -> Result<&RelativePath, Error> {
@@ -25,12 +36,6 @@ impl RelativePath {
         unsafe {
             std::mem::transmute(value)
         }
-    }
-
-    /// TODO
-    /// Needs docs.
-    pub fn ends_with(&self, needle: &[u8]) -> bool {
-        self.inner.ends_with(needle)
     }
 }
 
@@ -46,27 +51,26 @@ pub enum Error {
     IllegalUtf8(#[from] crate::Utf8Error),
 }
 
+fn relative_path_from_value_and_path<'a>(path_bstr: &'a BStr, path: &Path) -> Result<&'a RelativePath, Error> {
+    if path.is_absolute() {
+        return Err(Error::IsAbsolute);
+    }
+
+    let options = Options::default();
+
+    for component in path.components() {
+        let component = os_str_into_bstr(component.as_os_str())?;
+        gix_validate::path::component(component, None, options)?;
+    }
+
+    RelativePath::new_unchecked(BStr::new(path_bstr.as_bytes()))
+}
+
 impl<'a> TryFrom<&'a str> for &'a RelativePath {
     type Error = Error;
 
     fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        use std::path::Path;
-
-        let path: &std::path::Path = Path::new(value);
-
-        if path.is_absolute() {
-            return Err(Error::IsAbsolute);
-        }
-
-        let options: Options = Default::default();
-
-        for component in path.components() {
-            let component = os_str_into_bstr(component.as_os_str())?;
-
-            gix_validate::path::component(component, None, options)?;
-        }
-
-        RelativePath::new_unchecked(BStr::new(value.as_bytes()))
+        relative_path_from_value_and_path(value.into(), Path::new(value))
     }
 }
 
@@ -74,21 +78,18 @@ impl<'a> TryFrom<&'a BStr> for &'a RelativePath {
     type Error = Error;
 
     fn try_from(value: &'a BStr) -> Result<Self, Self::Error> {
-        let path: &std::path::Path = &try_from_bstr(value)?;
+        let path = try_from_bstr(value)?;
+        relative_path_from_value_and_path(value, &path)
+    }
+}
 
-        if path.is_absolute() {
-            return Err(Error::IsAbsolute);
-        }
+impl<'a> TryFrom<&'a [u8]> for &'a RelativePath {
+    type Error = Error;
 
-        let options: Options = Default::default();
-
-        for component in path.components() {
-            let component = os_str_into_bstr(component.as_os_str())?;
-
-            gix_validate::path::component(component, None, options)?;
-        }
-
-        RelativePath::new_unchecked(value)
+    #[inline]
+    fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
+        let path = try_from_byte_slice(value)?;
+        relative_path_from_value_and_path(value.as_bstr(), path)
     }
 }
 
@@ -97,21 +98,8 @@ impl<'a, const N: usize> TryFrom<&'a [u8; N]> for &'a RelativePath {
 
     #[inline]
     fn try_from(value: &'a [u8; N]) -> Result<Self, Self::Error> {
-        let path: &std::path::Path = try_from_byte_slice(value)?;
-
-        if path.is_absolute() {
-            return Err(Error::IsAbsolute);
-        }
-
-        let options: Options = Default::default();
-
-        for component in path.components() {
-            let component = os_str_into_bstr(component.as_os_str())?;
-
-            gix_validate::path::component(component, None, options)?;
-        }
-
-        RelativePath::new_unchecked(value.into())
+        let path = try_from_byte_slice(value.as_bstr())?;
+        relative_path_from_value_and_path(value.as_bstr(), path)
     }
 }
 
@@ -119,196 +107,7 @@ impl<'a> TryFrom<&'a BString> for &'a RelativePath {
     type Error = Error;
 
     fn try_from(value: &'a BString) -> Result<Self, Self::Error> {
-        let path: &std::path::Path = &try_from_bstr(value.as_bstr())?;
-
-        if path.is_absolute() {
-            return Err(Error::IsAbsolute);
-        }
-
-        let options: Options = Default::default();
-
-        for component in path.components() {
-            let component = os_str_into_bstr(component.as_os_str())?;
-
-            gix_validate::path::component(component, None, options)?;
-        }
-
-        RelativePath::new_unchecked(value.as_bstr())
-    }
-}
-
-/// This is required by a trait bound on [`from_str`](crate::from_bstr).
-impl<'a> From<&'a RelativePath> for Cow<'a, BStr> {
-    #[inline]
-    fn from(value: &'a RelativePath) -> Cow<'a, BStr> {
-        Cow::Borrowed(&value.inner)
-    }
-}
-
-impl AsRef<[u8]> for RelativePath {
-    #[inline]
-    fn as_ref(&self) -> &[u8] {
-        self.inner.as_bytes()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[cfg(not(windows))]
-    #[test]
-    fn absolute_paths_return_err() {
-        let path_str: &str = "/refs/heads";
-        let path_bstr: &BStr = path_str.into();
-        let path_u8: &[u8; 11] = b"/refs/heads";
-        let path_bstring: BString = "/refs/heads".into();
-
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_str),
-            Err(Error::IsAbsolute)
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_bstr),
-            Err(Error::IsAbsolute)
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_u8),
-            Err(Error::IsAbsolute)
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(&path_bstring),
-            Err(Error::IsAbsolute)
-        ));
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn absolute_paths_return_err() {
-        let path_str: &str = r"c:\refs\heads";
-        let path_bstr: &BStr = path_str.into();
-        let path_u8: &[u8; 13] = b"c:\\refs\\heads";
-        let path_bstring: BString = r"c:\refs\heads".into();
-
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_str),
-            Err(Error::IsAbsolute)
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_bstr),
-            Err(Error::IsAbsolute)
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_u8),
-            Err(Error::IsAbsolute)
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(&path_bstring),
-            Err(Error::IsAbsolute)
-        ));
-    }
-
-    #[cfg(not(windows))]
-    #[test]
-    fn dots_in_paths_return_err() {
-        let path_str: &str = "./heads";
-        let path_bstr: &BStr = path_str.into();
-        let path_u8: &[u8; 7] = b"./heads";
-        let path_bstring: BString = "./heads".into();
-
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_str),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_bstr),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_u8),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(&path_bstring),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn dots_in_paths_return_err() {
-        let path_str: &str = r".\heads";
-        let path_bstr: &BStr = path_str.into();
-        let path_u8: &[u8; 7] = b".\\heads";
-        let path_bstring: BString = r".\heads".into();
-
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_str),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_bstr),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_u8),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(&path_bstring),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-    }
-
-    #[cfg(not(windows))]
-    #[test]
-    fn double_dots_in_paths_return_err() {
-        let path_str: &str = "../heads";
-        let path_bstr: &BStr = path_str.into();
-        let path_u8: &[u8; 8] = b"../heads";
-        let path_bstring: BString = "../heads".into();
-
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_str),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_bstr),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_u8),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(&path_bstring),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn double_dots_in_paths_return_err() {
-        let path_str: &str = r"..\heads";
-        let path_bstr: &BStr = path_str.into();
-        let path_u8: &[u8; 8] = b"..\\heads";
-        let path_bstring: BString = r"..\heads".into();
-
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_str),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_bstr),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(path_u8),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
-        assert!(matches!(
-            TryInto::<&RelativePath>::try_into(&path_bstring),
-            Err(Error::ContainsInvalidComponent(_))
-        ));
+        let path = try_from_bstr(value.as_bstr())?;
+        relative_path_from_value_and_path(value.as_bstr(), &path)
     }
 }

--- a/gix-path/src/relative_path.rs
+++ b/gix-path/src/relative_path.rs
@@ -1,0 +1,314 @@
+use bstr::BStr;
+use bstr::BString;
+use bstr::ByteSlice;
+use gix_validate::path::component::Options;
+use std::borrow::Cow;
+
+use crate::os_str_into_bstr;
+use crate::try_from_bstr;
+use crate::try_from_byte_slice;
+
+/// A wrapper for `BStr`. It is used to enforce the following constraints:
+///
+/// - The path separator always is `/`, independent of the platform.
+/// - Only normal components are allowed.
+/// - It is always represented as a bunch of bytes.
+#[derive()]
+pub struct RelativePath {
+    inner: BStr,
+}
+
+impl RelativePath {
+    fn new_unchecked(value: &BStr) -> Result<&RelativePath, Error> {
+        // SAFETY: `RelativePath` is transparent and equivalent to a `&BStr` if provided as reference.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::mem::transmute(value)
+        }
+    }
+
+    /// TODO
+    /// Needs docs.
+    pub fn ends_with(&self, needle: &[u8]) -> bool {
+        self.inner.ends_with(needle)
+    }
+}
+
+/// The error used in [`RelativePath`].
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum Error {
+    #[error("A RelativePath is not allowed to be absolute")]
+    IsAbsolute,
+    #[error(transparent)]
+    ContainsInvalidComponent(#[from] gix_validate::path::component::Error),
+    #[error(transparent)]
+    IllegalUtf8(#[from] crate::Utf8Error),
+}
+
+impl<'a> TryFrom<&'a str> for &'a RelativePath {
+    type Error = Error;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        use std::path::Path;
+
+        let path: &std::path::Path = Path::new(value);
+
+        if path.is_absolute() {
+            return Err(Error::IsAbsolute);
+        }
+
+        let options: Options = Default::default();
+
+        for component in path.components() {
+            let component = os_str_into_bstr(component.as_os_str())?;
+
+            gix_validate::path::component(component, None, options)?;
+        }
+
+        RelativePath::new_unchecked(BStr::new(value.as_bytes()))
+    }
+}
+
+impl<'a> TryFrom<&'a BStr> for &'a RelativePath {
+    type Error = Error;
+
+    fn try_from(value: &'a BStr) -> Result<Self, Self::Error> {
+        let path: &std::path::Path = &try_from_bstr(value)?;
+
+        if path.is_absolute() {
+            return Err(Error::IsAbsolute);
+        }
+
+        let options: Options = Default::default();
+
+        for component in path.components() {
+            let component = os_str_into_bstr(component.as_os_str())?;
+
+            gix_validate::path::component(component, None, options)?;
+        }
+
+        RelativePath::new_unchecked(value)
+    }
+}
+
+impl<'a, const N: usize> TryFrom<&'a [u8; N]> for &'a RelativePath {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(value: &'a [u8; N]) -> Result<Self, Self::Error> {
+        let path: &std::path::Path = try_from_byte_slice(value)?;
+
+        if path.is_absolute() {
+            return Err(Error::IsAbsolute);
+        }
+
+        let options: Options = Default::default();
+
+        for component in path.components() {
+            let component = os_str_into_bstr(component.as_os_str())?;
+
+            gix_validate::path::component(component, None, options)?;
+        }
+
+        RelativePath::new_unchecked(value.into())
+    }
+}
+
+impl<'a> TryFrom<&'a BString> for &'a RelativePath {
+    type Error = Error;
+
+    fn try_from(value: &'a BString) -> Result<Self, Self::Error> {
+        let path: &std::path::Path = &try_from_bstr(value.as_bstr())?;
+
+        if path.is_absolute() {
+            return Err(Error::IsAbsolute);
+        }
+
+        let options: Options = Default::default();
+
+        for component in path.components() {
+            let component = os_str_into_bstr(component.as_os_str())?;
+
+            gix_validate::path::component(component, None, options)?;
+        }
+
+        RelativePath::new_unchecked(value.as_bstr())
+    }
+}
+
+/// This is required by a trait bound on [`from_str`](crate::from_bstr).
+impl<'a> From<&'a RelativePath> for Cow<'a, BStr> {
+    #[inline]
+    fn from(value: &'a RelativePath) -> Cow<'a, BStr> {
+        Cow::Borrowed(&value.inner)
+    }
+}
+
+impl AsRef<[u8]> for RelativePath {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(windows))]
+    #[test]
+    fn absolute_paths_return_err() {
+        let path_str: &str = "/refs/heads";
+        let path_bstr: &BStr = path_str.into();
+        let path_u8: &[u8; 11] = b"/refs/heads";
+        let path_bstring: BString = "/refs/heads".into();
+
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_str),
+            Err(Error::IsAbsolute)
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_bstr),
+            Err(Error::IsAbsolute)
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_u8),
+            Err(Error::IsAbsolute)
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(&path_bstring),
+            Err(Error::IsAbsolute)
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn absolute_paths_return_err() {
+        let path_str: &str = r"c:\refs\heads";
+        let path_bstr: &BStr = path_str.into();
+        let path_u8: &[u8; 13] = b"c:\\refs\\heads";
+        let path_bstring: BString = r"c:\refs\heads".into();
+
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_str),
+            Err(Error::IsAbsolute)
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_bstr),
+            Err(Error::IsAbsolute)
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_u8),
+            Err(Error::IsAbsolute)
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(&path_bstring),
+            Err(Error::IsAbsolute)
+        ));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn dots_in_paths_return_err() {
+        let path_str: &str = "./heads";
+        let path_bstr: &BStr = path_str.into();
+        let path_u8: &[u8; 7] = b"./heads";
+        let path_bstring: BString = "./heads".into();
+
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_str),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_bstr),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_u8),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(&path_bstring),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn dots_in_paths_return_err() {
+        let path_str: &str = r".\heads";
+        let path_bstr: &BStr = path_str.into();
+        let path_u8: &[u8; 7] = b".\\heads";
+        let path_bstring: BString = r".\heads".into();
+
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_str),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_bstr),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_u8),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(&path_bstring),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn double_dots_in_paths_return_err() {
+        let path_str: &str = "../heads";
+        let path_bstr: &BStr = path_str.into();
+        let path_u8: &[u8; 8] = b"../heads";
+        let path_bstring: BString = "../heads".into();
+
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_str),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_bstr),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_u8),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(&path_bstring),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn double_dots_in_paths_return_err() {
+        let path_str: &str = r"..\heads";
+        let path_bstr: &BStr = path_str.into();
+        let path_u8: &[u8; 8] = b"..\\heads";
+        let path_bstring: BString = r"..\heads".into();
+
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_str),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_bstr),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(path_u8),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+        assert!(matches!(
+            TryInto::<&RelativePath>::try_into(&path_bstring),
+            Err(Error::ContainsInvalidComponent(_))
+        ));
+    }
+}

--- a/gix-path/tests/path/main.rs
+++ b/gix-path/tests/path/main.rs
@@ -2,6 +2,7 @@ pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 mod convert;
 mod realpath;
+mod relative_path;
 mod home_dir {
     #[test]
     fn returns_existing_directory() {

--- a/gix-path/tests/path/relative_path.rs
+++ b/gix-path/tests/path/relative_path.rs
@@ -1,0 +1,160 @@
+use bstr::{BStr, BString};
+use gix_path::relative_path::Error;
+use gix_path::RelativePath;
+
+#[cfg(not(windows))]
+#[test]
+fn absolute_paths_return_err() {
+    let path_str: &str = "/refs/heads";
+    let path_bstr: &BStr = path_str.into();
+    let path_u8a: &[u8; 11] = b"/refs/heads";
+    let path_u8: &[u8] = &b"/refs/heads"[..];
+    let path_bstring: BString = "/refs/heads".into();
+
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_str),
+        Err(Error::IsAbsolute)
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_bstr),
+        Err(Error::IsAbsolute)
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_u8),
+        Err(Error::IsAbsolute)
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_u8a),
+        Err(Error::IsAbsolute)
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(&path_bstring),
+        Err(Error::IsAbsolute)
+    ));
+}
+
+#[cfg(windows)]
+#[test]
+fn absolute_paths_with_backslashes_return_err() {
+    let path_str: &str = r"c:\refs\heads";
+    let path_bstr: &BStr = path_str.into();
+    let path_u8: &[u8] = &b"c:\\refs\\heads"[..];
+    let path_bstring: BString = r"c:\refs\heads".into();
+
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_str),
+        Err(Error::IsAbsolute)
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_bstr),
+        Err(Error::IsAbsolute)
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_u8),
+        Err(Error::IsAbsolute)
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(&path_bstring),
+        Err(Error::IsAbsolute)
+    ));
+}
+
+#[test]
+fn dots_in_paths_return_err() {
+    let path_str: &str = "./heads";
+    let path_bstr: &BStr = path_str.into();
+    let path_u8: &[u8] = &b"./heads"[..];
+    let path_bstring: BString = "./heads".into();
+
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_str),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_bstr),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_u8),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(&path_bstring),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+}
+
+#[test]
+fn dots_in_paths_with_backslashes_return_err() {
+    let path_str: &str = r".\heads";
+    let path_bstr: &BStr = path_str.into();
+    let path_u8: &[u8] = &b".\\heads"[..];
+    let path_bstring: BString = r".\heads".into();
+
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_str),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_bstr),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_u8),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(&path_bstring),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+}
+
+#[test]
+fn double_dots_in_paths_return_err() {
+    let path_str: &str = "../heads";
+    let path_bstr: &BStr = path_str.into();
+    let path_u8: &[u8] = &b"../heads"[..];
+    let path_bstring: BString = "../heads".into();
+
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_str),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_bstr),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_u8),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(&path_bstring),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+}
+
+#[test]
+fn double_dots_in_paths_with_backslashes_return_err() {
+    let path_str: &str = r"..\heads";
+    let path_bstr: &BStr = path_str.into();
+    let path_u8: &[u8] = &b"..\\heads"[..];
+    let path_bstring: BString = r"..\heads".into();
+
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_str),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_bstr),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(path_u8),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+    assert!(matches!(
+        TryInto::<&RelativePath>::try_into(&path_bstring),
+        Err(Error::ContainsInvalidComponent(_))
+    ));
+}

--- a/gix-ref/src/namespace.rs
+++ b/gix-ref/src/namespace.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use gix_object::bstr::{BStr, BString, ByteSlice, ByteVec};
-use gix_path::relative_path::RelativePath;
+use gix_path::RelativePath;
 
 use crate::{FullName, FullNameRef, Namespace, PartialNameRef};
 

--- a/gix-ref/src/namespace.rs
+++ b/gix-ref/src/namespace.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use gix_object::bstr::{BStr, BString, ByteSlice, ByteVec};
+use gix_path::relative_path::RelativePath;
 
 use crate::{FullName, FullNameRef, Namespace, PartialNameRef};
 
@@ -20,9 +21,8 @@ impl Namespace {
     /// Append the given `prefix` to this namespace so it becomes usable for prefixed iteration.
     ///
     /// The prefix is a relative path with slash-separated path components.
-    // TODO: use `RelativePath` type instead (see #1921), or a trait that helps convert into it.
-    pub fn into_namespaced_prefix<'a>(mut self, prefix: impl Into<&'a BStr>) -> BString {
-        self.0.push_str(prefix.into());
+    pub fn into_namespaced_prefix(mut self, prefix: &RelativePath) -> BString {
+        self.0.push_str(prefix);
         gix_path::to_unix_separators_on_windows(self.0).into_owned()
     }
     pub(crate) fn into_namespaced_name(mut self, name: &FullNameRef) -> FullName {

--- a/gix-ref/src/store/file/loose/iter.rs
+++ b/gix-ref/src/store/file/loose/iter.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use gix_features::fs::walkdir::DirEntryIter;
 use gix_object::bstr::ByteSlice;
-use gix_path::relative_path::RelativePath;
+use gix_path::RelativePath;
 
 use crate::{file::iter::LooseThenPacked, store_impl::file, BString, FullName};
 

--- a/gix-ref/src/store/file/loose/iter.rs
+++ b/gix-ref/src/store/file/loose/iter.rs
@@ -2,8 +2,9 @@ use std::path::{Path, PathBuf};
 
 use gix_features::fs::walkdir::DirEntryIter;
 use gix_object::bstr::ByteSlice;
+use gix_path::relative_path::RelativePath;
 
-use crate::{file::iter::LooseThenPacked, store_impl::file, BStr, BString, FullName};
+use crate::{file::iter::LooseThenPacked, store_impl::file, BString, FullName};
 
 /// An iterator over all valid loose reference paths as seen from a particular base directory.
 pub(in crate::store_impl::file) struct SortedLoosePaths {
@@ -88,8 +89,7 @@ impl file::Store {
     /// starts with `foo`, like `refs/heads/foo` and `refs/heads/foobar`.
     ///
     /// Prefixes are relative paths with slash-separated components.
-    // TODO: use `RelativePath` type instead (see #1921), or a trait that helps convert into it.
-    pub fn loose_iter_prefixed<'a>(&self, prefix: impl Into<&'a BStr>) -> std::io::Result<LooseThenPacked<'_, '_>> {
-        self.iter_prefixed_packed(prefix.into(), None)
+    pub fn loose_iter_prefixed(&self, prefix: &RelativePath) -> std::io::Result<LooseThenPacked<'_, '_>> {
+        self.iter_prefixed_packed(prefix, None)
     }
 }

--- a/gix-ref/src/store/file/overlay_iter.rs
+++ b/gix-ref/src/store/file/overlay_iter.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use gix_object::bstr::ByteSlice;
-use gix_path::relative_path::RelativePath;
+use gix_path::RelativePath;
 
 /// An iterator stepping through sorted input of loose references and packed references, preferring loose refs over otherwise
 /// equivalent packed references.
@@ -294,9 +294,9 @@ impl<'a> IterInfo<'a> {
     }
 
     fn from_prefix(base: &'a Path, prefix: &'a RelativePath, precompose_unicode: bool) -> std::io::Result<Self> {
-        let prefix_path = gix_path::from_bstr(prefix);
+        let prefix_path = gix_path::from_bstr(prefix.as_ref().as_bstr());
         let iter_root = base.join(&prefix_path);
-        if prefix.ends_with(b"/") {
+        if prefix.as_ref().ends_with(b"/") {
             Ok(IterInfo::BaseAndIterRoot {
                 base,
                 iter_root,
@@ -310,7 +310,7 @@ impl<'a> IterInfo<'a> {
                 .to_owned();
             Ok(IterInfo::ComputedIterationRoot {
                 base,
-                prefix: prefix.into(),
+                prefix: prefix.as_ref().as_bstr().into(),
                 iter_root,
                 precompose_unicode,
             })

--- a/gix-ref/src/store/file/overlay_iter.rs
+++ b/gix-ref/src/store/file/overlay_iter.rs
@@ -12,6 +12,9 @@ use crate::{
     BStr, FullName, Namespace, Reference,
 };
 
+use gix_object::bstr::ByteSlice;
+use gix_path::relative_path::RelativePath;
+
 /// An iterator stepping through sorted input of loose references and packed references, preferring loose refs over otherwise
 /// equivalent packed references.
 ///
@@ -203,10 +206,9 @@ impl Platform<'_> {
     /// starts with `foo`, like `refs/heads/foo` and `refs/heads/foobar`.
     ///
     /// Prefixes are relative paths with slash-separated components.
-    // TODO: use `RelativePath` type instead (see #1921), or a trait that helps convert into it.
-    pub fn prefixed<'a>(&self, prefix: impl Into<&'a BStr>) -> std::io::Result<LooseThenPacked<'_, '_>> {
+    pub fn prefixed(&self, prefix: &RelativePath) -> std::io::Result<LooseThenPacked<'_, '_>> {
         self.store
-            .iter_prefixed_packed(prefix.into(), self.packed.as_ref().map(|b| &***b))
+            .iter_prefixed_packed(prefix, self.packed.as_ref().map(|b| &***b))
     }
 }
 
@@ -291,26 +293,8 @@ impl<'a> IterInfo<'a> {
         .peekable()
     }
 
-    fn from_prefix(
-        base: &'a Path,
-        prefix: impl Into<Cow<'a, BStr>>,
-        precompose_unicode: bool,
-    ) -> std::io::Result<Self> {
-        let prefix = prefix.into();
-        let prefix_path = gix_path::from_bstr(prefix.as_ref());
-        if prefix_path.is_absolute() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "prefix must be a relative path, like 'refs/heads/'",
-            ));
-        }
-        use std::path::Component::*;
-        if prefix_path.components().any(|c| matches!(c, CurDir | ParentDir)) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Refusing to handle prefixes with relative path components",
-            ));
-        }
+    fn from_prefix(base: &'a Path, prefix: &'a RelativePath, precompose_unicode: bool) -> std::io::Result<Self> {
+        let prefix_path = gix_path::from_bstr(prefix);
         let iter_root = base.join(&prefix_path);
         if prefix.ends_with(b"/") {
             Ok(IterInfo::BaseAndIterRoot {
@@ -326,7 +310,7 @@ impl<'a> IterInfo<'a> {
                 .to_owned();
             Ok(IterInfo::ComputedIterationRoot {
                 base,
-                prefix,
+                prefix: prefix.into(),
                 iter_root,
                 precompose_unicode,
             })
@@ -377,13 +361,11 @@ impl file::Store {
     /// starts with `foo`, like `refs/heads/foo` and `refs/heads/foobar`.
     ///
     /// Prefixes are relative paths with slash-separated components.
-    // TODO: use `RelativePath` type instead (see #1921), or a trait that helps convert into it.
-    pub fn iter_prefixed_packed<'a, 's, 'p>(
+    pub fn iter_prefixed_packed<'s, 'p>(
         &'s self,
-        prefix: impl Into<&'a BStr>,
+        prefix: &RelativePath,
         packed: Option<&'p packed::Buffer>,
     ) -> std::io::Result<LooseThenPacked<'p, 's>> {
-        let prefix = prefix.into();
         match self.namespace.as_ref() {
             None => {
                 let git_dir_info = IterInfo::from_prefix(self.git_dir(), prefix, self.precompose_unicode)?;
@@ -395,7 +377,8 @@ impl file::Store {
             }
             Some(namespace) => {
                 let prefix = namespace.to_owned().into_namespaced_prefix(prefix);
-                let git_dir_info = IterInfo::from_prefix(self.git_dir(), prefix.clone(), self.precompose_unicode)?;
+                let prefix = prefix.as_bstr().try_into().map_err(std::io::Error::other)?;
+                let git_dir_info = IterInfo::from_prefix(self.git_dir(), prefix, self.precompose_unicode)?;
                 let common_dir_info = self
                     .common_dir()
                     .map(|base| IterInfo::from_prefix(base, prefix, self.precompose_unicode))

--- a/gix-ref/tests/refs/file/worktree.rs
+++ b/gix-ref/tests/refs/file/worktree.rs
@@ -290,7 +290,7 @@ mod writable {
             assert_eq!(
                 store
                     .iter()?
-                    .prefixed(b"refs/stacks/")?
+                    .prefixed(b"refs/stacks/".try_into().unwrap())?
                     .map(Result::unwrap)
                     .map(|r| (r.name.to_string(), r.target.to_string()))
                     .collect::<Vec<_>>(),
@@ -571,7 +571,7 @@ mod writable {
             assert_eq!(
                 store
                     .iter()?
-                    .prefixed(b"refs/stacks/")?
+                    .prefixed(b"refs/stacks/".try_into().unwrap())?
                     .map(Result::unwrap)
                     .map(|r| (r.name.to_string(), r.target.to_string()))
                     .collect::<Vec<_>>(),

--- a/gix-ref/tests/refs/namespace.rs
+++ b/gix-ref/tests/refs/namespace.rs
@@ -3,13 +3,13 @@ fn into_namespaced_prefix() {
     assert_eq!(
         gix_ref::namespace::expand("foo")
             .unwrap()
-            .into_namespaced_prefix("prefix"),
+            .into_namespaced_prefix("prefix".try_into().unwrap()),
         "refs/namespaces/foo/prefix",
     );
     assert_eq!(
         gix_ref::namespace::expand("foo")
             .unwrap()
-            .into_namespaced_prefix("prefix/"),
+            .into_namespaced_prefix("prefix/".try_into().unwrap()),
         "refs/namespaces/foo/prefix/",
     );
 }

--- a/gix/src/open/mod.rs
+++ b/gix/src/open/mod.rs
@@ -56,6 +56,8 @@ pub enum Error {
     UnsafeGitDir { path: PathBuf },
     #[error(transparent)]
     EnvironmentAccessDenied(#[from] gix_sec::permission::Error<std::path::PathBuf>),
+    #[error(transparent)]
+    PrefixNotRelative(#[from] gix_path::relative_path::Error),
 }
 
 mod options;

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use gix_features::threading::OwnShared;
 use gix_object::bstr::ByteSlice;
-use gix_path::relative_path::RelativePath;
+use gix_path::RelativePath;
 use std::ffi::OsStr;
 use std::{borrow::Cow, path::PathBuf};
 

--- a/gix/src/reference/iter.rs
+++ b/gix/src/reference/iter.rs
@@ -1,7 +1,7 @@
 //!
 #![allow(clippy::empty_docs)]
 
-use gix_path::relative_path::RelativePath;
+use gix_path::RelativePath;
 use gix_ref::file::ReferenceExt;
 
 /// A platform to create iterators over references.
@@ -43,8 +43,6 @@ impl Platform<'_> {
     /// Return an iterator over all references that match the given `prefix`.
     ///
     /// These are of the form `refs/heads/` or `refs/remotes/origin`, and must not contain relative paths components like `.` or `..`.
-    // TODO: Create a custom `Path` type that enforces the requirements of git naturally, this type is surprising possibly on windows
-    //       and when not using a trailing '/' to signal directories.
     pub fn prefixed<'a>(
         &self,
         prefix: impl TryInto<&'a RelativePath, Error = gix_path::relative_path::Error>,

--- a/gix/tests/gix/repository/reference.rs
+++ b/gix/tests/gix/repository/reference.rs
@@ -1,5 +1,5 @@
 mod set_namespace {
-    use gix::{bstr::ByteSlice, refs::transaction::PreviousValue};
+    use gix::refs::transaction::PreviousValue;
     use gix_testtools::tempfile;
 
     fn easy_repo_rw() -> crate::Result<(gix::Repository, tempfile::TempDir)> {
@@ -48,7 +48,7 @@ mod set_namespace {
 
         assert_eq!(
             repo.references()?
-                .prefixed(b"refs/tags/".as_bstr())?
+                .prefixed("refs/tags/")?
                 .filter_map(Result::ok)
                 .map(|r| r.name().as_bstr().to_owned())
                 .collect::<Vec<_>>(),
@@ -81,8 +81,6 @@ mod set_namespace {
 }
 
 mod iter_references {
-    use gix::bstr::ByteSlice;
-
     use crate::util::hex_to_id;
 
     fn repo() -> crate::Result<gix::Repository> {
@@ -125,7 +123,7 @@ mod iter_references {
         let repo = repo()?;
         assert_eq!(
             repo.references()?
-                .prefixed(b"refs/heads/".as_bstr())?
+                .prefixed("refs/heads/")?
                 .filter_map(Result::ok)
                 .map(|r| (
                     r.name().as_bstr().to_string(),
@@ -156,7 +154,7 @@ mod iter_references {
         let repo = repo()?;
         assert_eq!(
             repo.references()?
-                .prefixed(b"refs/heads/".as_bstr())?
+                .prefixed(b"refs/heads/")?
                 .peeled()?
                 .filter_map(Result::ok)
                 .map(|r| (


### PR DESCRIPTION
This is a PoC that adds `RepositoryPathBuf` in `gix_object::tree`, for initial use in `gix_object::tree::Entry`. It is intended to make sure I start making the right changes in the right places.

This PR adds `RepositoryPathBuf` and uses it for `gix_object::tree::Entry::filename`. I adapted other places in the code until I got `just check` passing.
