### PR TITLE
Add missing `apt-get update` in CI `test` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Setup dependencies
-        run: sudo apt-get install -y --no-install-recommends liblzma-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends liblzma-dev
       - uses: extractions/setup-just@v3
       - uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
The CI `test` job's "Setup dependencies" step had `apt-get install` without having previously run `apt-get update`. This often does not work, and in a CI environment one should not typically expect it to work because package indexes in a virtual machine just provisioned from an image, if present at all, may be very outdated. But for some reason it had been working until recently, when breakages were observed, including in #1924 (though the breakage is not related to the changes in that PR).

This runs `apt-get update` before `apt-get install` in that CI job, as had already been done in the other CI jobs and as had likely always been intended. This should make the "Setup dependencies" step work again.

---

The reason I'm doing this as a separate PR rather than by adding a commit to #1924 is that it simplifies testing the same thing both in this upstream repository and in my fork, which I think might prove valuable in case any further troubleshooting is needed. (Doing it as a separate PR probably also makes the history slightly clearer, since this change is independent of the rationale of #1924, but that's secondary.)

I plan to make sure the `test` job gets past the "Setup dependencies" step, and the enable auto-merge.