### PR TITLE
More cargo-deny maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,8 +346,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          arguments: --workspace --all-features
           command: check advisories
+          arguments: --workspace --all-features
 
   cargo-deny:
     runs-on: ubuntu-latest
@@ -356,8 +356,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          arguments: --workspace --all-features
           command: check bans licenses sources
+          arguments: --workspace --all-features
 
   wasm:
     name: WebAssembly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,10 +344,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - name: Install tomlq
+        run: |
+          # The runner already has the `yq` command but not its associated `tomlq` command.
+          sudo apt-get update
+          sudo apt-get install yq
+      - name: Strict check, but omit gix-testtools
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories
+          arguments: --workspace --all-features --exclude gix-testtools
+      - name: Configure less strict check
+        run: |
+          filter='.advisories.ignore += [
+            { id: "RUSTSEC-2025-0021", reason: "gix-testtools can’t upgrade from old gix-features yet" }
+          ]'
+          tomlq "$filter" deny.toml --toml-output > deny-but-ignore-RUSTSEC-2025-0021.toml
+      - name: Less strict check, but include gix-testtools
+        uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check advisories
           arguments: --workspace --all-features
+          command-arguments: --config deny-but-ignore-RUSTSEC-2025-0021.toml
 
   cargo-deny:
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -29,7 +29,6 @@ allow = [
     "MIT",
     "MIT-0",
     "ISC",
-    "LicenseRef-ring",
     "OpenSSL",
     "Zlib",
     "MPL-2.0",

--- a/deny.toml
+++ b/deny.toml
@@ -9,8 +9,7 @@
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 ignore = [
-    # `paste` - macro crate without replacement
-    "RUSTSEC-2024-0436"
+    { id = "RUSTSEC-2024-0436", reason = "`paste` - macro crate without replacement" },
 ]
 
 


### PR DESCRIPTION
Changes:

- Remove the old `ring` license from the allowlist, since we no longer depend on any versions of `ring` that use it.

- Convert the comment explanation for why we ignore [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436.html) into reified form as the value of a `reason` key, so tools that process the file don't lose it (even if only to make debugging slightly easier when using `tomlq`).

- Split the `cargo-deny-advisories` scan into two scans (still in that one job) that cover what we covered before, *except* ignoring [RUSTSEC-2025-0021](https://rustsec.org/advisories/RUSTSEC-2025-0021.html) when the affected version is *only* reachable as a dependency of `gix-testtools`. This is as discussed in [#1924 (comment)](https://github.com/GitoxideLabs/gitoxide/pull/1924#issuecomment-2780161660), and it makes `cargo-deny-advisories` pass again.

See the commit messages for further details.

---

Regarding the license allowlist, disused licenses do seem to accumulate gradually; see also 9c708db (#1863). `cargo deny` supports configuring this as an error. But I have refrained from doing so, because:

- We don't list that many unusual licenses anymore.
- Which licenses produce the warning differs based on how `cargo deny check licenses` is run, showing another occurrence when `--all-features` is omitted, which might occasionally make sense to do when running it locally.