### PR TITLE
fix: cargo-auditable build error

### DIFF
--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -24,7 +24,8 @@ default = []
 ## If set, all IO will become blocking. The same types will be used preventing side-by-side usage of blocking and non-blocking IO.
 blocking-io = []
 ## Implement IO traits from `futures-io`.
-async-io = ["dep:futures-io", "dep:futures-lite", "dep:pin-project-lite"]
+# no `dep:` for futures-lite (https://github.com/rust-secure-code/cargo-auditable/issues/124)
+async-io = ["dep:futures-io", "futures-lite", "dep:pin-project-lite"]
 
 #! ### Other
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -30,11 +30,12 @@ blocking-client = [
     "fetch"
 ]
 ## As above, but provides async implementations instead.
+# no `dep:` for futures-lite (https://github.com/rust-secure-code/cargo-auditable/issues/124)
 async-client = [
     "gix-transport/async-client",
     "dep:async-trait",
     "dep:futures-io",
-    "dep:futures-lite",
+    "futures-lite",
     "handshake",
     "fetch"
 ]


### PR DESCRIPTION
Use `futures-lite` instead of `dep:futures-lite` in gix-packetline and gix-protocol.

This currently affects NixOS.

Related:
- https://github.com/NixOS/nixpkgs/pull/396234
- https://github.com/rust-secure-code/cargo-auditable/issues/124
- https://github.com/GitoxideLabs/gitoxide/pull/1024
