### PR TITLE
Test data-structure sizes in 32-bit Windows on CI, and fix `size_of_hasher`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,22 +312,19 @@ jobs:
   test-32bit-windows:
     runs-on: windows-latest
 
-    env:
-      TARGET: i686-pc-windows-msvc
-
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
-          targets: ${{ env.TARGET }}
+          toolchain: stable-i686-pc-windows-msvc
       - uses: Swatinem/rust-cache@v2
       - name: cargo check default features
-        run: cargo check --target $env:TARGET --workspace --bins --examples
+        run: cargo check --workspace --bins --examples
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest
       - name: Test (nextest)
-        run: cargo nextest run --target $env:TARGET --workspace --no-fail-fast
+        run: cargo nextest run --workspace --no-fail-fast
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,26 @@ jobs:
           GIX_TEST_IGNORE_ARCHIVES: '1'
         run: cargo nextest run --workspace --no-fail-fast
 
+  test-32bit-windows:
+    runs-on: windows-latest
+
+    env:
+      TARGET: i686-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ env.TARGET }}
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check default features
+        run: cargo check --target $env:TARGET --workspace --bins --examples
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - name: Test (nextest)
+        run: cargo nextest run --target $env:TARGET --workspace --no-fail-fast
+
   lint:
     runs-on: ubuntu-latest
 
@@ -504,6 +524,7 @@ jobs:
       - test-fast
       - test-fixtures-windows
       - test-32bit
+      - test-32bit-windows
       - lint
       - cargo-deny
       - check-packetline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,22 +309,23 @@ jobs:
           GIX_TEST_IGNORE_ARCHIVES: '1'
         run: cargo nextest run --workspace --no-fail-fast
 
-  test-32bit-windows:
+  test-32bit-windows-size:
     runs-on: windows-latest
+
+    env:
+      TARGET: i686-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable-i686-pc-windows-msvc
+          targets: ${{ env.TARGET }}
       - uses: Swatinem/rust-cache@v2
-      - name: cargo check default features
-        run: cargo check --workspace --bins --examples
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest
       - name: Test (nextest)
-        run: cargo nextest run --workspace --no-fail-fast
+        run: cargo nextest run --target $env:TARGET --workspace --no-fail-fast size
 
   lint:
     runs-on: ubuntu-latest
@@ -521,7 +522,7 @@ jobs:
       - test-fast
       - test-fixtures-windows
       - test-32bit
-      - test-32bit-windows
+      - test-32bit-windows-size
       - lint
       - cargo-deny
       - check-packetline

--- a/gix-hash/tests/hash/hasher.rs
+++ b/gix-hash/tests/hash/hasher.rs
@@ -1,12 +1,15 @@
 use gix_hash::{Hasher, ObjectId};
+use gix_testtools::size_ok;
 
 #[test]
 fn size_of_hasher() {
-    assert_eq!(
-        std::mem::size_of::<Hasher>(),
-        if cfg!(target_arch = "x86") { 820 } else { 824 },
-        "The size of this type may be relevant when hashing millions of objects,\
-        and shouldn't change unnoticed. The DetectionState alone clocks in at 724 bytes."
+    let actual = std::mem::size_of::<Hasher>();
+    let expected = 824;
+    assert!(
+        size_ok(actual, expected),
+        "The size of this type may be relevant when hashing millions of objects, and shouldn't\
+        change unnoticed: {actual} <~ {expected}\
+        (The DetectionState alone clocked in at 724 bytes when last examined.)"
     );
 }
 


### PR DESCRIPTION
Due to ABI differences between different 32-bit targets, the `size_of_hasher` test wrongly failed on `i686-pc-windows-msvc`.

Although the test case with that name was introduced in #1915, the failure is actually long-standing, in that an analogous faiure occurred in the old `size_of_sha1` test that preceded it and on which it is based. That failure only happened when the old `fast-sha1` feature was enabled, and not with the old `rustsha1` feature. It was not detected earlier as that target is irregularly tested, and built with `--no-default-features --features max-pure` more often than other targets due to difficulties building some other non-Rust dependencies on it (when not cross-compiling).

Since #1915, the failure is easier to detect, since we now use only one SHA-1 implementation, `sha1-checked`, so the test always fails on `i686-pc-windows-msvc`. This is only a bug in the test itself, not in any of the code under test.

This pull request makes two changes:

1. Detect this, future such test bugs, and possible size-related regressions in tests as well as in the code under test on 32-bit Windows, by adding a `test-32bit-windows-size` CI job that runs test cases across the workspace that have `size` in their names on the `i686-pc-windows-msvc` target.

2. Fix `size_of_hasher` by adjusting it to use `gix_testtools::size_ok`, which makes a `==` comparison on 64-bit targets but a `<=` comparison on 32-bit targets where there tends to be more variation in data structures' sizes. This is similar to some of the size assertion fixes in [#1687](https://github.com/GitoxideLabs/gitoxide/pull/1687) (77c3c59, fc13fc3).

The new CI job validates the test fix, but I am not sure if we should ultimately keep the new CI job. When it is not able to gain anything from caching of Rust dependencies, it takes about 8 minutes. This is shorter than any of the other Windows test jobs, but it is only running a small handful of tests.

If caching does not speed it up, then it might make sense to remove it eventually, especially if and when further Windows test jobs conferring more substantial beneift are added (such as to test that fixtures and Git configuration interaction work in an environment with MinGit, with the Git for Windows SDK, or in native Windows containers). For now I think it may be okay to have it.