### PR TITLE
Bump tokio to 1.44.2 to fix RUSTSEC-2025-0023

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,7 +3654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5292,9 +5292,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
This upgrades `tokio` from 1.44.1 to 1.44.2 in `Cargo.lock` to fix the advisory [RUSTSEC-2025-0023](https://rustsec.org/advisories/RUSTSEC-2025-0023.html) ("Broadcast channel calls clone in parallel, but does not require `Sync`").

This was done with `cargo update -p tokio`.