### PR TITLE
Add a second "DO NOT USE" feature to `gix-packetline-blocking`

### DIFF
--- a/gix-packetline-blocking/Cargo.toml
+++ b/gix-packetline-blocking/Cargo.toml
@@ -21,8 +21,11 @@ default = ["blocking-io"]
 ## If set, all IO will become blocking. The same types will be used preventing side-by-side usage of blocking and non-blocking IO.
 blocking-io = []
 
-## DO NOT USE, use instead `gix-packetline` directly.
+## DO NOT USE, instead use `gix-packetline` directly.
 async-io = []
+
+## DO NOT USE, instead use `gix-packetline` directly (and still don't specify `futures-lite`).
+futures-lite = []
 
 #! ### Other
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.


### PR DESCRIPTION
This adds a `futures-lite` feature to `gix-packetline-blocking`.

The new feature is undocumented except for the warning not to use it. It does nothing, and its purpose is to support an existing internal use of `gix-packetline-blocking` through an alias named `gix-packetline`.

This new feature should never be used except to keep `cargo check` commands with `--workspace` that list `gix-packetline/futures-lite` from failing due to the absent feature. Such `cargo check` commands are rare and `cargo check` should not typically be used this way. But RustRover automatically composes and runs such a command. This fixes a RustRover project discovery breakage commented on in #1929.

This "ghost feature" may be removed without warning. Nothing should rely on it in production or otherwise in a significant way. It is a bug for any software to break or change behavior if it is removed.

This addition is similar to the addition in be4de0d (#1123) of the `async-io` feature of `gix-packetline-blocking`, which likewise shouldn't be used. However, `gix-packetline-blocking/futures-lite` is even less elegant than `gix-packetline-blocking/async-io`, since `gix-packetline` doesn't explicitly delcare a `futures-lite` feature. Instead, we currrently don't use `dep:` for `futures-lite` because it breaks `cargo-auditable` (#1929).

---

This is not ready because there is at least one alternative that I am going to at least describe here and possibly change this to use. See https://github.com/GitoxideLabs/gitoxide/pull/1929#issuecomment-2783852929 for context, especially the part under "Edit 3".