### PR TITLE
Have `gix-filter` depend on `gix-packetline-blocking` unaliased

### DIFF
--- a/gix-filter/Cargo.toml
+++ b/gix-filter/Cargo.toml
@@ -22,7 +22,7 @@ gix-command = { version = "^0.5.0", path = "../gix-command" }
 gix-quote = { version = "^0.5.0", path = "../gix-quote" }
 gix-utils = { version = "^0.2.0", path = "../gix-utils" }
 gix-path = { version = "^0.10.15", path = "../gix-path" }
-gix-packetline = { package = "gix-packetline-blocking", version = "^0.18.3", path = "../gix-packetline-blocking" }
+gix-packetline-blocking = { version = "^0.18.3", path = "../gix-packetline-blocking" }
 gix-attributes = { version = "^0.25.0", path = "../gix-attributes" }
 
 encoding_rs = "0.8.32"

--- a/gix-filter/src/driver/process/client.rs
+++ b/gix-filter/src/driver/process/client.rs
@@ -41,7 +41,7 @@ pub mod invoke {
             #[error("Failed to read or write to the process")]
             Io(#[from] std::io::Error),
             #[error(transparent)]
-            PacketlineDecode(#[from] gix_packetline::decode::Error),
+            PacketlineDecode(#[from] gix_packetline_blocking::decode::Error),
         }
 
         impl From<super::Error> for Error {
@@ -65,17 +65,18 @@ impl Client {
         versions: &[usize],
         desired_capabilities: &[&str],
     ) -> Result<Self, handshake::Error> {
-        let mut out = gix_packetline::Writer::new(process.stdin.take().expect("configured stdin when spawning"));
+        let mut out =
+            gix_packetline_blocking::Writer::new(process.stdin.take().expect("configured stdin when spawning"));
         out.write_all(format!("{welcome_prefix}-client").as_bytes())?;
         for version in versions {
             out.write_all(format!("version={version}").as_bytes())?;
         }
-        gix_packetline::encode::flush_to_write(out.inner_mut())?;
+        gix_packetline_blocking::encode::flush_to_write(out.inner_mut())?;
         out.flush()?;
 
-        let mut input = gix_packetline::StreamingPeekableIter::new(
+        let mut input = gix_packetline_blocking::StreamingPeekableIter::new(
             process.stdout.take().expect("configured stdout when spawning"),
-            &[gix_packetline::PacketLineRef::Flush],
+            &[gix_packetline_blocking::PacketLineRef::Flush],
             false, /* packet tracing */
         );
         let mut read = input.as_read();
@@ -125,10 +126,10 @@ impl Client {
         for capability in desired_capabilities {
             out.write_all(format!("capability={capability}").as_bytes())?;
         }
-        gix_packetline::encode::flush_to_write(out.inner_mut())?;
+        gix_packetline_blocking::encode::flush_to_write(out.inner_mut())?;
         out.flush()?;
 
-        read.reset_with(&[gix_packetline::PacketLineRef::Flush]);
+        read.reset_with(&[gix_packetline_blocking::PacketLineRef::Flush]);
         let mut capabilities = HashSet::new();
         loop {
             buf.clear();
@@ -167,7 +168,7 @@ impl Client {
     ) -> Result<process::Status, invoke::Error> {
         self.send_command_and_meta(command, meta)?;
         std::io::copy(content, &mut self.input)?;
-        gix_packetline::encode::flush_to_write(self.input.inner_mut())?;
+        gix_packetline_blocking::encode::flush_to_write(self.input.inner_mut())?;
         self.input.flush()?;
         Ok(self.read_status()?)
     }
@@ -189,7 +190,7 @@ impl Client {
                 inspect_line(line.as_bstr());
             }
         }
-        self.out.reset_with(&[gix_packetline::PacketLineRef::Flush]);
+        self.out.reset_with(&[gix_packetline_blocking::PacketLineRef::Flush]);
         let status = self.read_status()?;
         Ok(status)
     }
@@ -197,7 +198,7 @@ impl Client {
     /// Return a `Read` implementation that reads the server process output until the next flush package, and validates
     /// the status. If the status indicates failure, the last read will also fail.
     pub fn as_read(&mut self) -> impl std::io::Read + '_ {
-        self.out.reset_with(&[gix_packetline::PacketLineRef::Flush]);
+        self.out.reset_with(&[gix_packetline_blocking::PacketLineRef::Flush]);
         ReadProcessOutputAndStatus {
             inner: self.out.as_read(),
         }
@@ -225,7 +226,7 @@ impl Client {
             buf.push_str(&value);
             self.input.write_all(&buf)?;
         }
-        gix_packetline::encode::flush_to_write(self.input.inner_mut())?;
+        gix_packetline_blocking::encode::flush_to_write(self.input.inner_mut())?;
         Ok(())
     }
 }
@@ -248,7 +249,7 @@ fn read_status(read: &mut PacketlineReader<'_>) -> std::io::Result<process::Stat
     if count > 0 && matches!(status, process::Status::Previous) {
         status = process::Status::Unset;
     }
-    read.reset_with(&[gix_packetline::PacketLineRef::Flush]);
+    read.reset_with(&[gix_packetline_blocking::PacketLineRef::Flush]);
     Ok(status)
 }
 
@@ -260,7 +261,7 @@ impl std::io::Read for ReadProcessOutputAndStatus<'_> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let num_read = self.inner.read(buf)?;
         if num_read == 0 {
-            self.inner.reset_with(&[gix_packetline::PacketLineRef::Flush]);
+            self.inner.reset_with(&[gix_packetline_blocking::PacketLineRef::Flush]);
             let status = read_status(&mut self.inner)?;
             if status.is_success() {
                 Ok(0)

--- a/gix-filter/src/driver/process/mod.rs
+++ b/gix-filter/src/driver/process/mod.rs
@@ -12,9 +12,9 @@ pub struct Client {
     /// The negotiated version of the protocol.
     version: usize,
     /// A way to send packet-line encoded information to the process.
-    input: gix_packetline::Writer<std::process::ChildStdin>,
+    input: gix_packetline_blocking::Writer<std::process::ChildStdin>,
     /// A way to read information sent to us by the process.
-    out: gix_packetline::StreamingPeekableIter<std::process::ChildStdout>,
+    out: gix_packetline_blocking::StreamingPeekableIter<std::process::ChildStdout>,
 }
 
 /// A handle to facilitate typical server interactions that include the handshake and command-invocations.
@@ -24,9 +24,9 @@ pub struct Server {
     /// The negotiated version of the protocol, it's the highest supported one.
     version: usize,
     /// A way to receive information from the client.
-    input: gix_packetline::StreamingPeekableIter<std::io::StdinLock<'static>>,
+    input: gix_packetline_blocking::StreamingPeekableIter<std::io::StdinLock<'static>>,
     /// A way to send information to the client.
-    out: gix_packetline::Writer<std::io::StdoutLock<'static>>,
+    out: gix_packetline_blocking::Writer<std::io::StdoutLock<'static>>,
 }
 
 /// The return status of an [invoked command][Client::invoke()].
@@ -109,5 +109,8 @@ pub mod client;
 ///
 pub mod server;
 
-type PacketlineReader<'a, T = std::process::ChildStdout> =
-    gix_packetline::read::WithSidebands<'a, T, fn(bool, &[u8]) -> gix_packetline::read::ProgressAction>;
+type PacketlineReader<'a, T = std::process::ChildStdout> = gix_packetline_blocking::read::WithSidebands<
+    'a,
+    T,
+    fn(bool, &[u8]) -> gix_packetline_blocking::read::ProgressAction,
+>;

--- a/gix-packetline-blocking/Cargo.toml
+++ b/gix-packetline-blocking/Cargo.toml
@@ -24,9 +24,6 @@ blocking-io = []
 ## DO NOT USE, instead use `gix-packetline` directly.
 async-io = []
 
-## DO NOT USE, instead use `gix-packetline` directly (and still don't specify `futures-lite`).
-futures-lite = []
-
 #! ### Other
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde = ["dep:serde", "bstr/serde"]


### PR DESCRIPTION
This removes the `gix-packetline-blocking/futures-lite` "ghost feature" added in d5dd239 (#1939), and instead:

- Changes `gix-filter` to depends on `gix-packetline-blocking` without aliasing it `gix-packetline`.
- Replaces uses of `gix_packetline` with `gix_packetline_blocking` in the code of `gix-filter`.

Thus, this replaces the solution in #1939 for the problem discussed in https://github.com/GitoxideLabs/gitoxide/pull/1929#issuecomment-2783852929 with a different solution that avoids carrying a "ghost feature."

In contrast, the long-standing `gix-packetline-blocking/async-io` feature added in be4de0d (#1123), though it should not be used, is *not* removed, because:

- It is referenced in attributes in `gix-packetline-blocking` code (because `gix-packetline-blocking/src` is copied from `gix-packetline/src` via `etc/copy-packetline.sh`).
- For that reason, removing it would cause the `clippy` run in the CI `lint` job to fail, as well as likely making various other reasonable operations fail.

---

This PR proposes the alternative alluded to in #1939. As they are described in https://github.com/GitoxideLabs/gitoxide/pull/1929#issuecomment-2783852929, this replaces way (1) with way (2). At the time it seemed like combining them, i.e. way (3), could make sense, but I think the phantom nature of the feature, together with how `gix-filter` seems to be the only user of `gix-packetline-blocking`, indicates that it shouldn't be carried if it's not actually being used.

The reason I didn't go with this initially is that I am not sure I understand why `gix-packetline-blocking` was aliased `gix-packetline` when given as a dependency of `gix-features`. If it was solely for the convenience of being able to write `gix_packetline` instead of `gix_packetline_blocking`, then I think the change here is an improvement. If there are deeper reasons, however, then I am not sure.

I think this could be done with `use gix_packetline_blocking as gix_packetline;`, but it didn't look like it would be better: it would have to be written in multiple places in the same file, due to the scope of `use` declarations in files that define multiple nested modules. (And maybe also related to special semantics for `#[from]`? But I am not sure about that.)