### PR TITLE
Tell Dependabot not to use conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,28 @@
 version: 2
 updates:
-  # We only use Dependabot *version* updates for GitHub Actions. Rust dependencies are checked via
-  # `cargo deny` and manually updated (see https://github.com/GitoxideLabs/gitoxide/issues/144), or
-  # by Dependabot *security* updates (which don't need the `cargo` ecosystem to be listed here).
+  # Only GitHub Actions dependencies receive Dependabot *version* updates. Rust dependencies are
+  # checked via `cargo deny` (https://github.com/GitoxideLabs/gitoxide/issues/144) and updated
+  # manually or via Dependabot *security* updates (which the restrictions here do not constrain).
+  - package-ecosystem: cargo
+    directory: '/'
+    schedule:
+      # We include this required key, but it only applies to version updates, which are suppressed.
+      interval: monthly
+    # Disable version updates for Rust dependencies. Security updates are still allowed.
+    open-pull-requests-limit: 0
+    commit-message:
+      # Avoid non-"purposeful" prefix due to Dependabot misdetecting style (see `DEVELOPMENT.md`).
+      prefix: ''
+    groups:
+      cargo:
+        patterns: ['*']
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: weekly
+    commit-message:
+      # Avoid non-"purposeful" prefix due to Dependabot misdetecting style (see `DEVELOPMENT.md`).
+      prefix: ''
     groups:
       github-actions:
         patterns: ['*']


### PR DESCRIPTION
Dependabot automatically examines existing commits' messages to decide what style to use, if no `commit.prefix` is configured. But gitoxide prefers that conventional commits be used only in limited circumstances: the "purposeful conventional commits" style detailed in `DEVELOPMENT.md`. Commits to bump dependencies should typically not be conventional, so Dependabot should not title its commits with prefixes that can be interpreted as meaningful conventional commits. But the style Dependabot has automatically picked here uses prefixes such as `build(deps): ...`.

In practice this does not cause serious problems so far and is unlikely ever to cause serious problems, so it would be fine to use Dependabot even if this behavior couldn't be changed. But there are a few reasons to configure Dependabot not to do this:

- Stylistic consistency.
- Decrease the likelihood of future undesired behavior if we later expand the use of Dependabot, such as to enable version updates (rather than just security updates) on Rust dependencies, where it would more often affect changelogs due to far more often editing per-crate `Cargo.toml` files than it currently does.
- Decrease the likelihood of future undesired behavior if a future version of `cargo-smart-release` treats more conventional commit prefixes specially.
- Make commit messages slightly easier to read if one is familiar with the commit message style used in this repository.
- Avoid giving newcomers the wrong idea about how and when commit messages in this project are expected to be conventional.

Roughly speaking, this configures Dependabot not to use any prefix. There does not appear to be any way to suppress the use of a prefix to restore the exact same behavior as if Dependabot had detected not to use a prefix (in particular, setting `prefix` to `null` produces an error and Dependabot will not use the configuration). So this instead sets an empty string as the prefix.

The difference between an empty prefix and no prefix, in terms of how Dependabot currently behaves for this repository, is that the commit message with an empty prefix does not start with a capital letter. But that is not a problem here, because we don't impose a stylistic preference as to whether to capitalize commit message titles; both styles are common, with the uncapitalized style being at least as common as the capitalized style.

To ensure this configuration works as intended, it has been tested in a fork (where force-pushing main doesn't cause any disruption). See https://github.com/EliahKagan/gitoxide/pull/16 for details.