### PR TITLE
Use one of the more standard forms of the Apache-2.0 license file

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -175,28 +175,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -176,6 +176,19 @@
 
    END OF TERMS AND CONDITIONS
 
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at


### PR DESCRIPTION
We currently have a nonstandard Apache-2.0 license file. The license terms and conditions themselves, including the exact text of them, are standard, fortunately, and always have been--and this PR makes sure not to change that.

This traces the history of how the appendix text (the text after "END OF TERMS AND CONDITIONS") has taken various non-ideal forms, and shows two approaches that I believe are preferable to what we have now, choosing one:

- The first commit here, c66814f, changes the appendix to read as it does in the officially distributed plaintext Apache-2.0 license file, which is one of two good options.
- The second commit, 519970d, removes the appendix altogether, which is the other good option.

I don't actually prefer the second option. I think they are about equally good, with the first option possibly being slightly better in that it uses [the exact Apache-2.0 license file](https://www.[apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt)) that one can download from [the official site presenting the license](https://www.apache.org/licenses/LICENSE-2.0). (This is also the same as the [choosealicense.com](https://choosealicense.com/) version, except that version omits the blank line at the very beginning of the file.) But I think either approach is somewhat preferable to the current situation.

If we go with the first option, as I actually slightly prefer, then the second commit can be dropped. If we go with the second option, then I suggest keeping both commits rather than squashing them, since the first one readily establishes in the diff that the nonstandard trailing text in `LICENSE-APACHE` came from the standard appendix.

### Review

It seems to me that the changes here are not very contentious. Nonetheless, I do not want to make any change to a license file without review. Furthermore, there is the question of which approach to take.

I recommend consulting the commit messages for details before allowing this to be merged (or before deciding whether to merge it or which of the two approaches to take). I say this because, although the commit messages are of course *not* legal documents, people may look at them in the history to understand what happened with the licenses. I would be happy to revise or rewrite them if requested.

Most of the interesting information in this pull request is in the c66814f commit message. This pull request description mostly does not duplicate it.

### Outscoped

In this PR I have made only changes that strictly improve clarity and that do not modify or appear to modify any license obligations.

As detailed in the c66814f commit message, part of the history prior to this PR had involved removing a copyright line from the Apache-2.0 license. This was a copyright line where no *actual* copyright line was expected nor present in any standard Apache-2.0 license file, and which seems to have caused problems with tooling (#1232). However, the copyright line at the top of the MIT license file was also removed along with it. That removal should possibly be undone.

It is extremely common that the MIT license carry a copyright line, so it is unlikely that removing it was helpful. (Any tooling used at scale that would break on it would presumably incur thousands of other breakages too. Even if not, the responsibility would be in the tool with the bug.) Also, there are some problems that can arise from removing the copyright line from the MIT license. One such problem, even if all copyright holders agree that it may be removed, is that the license stops making sense because "The above copyright notice" has no referent.

The practice of removing it can be seen in some other Rust projects, and I suspect that the practice may be rooted in the erstwhile removal of the copyright notice in the MIT license file of the rust-lang/rust repository. But that was corrected in https://github.com/rust-lang/rust/commit/f9c16997dc016a3ef1456f56df2ab564a1c48cb2 (https://github.com/rust-lang/rust/pull/133461), and the rust-lang/rust MIT license file again carries a copyright notice.