### PR TITLE
`gix-blame`: Replace `BTreeMap` by `SmallVec`

### DIFF
--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -114,7 +114,7 @@ pub fn file(
             break;
         }
 
-        let is_still_suspect = hunks_to_blame.iter().any(|hunk| hunk.suspects.contains_key(&suspect));
+        let is_still_suspect = hunks_to_blame.iter().any(|hunk| hunk.has_suspect(&suspect));
         if !is_still_suspect {
             // There are no `UnblamedHunk`s associated with this `suspect`, so we can continue with
             // the next one.
@@ -189,7 +189,7 @@ pub fn file(
                 .collect();
 
             for hunk in hunks_to_blame.iter() {
-                if let Some(range_in_suspect) = hunk.suspects.get(&suspect) {
+                if let Some(range_in_suspect) = hunk.get_range(&suspect) {
                     let range_in_blamed_file = hunk.range_in_blamed_file.clone();
 
                     for (blamed_line_number, source_line_number) in range_in_blamed_file.zip(range_in_suspect.clone()) {


### PR DESCRIPTION
This PR increases `gix-blame`’s performance by replacing `suspects: BTreeMap` with `suspects: SmallVec`.

A `SmallVec` provides a better trade-off with respect to performance than a `BTreeMap` because `suspects` in most cases only contains 1 item. The cost of calling `BTreeMap::insert` and `BTreeMap::remove` becomes noticeable in profiling the longer a blame’s history gets and the more hunks a file is split into.

For smaller blames, the benefits are negligible, but for larger repos and larger files they are so significant that I’m worried I might have made a mistake trying to measure them. :smile:

The following benchmarks compare this PR against `main`.

```
❯ env GIT_DIR="$HOME/github/Byron/gitoxide/.git" hyperfine --warmup 1 --export-markdown results.md '$HOME/github/Byron/gitoxide/target/profiling/gix blame Cargo.lock' '$HOME/worktrees/gitoxide/branch-6/target/profiling/gix blame Cargo.lock'
Benchmark 1: $HOME/github/Byron/gitoxide/target/profiling/gix blame Cargo.lock
  Time (mean ± σ):      1.482 s ±  0.009 s    [User: 1.284 s, System: 0.192 s]
  Range (min … max):    1.468 s …  1.499 s    10 runs

Benchmark 2: $HOME/worktrees/gitoxide/branch-6/target/profiling/gix blame Cargo.lock
  Time (mean ± σ):      1.269 s ±  0.008 s    [User: 1.078 s, System: 0.185 s]
  Range (min … max):    1.261 s …  1.289 s    10 runs

Summary
  '$HOME/worktrees/gitoxide/branch-6/target/profiling/gix blame Cargo.lock' ran
    1.17 ± 0.01 times faster than '$HOME/github/Byron/gitoxide/target/profiling/gix blame Cargo.lock'

❯ env GIT_DIR="$HOME/github/torvalds/linux/.git" hyperfine --warmup 1 --export-markdown results.md '$HOME/github/Byron/gitoxide/target/profiling/gix blame CREDITS' '$HOME/worktrees/gitoxide/branch-6/target/profiling/gix blame CREDITS'
Benchmark 1: $HOME/github/Byron/gitoxide/target/profiling/gix blame CREDITS
  Time (mean ± σ):      2.207 s ±  0.026 s    [User: 2.026 s, System: 0.174 s]
  Range (min … max):    2.179 s …  2.261 s    10 runs

Benchmark 2: $HOME/worktrees/gitoxide/branch-6/target/profiling/gix blame CREDITS
  Time (mean ± σ):      1.591 s ±  0.015 s    [User: 1.411 s, System: 0.174 s]
  Range (min … max):    1.576 s …  1.629 s    10 runs

Summary
  '$HOME/worktrees/gitoxide/branch-6/target/profiling/gix blame CREDITS' ran
    1.39 ± 0.02 times faster than '$HOME/github/Byron/gitoxide/target/profiling/gix blame CREDITS'
```
