### PR TITLE
Remove old unused cargo-deny `license.clarify` entry

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -50,12 +50,3 @@ deny = [
     # end range due to https://github.com/serde-rs/serde/pull/2590
     { name = "serde_derive", version = ">1.0.171, <1.0.185" },
 ]
-
-
-[[licenses.clarify]]
-name = "ring"
-expression = "LicenseRef-ring"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 },
-]
-


### PR DESCRIPTION
3cfd7fa (#1927) removed `LicenseRef-ring` from the `cargo deny` license allowlist, because we no longer used any `ring` version old enough to involve the old custom license. But the associated entry in the `license.clarify` array that definded `LicenseRef-ring` was not removed, even though it's not needed either given that the license it clarifies is no longer referenced. This cleans that up.