### PR TITLE
Always let Dependabot propose `Cargo.lock` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,12 @@ updates:
     commit-message:
       # Avoid non-"purposeful" prefix due to Dependabot misdetecting style (see `DEVELOPMENT.md`).
       prefix: ''
+    allow:
+      - dependency-type: all
     groups:
       cargo:
         patterns: ['*']
+
   - package-ecosystem: github-actions
     directory: '/'
     schedule:


### PR DESCRIPTION
This fixes a bug in the `dependabot.yml` configuration since #1948, where we intend Dependabot to include the effect of `cargo update`, but this does not happen because `dependency-type: all` was not explicitly allowed.

This does not make an analogous change to the Dependabot configuration for GitHub Actions, because `all` and `direct` currently have the same effect for them (and it is not obvious how it would work if that ever changes, or which we would prefer).

For details on why this is needed for Dependabot to update most locked dependencies in `Cargo.lock` aside from the case where the update is done as part of updating a `Cargo.toml` dependency, see:

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#allowing-specific-dependencies-to-be-updated
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#dependency-type-allow

---

This does not change the cadence, which is still set to monthly. Dependabot will perform a check after this is merged, because any change to `dependabot.yml` triggers new Dependabot version update checks for all configured ecosystems. It will open a PR because there will be updates, *most* but not all of which will be changes to `Cargo.lock` updating transitive dependencies that were not covered before due to the configuration shortcoming that this is fixing.

The fork-internal Dependabot test PR I used to verify these changes, formed by pushing this change to main in my fork and subsequently rewinding, was https://github.com/EliahKagan/gitoxide/pull/22. This roughly reflects what the first Dependabot PR after this configuration change is merged will look like.

I will make a corresponding change to `dependabot.yml` in `cargo-smart-release`, where https://github.com/GitoxideLabs/cargo-smart-release/pull/52 had the same bug as #1948. *(Edit: This change is https://github.com/GitoxideLabs/cargo-smart-release/pull/58.)*

No such change in `prodash` is needed. This is because Dependabot version updates are only used for GitHub Actions, not for Rust/`cargo` dependencies, and also because we are not currently committing `Cargo.lock` in `prodash`.

The problem this is fixing does not affect the behavior of [Dependabot security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates), which are already attempted for all types of dependencies.