### PR TITLE
Improve support for multiple blame ranges

### DIFF
--- a/gix-blame/src/error.rs
+++ b/gix-blame/src/error.rs
@@ -28,7 +28,9 @@ pub enum Error {
     #[error(transparent)]
     DiffTree(#[from] gix_diff::tree::Error),
     #[error("Invalid line range was given, line range is expected to be a 1-based inclusive range in the format '<start>,<end>'")]
-    InvalidLineRange,
+    InvalidOneBasedLineRange,
+    #[error("Invalid line range was given, line range is expected to be a 0-based inclusive range in the format '<start>,<end>'")]
+    InvalidZeroBasedLineRange,
     #[error("Failure to decode commit during traversal")]
     DecodeCommit(#[from] gix_object::decode::Error),
     #[error("Failed to get parent from commitgraph during traversal")]

--- a/gix-blame/src/error.rs
+++ b/gix-blame/src/error.rs
@@ -29,8 +29,8 @@ pub enum Error {
     DiffTree(#[from] gix_diff::tree::Error),
     #[error("Invalid line range was given, line range is expected to be a 1-based inclusive range in the format '<start>,<end>'")]
     InvalidOneBasedLineRange,
-    #[error("Invalid line range was given, line range is expected to be a 0-based inclusive range in the format '<start>,<end>'")]
-    InvalidZeroBasedLineRange,
+    #[error("Invalid range addition was attempted. Cannot add a range to a whole file.")]
+    InvalidRangeAddition,
     #[error("Failure to decode commit during traversal")]
     DecodeCommit(#[from] gix_object::decode::Error),
     #[error("Failed to get parent from commitgraph during traversal")]

--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -94,15 +94,11 @@ pub fn file(
         return Ok(Outcome::default());
     }
 
-    let ranges = options.range.to_zero_based_exclusive(num_lines_in_blamed)?;
-    let mut hunks_to_blame = Vec::with_capacity(ranges.len());
-
-    for range in ranges {
-        hunks_to_blame.push(UnblamedHunk {
-            range_in_blamed_file: range.clone(),
-            suspects: [(suspect, range)].into(),
-        });
-    }
+    let ranges_to_blame = options.ranges.to_ranges(num_lines_in_blamed);
+    let mut hunks_to_blame = ranges_to_blame
+        .into_iter()
+        .map(|range| UnblamedHunk::new(range, suspect))
+        .collect::<Vec<_>>();
 
     let (mut buf, mut buf2) = (Vec::new(), Vec::new());
     let commit = find_commit(cache.as_ref(), &odb, &suspect, &mut buf)?;

--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -94,7 +94,7 @@ pub fn file(
         return Ok(Outcome::default());
     }
 
-    let ranges_to_blame = options.ranges.to_ranges(num_lines_in_blamed);
+    let ranges_to_blame = options.ranges.to_zero_based_exclusive_ranges(num_lines_in_blamed);
     let mut hunks_to_blame = ranges_to_blame
         .into_iter()
         .map(|range| UnblamedHunk::new(range, suspect))

--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -144,7 +144,7 @@ pub struct Options {
     /// The algorithm to use for diffing.
     pub diff_algorithm: gix_diff::blob::Algorithm,
     /// The ranges to blame in the file.
-    pub range: BlameRanges,
+    pub ranges: BlameRanges,
     /// Don't consider commits before the given date.
     pub since: Option<gix_date::Time>,
 }

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -384,7 +384,7 @@ mod blame_ranges {
     }
 
     #[test]
-    fn multiple_ranges_usingfrom_ranges() {
+    fn multiple_ranges_using_from_ranges() {
         let Fixture {
             odb,
             mut resource_cache,

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -332,7 +332,7 @@ mod blame_ranges {
             "simple.txt".into(),
             gix_blame::Options {
                 diff_algorithm: gix_diff::blob::Algorithm::Histogram,
-                ranges: BlameRanges::from_one_based_inclusive_range(1..=2),
+                ranges: BlameRanges::from_one_based_inclusive_range(1..=2).unwrap(),
                 since: None,
             },
         )
@@ -359,7 +359,8 @@ mod blame_ranges {
             1..=2, // Lines 1-2
             1..=1, // Duplicate range, should be ignored
             4..=4, // Line 4
-        ]);
+        ])
+        .unwrap();
 
         let lines_blamed = gix_blame::file(
             &odb,
@@ -392,7 +393,7 @@ mod blame_ranges {
             suspect,
         } = Fixture::new().unwrap();
 
-        let ranges = BlameRanges::from_one_based_inclusive_ranges(vec![1..=2, 1..=1, 4..=4]);
+        let ranges = BlameRanges::from_one_based_inclusive_ranges(vec![1..=2, 1..=1, 4..=4]).unwrap();
 
         let lines_blamed = gix_blame::file(
             &odb,

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -194,7 +194,7 @@ macro_rules! mktest {
                 format!("{}.txt", $case).as_str().into(),
                 gix_blame::Options {
                     diff_algorithm: gix_diff::blob::Algorithm::Histogram,
-                    range: BlameRanges::default(),
+                    ranges: BlameRanges::default(),
                     since: None,
                 },
             )?
@@ -265,7 +265,7 @@ fn diff_disparity() {
             format!("{case}.txt").as_str().into(),
             gix_blame::Options {
                 diff_algorithm: gix_diff::blob::Algorithm::Histogram,
-                range: BlameRanges::default(),
+                ranges: BlameRanges::default(),
                 since: None,
             },
         )
@@ -297,7 +297,7 @@ fn since() {
         "simple.txt".into(),
         gix_blame::Options {
             diff_algorithm: gix_diff::blob::Algorithm::Histogram,
-            range: BlameRanges::default(),
+            ranges: BlameRanges::default(),
             since: Some(gix_date::parse("2025-01-31", None).unwrap()),
         },
     )
@@ -332,7 +332,7 @@ mod blame_ranges {
             "simple.txt".into(),
             gix_blame::Options {
                 diff_algorithm: gix_diff::blob::Algorithm::Histogram,
-                range: BlameRanges::from_range(1..=2),
+                ranges: BlameRanges::from_range(1..=2),
                 since: None,
             },
         )
@@ -368,7 +368,7 @@ mod blame_ranges {
             "simple.txt".into(),
             gix_blame::Options {
                 diff_algorithm: gix_diff::blob::Algorithm::Histogram,
-                range: ranges,
+                ranges,
                 since: None,
             },
         )
@@ -401,7 +401,7 @@ mod blame_ranges {
             "simple.txt".into(),
             gix_blame::Options {
                 diff_algorithm: gix_diff::blob::Algorithm::Histogram,
-                range: ranges,
+                ranges,
                 since: None,
             },
         )

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -332,7 +332,7 @@ mod blame_ranges {
             "simple.txt".into(),
             gix_blame::Options {
                 diff_algorithm: gix_diff::blob::Algorithm::Histogram,
-                ranges: BlameRanges::from_range(1..=2),
+                ranges: BlameRanges::from_one_based_inclusive_range(1..=2),
                 since: None,
             },
         )
@@ -355,10 +355,11 @@ mod blame_ranges {
             suspect,
         } = Fixture::new().unwrap();
 
-        let mut ranges = BlameRanges::new();
-        ranges.add_range(1..=2); // Lines 1-2
-        ranges.add_range(1..=1); // Duplicate range, should be ignored
-        ranges.add_range(4..=4); // Line 4
+        let ranges = BlameRanges::from_one_based_inclusive_ranges(vec![
+            1..=2, // Lines 1-2
+            1..=1, // Duplicate range, should be ignored
+            4..=4, // Line 4
+        ]);
 
         let lines_blamed = gix_blame::file(
             &odb,
@@ -391,7 +392,7 @@ mod blame_ranges {
             suspect,
         } = Fixture::new().unwrap();
 
-        let ranges = BlameRanges::from_ranges(vec![1..=2, 1..=1, 4..=4]);
+        let ranges = BlameRanges::from_one_based_inclusive_ranges(vec![1..=2, 1..=1, 4..=4]);
 
         let lines_blamed = gix_blame::file(
             &odb,

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -1578,7 +1578,7 @@ pub fn main() -> Result<()> {
                     &file,
                     gix::blame::Options {
                         diff_algorithm,
-                        ranges: gix::blame::BlameRanges::from_ranges(ranges),
+                        ranges: gix::blame::BlameRanges::from_one_based_inclusive_ranges(ranges),
                         since,
                     },
                     out,

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -1578,7 +1578,7 @@ pub fn main() -> Result<()> {
                     &file,
                     gix::blame::Options {
                         diff_algorithm,
-                        ranges: gix::blame::BlameRanges::from_one_based_inclusive_ranges(ranges),
+                        ranges: gix::blame::BlameRanges::from_one_based_inclusive_ranges(ranges)?,
                         since,
                     },
                     out,

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -1578,7 +1578,7 @@ pub fn main() -> Result<()> {
                     &file,
                     gix::blame::Options {
                         diff_algorithm,
-                        range: gix::blame::BlameRanges::from_ranges(ranges),
+                        ranges: gix::blame::BlameRanges::from_ranges(ranges),
                         since,
                     },
                     out,


### PR DESCRIPTION
This PR implements various improvements suggested in PR #1973.

The main change is converting the `BlameRanges` struct, into an enum to support both `OneBasedInclusive` and `ZeroBasedExclusive` range formats. The `FullFile` variant, denotes that the entire file is to be blamed, serves as a more explicit substitute for a previously used "empty" range.