### PR TITLE
Correctly process overlapping unblamed hunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,6 +1567,7 @@ dependencies = [
  "gix-trace 0.1.12",
  "gix-traverse 0.46.1",
  "gix-worktree 0.41.0",
+ "pretty_assertions",
  "smallvec",
  "thiserror 2.0.12",
 ]

--- a/gix-blame/Cargo.toml
+++ b/gix-blame/Cargo.toml
@@ -31,3 +31,4 @@ gix-fs = { path = "../gix-fs" }
 gix-index = { path = "../gix-index" }
 gix-odb = { path = "../gix-odb" }
 gix-testtools = { path = "../tests/tools" }
+pretty_assertions = "1.4.0"

--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -303,33 +303,6 @@ pub fn file(
             unblamed_hunk.remove_blame(suspect);
             true
         });
-
-        // This block asserts that line ranges for each suspect never overlap. If they did overlap
-        // this would mean that the same line in a *Source File* would map to more than one line in
-        // the *Blamed File* and this is not possible.
-        #[cfg(debug_assertions)]
-        {
-            let ranges = hunks_to_blame.iter().fold(
-                std::collections::BTreeMap::<ObjectId, Vec<Range<u32>>>::new(),
-                |mut acc, hunk| {
-                    for (suspect, range) in hunk.suspects.clone() {
-                        acc.entry(suspect).or_default().push(range);
-                    }
-
-                    acc
-                },
-            );
-
-            for (_, mut ranges) in ranges {
-                ranges.sort_by(|a, b| a.start.cmp(&b.start));
-
-                for window in ranges.windows(2) {
-                    if let [a, b] = window {
-                        assert!(a.end <= b.start, "#{hunks_to_blame:#?}");
-                    }
-                }
-            }
-        }
     }
 
     debug_assert_eq!(

--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -197,15 +197,16 @@ pub fn file(
                 if let Some(range_in_suspect) = hunk.get_range(&suspect) {
                     let range_in_blamed_file = hunk.range_in_blamed_file.clone();
 
-                    for (blamed_line_number, source_line_number) in range_in_blamed_file.zip(range_in_suspect.clone()) {
-                        let source_token = source_lines_as_tokens[source_line_number as usize];
-                        let blame_token = blamed_lines_as_tokens[blamed_line_number as usize];
+                    let source_lines = range_in_suspect
+                        .clone()
+                        .map(|i| BString::new(source_interner[source_lines_as_tokens[i as usize]].into()))
+                        .collect::<Vec<_>>();
+                    let blamed_lines = range_in_blamed_file
+                        .clone()
+                        .map(|i| BString::new(blamed_interner[blamed_lines_as_tokens[i as usize]].into()))
+                        .collect::<Vec<_>>();
 
-                        let source_line = BString::new(source_interner[source_token].into());
-                        let blamed_line = BString::new(blamed_interner[blame_token].into());
-
-                        assert_eq!(source_line, blamed_line);
-                    }
+                    assert_eq!(source_lines, blamed_lines);
                 }
             }
         }

--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -37,7 +37,8 @@ use crate::{BlameEntry, Error, Options, Outcome, Statistics};
 ///
 /// *For brevity, `HEAD` denotes the starting point of the blame operation. It could be any commit, or even commits that
 /// represent the worktree state.
-/// We begin with a single *Unblamed Hunk* and a single suspect, usually the `HEAD` commit as the commit containing the
+///
+/// We begin with one or more *Unblamed Hunks* and a single suspect, usually the `HEAD` commit as the commit containing the
 /// *Blamed File*, so that it contains the entire file, with the first commit being a candidate for the entire *Blamed File*.
 /// We traverse the commit graph starting at the first suspect, and see if there have been changes to `file_path`.
 /// If so, we have found a *Source File* and a *Suspect* commit, and have hunks that represent these changes.

--- a/gix-blame/src/file/mod.rs
+++ b/gix-blame/src/file/mod.rs
@@ -8,11 +8,12 @@ use crate::types::{BlameEntry, Change, Either, LineRange, Offset, UnblamedHunk};
 
 pub(super) mod function;
 
-/// Compare a section from the *Blamed File* (`hunk`) with a change from a diff and see if there
-/// is an intersection with `change`. Based on that intersection, we may generate a [`BlameEntry`] for `out`
-/// and/or split the `hunk` into multiple.
+/// Compare a section from a potential *Source File* (`hunk`) with a change from a diff and see if
+/// there is an intersection with `change`. Based on that intersection, we may generate a
+/// [`BlameEntry`] for `out` and/or split the `hunk` into multiple.
 ///
-/// This is the core of the blame implementation as it matches regions in *Source File* to the *Blamed File*.
+/// This is the core of the blame implementation as it matches regions in *Blamed File* to
+/// corresponding regions in one or more than one *Source File*.
 fn process_change(
     new_hunks_to_blame: &mut Vec<UnblamedHunk>,
     offset: &mut Offset,

--- a/gix-blame/src/file/mod.rs
+++ b/gix-blame/src/file/mod.rs
@@ -325,8 +325,8 @@ fn process_change(
 /// `process_changes` assumes that ranges coming from the same *Source File* can and do
 /// occasionally overlap. If it were a desirable property of the blame algorithm as a whole to
 /// never have two different lines from a *Blamed File* mapped to the same line in a *Source File*,
-/// this property would need to be enforced at a higher level than `process_changes` if which case
-/// the nested loops could potentially be flattened into one.
+/// this property would need to be enforced at a higher level than `process_changes`.
+/// Then the nested loops could potentially be flattened into one.
 fn process_changes(
     hunks_to_blame: Vec<UnblamedHunk>,
     changes: Vec<Change>,
@@ -335,13 +335,11 @@ fn process_changes(
 ) -> Vec<UnblamedHunk> {
     let mut new_hunks_to_blame = Vec::new();
 
-    for hunk in hunks_to_blame {
-        let mut hunk = Some(hunk);
-
+    for mut hunk in hunks_to_blame.into_iter().map(Some) {
         let mut offset_in_destination = Offset::Added(0);
 
-        let mut changes_iter = changes.iter();
-        let mut change: Option<Change> = changes_iter.next().cloned();
+        let mut changes_iter = changes.iter().cloned();
+        let mut change = changes_iter.next();
 
         loop {
             (hunk, change) = process_change(
@@ -353,7 +351,7 @@ fn process_changes(
                 change,
             );
 
-            change = change.or_else(|| changes_iter.next().cloned());
+            change = change.or_else(|| changes_iter.next());
 
             if hunk.is_none() {
                 break;

--- a/gix-blame/src/file/mod.rs
+++ b/gix-blame/src/file/mod.rs
@@ -341,7 +341,7 @@ fn process_changes(
         let mut offset_in_destination = Offset::Added(0);
 
         let mut changes_iter = changes.iter();
-        let mut change: Option<Change> = changes_iter.next().map(|change| change.clone());
+        let mut change: Option<Change> = changes_iter.next().cloned();
 
         loop {
             (hunk, change) = process_change(
@@ -353,7 +353,7 @@ fn process_changes(
                 change,
             );
 
-            change = change.or_else(|| changes_iter.next().map(|change| change.clone()));
+            change = change.or_else(|| changes_iter.next().cloned());
 
             if hunk.is_none() {
                 break;

--- a/gix-blame/src/file/mod.rs
+++ b/gix-blame/src/file/mod.rs
@@ -320,36 +320,43 @@ fn process_change(
 
 /// Consume `hunks_to_blame` and `changes` to pair up matches ranges (also overlapping) with each other.
 /// Once a match is found, it's pushed onto `out`.
+///
+/// `process_changes` assumes that ranges coming from the same *Source File* can and do
+/// occasionally overlap. If it were a desirable property of the blame algorithm as a whole to
+/// never have two different lines from a *Blamed File* mapped to the same line in a *Source File*,
+/// this property would need to be enforced at a higher level than `process_changes` if which case
+/// the nested loops could potentially be flattened into one.
 fn process_changes(
     hunks_to_blame: Vec<UnblamedHunk>,
     changes: Vec<Change>,
     suspect: ObjectId,
     parent: ObjectId,
 ) -> Vec<UnblamedHunk> {
-    let mut hunks_iter = hunks_to_blame.into_iter();
-    let mut changes_iter = changes.into_iter();
-
-    let mut hunk = hunks_iter.next();
-    let mut change = changes_iter.next();
-
     let mut new_hunks_to_blame = Vec::new();
-    let mut offset_in_destination = Offset::Added(0);
 
-    loop {
-        (hunk, change) = process_change(
-            &mut new_hunks_to_blame,
-            &mut offset_in_destination,
-            suspect,
-            parent,
-            hunk,
-            change,
-        );
+    for hunk in hunks_to_blame {
+        let mut hunk = Some(hunk);
 
-        hunk = hunk.or_else(|| hunks_iter.next());
-        change = change.or_else(|| changes_iter.next());
+        let mut offset_in_destination = Offset::Added(0);
 
-        if hunk.is_none() && change.is_none() {
-            break;
+        let mut changes_iter = changes.iter();
+        let mut change: Option<Change> = changes_iter.next().map(|change| change.clone());
+
+        loop {
+            (hunk, change) = process_change(
+                &mut new_hunks_to_blame,
+                &mut offset_in_destination,
+                suspect,
+                parent,
+                hunk,
+                change,
+            );
+
+            change = change.or_else(|| changes_iter.next().map(|change| change.clone()));
+
+            if hunk.is_none() {
+                break;
+            }
         }
     }
     new_hunks_to_blame

--- a/gix-blame/src/lib.rs
+++ b/gix-blame/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! ### Terminology
 //!
-//! * **Source File**
-//!    - The file as it exists in `HEAD`.
-//!    - the initial state with all lines that we need to associate with a *Source File*.
 //! * **Blamed File**
+//!    - The file as it exists in `HEAD`.
+//!    - the initial state with all lines that we need to associate with a *Blamed File*.
+//! * **Source File**
 //!    - A file at a version (i.e. commit) that introduces hunks into the final 'image'.
 //! * **Suspects**
 //!    - The versions of the files that can contain hunks that we could use in the final 'image'

--- a/gix-blame/src/lib.rs
+++ b/gix-blame/src/lib.rs
@@ -4,13 +4,13 @@
 //!
 //! * **Blamed File**
 //!    - The file as it exists in `HEAD`.
-//!    - the initial state with all lines that we need to associate with a *Blamed File*.
+//!    - the initial state with all lines that we need to associate with a *Source File*.
 //! * **Source File**
-//!    - A file at a version (i.e. commit) that introduces hunks into the final 'image'.
+//!    - A file at a version (i.e., commit) that introduces hunks into the final 'image' of the *Blamed File*.
 //! * **Suspects**
 //!    - The versions of the files that can contain hunks that we could use in the final 'image'
 //!    - multiple at the same time as the commit-graph may split up.
-//!    - turns into *Source File* once we have found an association into the *Blamed File*.
+//!    - They turn into a *Source File* once we have found an association into the *Blamed File*.
 #![deny(rust_2018_idioms, missing_docs)]
 #![forbid(unsafe_code)]
 

--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -353,7 +353,10 @@ pub(crate) enum Either<T, U> {
 }
 
 /// A single change between two blobs, or an unchanged region.
-#[derive(Debug, PartialEq)]
+///
+/// Line numbers refer to the file that is referred to as `after` or `NewOrDestination`, depending
+/// on the context.
+#[derive(Clone, Debug, PartialEq)]
 pub enum Change {
     /// A range of tokens that wasn't changed.
     Unchanged(Range<u32>),


### PR DESCRIPTION
- Provide more context in assertion
- Correctly process overlapping unblamed hunks
- Use *Blamed File* and *Source File* more consistently

This PR finally, I hope!, fixes the last remaining larger issue in the blame algorithm.

Previously, `process_changes` assumed that `UnblamedHunk`s would never overlap and produced incorrect results if they did. This constraint has been lifted.

As a consequence, the high-level assumption that two different lines from a *Blamed File* can never map to the same line in a *Source File* has been lifted as well. There is not really a way to enforce this constraint in the blame algorithm alone as it heavily depends on the algorithm used for diffing.

Running `gix blame CREDITS` in the Linux kernel, I was not able to detect any meaningful changes between this PR and `main` in terms of performance. `process_changes` barely shows up in the profile (at about 0.1 % in both cases), so the impact seems to be negligible.

Fixes #1847.
