### PR TITLE
Don't install `openssl` and `gnu-sed` on macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,9 +171,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Setup dependencies (macos)
-        if: startsWith(matrix.os, 'macos')
-        run: brew install openssl gnu-sed
       - name: cargo check default features
         if: startsWith(matrix.os, 'windows')
         run: cargo check --workspace --bins --examples


### PR DESCRIPTION
Rationale:

- For `openssl`, the `macos-latest` image already has it, and the installation is currently (and has for some time been) a no-op:

      Warning: openssl@3 3.5.0 is already installed and up-to-date.
      To reinstall 3.5.0, run:
        brew reinstall openssl@3

  The workflow has attempted to install `openssl` explicitly via `brew` since a7db791 ([#295](https://github.com/GitoxideLabs/gitoxide/pull/295)). This was described as an effort to fix the build on macOS 11, and from context it looks like it was useful, and likely necessaryn at the time. But `macos-latest` is currently macOS 14 or higher.

  More significantly, `openssl` on the macOS CI runners had been version 1.1, but it is version 3 since [actions/runner-images#10851](https://github.com/actions/runner-images/pull/10851). The images seem to keep a current version. If that changes, then it might once again be a good idea to upgrade via `brew`, but might not.

- For `gnu-sed`, we are not using it. The executable was being set up on CI only as `gsed`:

      ==> Downloading https://ghcr.io/v2/homebrew/core/gnu-sed/manifests/4.9-3
      ==> Fetching gnu-sed
      ==> Downloading https://ghcr.io/v2/homebrew/core/gnu-sed/blobs/sha256:829d21105387351f6c7b07cd845d7e234c1a460ea5e50cc2f5dbcface45e378d
      ==> Pouring gnu-sed--4.9.arm64_sonoma.bottle.3.tar.gz
      ==> Caveats
      GNU "sed" has been installed as "gsed".
      If you need to use it as "sed", you can add a "gnubin" directory
      to your PATH from your bashrc like:

          PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"
      ==> Summary
      🍺  /opt/homebrew/Cellar/gnu-sed/4.9: 13 files, 616.4KB

  But no references to `gsed` remain. Specifically, in [#392](https://github.com/GitoxideLabs/gitoxide/pull/392), `gsed` was used in `make_rebase_i_repo.sh` as of ac3c8c7. But it was removed in fc61c0d, which was later in that same PR. There have been no uses of `gsed` in this project since then.