### PR TITLE
Refactor crate loops in CI `wasm` jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,14 +387,39 @@ jobs:
         if: endsWith(matrix.target, '-wasi')
         run: |
           set +x
-          for name in gix-sec; do
-            (cd -- "$name" && cargo build --target "$TARGET")
+          for crate in gix-sec; do
+            (cd -- "$crate" && cargo build --target "$TARGET")
           done
       - name: crates without feature toggles
         run: |
+          crates=(
+            gix-actor
+            gix-attributes
+            gix-bitmap
+            gix-chunk
+            gix-command
+            gix-commitgraph
+            gix-config-value
+            gix-date
+            gix-glob
+            gix-hash
+            gix-hashtable
+            gix-mailmap
+            gix-object
+            gix-packetline
+            gix-path
+            gix-pathspec
+            gix-prompt
+            gix-quote
+            gix-refspec
+            gix-revision
+            gix-traverse
+            gix-url
+            gix-validate
+          )
           set +x
-          for name in gix-actor gix-attributes gix-bitmap gix-chunk gix-command gix-commitgraph gix-config-value gix-date gix-glob gix-hash gix-hashtable gix-mailmap gix-object gix-packetline gix-path gix-pathspec gix-prompt gix-quote gix-refspec gix-revision gix-traverse gix-url gix-validate; do
-            (cd -- "$name" && cargo build --target "$TARGET")
+          for crate in "${crates[@]}"; do
+            (cd -- "$crate" && cargo build --target "$TARGET")
           done
       - name: features of gix-features
         run: |
@@ -405,8 +430,8 @@ jobs:
       - name: crates with 'wasm' feature
         run: |
           set +x
-          for name in gix-pack; do
-            (cd -- "$name" && cargo build --features wasm --target "$TARGET")
+          for crate in gix-pack; do
+            (cd -- "$crate" && cargo build --features wasm --target "$TARGET")
           done
       - name: gix-pack with all features (including wasm)
         run: cd gix-pack && cargo build --all-features --target "$TARGET"


### PR DESCRIPTION
This is a minor refactoring that should not affect behavior. There are two changes:

- Use a `bash` array for the long list of crates without feature toggles, to make clear what crates are covered in this loop, and so any changes to the list produce clearer diffs, and to improve the general readability of the workflow.

- In each loop, rename the variable from `name` to `crate`, to make the meaning clearer. The other significant kind of loop in this job is over `feature`, so this makes the contrast clear. (Other loops over array items in other jobs in the workflow, where the general variable name `name` could be used, already instead use the more specific variable names `package` and `cmd`.)

This may slightly mitigate #1988 in that it makes it easier for the big list to be manually inspected, but it does not fix that issue.

I'm doing this before opening a PR related to #1989 since otherwise there is likely to be a conflict between them. (Such a PR may modify the bodies of the loops--to verify that they work with `-p` as intended--which for each loop would modify a line adjacent to the line modified here.)