### PR TITLE
Stop special-casing RUSTSEC-2025-0021 for `cargo deny` on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,28 +330,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install tomlq
-        run: |
-          # The runner already has the `yq` command but not its associated `tomlq` command.
-          sudo apt-get update
-          sudo apt-get install yq
-      - name: Strict check, but omit gix-testtools
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check advisories
-          arguments: --workspace --all-features --exclude gix-testtools
-      - name: Configure less strict check
-        run: |
-          filter='.advisories.ignore += [
-            { id: "RUSTSEC-2025-0021", reason: "gix-testtools can’t upgrade from old gix-features yet" }
-          ]'
-          tomlq "$filter" deny.toml --toml-output > deny-but-ignore-RUSTSEC-2025-0021.toml
-      - name: Less strict check, but include gix-testtools
-        uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check advisories
           arguments: --workspace --all-features
-          command-arguments: --config deny-but-ignore-RUSTSEC-2025-0021.toml
 
   cargo-deny:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit 67d9bf494315a6b5b172bd81b330b1c60d16d46d, but not the other changes from #1927.

`gix-testtools` 0.16.1 has the change in 9b12d50 (#1972) from depending on previous SemVer-incompatible versions of `gix-*` crates to depending on the current versions. Since then, nothing affected by [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436.html) appears in our dependency tree, and it is no longer necessary or desirable to use a more complicated `cargo deny check advisories` scanning approach allowing that advisory through `gix-testtools`.

---

[The scan](https://github.com/GitoxideLabs/gitoxide/actions/runs/14827065312/job/41621720437?pr=1991) looks good. As expected, even without special casing that advisory, the `advisories` check passes.

Note that this is not related to #1989, except in that they are both unblocked by #1972.