### PR TITLE
Let `gix-testtools` use `gix-*` workspace crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
         run: |
           set +x
           for crate in gix-sec; do
-            (cd -- "$crate" && cargo build --target "$TARGET")
+            cargo build -p "$crate" --target "$TARGET"
           done
       - name: crates without feature toggles
         run: |
@@ -401,22 +401,22 @@ jobs:
           )
           set +x
           for crate in "${crates[@]}"; do
-            (cd -- "$crate" && cargo build --target "$TARGET")
+            cargo build -p "$crate" --target "$TARGET"
           done
       - name: features of gix-features
         run: |
           set +x
           for feature in progress parallel io-pipe crc32 zlib cache-efficiency-debug; do
-            (cd gix-features && cargo build --features "$feature" --target "$TARGET")
+            cargo build -p gix-features --features "$feature" --target "$TARGET"
           done
       - name: crates with 'wasm' feature
         run: |
           set +x
           for crate in gix-pack; do
-            (cd -- "$crate" && cargo build --features wasm --target "$TARGET")
+            cargo build -p "$crate" --features wasm --target "$TARGET"
           done
       - name: gix-pack with all features (including wasm)
-        run: cd gix-pack && cargo build --all-features --target "$TARGET"
+        run: cargo build -p gix-pack --all-features --target "$TARGET"
 
   check-packetline:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
  "futures-lite",
  "gitoxide-core",
  "gix",
- "gix-features 0.42.1",
+ "gix-features",
  "is-terminal",
  "once_cell",
  "prodash",
@@ -1375,54 +1375,54 @@ dependencies = [
  "async-std",
  "document-features",
  "gix",
- "gix-actor 0.35.1",
+ "gix-actor",
  "gix-archive",
- "gix-attributes 0.26.0",
+ "gix-attributes",
  "gix-blame",
  "gix-command",
- "gix-commitgraph 0.28.0",
+ "gix-commitgraph",
  "gix-config",
  "gix-credentials",
- "gix-date 0.10.1",
+ "gix-date",
  "gix-diff",
  "gix-dir",
- "gix-discover 0.40.1",
- "gix-features 0.42.1",
+ "gix-discover",
+ "gix-features",
  "gix-filter",
- "gix-fs 0.15.0",
- "gix-glob 0.20.0",
- "gix-hash 0.18.0",
- "gix-hashtable 0.8.1",
- "gix-ignore 0.15.0",
- "gix-index 0.40.0",
- "gix-lock 17.1.0",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
  "gix-mailmap",
  "gix-merge",
  "gix-negotiate",
- "gix-object 0.49.1",
+ "gix-object",
  "gix-odb",
  "gix-pack",
- "gix-path 0.10.17",
+ "gix-path",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
- "gix-ref 0.52.1",
+ "gix-ref",
  "gix-refspec",
  "gix-revision",
- "gix-revwalk 0.20.1",
- "gix-sec 0.11.0",
+ "gix-revwalk",
+ "gix-sec",
  "gix-shallow",
  "gix-status",
  "gix-submodule",
- "gix-tempfile 17.1.0",
+ "gix-tempfile",
  "gix-testtools",
- "gix-trace 0.1.12",
+ "gix-trace",
  "gix-transport",
- "gix-traverse 0.46.1",
+ "gix-traverse",
  "gix-url",
- "gix-utils 0.3.0",
- "gix-validate 0.10.0",
- "gix-worktree 0.41.0",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
  "gix-worktree-state",
  "gix-worktree-stream",
  "insta",
@@ -1447,27 +1447,13 @@ version = "0.35.1"
 dependencies = [
  "bstr",
  "document-features",
- "gix-date 0.10.1",
- "gix-hash 0.18.0",
+ "gix-date",
+ "gix-hash",
  "gix-testtools",
- "gix-utils 0.3.0",
+ "gix-utils",
  "itoa",
  "pretty_assertions",
  "serde",
- "thiserror 2.0.12",
- "winnow",
-]
-
-[[package]]
-name = "gix-actor"
-version = "0.35.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b300e6e4f31f3f6bd2de5e2b0caab192ced00dc0fcd0f7cc56e28c575c8e1ff"
-dependencies = [
- "bstr",
- "gix-date 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa",
  "thiserror 2.0.12",
  "winnow",
 ]
@@ -1479,15 +1465,15 @@ dependencies = [
  "bstr",
  "document-features",
  "flate2",
- "gix-attributes 0.26.0",
- "gix-date 0.10.1",
+ "gix-attributes",
+ "gix-date",
  "gix-filter",
- "gix-hash 0.18.0",
- "gix-object 0.49.1",
+ "gix-hash",
+ "gix-object",
  "gix-odb",
- "gix-path 0.10.17",
+ "gix-path",
  "gix-testtools",
- "gix-worktree 0.41.0",
+ "gix-worktree",
  "gix-worktree-stream",
  "jiff",
  "tar",
@@ -1501,12 +1487,12 @@ version = "0.26.0"
 dependencies = [
  "bstr",
  "document-features",
- "gix-fs 0.15.0",
- "gix-glob 0.20.0",
- "gix-path 0.10.17",
- "gix-quote 0.6.0",
+ "gix-fs",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
  "gix-testtools",
- "gix-trace 0.1.12",
+ "gix-trace",
  "kstring",
  "serde",
  "smallvec",
@@ -1515,36 +1501,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-attributes"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e26b3ac280ddb25bb6980d34f4a82ee326f78bf2c6d4ea45eef2d940048b8e"
-dependencies = [
- "bstr",
- "gix-glob 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-quote 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "kstring",
- "smallvec",
- "thiserror 2.0.12",
- "unicode-bom",
-]
-
-[[package]]
 name = "gix-bitmap"
 version = "0.2.14"
 dependencies = [
  "gix-testtools",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "gix-bitmap"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540"
-dependencies = [
  "thiserror 2.0.12",
 ]
 
@@ -1552,21 +1512,21 @@ dependencies = [
 name = "gix-blame"
 version = "0.2.1"
 dependencies = [
- "gix-commitgraph 0.28.0",
- "gix-date 0.10.1",
+ "gix-commitgraph",
+ "gix-date",
  "gix-diff",
  "gix-filter",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
  "gix-odb",
- "gix-ref 0.52.1",
- "gix-revwalk 0.20.1",
+ "gix-ref",
+ "gix-revwalk",
  "gix-testtools",
- "gix-trace 0.1.12",
- "gix-traverse 0.46.1",
- "gix-worktree 0.41.0",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
  "pretty_assertions",
  "smallvec",
  "thiserror 2.0.12",
@@ -1580,23 +1540,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-chunk"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f"
-dependencies = [
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "gix-command"
 version = "0.6.0"
 dependencies = [
  "bstr",
- "gix-path 0.10.17",
- "gix-quote 0.6.0",
+ "gix-path",
+ "gix-quote",
  "gix-testtools",
- "gix-trace 0.1.12",
+ "gix-trace",
  "once_cell",
  "shell-words",
 ]
@@ -1607,25 +1558,12 @@ version = "0.28.0"
 dependencies = [
  "bstr",
  "document-features",
- "gix-chunk 0.4.11",
- "gix-date 0.10.1",
- "gix-hash 0.18.0",
+ "gix-chunk",
+ "gix-date",
+ "gix-hash",
  "gix-testtools",
  "memmap2",
  "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "gix-commitgraph"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05050fd6caa6c731fe3bd7f9485b3b520be062d3d139cb2626e052d6c127951"
-dependencies = [
- "bstr",
- "gix-chunk 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap2",
  "thiserror 2.0.12",
 ]
 
@@ -1637,11 +1575,11 @@ dependencies = [
  "criterion",
  "document-features",
  "gix-config-value",
- "gix-features 0.42.1",
- "gix-glob 0.20.0",
- "gix-path 0.10.17",
- "gix-ref 0.52.1",
- "gix-sec 0.11.0",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
  "memchr",
  "once_cell",
  "serde",
@@ -1659,9 +1597,9 @@ dependencies = [
  "bytesize",
  "cap",
  "gix-config",
- "gix-path 0.10.17",
- "gix-ref 0.52.1",
- "gix-sec 0.11.0",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
  "gix-testtools",
  "serial_test",
 ]
@@ -1673,7 +1611,7 @@ dependencies = [
  "bitflags 2.9.0",
  "bstr",
  "document-features",
- "gix-path 0.10.17",
+ "gix-path",
  "libc",
  "serde",
  "thiserror 2.0.12",
@@ -1687,11 +1625,11 @@ dependencies = [
  "document-features",
  "gix-command",
  "gix-config-value",
- "gix-path 0.10.17",
+ "gix-path",
  "gix-prompt",
- "gix-sec 0.11.0",
+ "gix-sec",
  "gix-testtools",
- "gix-trace 0.1.12",
+ "gix-trace",
  "gix-url",
  "once_cell",
  "serde",
@@ -1704,7 +1642,7 @@ version = "0.10.1"
 dependencies = [
  "bstr",
  "document-features",
- "gix-hash 0.18.0",
+ "gix-hash",
  "gix-testtools",
  "itoa",
  "jiff",
@@ -1716,38 +1654,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-date"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a98593f1f1e14b9fa15c5b921b2c465e904d698b9463e21bb377be8376c3c1a"
-dependencies = [
- "bstr",
- "itoa",
- "jiff",
- "smallvec",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "gix-diff"
 version = "0.52.1"
 dependencies = [
  "bstr",
  "document-features",
  "getrandom 0.2.15",
- "gix-attributes 0.26.0",
+ "gix-attributes",
  "gix-command",
  "gix-filter",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
- "gix-path 0.10.17",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
  "gix-pathspec",
- "gix-tempfile 17.1.0",
- "gix-trace 0.1.12",
- "gix-traverse 0.46.1",
- "gix-worktree 0.41.0",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
  "imara-diff",
  "serde",
  "thiserror 2.0.12",
@@ -1759,15 +1684,15 @@ version = "0.0.0"
 dependencies = [
  "gix-diff",
  "gix-filter",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
  "gix-odb",
  "gix-pathspec",
  "gix-testtools",
- "gix-traverse 0.46.1",
- "gix-worktree 0.41.0",
+ "gix-traverse",
+ "gix-worktree",
  "insta",
  "pretty_assertions",
  "shell-words",
@@ -1778,17 +1703,17 @@ name = "gix-dir"
 version = "0.14.1"
 dependencies = [
  "bstr",
- "gix-discover 0.40.1",
- "gix-fs 0.15.0",
- "gix-ignore 0.15.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
- "gix-path 0.10.17",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
  "gix-pathspec",
  "gix-testtools",
- "gix-trace 0.1.12",
- "gix-utils 0.3.0",
- "gix-worktree 0.41.0",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
  "pretty_assertions",
  "thiserror 2.0.12",
 ]
@@ -1800,31 +1725,15 @@ dependencies = [
  "bstr",
  "defer",
  "dunce",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-path 0.10.17",
- "gix-ref 0.52.1",
- "gix-sec 0.11.0",
+ "gix-fs",
+ "gix-hash",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
  "gix-testtools",
  "is_ci",
  "serial_test",
  "tempfile",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "gix-discover"
-version = "0.40.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccfe3e25b4ea46083916c56db3ba9d1e6ef6dce54da485f0463f9fc0fe1837c"
-dependencies = [
- "bstr",
- "dunce",
- "gix-fs 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-ref 0.52.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-sec 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.12",
 ]
 
@@ -1839,28 +1748,14 @@ dependencies = [
  "crossbeam-channel",
  "document-features",
  "flate2",
- "gix-path 0.10.17",
- "gix-trace 0.1.12",
- "gix-utils 0.3.0",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
  "libc",
  "once_cell",
  "parking_lot",
  "prodash",
  "thiserror 2.0.12",
- "walkdir",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f4399af6ec4fd9db84dd4cf9656c5c785ab492ab40a7c27ea92b4241923fed"
-dependencies = [
- "gix-path 0.10.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc",
- "prodash",
  "walkdir",
 ]
 
@@ -1874,17 +1769,17 @@ version = "0.19.1"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes 0.26.0",
+ "gix-attributes",
  "gix-command",
- "gix-hash 0.18.0",
- "gix-object 0.49.1",
+ "gix-hash",
+ "gix-object",
  "gix-packetline-blocking",
- "gix-path 0.10.17",
- "gix-quote 0.6.0",
+ "gix-path",
+ "gix-quote",
  "gix-testtools",
- "gix-trace 0.1.12",
- "gix-utils 0.3.0",
- "gix-worktree 0.41.0",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
  "serial_test",
  "smallvec",
  "thiserror 2.0.12",
@@ -1897,9 +1792,9 @@ dependencies = [
  "bstr",
  "crossbeam-channel",
  "fastrand",
- "gix-features 0.42.1",
- "gix-path 0.10.17",
- "gix-utils 0.3.0",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
  "is_ci",
  "serde",
  "tempfile",
@@ -1907,26 +1802,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-fs"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a0637149b4ef24d3ea55f81f77231401c8463fae6da27331c987957eb597c7"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "gix-fsck"
 version = "0.11.1"
 dependencies = [
- "gix-hash 0.18.0",
- "gix-hashtable 0.8.1",
- "gix-object 0.49.1",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
  "gix-odb",
  "gix-testtools",
 ]
@@ -1938,22 +1819,10 @@ dependencies = [
  "bitflags 2.9.0",
  "bstr",
  "document-features",
- "gix-features 0.42.1",
- "gix-path 0.10.17",
+ "gix-features",
+ "gix-path",
  "gix-testtools",
  "serde",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2926b03666e83b8d01c10cf06e5733521aacbd2d97179a4c9b1fdddabb9e937d"
-dependencies = [
- "bitflags 2.9.0",
- "bstr",
- "gix-features 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1962,7 +1831,7 @@ version = "0.18.0"
 dependencies = [
  "document-features",
  "faster-hex",
- "gix-features 0.42.1",
+ "gix-features",
  "gix-testtools",
  "serde",
  "sha1-checked",
@@ -1970,33 +1839,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-hash"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4900562c662852a6b42e2ef03442eccebf24f047d8eab4f23bc12ef0d785d8"
-dependencies = [
- "faster-hex",
- "gix-features 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha1-checked",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "gix-hashtable"
 version = "0.8.1"
 dependencies = [
- "gix-hash 0.18.0",
- "hashbrown 0.14.5",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-hashtable"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b5cb3c308b4144f2612ff64e32130e641279fcf1a84d8d40dad843b4f64904"
-dependencies = [
- "gix-hash 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-hash",
  "hashbrown 0.14.5",
  "parking_lot",
 ]
@@ -2007,25 +1853,12 @@ version = "0.15.0"
 dependencies = [
  "bstr",
  "document-features",
- "gix-fs 0.15.0",
- "gix-glob 0.20.0",
- "gix-path 0.10.17",
+ "gix-fs",
+ "gix-glob",
+ "gix-path",
  "gix-testtools",
- "gix-trace 0.1.12",
+ "gix-trace",
  "serde",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-ignore"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae358c3c96660b10abc7da63c06788dfded603e717edbd19e38c6477911b71c8"
-dependencies = [
- "bstr",
- "gix-glob 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-trace 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bom",
 ]
 
@@ -2038,50 +1871,22 @@ dependencies = [
  "document-features",
  "filetime",
  "fnv",
- "gix-bitmap 0.2.14",
- "gix-features 0.42.1",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-lock 17.1.0",
- "gix-object 0.49.1",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
  "gix-testtools",
- "gix-traverse 0.46.1",
- "gix-utils 0.3.0",
- "gix-validate 0.10.0",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
  "hashbrown 0.14.5",
  "itoa",
  "libc",
  "memmap2",
  "rustix 1.0.7",
  "serde",
- "smallvec",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "gix-index"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d505aea7d7c4267a3153cb90c712a89970b4dd02a2cb3205be322891f530b5"
-dependencies = [
- "bitflags 2.9.0",
- "bstr",
- "filetime",
- "fnv",
- "gix-bitmap 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-fs 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-lock 17.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.49.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-traverse 0.46.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.14.5",
- "itoa",
- "libc",
- "memmap2",
- "rustix 1.0.7",
  "smallvec",
  "thiserror 2.0.12",
 ]
@@ -2092,10 +1897,10 @@ version = "0.0.0"
 dependencies = [
  "bstr",
  "filetime",
- "gix-features 0.42.1",
- "gix-hash 0.18.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
+ "gix-features",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
  "gix-odb",
  "gix-testtools",
 ]
@@ -2108,20 +1913,9 @@ version = "0.0.0"
 name = "gix-lock"
 version = "17.1.0"
 dependencies = [
- "gix-tempfile 17.1.0",
- "gix-utils 0.3.0",
+ "gix-tempfile",
+ "gix-utils",
  "tempfile",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "gix-lock"
-version = "17.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796"
-dependencies = [
- "gix-tempfile 17.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.12",
 ]
 
@@ -2141,8 +1935,8 @@ version = "0.27.1"
 dependencies = [
  "bstr",
  "document-features",
- "gix-actor 0.35.1",
- "gix-date 0.10.1",
+ "gix-actor",
+ "gix-date",
  "gix-testtools",
  "serde",
  "thiserror 2.0.12",
@@ -2157,20 +1951,20 @@ dependencies = [
  "gix-command",
  "gix-diff",
  "gix-filter",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
  "gix-odb",
- "gix-path 0.10.17",
- "gix-quote 0.6.0",
+ "gix-path",
+ "gix-quote",
  "gix-revision",
- "gix-revwalk 0.20.1",
- "gix-tempfile 17.1.0",
+ "gix-revwalk",
+ "gix-tempfile",
  "gix-testtools",
- "gix-trace 0.1.12",
- "gix-utils 0.3.0",
- "gix-worktree 0.41.0",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
  "imara-diff",
  "pretty_assertions",
  "serde",
@@ -2183,13 +1977,13 @@ name = "gix-negotiate"
 version = "0.20.1"
 dependencies = [
  "bitflags 2.9.0",
- "gix-commitgraph 0.28.0",
- "gix-date 0.10.1",
- "gix-hash 0.18.0",
- "gix-object 0.49.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
  "gix-odb",
- "gix-ref 0.52.1",
- "gix-revwalk 0.20.1",
+ "gix-ref",
+ "gix-revwalk",
  "gix-testtools",
  "smallvec",
  "thiserror 2.0.12",
@@ -2206,16 +2000,16 @@ dependencies = [
  "bstr",
  "criterion",
  "document-features",
- "gix-actor 0.35.1",
- "gix-date 0.10.1",
- "gix-features 0.42.1",
- "gix-hash 0.18.0",
- "gix-hashtable 0.8.1",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
  "gix-odb",
- "gix-path 0.10.17",
+ "gix-path",
  "gix-testtools",
- "gix-utils 0.3.0",
- "gix-validate 0.10.0",
+ "gix-utils",
+ "gix-validate",
  "itoa",
  "pretty_assertions",
  "serde",
@@ -2226,41 +2020,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-object"
-version = "0.49.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d957ca3640c555d48bb27f8278c67169fa1380ed94f6452c5590742524c40fbb"
-dependencies = [
- "bstr",
- "gix-actor 0.35.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-date 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hashtable 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa",
- "smallvec",
- "thiserror 2.0.12",
- "winnow",
-]
-
-[[package]]
 name = "gix-odb"
 version = "0.69.1"
 dependencies = [
  "arc-swap",
  "document-features",
- "gix-date 0.10.1",
- "gix-features 0.42.1",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-hashtable 0.8.1",
- "gix-object 0.49.1",
+ "gix-date",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
  "gix-pack",
- "gix-path 0.10.17",
- "gix-quote 0.6.0",
+ "gix-path",
+ "gix-quote",
  "parking_lot",
  "serde",
  "tempfile",
@@ -2273,11 +2046,11 @@ version = "0.0.0"
 dependencies = [
  "crossbeam-channel",
  "filetime",
- "gix-actor 0.35.1",
- "gix-date 0.10.1",
- "gix-features 0.42.1",
- "gix-hash 0.18.0",
- "gix-object 0.49.1",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-object",
  "gix-odb",
  "gix-pack",
  "gix-testtools",
@@ -2291,16 +2064,16 @@ version = "0.59.1"
 dependencies = [
  "clru",
  "document-features",
- "gix-chunk 0.4.11",
+ "gix-chunk",
  "gix-diff",
- "gix-features 0.42.1",
- "gix-hash 0.18.0",
- "gix-hashtable 0.8.1",
- "gix-object 0.49.1",
- "gix-path 0.10.17",
- "gix-tempfile 17.1.0",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
  "gix-testtools",
- "gix-traverse 0.46.1",
+ "gix-traverse",
  "memmap2",
  "parking_lot",
  "serde",
@@ -2314,13 +2087,13 @@ name = "gix-pack-tests"
 version = "0.0.0"
 dependencies = [
  "bstr",
- "gix-features 0.42.1",
- "gix-hash 0.18.0",
- "gix-object 0.49.1",
+ "gix-features",
+ "gix-hash",
+ "gix-object",
  "gix-odb",
  "gix-pack",
  "gix-testtools",
- "gix-traverse 0.46.1",
+ "gix-traverse",
  "maplit",
  "memmap2",
 ]
@@ -2335,10 +2108,10 @@ dependencies = [
  "faster-hex",
  "futures-io",
  "futures-lite",
- "gix-hash 0.18.0",
+ "gix-hash",
  "gix-odb",
  "gix-pack",
- "gix-trace 0.1.12",
+ "gix-trace",
  "maybe-async",
  "pin-project-lite",
  "serde",
@@ -2352,7 +2125,7 @@ dependencies = [
  "bstr",
  "document-features",
  "faster-hex",
- "gix-trace 0.1.12",
+ "gix-trace",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -2363,8 +2136,8 @@ version = "0.10.17"
 dependencies = [
  "bstr",
  "gix-testtools",
- "gix-trace 0.1.12",
- "gix-validate 0.10.0",
+ "gix-trace",
+ "gix-validate",
  "home",
  "known-folders",
  "once_cell",
@@ -2375,29 +2148,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-path"
-version = "0.10.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c091d2e887e02c3462f52252c5ea61150270c0f2657b642e8d0d6df56c16e642"
-dependencies = [
- "bstr",
- "gix-trace 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "home",
- "once_cell",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "gix-pathspec"
 version = "0.11.0"
 dependencies = [
  "bitflags 2.9.0",
  "bstr",
- "gix-attributes 0.26.0",
+ "gix-attributes",
  "gix-config-value",
- "gix-glob 0.20.0",
- "gix-path 0.10.17",
+ "gix-glob",
+ "gix-path",
  "gix-testtools",
  "once_cell",
  "serial_test",
@@ -2429,20 +2188,20 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "gix-credentials",
- "gix-date 0.10.1",
- "gix-features 0.42.1",
- "gix-hash 0.18.0",
- "gix-lock 17.1.0",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
  "gix-negotiate",
- "gix-object 0.49.1",
+ "gix-object",
  "gix-packetline",
- "gix-ref 0.52.1",
+ "gix-ref",
  "gix-refspec",
- "gix-revwalk 0.20.1",
+ "gix-revwalk",
  "gix-shallow",
- "gix-trace 0.1.12",
+ "gix-trace",
  "gix-transport",
- "gix-utils 0.3.0",
+ "gix-utils",
  "maybe-async",
  "serde",
  "thiserror 2.0.12",
@@ -2454,18 +2213,7 @@ name = "gix-quote"
 version = "0.6.0"
 dependencies = [
  "bstr",
- "gix-utils 0.3.0",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "gix-quote"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a375a75b4d663e8bafe3bf4940a18a23755644c13582fa326e99f8f987d83fd"
-dependencies = [
- "bstr",
- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-utils",
  "thiserror 2.0.12",
 ]
 
@@ -2478,41 +2226,20 @@ name = "gix-ref"
 version = "0.52.1"
 dependencies = [
  "document-features",
- "gix-actor 0.35.1",
- "gix-date 0.10.1",
- "gix-features 0.42.1",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-lock 17.1.0",
- "gix-object 0.49.1",
- "gix-path 0.10.17",
- "gix-tempfile 17.1.0",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
  "gix-testtools",
- "gix-utils 0.3.0",
- "gix-validate 0.10.0",
+ "gix-utils",
+ "gix-validate",
  "memmap2",
  "serde",
- "thiserror 2.0.12",
- "winnow",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.52.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1b7985657029684d759f656b09abc3e2c73085596d5cdb494428823970a7762"
-dependencies = [
- "gix-actor 0.35.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-fs 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-lock 17.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.49.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-tempfile 17.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-utils 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap2",
  "thiserror 2.0.12",
  "winnow",
 ]
@@ -2521,18 +2248,18 @@ dependencies = [
 name = "gix-ref-tests"
 version = "0.0.0"
 dependencies = [
- "gix-actor 0.35.1",
- "gix-date 0.10.1",
- "gix-discover 0.40.1",
- "gix-features 0.42.1",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-lock 17.1.0",
- "gix-object 0.49.1",
+ "gix-actor",
+ "gix-date",
+ "gix-discover",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
  "gix-odb",
- "gix-ref 0.52.1",
+ "gix-ref",
  "gix-testtools",
- "gix-validate 0.10.0",
+ "gix-validate",
  "insta",
 ]
 
@@ -2541,10 +2268,10 @@ name = "gix-refspec"
 version = "0.30.1"
 dependencies = [
  "bstr",
- "gix-hash 0.18.0",
+ "gix-hash",
  "gix-revision",
  "gix-testtools",
- "gix-validate 0.10.0",
+ "gix-validate",
  "smallvec",
  "thiserror 2.0.12",
 ]
@@ -2556,15 +2283,15 @@ dependencies = [
  "bitflags 2.9.0",
  "bstr",
  "document-features",
- "gix-commitgraph 0.28.0",
- "gix-date 0.10.1",
- "gix-hash 0.18.0",
- "gix-hashtable 0.8.1",
- "gix-object 0.49.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
  "gix-odb",
- "gix-revwalk 0.20.1",
+ "gix-revwalk",
  "gix-testtools",
- "gix-trace 0.1.12",
+ "gix-trace",
  "permutohedron",
  "serde",
  "thiserror 2.0.12",
@@ -2574,27 +2301,12 @@ dependencies = [
 name = "gix-revwalk"
 version = "0.20.1"
 dependencies = [
- "gix-commitgraph 0.28.0",
- "gix-date 0.10.1",
- "gix-hash 0.18.0",
- "gix-hashtable 0.8.1",
- "gix-object 0.49.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
  "gix-testtools",
- "smallvec",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "gix-revwalk"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc756b73225bf005ddeb871d1ca7b3c33e2417d0d53e56effa5a36765b52b28"
-dependencies = [
- "gix-commitgraph 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-date 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hashtable 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.49.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec",
  "thiserror 2.0.12",
 ]
@@ -2605,22 +2317,10 @@ version = "0.11.0"
 dependencies = [
  "bitflags 2.9.0",
  "document-features",
- "gix-path 0.10.17",
+ "gix-path",
  "libc",
  "serde",
  "tempfile",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0dabbc78c759ecc006b970339394951b2c8e1e38a37b072c105b80b84c308fd"
-dependencies = [
- "bitflags 2.9.0",
- "gix-path 0.10.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc",
  "windows-sys 0.59.0",
 ]
 
@@ -2633,8 +2333,8 @@ name = "gix-shallow"
 version = "0.4.0"
 dependencies = [
  "bstr",
- "gix-hash 0.18.0",
- "gix-lock 17.1.0",
+ "gix-hash",
+ "gix-lock",
  "serde",
  "thiserror 2.0.12",
 ]
@@ -2648,15 +2348,15 @@ dependencies = [
  "filetime",
  "gix-diff",
  "gix-dir",
- "gix-features 0.42.1",
+ "gix-features",
  "gix-filter",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
- "gix-path 0.10.17",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
  "gix-pathspec",
- "gix-worktree 0.41.0",
+ "gix-worktree",
  "portable-atomic",
  "thiserror 2.0.12",
 ]
@@ -2669,18 +2369,18 @@ dependencies = [
  "filetime",
  "gix-diff",
  "gix-dir",
- "gix-features 0.42.1",
+ "gix-features",
  "gix-filter",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
  "gix-odb",
- "gix-path 0.10.17",
+ "gix-path",
  "gix-pathspec",
  "gix-status",
  "gix-testtools",
- "gix-worktree 0.41.0",
+ "gix-worktree",
  "pretty_assertions",
 ]
 
@@ -2690,8 +2390,8 @@ version = "0.19.1"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-features 0.42.1",
- "gix-path 0.10.17",
+ "gix-features",
+ "gix-path",
  "gix-pathspec",
  "gix-refspec",
  "gix-testtools",
@@ -2705,22 +2405,7 @@ version = "17.1.0"
 dependencies = [
  "dashmap",
  "document-features",
- "gix-fs 0.15.0",
- "libc",
- "once_cell",
- "parking_lot",
- "signal-hook",
- "signal-hook-registry",
- "tempfile",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "17.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c750e8c008453a2dba67a2b0d928b7716e05da31173a3f5e351d5457ad4470aa"
-dependencies = [
- "gix-fs 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-fs",
  "libc",
  "once_cell",
  "parking_lot",
@@ -2738,11 +2423,11 @@ dependencies = [
  "document-features",
  "fastrand",
  "fs_extra",
- "gix-discover 0.40.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-fs 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-lock 17.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-tempfile 17.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-worktree 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-discover",
+ "gix-fs",
+ "gix-lock",
+ "gix-tempfile",
+ "gix-worktree",
  "io-close",
  "is_ci",
  "once_cell",
@@ -2767,12 +2452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-trace"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7"
-
-[[package]]
 name = "gix-transport"
 version = "0.47.0"
 dependencies = [
@@ -2787,12 +2466,12 @@ dependencies = [
  "futures-lite",
  "gix-command",
  "gix-credentials",
- "gix-features 0.42.1",
- "gix-hash 0.18.0",
+ "gix-features",
+ "gix-hash",
  "gix-pack",
  "gix-packetline",
- "gix-quote 0.6.0",
- "gix-sec 0.11.0",
+ "gix-quote",
+ "gix-sec",
  "gix-url",
  "maybe-async",
  "pin-project-lite",
@@ -2806,29 +2485,12 @@ name = "gix-traverse"
 version = "0.46.1"
 dependencies = [
  "bitflags 2.9.0",
- "gix-commitgraph 0.28.0",
- "gix-date 0.10.1",
- "gix-hash 0.18.0",
- "gix-hashtable 0.8.1",
- "gix-object 0.49.1",
- "gix-revwalk 0.20.1",
- "smallvec",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.46.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39094185f6d9a4d81101130fbbf7f598a06441d774ae3b3ae7930a613bbe1157"
-dependencies = [
- "bitflags 2.9.0",
- "gix-commitgraph 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-date 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hashtable 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.49.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-revwalk 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
  "smallvec",
  "thiserror 2.0.12",
 ]
@@ -2837,12 +2499,12 @@ dependencies = [
 name = "gix-traverse-tests"
 version = "0.0.0"
 dependencies = [
- "gix-commitgraph 0.28.0",
- "gix-hash 0.18.0",
- "gix-object 0.49.1",
+ "gix-commitgraph",
+ "gix-hash",
+ "gix-object",
  "gix-odb",
  "gix-testtools",
- "gix-traverse 0.46.1",
+ "gix-traverse",
  "insta",
 ]
 
@@ -2857,8 +2519,8 @@ dependencies = [
  "assert_matches",
  "bstr",
  "document-features",
- "gix-features 0.42.1",
- "gix-path 0.10.17",
+ "gix-features",
+ "gix-path",
  "gix-testtools",
  "percent-encoding",
  "serde",
@@ -2876,16 +2538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-utils"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5351af2b172caf41a3728eb4455326d84e0d70fe26fc4de74ab0bd37df4191c5"
-dependencies = [
- "fastrand",
- "unicode-normalization",
-]
-
-[[package]]
 name = "gix-validate"
 version = "0.10.0"
 dependencies = [
@@ -2895,51 +2547,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-validate"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d"
-dependencies = [
- "bstr",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "gix-worktree"
 version = "0.41.0"
 dependencies = [
  "bstr",
  "document-features",
- "gix-attributes 0.26.0",
- "gix-features 0.42.1",
- "gix-fs 0.15.0",
- "gix-glob 0.20.0",
- "gix-hash 0.18.0",
- "gix-ignore 0.15.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
- "gix-path 0.10.17",
- "gix-validate 0.10.0",
+ "gix-attributes",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
  "serde",
-]
-
-[[package]]
-name = "gix-worktree"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f1916f8d928268300c977d773dd70a8746b646873b77add0a34876a8c847e9"
-dependencies = [
- "bstr",
- "gix-attributes 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-features 0.42.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-fs 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-glob 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-hash 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-ignore 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-index 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-object 0.49.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-path 0.10.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "gix-validate 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2947,15 +2570,15 @@ name = "gix-worktree-state"
 version = "0.19.0"
 dependencies = [
  "bstr",
- "gix-features 0.42.1",
+ "gix-features",
  "gix-filter",
- "gix-fs 0.15.0",
- "gix-glob 0.20.0",
- "gix-hash 0.18.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
- "gix-path 0.10.17",
- "gix-worktree 0.41.0",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
  "io-close",
  "thiserror 2.0.12",
 ]
@@ -2964,13 +2587,13 @@ dependencies = [
 name = "gix-worktree-state-tests"
 version = "0.0.0"
 dependencies = [
- "gix-discover 0.40.1",
- "gix-features 0.42.1",
+ "gix-discover",
+ "gix-features",
  "gix-filter",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
  "gix-odb",
  "gix-testtools",
  "gix-worktree-state",
@@ -2983,17 +2606,17 @@ dependencies = [
 name = "gix-worktree-stream"
 version = "0.21.1"
 dependencies = [
- "gix-attributes 0.26.0",
- "gix-features 0.42.1",
+ "gix-attributes",
+ "gix-features",
  "gix-filter",
- "gix-fs 0.15.0",
- "gix-hash 0.18.0",
- "gix-object 0.49.1",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
  "gix-odb",
- "gix-path 0.10.17",
+ "gix-path",
  "gix-testtools",
- "gix-traverse 0.46.1",
- "gix-worktree 0.41.0",
+ "gix-traverse",
+ "gix-worktree",
  "parking_lot",
  "thiserror 2.0.12",
 ]
@@ -3003,19 +2626,19 @@ name = "gix-worktree-tests"
 version = "0.0.0"
 dependencies = [
  "bstr",
- "gix-attributes 0.26.0",
- "gix-discover 0.40.1",
- "gix-features 0.42.1",
- "gix-fs 0.15.0",
- "gix-glob 0.20.0",
- "gix-hash 0.18.0",
- "gix-ignore 0.15.0",
- "gix-index 0.40.0",
- "gix-object 0.49.1",
+ "gix-attributes",
+ "gix-discover",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
  "gix-odb",
- "gix-path 0.10.17",
+ "gix-path",
  "gix-testtools",
- "gix-worktree 0.41.0",
+ "gix-worktree",
  "symlink",
 ]
 

--- a/justfile
+++ b/justfile
@@ -63,22 +63,16 @@ check:
     cargo check -p gix-pack --no-default-features
     cargo check -p gix-pack --no-default-features --features generate
     cargo check -p gix-pack --no-default-features --features streaming-input
-    cd gix-hash; \
-        set -ex; \
-        cargo check --all-features; \
-        cargo check
-    cd gix-object; \
-        set -ex; \
-        cargo check --all-features; \
-        cargo check --features verbose-object-parsing-errors
-    cd gix-attributes && cargo check --features serde
-    cd gix-glob && cargo check --features serde
-    cd gix-worktree; \
-        set -ex; \
-        cargo check --features serde; \
-        cargo check --no-default-features;
-    cd gix-actor && cargo check --features serde
-    cd gix-date && cargo check --features serde
+    cargo check -p gix-hash --all-features
+    cargo check -p gix-hash
+    cargo check -p gix-object --all-features
+    cargo check -p gix-object --features verbose-object-parsing-errors
+    cargo check -p gix-attributes --features serde
+    cargo check -p gix-glob --features serde
+    cargo check -p gix-worktree --features serde
+    cargo check -p gix-worktree --no-default-features
+    cargo check -p gix-actor --features serde
+    cargo check -p gix-date --features serde
     cargo check -p gix-tempfile --features signals
     cargo check -p gix-tempfile --features hp-hashmap
     cargo check -p gix-pack --features serde
@@ -87,7 +81,7 @@ check:
     cargo check -p gix-pack --features object-cache-dynamic
     cargo check -p gix-packetline --features blocking-io
     cargo check -p gix-packetline --features async-io
-    cd gix-index && cargo check --features serde
+    cargo check -p gix-index --features serde
     cargo check -p gix-credentials --features serde
     cargo check -p gix-sec --features serde
     cargo check -p gix-revision --features serde
@@ -104,9 +98,7 @@ check:
     cargo check -p gix-features --features crc32
     cargo check -p gix-features --features zlib
     cargo check -p gix-features --features cache-efficiency-debug
-    cd gix-commitgraph; \
-      set -ex; \
-      cargo check --all-features
+    cargo check -p gix-commitgraph --all-features
     cargo check -p gix-config-value --all-features
     cargo check -p gix-config --all-features
     cargo check -p gix-diff --no-default-features
@@ -158,10 +150,8 @@ unit-tests:
     cargo nextest run -p gix-status-tests --features gix-features-parallel
     cargo nextest run -p gix-worktree-state-tests --features gix-features-parallel
     cargo nextest run -p gix-worktree-tests --features gix-features-parallel
-    cd gix-object; \
-        set -ex; \
-        cargo nextest run; \
-        cargo nextest run --features verbose-object-parsing-errors
+    cargo nextest run -p gix-object
+    cargo nextest run -p gix-object --features verbose-object-parsing-errors
     cargo nextest run -p gix-tempfile --features signals
     cargo nextest run -p gix-features --all-features
     cargo nextest run -p gix-ref-tests --all-features

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -25,11 +25,11 @@ default = []
 xz = ["dep:xz2"]
 
 [dependencies]
-gix-lock = "17.1.0"
-gix-discover = "0.40.1"
-gix-worktree = "0.41.0"
-gix-fs = "0.15.0"
-gix-tempfile = { version = "17.1.0", default-features = false, features = ["signals"] }
+gix-lock = { version = "17.1.0", path = "../../gix-lock" }
+gix-discover = { version = "0.40.1", path = "../../gix-discover" }
+gix-worktree = { version = "0.41.0", path = "../../gix-worktree" }
+gix-fs = { version = "0.15.0", path = "../../gix-fs" }
+gix-tempfile = { version = "17.1.0", path = "../../gix-tempfile", default-features = false, features = ["signals"] }
 
 winnow = { version = "0.7.7", features = ["simd"] }
 fastrand = "2.0.0"


### PR DESCRIPTION
Fixes #1989

This is the PR I had promised in #1989 to demonstrate the effect of the fix proposed there. Based on the last paragraph of https://github.com/GitoxideLabs/gitoxide/issues/1989#issuecomment-2849897654, I am guessing that this is not suitable for merging at this time, or maybe even at all, and therefore that this is effectively just an experiment rather than something to be merged. I recommend:

- Closing this without merging, if it is unlikely that the changes here would be wanted soon.
- Marking it as a draft (or asking me to do so) if the changes here might be wanted soon.
- Merging this if the changes are wanted now, though my understanding of what you have said makes me suspect that is not the case.

(The "other tradeoffs to consider" that I had alluded to in the description of #1989 are detailed in the bulleted list under "However:" in the commit message for the first commit here, 7e057f2c73a70a2cd56bbc5484e6141feef2f014. However, if this should not be integrated due to cargo-smart-release possibly not being ready for it, then it may not be necessary to look at that.)