### PR TITLE
Remove `:/` baseline skip (always check `:/` baselines)

### DIFF
--- a/gix/tests/gix/revision/spec/from_bytes/regex.rs
+++ b/gix/tests/gix/revision/spec/from_bytes/regex.rs
@@ -67,22 +67,10 @@ mod find_youngest_matching_commit {
     fn contained_string_matches() {
         let repo = repo("complex_graph").unwrap();
 
-        // See the comment on `skip_some_baselines` in the `regex_matches` test function below.
-        let skip_some_baselines = !is_ci::cached()
-            && std::env::var_os("GIX_TEST_IGNORE_ARCHIVES").is_some()
-            && ((2, 47, 0)..(2, 48, 0)).contains(&gix_testtools::GIT_VERSION);
-
-        if skip_some_baselines {
-            assert_eq!(
-                parse_spec_no_baseline(":/message", &repo).unwrap(),
-                Spec::from_id(hex_to_id("ef80b4b77b167f326351c93284dc0eb00dd54ff4").attach(&repo))
-            );
-        } else {
-            assert_eq!(
-                parse_spec(":/message", &repo).unwrap(),
-                Spec::from_id(hex_to_id("ef80b4b77b167f326351c93284dc0eb00dd54ff4").attach(&repo))
-            );
-        }
+        assert_eq!(
+            parse_spec(":/message", &repo).unwrap(),
+            Spec::from_id(hex_to_id("ef80b4b77b167f326351c93284dc0eb00dd54ff4").attach(&repo))
+        );
 
         assert_eq!(
             parse_spec("@^{/!-B}", &repo).unwrap(),
@@ -90,17 +78,10 @@ mod find_youngest_matching_commit {
             "negations work as well"
         );
 
-        if skip_some_baselines {
-            assert_eq!(
-                parse_spec_no_baseline(":/!-message", &repo).unwrap(),
-                Spec::from_id(hex_to_id("55e825ebe8fd2ff78cad3826afb696b96b576a7e").attach(&repo))
-            );
-        } else {
-            assert_eq!(
-                parse_spec(":/!-message", &repo).unwrap(),
-                Spec::from_id(hex_to_id("55e825ebe8fd2ff78cad3826afb696b96b576a7e").attach(&repo))
-            );
-        }
+        assert_eq!(
+            parse_spec(":/!-message", &repo).unwrap(),
+            Spec::from_id(hex_to_id("55e825ebe8fd2ff78cad3826afb696b96b576a7e").attach(&repo))
+        );
 
         assert_eq!(
             parse_spec_no_baseline(":/messa.e", &repo).unwrap_err().to_string(),
@@ -114,52 +95,20 @@ mod find_youngest_matching_commit {
     fn regex_matches() {
         let repo = repo("complex_graph").unwrap();
 
-        // Traversal order with `:/` was broken in Git 2.47.*, so some `parse_spec` assertions
-        // fail. The fix is in Git 2.48.* but is not backported. This causes incorrect baselines to
-        // be computed when `GIX_TEST_IGNORE_ARCHIVES` is set. If that is not set, then archived
-        // baselines are used and there is no problem. On CI, we assume a sufficiently new version
-        // of Git. Otherwise, if `GIX_TEST_IGNORE_ARCHIVES` is set and Git 2.47.* is used, we skip
-        // the baseline check, to allow the rest of the test to proceed. This accommodates local
-        // development environments with a system-provided Git 2.47.*, though archives generated on
-        // such a system should not be committed, as they would still contain incorrect baselines.
-        // Please note that this workaround may be removed in the future. For more details, see:
-        //
-        //  - https://lore.kernel.org/git/Z1LJSADiStlFicTL@pks.im/T/
-        //  - https://lore.kernel.org/git/Z1LtS-8f8WZyobz3@pks.im/T/
-        //  - https://github.com/git/git/blob/v2.48.0/Documentation/RelNotes/2.48.0.txt#L294-L296
-        //  - https://github.com/GitoxideLabs/gitoxide/issues/1622
-        let skip_some_baselines = !is_ci::cached()
-            && std::env::var_os("GIX_TEST_IGNORE_ARCHIVES").is_some()
-            && ((2, 47, 0)..(2, 48, 0)).contains(&gix_testtools::GIT_VERSION);
-
-        if skip_some_baselines {
-            assert_eq!(
-                parse_spec_no_baseline(":/mes.age", &repo).unwrap(),
-                Spec::from_id(hex_to_id("ef80b4b77b167f326351c93284dc0eb00dd54ff4").attach(&repo))
-            );
-        } else {
-            assert_eq!(
-                parse_spec(":/mes.age", &repo).unwrap(),
-                Spec::from_id(hex_to_id("ef80b4b77b167f326351c93284dc0eb00dd54ff4").attach(&repo))
-            );
-        }
+        assert_eq!(
+            parse_spec(":/mes.age", &repo).unwrap(),
+            Spec::from_id(hex_to_id("ef80b4b77b167f326351c93284dc0eb00dd54ff4").attach(&repo))
+        );
 
         assert_eq!(
             parse_spec(":/not there", &repo).unwrap_err().to_string(),
             "None of 10 commits reached from all references matched regex \"not there\""
         );
 
-        if skip_some_baselines {
-            assert_eq!(
-                parse_spec_no_baseline(":/!-message", &repo).unwrap(),
-                Spec::from_id(hex_to_id("55e825ebe8fd2ff78cad3826afb696b96b576a7e").attach(&repo))
-            );
-        } else {
-            assert_eq!(
-                parse_spec(":/!-message", &repo).unwrap(),
-                Spec::from_id(hex_to_id("55e825ebe8fd2ff78cad3826afb696b96b576a7e").attach(&repo))
-            );
-        }
+        assert_eq!(
+            parse_spec(":/!-message", &repo).unwrap(),
+            Spec::from_id(hex_to_id("55e825ebe8fd2ff78cad3826afb696b96b576a7e").attach(&repo))
+        );
 
         assert_eq!(
             parse_spec("@^{/!-B}", &repo).unwrap(),

--- a/gix/tests/gix/revision/spec/from_bytes/regex.rs
+++ b/gix/tests/gix/revision/spec/from_bytes/regex.rs
@@ -67,10 +67,22 @@ mod find_youngest_matching_commit {
     fn contained_string_matches() {
         let repo = repo("complex_graph").unwrap();
 
-        assert_eq!(
-            parse_spec(":/message", &repo).unwrap(),
-            Spec::from_id(hex_to_id("ef80b4b77b167f326351c93284dc0eb00dd54ff4").attach(&repo))
-        );
+        // See the comment on `skip_some_baselines` in the `regex_matches` test function below.
+        let skip_some_baselines = !is_ci::cached()
+            && std::env::var_os("GIX_TEST_IGNORE_ARCHIVES").is_some()
+            && ((2, 47, 0)..(2, 48, 0)).contains(&gix_testtools::GIT_VERSION);
+
+        if skip_some_baselines {
+            assert_eq!(
+                parse_spec_no_baseline(":/message", &repo).unwrap(),
+                Spec::from_id(hex_to_id("ef80b4b77b167f326351c93284dc0eb00dd54ff4").attach(&repo))
+            );
+        } else {
+            assert_eq!(
+                parse_spec(":/message", &repo).unwrap(),
+                Spec::from_id(hex_to_id("ef80b4b77b167f326351c93284dc0eb00dd54ff4").attach(&repo))
+            );
+        }
 
         assert_eq!(
             parse_spec("@^{/!-B}", &repo).unwrap(),
@@ -78,10 +90,17 @@ mod find_youngest_matching_commit {
             "negations work as well"
         );
 
-        assert_eq!(
-            parse_spec(":/!-message", &repo).unwrap(),
-            Spec::from_id(hex_to_id("55e825ebe8fd2ff78cad3826afb696b96b576a7e").attach(&repo))
-        );
+        if skip_some_baselines {
+            assert_eq!(
+                parse_spec_no_baseline(":/!-message", &repo).unwrap(),
+                Spec::from_id(hex_to_id("55e825ebe8fd2ff78cad3826afb696b96b576a7e").attach(&repo))
+            );
+        } else {
+            assert_eq!(
+                parse_spec(":/!-message", &repo).unwrap(),
+                Spec::from_id(hex_to_id("55e825ebe8fd2ff78cad3826afb696b96b576a7e").attach(&repo))
+            );
+        }
 
         assert_eq!(
             parse_spec_no_baseline(":/messa.e", &repo).unwrap_err().to_string(),
@@ -95,16 +114,21 @@ mod find_youngest_matching_commit {
     fn regex_matches() {
         let repo = repo("complex_graph").unwrap();
 
-        // The full Linux CI `test` job regenerates baselines instead of taking them from archives.
-        // Traversal order with `:/` is broken in Git 2.47.*, so some `parse_spec` assertions fail.
-        // The fix is in Git 2.48.* but is not backported. For now, we use `parse_spec_no_baseline`
-        // in affected test cases when they are run on CI with Git 2.47.*. For details, see:
+        // Traversal order with `:/` was broken in Git 2.47.*, so some `parse_spec` assertions
+        // fail. The fix is in Git 2.48.* but is not backported. This causes incorrect baselines to
+        // be computed when `GIX_TEST_IGNORE_ARCHIVES` is set. If that is not set, then archived
+        // baselines are used and there is no problem. On CI, we assume a sufficiently new version
+        // of Git. Otherwise, if `GIX_TEST_IGNORE_ARCHIVES` is set and Git 2.47.* is used, we skip
+        // the baseline check, to allow the rest of the test to proceed. This accommodates local
+        // development environments with a system-provided Git 2.47.*, though archives generated on
+        // such a system should not be committed, as they would still contain incorrect baselines.
+        // Please note that this workaround may be removed in the future. For more details, see:
         //
         //  - https://lore.kernel.org/git/Z1LJSADiStlFicTL@pks.im/T/
         //  - https://lore.kernel.org/git/Z1LtS-8f8WZyobz3@pks.im/T/
         //  - https://github.com/git/git/blob/v2.48.0/Documentation/RelNotes/2.48.0.txt#L294-L296
         //  - https://github.com/GitoxideLabs/gitoxide/issues/1622
-        let skip_some_baselines = is_ci::cached()
+        let skip_some_baselines = !is_ci::cached()
             && std::env::var_os("GIX_TEST_IGNORE_ARCHIVES").is_some()
             && ((2, 47, 0)..(2, 48, 0)).contains(&gix_testtools::GIT_VERSION);
 


### PR DESCRIPTION
Closes #1622 

This rolls back all changes made to work around the Git 2.47.\* bug that underlines #1622, because:

- We shouldn't suppress the baseline check on CI anymore. That is only needed with Git 2.47.\*, and CI is expected to have a recent Git. Currently the GitHub runners have 2.49.\*.

- It is tempting to change the suppression to occur locally instead, to support more development environments. But of prominent distributions, it looks like only Alpine Linux will carry a downstream 2.47.\* for an extended time, and only in one version. The problem doing the suppression locally is that affected systems still won't be fully usable for development, as `GIX_TEST_IGNORE_ARCHIVES=1` runs on them will still produce archives with broken baselines, which would appear to be suitable for committing due to all tests passing, even though they should not be committed.

This is done in two commits because the first commit takes the route of preserving the suppression but inverting its CI check so the suppression occurs locally instead of on CI, as well as extending the suppression to cover not only the `regex_matches` test but also the related and analogous `contained_string_matches` test, which was equally affected by #1622 except that it is not run nearly as often since default features include the feature that `regex_matches` tests and `contained_string_matches` does not.

This way, in the unlikely but not entirely implausible event that we do want to bring back the suppression, we can do so by reverting b623bf1802474d92dbd0b63856c0b3b1f664e8d7 specifically, and the improved form of the suppression in 2400158d6ce2ff28d428402f2d4030c04cd5f470 will be in place.

More details on all this can be found in the commit messages. For context, see https://github.com/GitoxideLabs/gitoxide/issues/1622#issuecomment-2599247175. This PR makes covers (2) and (3) of the plan there.