### PR TITLE
Regroup CI doctests and adjust `unit-tests` recipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,8 +181,6 @@ jobs:
         env:
           GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI: '1'
         run: cargo nextest run --workspace --no-fail-fast
-      - name: Doctest
-        run: cargo test --workspace --doc --no-fail-fast
       - name: Check that tracked archives are up to date
         run: git diff --exit-code  # If this fails, the fix is usually to commit a regenerated archive.
 
@@ -277,7 +275,7 @@ jobs:
           GIX_TEST_IGNORE_ARCHIVES: '1'
         run: cargo nextest run --workspace --no-fail-fast
 
-  test-32bit-windows-size:
+  test-32bit-windows-size-doc:
     runs-on: windows-latest
 
     env:
@@ -292,8 +290,10 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest
-      - name: Test (nextest)
+      - name: Test data structure sizes (nextest)
         run: cargo nextest run --target $env:TARGET --workspace --no-fail-fast size
+      - name: Doctest
+        run: cargo test --workspace --doc --no-fail-fast
 
   lint:
     runs-on: ubuntu-latest
@@ -497,7 +497,7 @@ jobs:
       - test-fast
       - test-fixtures-windows
       - test-32bit
-      - test-32bit-windows-size
+      - test-32bit-windows-size-doc
       - lint
       - cargo-deny
       - check-packetline

--- a/justfile
+++ b/justfile
@@ -144,41 +144,41 @@ doc $RUSTDOCFLAGS='-D warnings':
 
 # Run all unit tests
 unit-tests:
-    cargo nextest run
-    cargo test --doc
-    cargo nextest run -p gix-testtools
-    cargo nextest run -p gix-testtools --features xz
-    cargo nextest run -p gix-archive --no-default-features
-    cargo nextest run -p gix-archive --features tar
-    cargo nextest run -p gix-archive --features tar_gz
-    cargo nextest run -p gix-archive --features zip
-    cargo nextest run -p gix-status-tests --features gix-features-parallel
-    cargo nextest run -p gix-worktree-state-tests --features gix-features-parallel
-    cargo nextest run -p gix-worktree-tests --features gix-features-parallel
-    cargo nextest run -p gix-object
-    cargo nextest run -p gix-object --features verbose-object-parsing-errors
-    cargo nextest run -p gix-tempfile --features signals
-    cargo nextest run -p gix-features --all-features
-    cargo nextest run -p gix-ref-tests --all-features
-    cargo nextest run -p gix-odb --all-features
-    cargo nextest run -p gix-odb-tests --features gix-features-parallel
-    cargo nextest run -p gix-pack --all-features
-    cargo nextest run -p gix-pack-tests --features all-features
-    cargo nextest run -p gix-pack-tests --features gix-features-parallel
-    cargo nextest run -p gix-index-tests --features gix-features-parallel
-    cargo nextest run -p gix-packetline --features blocking-io,maybe-async/is_sync --test blocking-packetline
-    cargo nextest run -p gix-packetline --features async-io --test async-packetline
-    cargo nextest run -p gix-transport --features http-client-curl,maybe-async/is_sync
-    cargo nextest run -p gix-transport --features http-client-reqwest,maybe-async/is_sync
-    cargo nextest run -p gix-transport --features async-client
-    cargo nextest run -p gix-protocol --features blocking-client
-    cargo nextest run -p gix-protocol --features async-client
-    cargo nextest run -p gix --no-default-features
-    cargo nextest run -p gix --no-default-features --features basic,comfort,max-performance-safe
-    cargo nextest run -p gix --no-default-features --features basic,extras,comfort,need-more-recent-msrv
-    cargo nextest run -p gix --features async-network-client
-    cargo nextest run -p gix --features blocking-network-client
-    cargo nextest run -p gitoxide-core --lib --no-tests=warn
+    cargo nextest run --no-fail-fast
+    cargo nextest run -p gix-testtools --no-fail-fast
+    cargo nextest run -p gix-testtools --features xz --no-fail-fast
+    cargo nextest run -p gix-archive --no-default-features --no-fail-fast
+    cargo nextest run -p gix-archive --features tar --no-fail-fast
+    cargo nextest run -p gix-archive --features tar_gz --no-fail-fast
+    cargo nextest run -p gix-archive --features zip --no-fail-fast
+    cargo nextest run -p gix-status-tests --features gix-features-parallel --no-fail-fast
+    cargo nextest run -p gix-worktree-state-tests --features gix-features-parallel --no-fail-fast
+    cargo nextest run -p gix-worktree-tests --features gix-features-parallel --no-fail-fast
+    cargo nextest run -p gix-object --no-fail-fast
+    cargo nextest run -p gix-object --features verbose-object-parsing-errors --no-fail-fast
+    cargo nextest run -p gix-tempfile --features signals --no-fail-fast
+    cargo nextest run -p gix-features --all-features --no-fail-fast
+    cargo nextest run -p gix-ref-tests --all-features --no-fail-fast
+    cargo nextest run -p gix-odb --all-features --no-fail-fast
+    cargo nextest run -p gix-odb-tests --features gix-features-parallel --no-fail-fast
+    cargo nextest run -p gix-pack --all-features --no-fail-fast
+    cargo nextest run -p gix-pack-tests --features all-features --no-fail-fast
+    cargo nextest run -p gix-pack-tests --features gix-features-parallel --no-fail-fast
+    cargo nextest run -p gix-index-tests --features gix-features-parallel --no-fail-fast
+    cargo nextest run -p gix-packetline --features blocking-io,maybe-async/is_sync --test blocking-packetline --no-fail-fast
+    cargo nextest run -p gix-packetline --features async-io --test async-packetline --no-fail-fast
+    cargo nextest run -p gix-transport --features http-client-curl,maybe-async/is_sync --no-fail-fast
+    cargo nextest run -p gix-transport --features http-client-reqwest,maybe-async/is_sync --no-fail-fast
+    cargo nextest run -p gix-transport --features async-client --no-fail-fast
+    cargo nextest run -p gix-protocol --features blocking-client --no-fail-fast
+    cargo nextest run -p gix-protocol --features async-client --no-fail-fast
+    cargo nextest run -p gix --no-default-features --no-fail-fast
+    cargo nextest run -p gix --no-default-features --features basic,comfort,max-performance-safe --no-fail-fast
+    cargo nextest run -p gix --no-default-features --features basic,extras,comfort,need-more-recent-msrv --no-fail-fast
+    cargo nextest run -p gix --features async-network-client --no-fail-fast
+    cargo nextest run -p gix --features blocking-network-client --no-fail-fast
+    cargo nextest run -p gitoxide-core --lib --no-tests=warn --no-fail-fast
+    cargo test --workspace --doc --no-fail-fast
 
 # These tests aren't run by default as they are flaky (even locally)
 unit-tests-flaky:


### PR DESCRIPTION
This distributes work across CI jobs more evenly. In particular, it speeds up `test-fast` on `windows-latest` (which had become the slowest of all CI jobs, including other Windows jobs). To do so, it leverages the idea that the doctests are important enough that we should probably continue automatically running them on Windows, but not so important that it particularly matters which of reasonably normal Windows environments and targets they run for.

Those changes entail modifying the `justfile`, so I've included the further overlapping change of adding `--no-fail-fast` to the commands in the `unit-tests` recipe there. This benefits CI, and I think does not hurt local runs either.

This also makes it so that the doctest-running command in `just unit-tests` runs more than zero doctests, which I think is the more intuitive effect. (That is, it runs all doctests in the workspace, rather than just all the doctests in the `gitoxide` crate, of which there currently aren't any.)

Substantial further details, including about what this is trying to improve, and rationale, are in the commit message.

The diff, as shown on GitHub, is somewhat confusing in `justfile`. Except for one line that is moved and changed, all changed lines are actually changed only by having `--no-fail-fast` added to the end.