### PR TITLE
Improve MSRV check and fix `aria-label` in MSRV badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,7 +433,8 @@ jobs:
 
     defaults:
       run:
-        shell: bash  # Use bash even on Windows, if we ever reenable windows-latest for testing.
+        # Use `bash` even on Windows, if we ever reenable `windows-latest` for testing.
+        shell: bash
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -33,20 +33,16 @@ jobs:
       # IMPORTANT: adjust etc/msrv-badge.svg as well
       RUST_VERSION: 1.75.0
 
-    defaults:
-      run:
-        # Use `bash` even in the Windows job, so any failing command fails its step (due to `-e`).
-        shell: bash
-
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
       - name: Set up ${{ env.RUST_VERSION }} (MSRV) and nightly toolchains
-        run: |
-          rustup toolchain install ${{ env.RUST_VERSION }} nightly --profile minimal --no-self-update
-          rustup default ${{ env.RUST_VERSION }}
+        run: rustup toolchain install ${{ env.RUST_VERSION }} nightly --profile minimal --no-self-update
+      - name: Set ${{ env.RUST_VERSION }} (MSRV) as default
+        run: rustup default ${{ env.RUST_VERSION }}
       - name: Downgrade locked dependencies to lowest allowed versions
         run: |
-          cargo +nightly update -Zminimal-versions  # TODO(msrv): Use non-`-Z` way when available.
+          # TODO(msrv): Use `cargo update --minimal-versions` when `--minimal-versions` is available.
+          cargo +nightly update -Zminimal-versions
       - name: Run some `cargo check` commands on `gix`
         run: just ci-check-msrv

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -33,6 +33,11 @@ jobs:
       # IMPORTANT: adjust etc/msrv-badge.svg as well
       rust_version: 1.75.0
 
+    defaults:
+      run:
+        # Use `bash` even in the Windows job, so any failing command fails its step (due to `-e`).
+        shell: bash
+
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       # dictated by `firefox` to support the `helix` editor, but now probably effectively be controlled by `jiff`, which also aligns with `regex`.
       # IMPORTANT: adjust etc/msrv-badge.svg as well
-      rust_version: 1.75.0
+      RUST_VERSION: 1.75.0
 
     defaults:
       run:
@@ -41,8 +41,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
-      - run: |
-          rustup toolchain install ${{ env.rust_version }} nightly --profile minimal --no-self-update
-          rustup default ${{ env.rust_version }}
-          cargo +nightly update -Zminimal-versions
-      - run: just ci-check-msrv
+      - name: Set up ${{ env.RUST_VERSION }} (MSRV) and nightly toolchains
+        run: |
+          rustup toolchain install ${{ env.RUST_VERSION }} nightly --profile minimal --no-self-update
+          rustup default ${{ env.RUST_VERSION }}
+      - name: Downgrade locked dependencies to lowest allowed versions
+        run: |
+          cargo +nightly update -Zminimal-versions  # TODO(msrv): Use non-`-Z` way when available.
+          git add Cargo.lock  # Stage for a later `git diff` check.
+      - name: Run some `cargo check` commands on `gix`
+        run: just ci-check-msrv
+      - name: Check `cargo` didn't have to change the versions
+        run: git diff --exit-code -- Cargo.lock

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -48,8 +48,5 @@ jobs:
       - name: Downgrade locked dependencies to lowest allowed versions
         run: |
           cargo +nightly update -Zminimal-versions  # TODO(msrv): Use non-`-Z` way when available.
-          git add Cargo.lock  # Stage for a later `git diff` check.
       - name: Run some `cargo check` commands on `gix`
         run: just ci-check-msrv
-      - name: Check `cargo` didn't have to change the versions
-        run: git diff --exit-code -- Cargo.lock

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -45,5 +45,5 @@ jobs:
         run: |
           # TODO(msrv): Use `cargo update --minimal-versions` when `--minimal-versions` is available.
           cargo +nightly update -Zminimal-versions
-      - name: Run some `cargo check` commands on `gix`
+      - name: Run some `cargo build` commands on `gix`
         run: just ci-check-msrv

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -29,8 +29,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      # dictated by `firefox` to support the `helix` editor, but now probably effectively be controlled by `jiff`, which also aligns with `regex`.
-      # IMPORTANT: adjust etc/msrv-badge.svg as well
+      # This is dictated by `firefox` to support the `helix` editor, but now probably effectively
+      # be controlled by `jiff`, which also aligns with `regex`.
+      # IMPORTANT: When adjusting, change all occurrences in `etc/msrv-badge.svg` as well.
       RUST_VERSION: 1.75.0
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ bench-gix-config:
 
 check-msrv-on-ci: ## Check the minimal support rust version for currently installed Rust version
 	rustc --version
-	cargo check --locked --package gix
-	cargo check --locked --package gix --no-default-features --features async-network-client,max-performance
+	cargo build --locked --package gix
+	cargo build --locked --package gix --no-default-features --features async-network-client,max-performance
 
 ##@ Maintenance
 

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ bench-gix-config:
 
 check-msrv-on-ci: ## Check the minimal support rust version for currently installed Rust version
 	rustc --version
-	cargo check --package gix
-	cargo check --package gix --no-default-features --features async-network-client,max-performance
+	cargo check --locked --package gix
+	cargo check --locked --package gix --no-default-features --features async-network-client,max-performance
 
 ##@ Maintenance
 

--- a/etc/msrv-badge.svg
+++ b/etc/msrv-badge.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="92" height="20" role="img" aria-label="rustc: 1.70.0+">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="92" height="20" role="img" aria-label="rustc: 1.75.0+">
     <title>rustc: 1.75.0+</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>

--- a/justfile
+++ b/justfile
@@ -238,7 +238,11 @@ cross-test-android: (cross-test 'armv7-linux-androideabi' '--no-default-features
 check-size:
     etc/check-package-size.sh
 
-# Check the minimal support Rust version, with the currently installed Rust version
+# Assume the current default toolchain is the Minimal Supported Rust Version and check against it
+#
+# This is run on CI in `msrv.yml`, after the MSRV toolchain is installed and set as default, and
+# after dependencies in `Cargo.lock` are downgraded to the latest MSRV-compatible versions.
+# Only if those or similar steps are done first does this recipe really validate the MSRV.
 ci-check-msrv:
     rustc --version
     cargo check -p gix

--- a/justfile
+++ b/justfile
@@ -246,8 +246,8 @@ check-size:
 # Check the MSRV, *if* the toolchain is set and `Cargo.lock` is downgraded (used on CI)
 ci-check-msrv:
     rustc --version
-    cargo check -p gix
-    cargo check -p gix --no-default-features --features async-network-client,max-performance
+    cargo check --locked -p gix
+    cargo check --locked -p gix --no-default-features --features async-network-client,max-performance
 
 # Enter a nix-shell able to build on macOS
 nix-shell-macos:

--- a/justfile
+++ b/justfile
@@ -238,11 +238,12 @@ cross-test-android: (cross-test 'armv7-linux-androideabi' '--no-default-features
 check-size:
     etc/check-package-size.sh
 
-# Assume the current default toolchain is the Minimal Supported Rust Version and check against it
+# This assumes the current default toolchain is the Minimal Supported Rust Version and checks
+# against it. This is run on CI in `msrv.yml`, after the MSRV toolchain is installed and set as
+# default, and after dependencies in `Cargo.lock` are downgraded to the latest MSRV-compatible
+# versions. Only if those or similar steps are done first does this work to validate the MSRV.
 #
-# This is run on CI in `msrv.yml`, after the MSRV toolchain is installed and set as default, and
-# after dependencies in `Cargo.lock` are downgraded to the latest MSRV-compatible versions.
-# Only if those or similar steps are done first does this recipe really validate the MSRV.
+# Check the MSRV, *if* the toolchain is set and `Cargo.lock` is downgraded (used on CI)
 ci-check-msrv:
     rustc --version
     cargo check -p gix

--- a/justfile
+++ b/justfile
@@ -246,8 +246,8 @@ check-size:
 # Check the MSRV, *if* the toolchain is set and `Cargo.lock` is downgraded (used on CI)
 ci-check-msrv:
     rustc --version
-    cargo check --locked -p gix
-    cargo check --locked -p gix --no-default-features --features async-network-client,max-performance
+    cargo build --locked -p gix
+    cargo build --locked -p gix --no-default-features --features async-network-client,max-performance
 
 # Enter a nix-shell able to build on macOS
 nix-shell-macos:


### PR DESCRIPTION
This makes several improvements to the MSRV check. Most are to make clearer what is going on, in the `msrv.yml` workflow and elsewhere, by modifying and expanding comments, and by slightly reorganizing the commands. But this also improves the robustness of the check, by:

- Fixing a bug where jobs could report the wrong status, which was analogous to [#1559](https://github.com/GitoxideLabs/gitoxide/pull/1559) but much less likely to occur. If both the `rustup` commands were to fail, but only on Windows, then the third command that was in that same step with them could cause the whole step to fail--since `pwsh` is used by default on Windows and it doesn't have anything analogous to `-e`--whereupon the usually more recent toolchain preinstalled in the `windows-2022` runner would be tested with, instead of the MSRV. I don't think this has actually happened in any runs so far, but I think it's worth preventing entirely.
- Passing `--locked` to the `cargo` commands in the `ci-check-msrv` recipe, so they fail if they would have to further modify `Cargo.lock`, rather than modifying it and continuing. This is because the effects of `-Zminimal-versions` are non-obvious and subject to change (`--minimal-versions` has not been stabilized), and also to try to account at least partially for possible disagreement in what the minimal dependency versions are between the `nightly` toolchain that is used to downgrade the locked dependencies (because only `nightly` has `-Zminimal-versions`) and the old stable toolchain versioned at the MSRV.
- Using `cargo build` instead of `cargo check` in the `ci-check-msrv` recipe, as suggested in [#1808 (comment)](https://github.com/GitoxideLabs/gitoxide/issues/1808#issuecomment-2614260268). (Please note, however, that [#1808](https://github.com/GitoxideLabs/gitoxide/issues/1808) is still probably not completely fixed. My guess is that the build problems noted there occurred, and could still occur, in some features, or some crates, that are not covered by the commands in the recipe.)

This also fixes an accessibility bug in the MSRV badge, where the [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label) attribute of the top-level `svg` element had the value `rustc: 1.70.0+`, instead of the correct and intended value `rustc: 1.75.0+` that was already present in the other places in the SVG code where the version appears (dc1d271).