### PR TITLE
Test `overwrite_existing` apparent symlink dereferencing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,6 +2599,7 @@ dependencies = [
  "gix-worktree-state",
  "once_cell",
  "symlink",
+ "test-case",
  "walkdir",
 ]
 
@@ -4755,6 +4756,39 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "test-case-core",
+]
 
 [[package]]
 name = "thiserror"

--- a/gix-worktree-state/tests/Cargo.toml
+++ b/gix-worktree-state/tests/Cargo.toml
@@ -33,3 +33,4 @@ symlink = "0.1.0"
 once_cell = "1.21.3"
 
 walkdir = "2.3.2"
+test-case = "3.3.1"

--- a/gix-worktree-state/tests/state/checkout.rs
+++ b/gix-worktree-state/tests/state/checkout.rs
@@ -12,6 +12,7 @@ use gix_object::{bstr::ByteSlice, Data};
 use gix_testtools::tempfile::TempDir;
 use gix_worktree_state::checkout::Collision;
 use once_cell::sync::Lazy;
+use test_case::test_matrix;
 
 use crate::fixture_path;
 
@@ -103,8 +104,8 @@ fn accidental_writes_through_symlinks_are_prevented_if_overwriting_is_forbidden(
     }
 }
 
-#[test]
-fn writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed() {
+#[test_matrix(0..=999)]
+fn writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed(_i: i32) {
     let mut opts = opts_from_probe();
     // with overwrite mode
     opts.overwrite_existing = true;


### PR DESCRIPTION
To investigate #2006, this explodes the occasionally failing test `writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed` into 1000 identical tests, using `test_case::test_matrix`.

When run in series, they all pass, but when run in parallel with `cargo nextest`, some failures always occur, at least when this is done on macOS. This is as predicted in:
https://github.com/GitoxideLabs/gitoxide/issues/2006#issuecomment-2866226601

A more specific result in local testing on macOS 15 is that, while the number of failures is 0 with `--test-threads=1`, with 2 or more threads, the number of failures tends to *decrease* with the number of threads. The most failures occur with `--test-threads=2`, about 30 on the system tested, while `--test-threads=16` has about 10 failures.

The tests were run with this command, with any `--test-threads=<N>` argument added:

```sh
cargo nextest run -p gix-worktree-state-tests writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed --no-fail-fast
```

See https://github.com/GitoxideLabs/gitoxide/issues/2006#issuecomment-2868766118 for substantial further details and other relevant information and ideas.

(Maybe this PR can turn into a fix, once the cause is figured out. If not, it could be superseded by the fix and closed.)