### PR TITLE
release gix index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "bstr",
  "document-features",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "bitflags 2.9.0",
  "bstr",
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.17"
+version = "0.10.18"
 dependencies = [
  "bstr",
  "gix-testtools",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.46.1"
+version = "0.46.2"
 dependencies = [
  "bitflags 2.9.0",
  "gix-commitgraph",

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -30,8 +30,8 @@ zip = ["dep:flate2", "dep:zip"]
 [dependencies]
 gix-worktree-stream = { version = "^0.21.1", path = "../gix-worktree-stream" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
-gix-path = { version = "^0.10.17", path = "../gix-path", optional = true }
-gix-date = { version = "^0.10.1", path = "../gix-date" }
+gix-path = { version = "^0.10.18", path = "../gix-path", optional = true }
+gix-date = { version = "^0.10.2", path = "../gix-date" }
 
 flate2 = { version = "1.1.1", optional = true, default-features = false, features = ["zlib-rs"] }
 zip = { version = "2.6.1", optional = true, default-features = false, features = ["deflate"] }

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 serde = ["dep:serde", "bstr/serde", "gix-glob/serde", "kstring/serde"]
 
 [dependencies]
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-quote = { version = "^0.6.0", path = "../gix-quote" }
 gix-glob = { version = "^0.20.0", path = "../gix-glob" }
 gix-trace = { version = "^0.1.12", path = "../gix-trace" }

--- a/gix-blame/Cargo.toml
+++ b/gix-blame/Cargo.toml
@@ -14,12 +14,12 @@ rust-version = "1.70"
 gix-commitgraph = { version = "^0.28.0", path = "../gix-commitgraph" }
 gix-revwalk = { version = "^0.20.1", path = "../gix-revwalk" }
 gix-trace = { version = "^0.1.12", path = "../gix-trace" }
-gix-date = { version = "^0.10.1", path = "../gix-date" }
+gix-date = { version = "^0.10.2", path = "../gix-date" }
 gix-diff = { version = "^0.52.1", path = "../gix-diff", default-features = false, features = ["blob"] }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-worktree = { version = "^0.41.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }
-gix-traverse = { version = "^0.46.1", path = "../gix-traverse" }
+gix-traverse = { version = "^0.46.2", path = "../gix-traverse" }
 
 smallvec = "1.15.0"
 thiserror = "2.0.0"

--- a/gix-command/Cargo.toml
+++ b/gix-command/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 
 [dependencies]
 gix-trace = { version = "^0.1.12", path = "../gix-trace" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-quote = { version = "^0.6.0", path = "../gix-quote" }
 
 bstr = { version = "1.12.0", default-features = false, features = ["std", "unicode"] }

--- a/gix-config-value/Cargo.toml
+++ b/gix-config-value/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 serde = ["dep:serde", "bstr/serde"]
 
 [dependencies]
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 
 thiserror = "2.0.0"
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -21,7 +21,7 @@ serde = ["dep:serde", "bstr/serde", "gix-sec/serde", "gix-ref/serde", "gix-glob/
 [dependencies]
 gix-features = { version = "^0.42.1", path = "../gix-features" }
 gix-config-value = { version = "^0.15.0", path = "../gix-config-value" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-sec = { version = "^0.11.0", path = "../gix-sec" }
 gix-ref = { version = "^0.52.1", path = "../gix-ref" }
 gix-glob = { version = "^0.20.0", path = "../gix-glob" }

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -21,7 +21,7 @@ serde = ["dep:serde", "bstr/serde", "gix-sec/serde"]
 [dependencies]
 gix-sec = { version = "^0.11.0", path = "../gix-sec" }
 gix-url = { version = "^0.31.0", path = "../gix-url" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-command = { version = "^0.6.0", path = "../gix-command" }
 gix-config-value = { version = "^0.15.0", path = "../gix-config-value" }
 gix-prompt = { version = "^0.11.0", path = "../gix-prompt" }

--- a/gix-date/CHANGELOG.md
+++ b/gix-date/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.10.2 (2025-05-10)
 
 A maintenance release without user-facing changes.
 
@@ -13,7 +13,7 @@ A maintenance release without user-facing changes.
 
 <csr-read-only-do-not-edit/>
 
- - 4 commits contributed to the release over the course of 14 calendar days.
+ - 5 commits contributed to the release over the course of 14 calendar days.
  - 14 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 2 unique issues were worked on: [#1979](https://github.com/GitoxideLabs/gitoxide/issues/1979), [#1984](https://github.com/GitoxideLabs/gitoxide/issues/1984)
@@ -29,6 +29,7 @@ A maintenance release without user-facing changes.
  * **[#1984](https://github.com/GitoxideLabs/gitoxide/issues/1984)**
     - Further upgrade `jiff` to fix fuzz failures ([`0be4dd4`](https://github.com/GitoxideLabs/gitoxide/commit/0be4dd4e037e8a3080ef335913e06bc2584fd96d))
  * **Uncategorized**
+    - Prepare changelogs prior to release of `gix-index` ([`bfc4880`](https://github.com/GitoxideLabs/gitoxide/commit/bfc48801bf3ed39cdf7ec02e01aa3cfb6181705f))
     - Merge pull request #1984 from GitoxideLabs/fuzz ([`f965540`](https://github.com/GitoxideLabs/gitoxide/commit/f965540c162ed3e23bd0d7ad9083093033647e51))
     - Merge pull request #1971 from GitoxideLabs/new-release ([`8d4c4d1`](https://github.com/GitoxideLabs/gitoxide/commit/8d4c4d1e09f84c962c29d98a686c64228196ac13))
 </details>

--- a/gix-date/CHANGELOG.md
+++ b/gix-date/CHANGELOG.md
@@ -5,13 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+A maintenance release without user-facing changes.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 4 commits contributed to the release over the course of 14 calendar days.
+ - 14 days passed between releases.
+ - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 2 unique issues were worked on: [#1979](https://github.com/GitoxideLabs/gitoxide/issues/1979), [#1984](https://github.com/GitoxideLabs/gitoxide/issues/1984)
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **[#1979](https://github.com/GitoxideLabs/gitoxide/issues/1979)**
+    - Reproduce fuzz-failure ([`6bf1be6`](https://github.com/GitoxideLabs/gitoxide/commit/6bf1be67ba93c1b8e467e3c3127438d1eb43897e))
+ * **[#1984](https://github.com/GitoxideLabs/gitoxide/issues/1984)**
+    - Further upgrade `jiff` to fix fuzz failures ([`0be4dd4`](https://github.com/GitoxideLabs/gitoxide/commit/0be4dd4e037e8a3080ef335913e06bc2584fd96d))
+ * **Uncategorized**
+    - Merge pull request #1984 from GitoxideLabs/fuzz ([`f965540`](https://github.com/GitoxideLabs/gitoxide/commit/f965540c162ed3e23bd0d7ad9083093033647e51))
+    - Merge pull request #1971 from GitoxideLabs/new-release ([`8d4c4d1`](https://github.com/GitoxideLabs/gitoxide/commit/8d4c4d1e09f84c962c29d98a686c64228196ac13))
+</details>
+
 ## 0.10.1 (2025-04-26)
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 1 commit contributed to the release.
+ - 3 commits contributed to the release.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -22,7 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-date v0.10.1, gix-utils v0.3.0, gix-actor v0.35.1, gix-validate v0.10.0, gix-path v0.10.17, gix-features v0.42.1, gix-hash v0.18.0, gix-hashtable v0.8.1, gix-object v0.49.1, gix-glob v0.20.0, gix-quote v0.6.0, gix-attributes v0.26.0, gix-command v0.6.0, gix-packetline-blocking v0.19.0, gix-filter v0.19.1, gix-fs v0.15.0, gix-commitgraph v0.28.0, gix-revwalk v0.20.1, gix-traverse v0.46.1, gix-worktree-stream v0.21.1, gix-archive v0.21.1, gix-tempfile v17.1.0, gix-lock v17.1.0, gix-index v0.40.0, gix-config-value v0.15.0, gix-pathspec v0.11.0, gix-ignore v0.15.0, gix-worktree v0.41.0, gix-diff v0.52.1, gix-blame v0.2.1, gix-ref v0.52.1, gix-sec v0.11.0, gix-config v0.45.1, gix-prompt v0.11.0, gix-url v0.31.0, gix-credentials v0.29.0, gix-discover v0.40.1, gix-dir v0.14.1, gix-mailmap v0.27.1, gix-revision v0.34.1, gix-merge v0.5.1, gix-negotiate v0.20.1, gix-pack v0.59.1, gix-odb v0.69.1, gix-refspec v0.30.1, gix-shallow v0.4.0, gix-packetline v0.19.0, gix-transport v0.47.0, gix-protocol v0.50.1, gix-status v0.19.1, gix-submodule v0.19.1, gix-worktree-state v0.19.0, gix v0.72.1, gix-fsck v0.11.1, gitoxide-core v0.47.1, gitoxide v0.44.0 ([`e104545`](https://github.com/GitoxideLabs/gitoxide/commit/e104545b78951ca882481d4a58f4425a8bc81c87))
     - Bump all prior pratch levels to majors ([`5f7f805`](https://github.com/GitoxideLabs/gitoxide/commit/5f7f80570e1a5522e76ea58cccbb957249a0dffe))
+    - Merge pull request #1969 from GitoxideLabs/new-release ([`631f07a`](https://github.com/GitoxideLabs/gitoxide/commit/631f07ad0c1cb93d9da42cf2c8499584fe91880a))
 </details>
 
 ## 0.10.0 (2025-04-25)

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-date"
-version = "0.10.1"
+version = "0.10.2"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project parsing dates the way git does"

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -27,7 +27,7 @@ wasm = ["dep:getrandom"]
 doctest = false
 
 [dependencies]
-gix-index = { version = "^0.40.0", path = "../gix-index", optional = true }
+gix-index = { version = "^0.40.1", path = "../gix-index", optional = true }
 gix-pathspec = { version = "^0.11.0", path = "../gix-pathspec", optional = true }
 gix-attributes = { version = "^0.26.0", path = "../gix-attributes", optional = true }
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
@@ -35,11 +35,11 @@ gix-object = { version = "^0.49.1", path = "../gix-object" }
 gix-filter = { version = "^0.19.1", path = "../gix-filter", optional = true }
 gix-worktree = { version = "^0.41.0", path = "../gix-worktree", default-features = false, features = ["attributes"], optional = true }
 gix-command = { version = "^0.6.0", path = "../gix-command", optional = true }
-gix-path = { version = "^0.10.17", path = "../gix-path", optional = true }
+gix-path = { version = "^0.10.18", path = "../gix-path", optional = true }
 gix-fs = { version = "^0.15.0", path = "../gix-fs", optional = true }
 gix-tempfile = { version = "^17.1.0", path = "../gix-tempfile", optional = true }
 gix-trace = { version = "^0.1.12", path = "../gix-trace", optional = true }
-gix-traverse = { version = "^0.46.1", path = "../gix-traverse", optional = true }
+gix-traverse = { version = "^0.46.2", path = "../gix-traverse", optional = true }
 
 thiserror = "2.0.0"
 imara-diff = { version = "0.1.7", optional = true }

--- a/gix-dir/Cargo.toml
+++ b/gix-dir/Cargo.toml
@@ -16,10 +16,10 @@ test = false
 
 [dependencies]
 gix-trace = { version = "^0.1.12", path = "../gix-trace" }
-gix-index = { version = "^0.40.0", path = "../gix-index" }
+gix-index = { version = "^0.40.1", path = "../gix-index" }
 gix-discover = { version = "^0.40.1", path = "../gix-discover" }
 gix-fs = { version = "^0.15.0", path = "../gix-fs" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-pathspec = { version = "^0.11.0", path = "../gix-pathspec" }
 gix-worktree = { version = "^0.41.0", path = "../gix-worktree", default-features = false }
 gix-object = { version = "^0.49.1", path = "../gix-object" }

--- a/gix-discover/Cargo.toml
+++ b/gix-discover/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 
 [dependencies]
 gix-sec = { version = "^0.11.0", path = "../gix-sec" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-ref = { version = "^0.52.1", path = "../gix-ref" }
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-fs = { version = "^0.15.0", path = "../gix-fs" }

--- a/gix-filter/Cargo.toml
+++ b/gix-filter/Cargo.toml
@@ -21,7 +21,7 @@ gix-object = { version = "^0.49.1", path = "../gix-object" }
 gix-command = { version = "^0.6.0", path = "../gix-command" }
 gix-quote = { version = "^0.6.0", path = "../gix-quote" }
 gix-utils = { version = "^0.3.0", path = "../gix-utils" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-packetline-blocking = { version = "^0.19.0", path = "../gix-packetline-blocking" }
 gix-attributes = { version = "^0.26.0", path = "../gix-attributes" }
 

--- a/gix-glob/Cargo.toml
+++ b/gix-glob/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 serde = ["dep:serde", "bstr/serde", "bitflags/serde"]
 
 [dependencies]
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-features = { version = "^0.42.1", path = "../gix-features" }
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 bitflags = "2"

--- a/gix-ignore/Cargo.toml
+++ b/gix-ignore/Cargo.toml
@@ -20,7 +20,7 @@ serde = ["dep:serde", "bstr/serde", "gix-glob/serde"]
 
 [dependencies]
 gix-glob = { version = "^0.20.0", path = "../gix-glob" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-trace = { version = "^0.1.12", path = "../gix-trace" }
 
 bstr = { version = "1.12.0", default-features = false, features = ["std", "unicode"] }

--- a/gix-index/CHANGELOG.md
+++ b/gix-index/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.40.1 (2025-05-10)
 
 ### Bug Fixes
 
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 5 commits contributed to the release over the course of 14 calendar days.
+ - 6 commits contributed to the release over the course of 14 calendar days.
  - 14 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Prepare changelogs prior to release of `gix-index` ([`bfc4880`](https://github.com/GitoxideLabs/gitoxide/commit/bfc48801bf3ed39cdf7ec02e01aa3cfb6181705f))
     - Merge pull request #2005 from 0-wiz-0/main ([`33c4d6b`](https://github.com/GitoxideLabs/gitoxide/commit/33c4d6b6656c994ed090f2fddd70e014401baf30))
     - Fix build on NetBSD ([`00e8934`](https://github.com/GitoxideLabs/gitoxide/commit/00e89341cd89f58d031eee8a4e60f6ebdcd53185))
     - Merge pull request #1977 from GitoxideLabs/dependabot/cargo/cargo-811d7b929d ([`800738a`](https://github.com/GitoxideLabs/gitoxide/commit/800738a37f3d33926a427edfa294423bbe3f2b66))

--- a/gix-index/CHANGELOG.md
+++ b/gix-index/CHANGELOG.md
@@ -5,13 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Bug Fixes
+
+ - <csr-id-00e89341cd89f58d031eee8a4e60f6ebdcd53185/> Fix build on NetBSD
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 5 commits contributed to the release over the course of 14 calendar days.
+ - 14 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Merge pull request #2005 from 0-wiz-0/main ([`33c4d6b`](https://github.com/GitoxideLabs/gitoxide/commit/33c4d6b6656c994ed090f2fddd70e014401baf30))
+    - Fix build on NetBSD ([`00e8934`](https://github.com/GitoxideLabs/gitoxide/commit/00e89341cd89f58d031eee8a4e60f6ebdcd53185))
+    - Merge pull request #1977 from GitoxideLabs/dependabot/cargo/cargo-811d7b929d ([`800738a`](https://github.com/GitoxideLabs/gitoxide/commit/800738a37f3d33926a427edfa294423bbe3f2b66))
+    - Bump the cargo group with 12 updates ([`4408166`](https://github.com/GitoxideLabs/gitoxide/commit/4408166bf56197a67419277a4ef8feeba9060fee))
+    - Merge pull request #1971 from GitoxideLabs/new-release ([`8d4c4d1`](https://github.com/GitoxideLabs/gitoxide/commit/8d4c4d1e09f84c962c29d98a686c64228196ac13))
+</details>
+
 ## 0.40.0 (2025-04-26)
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 1 commit contributed to the release.
+ - 3 commits contributed to the release.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -22,7 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-date v0.10.1, gix-utils v0.3.0, gix-actor v0.35.1, gix-validate v0.10.0, gix-path v0.10.17, gix-features v0.42.1, gix-hash v0.18.0, gix-hashtable v0.8.1, gix-object v0.49.1, gix-glob v0.20.0, gix-quote v0.6.0, gix-attributes v0.26.0, gix-command v0.6.0, gix-packetline-blocking v0.19.0, gix-filter v0.19.1, gix-fs v0.15.0, gix-commitgraph v0.28.0, gix-revwalk v0.20.1, gix-traverse v0.46.1, gix-worktree-stream v0.21.1, gix-archive v0.21.1, gix-tempfile v17.1.0, gix-lock v17.1.0, gix-index v0.40.0, gix-config-value v0.15.0, gix-pathspec v0.11.0, gix-ignore v0.15.0, gix-worktree v0.41.0, gix-diff v0.52.1, gix-blame v0.2.1, gix-ref v0.52.1, gix-sec v0.11.0, gix-config v0.45.1, gix-prompt v0.11.0, gix-url v0.31.0, gix-credentials v0.29.0, gix-discover v0.40.1, gix-dir v0.14.1, gix-mailmap v0.27.1, gix-revision v0.34.1, gix-merge v0.5.1, gix-negotiate v0.20.1, gix-pack v0.59.1, gix-odb v0.69.1, gix-refspec v0.30.1, gix-shallow v0.4.0, gix-packetline v0.19.0, gix-transport v0.47.0, gix-protocol v0.50.1, gix-status v0.19.1, gix-submodule v0.19.1, gix-worktree-state v0.19.0, gix v0.72.1, gix-fsck v0.11.1, gitoxide-core v0.47.1, gitoxide v0.44.0 ([`e104545`](https://github.com/GitoxideLabs/gitoxide/commit/e104545b78951ca882481d4a58f4425a8bc81c87))
     - Bump all prior pratch levels to majors ([`5f7f805`](https://github.com/GitoxideLabs/gitoxide/commit/5f7f80570e1a5522e76ea58cccbb957249a0dffe))
+    - Merge pull request #1969 from GitoxideLabs/new-release ([`631f07a`](https://github.com/GitoxideLabs/gitoxide/commit/631f07ad0c1cb93d9da42cf2c8499584fe91880a))
 </details>
 
 ## 0.39.1 (2025-04-25)

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-index"
-version = "0.40.0"
+version = "0.40.1"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A work-in-progress crate of the gitoxide project dedicated implementing the git index file"
@@ -29,7 +29,7 @@ gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-bitmap = { version = "^0.2.14", path = "../gix-bitmap" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
 gix-validate = { version = "^0.10.0", path = "../gix-validate" }
-gix-traverse = { version = "^0.46.1", path = "../gix-traverse" }
+gix-traverse = { version = "^0.46.2", path = "../gix-traverse" }
 gix-lock = { version = "^17.1.0", path = "../gix-lock" }
 gix-fs = { version = "^0.15.0", path = "../gix-fs" }
 gix-utils = { version = "^0.3.0", path = "../gix-utils" }

--- a/gix-mailmap/Cargo.toml
+++ b/gix-mailmap/Cargo.toml
@@ -20,7 +20,7 @@ serde = ["dep:serde", "bstr/serde", "gix-actor/serde"]
 
 [dependencies]
 gix-actor = { version = "^0.35.1", path = "../gix-actor" }
-gix-date = { version = "^0.10.1", path = "../gix-date" }
+gix-date = { version = "^0.10.2", path = "../gix-date" }
 bstr = { version = "1.12.0", default-features = false, features = ["std", "unicode"] }
 thiserror = "2.0.0"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }

--- a/gix-merge/Cargo.toml
+++ b/gix-merge/Cargo.toml
@@ -24,7 +24,7 @@ gix-object = { version = "^0.49.1", path = "../gix-object" }
 gix-filter = { version = "^0.19.1", path = "../gix-filter" }
 gix-worktree = { version = "^0.41.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }
 gix-command = { version = "^0.6.0", path = "../gix-command" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-fs = { version = "^0.15.0", path = "../gix-fs" }
 gix-tempfile = { version = "^17.1.0", path = "../gix-tempfile" }
 gix-trace = { version = "^0.1.12", path = "../gix-trace" }
@@ -32,7 +32,7 @@ gix-quote = { version = "^0.6.0", path = "../gix-quote" }
 gix-revision = { version = "^0.34.1", path = "../gix-revision", default-features = false, features = ["merge_base"] }
 gix-revwalk = { version = "^0.20.1", path = "../gix-revwalk" }
 gix-diff = { version = "^0.52.1", path = "../gix-diff", default-features = false, features = ["blob"] }
-gix-index = { version = "^0.40.0", path = "../gix-index" }
+gix-index = { version = "^0.40.1", path = "../gix-index" }
 
 thiserror = "2.0.0"
 imara-diff = { version = "0.1.7" }

--- a/gix-negotiate/Cargo.toml
+++ b/gix-negotiate/Cargo.toml
@@ -18,7 +18,7 @@ test = false
 [dependencies]
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
-gix-date = { version = "^0.10.1", path = "../gix-date" }
+gix-date = { version = "^0.10.2", path = "../gix-date" }
 gix-commitgraph = { version = "^0.28.0", path = "../gix-commitgraph" }
 gix-revwalk = { version = "^0.20.1", path = "../gix-revwalk" }
 thiserror = "2.0.0"

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -23,8 +23,8 @@ serde = ["dep:serde", "gix-hash/serde", "gix-object/serde", "gix-pack/serde"]
 gix-features = { version = "^0.42.1", path = "../gix-features", features = ["walkdir", "zlib", "crc32"] }
 gix-hashtable = { version = "^0.8.1", path = "../gix-hashtable" }
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
-gix-date = { version = "^0.10.1", path = "../gix-date" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-date = { version = "^0.10.2", path = "../gix-date" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-quote = { version = "^0.6.0", path = "../gix-quote" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
 gix-pack = { version = "^0.59.1", path = "../gix-pack", default-features = false }

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -35,14 +35,14 @@ wasm = ["gix-diff?/wasm"]
 
 [dependencies]
 gix-features = { version = "^0.42.1", path = "../gix-features", features = ["crc32", "progress", "zlib"] }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-chunk = { version = "^0.4.11", path = "../gix-chunk" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
 gix-hashtable = { version = "^0.8.1", path = "../gix-hashtable", optional = true }
 
 # for streaming of packs (input, output)
-gix-traverse = { version = "^0.46.1", path = "../gix-traverse", optional = true }
+gix-traverse = { version = "^0.46.2", path = "../gix-traverse", optional = true }
 gix-diff = { version = "^0.52.1", path = "../gix-diff", default-features = false, optional = true }
 
 memmap2 = "0.9.0"

--- a/gix-path/CHANGELOG.md
+++ b/gix-path/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.10.18 (2025-05-10)
 
 A maintenance release without user-facing changes.
 
@@ -13,7 +13,7 @@ A maintenance release without user-facing changes.
 
 <csr-read-only-do-not-edit/>
 
- - 3 commits contributed to the release over the course of 14 calendar days.
+ - 4 commits contributed to the release over the course of 14 calendar days.
  - 14 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -31,6 +31,7 @@ A maintenance release without user-facing changes.
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Prepare changelogs prior to release of `gix-index` ([`bfc4880`](https://github.com/GitoxideLabs/gitoxide/commit/bfc48801bf3ed39cdf7ec02e01aa3cfb6181705f))
     - Merge pull request #1975 from GitoxideLabs/improvements ([`28935a5`](https://github.com/GitoxideLabs/gitoxide/commit/28935a56ff91f1fc2c17a7d23b057cf7119144e9))
     - Thanks clippy ([`dbf65c9`](https://github.com/GitoxideLabs/gitoxide/commit/dbf65c95644e6a134e7f9b75e7871479720b4deb))
     - Merge pull request #1971 from GitoxideLabs/new-release ([`8d4c4d1`](https://github.com/GitoxideLabs/gitoxide/commit/8d4c4d1e09f84c962c29d98a686c64228196ac13))
@@ -147,6 +148,13 @@ A maintenance release without user-facing changes.
    - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
    - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
    - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+   - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+- https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+- https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+- https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+- https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+- https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+- https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
 - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
 - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
 - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831

--- a/gix-path/CHANGELOG.md
+++ b/gix-path/CHANGELOG.md
@@ -5,13 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+A maintenance release without user-facing changes.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 3 commits contributed to the release over the course of 14 calendar days.
+ - 14 days passed between releases.
+ - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Thanks Clippy
+
+<csr-read-only-do-not-edit/>
+
+[Clippy](https://github.com/rust-lang/rust-clippy) helped 1 time to make code idiomatic. 
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Merge pull request #1975 from GitoxideLabs/improvements ([`28935a5`](https://github.com/GitoxideLabs/gitoxide/commit/28935a56ff91f1fc2c17a7d23b057cf7119144e9))
+    - Thanks clippy ([`dbf65c9`](https://github.com/GitoxideLabs/gitoxide/commit/dbf65c95644e6a134e7f9b75e7871479720b4deb))
+    - Merge pull request #1971 from GitoxideLabs/new-release ([`8d4c4d1`](https://github.com/GitoxideLabs/gitoxide/commit/8d4c4d1e09f84c962c29d98a686c64228196ac13))
+</details>
+
 ## 0.10.17 (2025-04-26)
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 1 commit contributed to the release.
+ - 3 commits contributed to the release.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -22,7 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-date v0.10.1, gix-utils v0.3.0, gix-actor v0.35.1, gix-validate v0.10.0, gix-path v0.10.17, gix-features v0.42.1, gix-hash v0.18.0, gix-hashtable v0.8.1, gix-object v0.49.1, gix-glob v0.20.0, gix-quote v0.6.0, gix-attributes v0.26.0, gix-command v0.6.0, gix-packetline-blocking v0.19.0, gix-filter v0.19.1, gix-fs v0.15.0, gix-commitgraph v0.28.0, gix-revwalk v0.20.1, gix-traverse v0.46.1, gix-worktree-stream v0.21.1, gix-archive v0.21.1, gix-tempfile v17.1.0, gix-lock v17.1.0, gix-index v0.40.0, gix-config-value v0.15.0, gix-pathspec v0.11.0, gix-ignore v0.15.0, gix-worktree v0.41.0, gix-diff v0.52.1, gix-blame v0.2.1, gix-ref v0.52.1, gix-sec v0.11.0, gix-config v0.45.1, gix-prompt v0.11.0, gix-url v0.31.0, gix-credentials v0.29.0, gix-discover v0.40.1, gix-dir v0.14.1, gix-mailmap v0.27.1, gix-revision v0.34.1, gix-merge v0.5.1, gix-negotiate v0.20.1, gix-pack v0.59.1, gix-odb v0.69.1, gix-refspec v0.30.1, gix-shallow v0.4.0, gix-packetline v0.19.0, gix-transport v0.47.0, gix-protocol v0.50.1, gix-status v0.19.1, gix-submodule v0.19.1, gix-worktree-state v0.19.0, gix v0.72.1, gix-fsck v0.11.1, gitoxide-core v0.47.1, gitoxide v0.44.0 ([`e104545`](https://github.com/GitoxideLabs/gitoxide/commit/e104545b78951ca882481d4a58f4425a8bc81c87))
     - Bump all prior pratch levels to majors ([`5f7f805`](https://github.com/GitoxideLabs/gitoxide/commit/5f7f80570e1a5522e76ea58cccbb957249a0dffe))
+    - Merge pull request #1969 from GitoxideLabs/new-release ([`631f07a`](https://github.com/GitoxideLabs/gitoxide/commit/631f07ad0c1cb93d9da42cf2c8499584fe91880a))
 </details>
 
 ## 0.10.16 (2025-04-25)
@@ -113,6 +146,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
    - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
    - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+   - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+- https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+- https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+- https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+- https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
+- https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
 - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
 - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831
 - https://github.com/GitoxideLabs/gitoxide/pull/1862#issuecomment-2692158831

--- a/gix-path/Cargo.toml
+++ b/gix-path/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-path"
-version = "0.10.17"
+version = "0.10.18"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing paths and their conversions"

--- a/gix-pathspec/Cargo.toml
+++ b/gix-pathspec/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 
 [dependencies]
 gix-glob = { version = "^0.20.0", path = "../gix-glob" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-attributes = { version = "^0.26.0", path = "../gix-attributes" }
 gix-config-value = { version = "^0.15.0", path = "../gix-config-value" }
 

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -74,7 +74,7 @@ gix-features = { version = "^0.42.1", path = "../gix-features", features = [
 gix-transport = { version = "^0.47.0", path = "../gix-transport" }
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-shallow = { version = "^0.4.0", path = "../gix-shallow" }
-gix-date = { version = "^0.10.1", path = "../gix-date" }
+gix-date = { version = "^0.10.2", path = "../gix-date" }
 gix-utils = { version = "^0.3.0", path = "../gix-utils" }
 gix-ref = { version = "^0.52.1", path = "../gix-ref" }
 

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -23,7 +23,7 @@ serde = ["dep:serde", "gix-hash/serde", "gix-actor/serde", "gix-object/serde"]
 [dependencies]
 gix-features = { version = "^0.42.1", path = "../gix-features", features = ["walkdir"] }
 gix-fs = { version = "^0.15.0", path = "../gix-fs" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
 gix-utils = { version = "^0.3.0", path = "../gix-utils" }

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -29,7 +29,7 @@ serde = ["dep:serde", "gix-hash/serde", "gix-object/serde"]
 [dependencies]
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
-gix-date = { version = "^0.10.1", path = "../gix-date" }
+gix-date = { version = "^0.10.2", path = "../gix-date" }
 gix-hashtable = { version = "^0.8.1", path = "../gix-hashtable", optional = true }
 gix-revwalk = { version = "^0.20.1", path = "../gix-revwalk" }
 gix-commitgraph = { version = "^0.28.0", path = "../gix-commitgraph" }

--- a/gix-sec/Cargo.toml
+++ b/gix-sec/Cargo.toml
@@ -31,7 +31,7 @@ document-features = { version = "0.2.1", optional = true }
 libc = "0.2.172"
 
 [target.'cfg(windows)'.dependencies]
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 windows-sys = { version = "0.59.0", features = [
     "Win32_Foundation",
     "Win32_Security_Authorization",

--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -20,11 +20,11 @@ doctest = false
 worktree-rewrites = ["dep:gix-dir", "dep:gix-diff"]
 
 [dependencies]
-gix-index = { version = "^0.40.0", path = "../gix-index" }
+gix-index = { version = "^0.40.1", path = "../gix-index" }
 gix-fs = { version = "^0.15.0", path = "../gix-fs" }
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-features = { version = "^0.42.1", path = "../gix-features", features = ["progress"] }
 gix-filter = { version = "^0.19.1", path = "../gix-filter" }
 gix-worktree = { version = "^0.41.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }

--- a/gix-submodule/Cargo.toml
+++ b/gix-submodule/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 gix-pathspec = { version = "^0.11.0", path = "../gix-pathspec" }
 gix-refspec = { version = "^0.30.1", path = "../gix-refspec" }
 gix-config = { version = "^0.45.1", path = "../gix-config" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-url = { version = "^0.31.0", path = "../gix-url" }
 
 bstr = { version = "1.12.0", default-features = false }

--- a/gix-traverse/CHANGELOG.md
+++ b/gix-traverse/CHANGELOG.md
@@ -5,13 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### New Features
+
+ - <csr-id-b40ba17c2f7d8c09181ab198c6b89bba976b727b/> Add `commit::Either::commit_time()`
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 6 commits contributed to the release over the course of 14 calendar days.
+ - 14 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Merge pull request #1977 from GitoxideLabs/dependabot/cargo/cargo-811d7b929d ([`800738a`](https://github.com/GitoxideLabs/gitoxide/commit/800738a37f3d33926a427edfa294423bbe3f2b66))
+    - Bump the cargo group with 12 updates ([`4408166`](https://github.com/GitoxideLabs/gitoxide/commit/4408166bf56197a67419277a4ef8feeba9060fee))
+    - Merge pull request #1974 from cruessler/move-commit-time-to-either ([`8be3193`](https://github.com/GitoxideLabs/gitoxide/commit/8be3193eb34ac5deadb0ade60ba01cb3c97f6135))
+    - Refactor ([`9c3e288`](https://github.com/GitoxideLabs/gitoxide/commit/9c3e2880f2996dde9bbdd0c83b498f831054e56f))
+    - Add `commit::Either::commit_time()` ([`b40ba17`](https://github.com/GitoxideLabs/gitoxide/commit/b40ba17c2f7d8c09181ab198c6b89bba976b727b))
+    - Merge pull request #1971 from GitoxideLabs/new-release ([`8d4c4d1`](https://github.com/GitoxideLabs/gitoxide/commit/8d4c4d1e09f84c962c29d98a686c64228196ac13))
+</details>
+
 ## 0.46.1 (2025-04-26)
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 1 commit contributed to the release.
+ - 3 commits contributed to the release.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -22,7 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-date v0.10.1, gix-utils v0.3.0, gix-actor v0.35.1, gix-validate v0.10.0, gix-path v0.10.17, gix-features v0.42.1, gix-hash v0.18.0, gix-hashtable v0.8.1, gix-object v0.49.1, gix-glob v0.20.0, gix-quote v0.6.0, gix-attributes v0.26.0, gix-command v0.6.0, gix-packetline-blocking v0.19.0, gix-filter v0.19.1, gix-fs v0.15.0, gix-commitgraph v0.28.0, gix-revwalk v0.20.1, gix-traverse v0.46.1, gix-worktree-stream v0.21.1, gix-archive v0.21.1, gix-tempfile v17.1.0, gix-lock v17.1.0, gix-index v0.40.0, gix-config-value v0.15.0, gix-pathspec v0.11.0, gix-ignore v0.15.0, gix-worktree v0.41.0, gix-diff v0.52.1, gix-blame v0.2.1, gix-ref v0.52.1, gix-sec v0.11.0, gix-config v0.45.1, gix-prompt v0.11.0, gix-url v0.31.0, gix-credentials v0.29.0, gix-discover v0.40.1, gix-dir v0.14.1, gix-mailmap v0.27.1, gix-revision v0.34.1, gix-merge v0.5.1, gix-negotiate v0.20.1, gix-pack v0.59.1, gix-odb v0.69.1, gix-refspec v0.30.1, gix-shallow v0.4.0, gix-packetline v0.19.0, gix-transport v0.47.0, gix-protocol v0.50.1, gix-status v0.19.1, gix-submodule v0.19.1, gix-worktree-state v0.19.0, gix v0.72.1, gix-fsck v0.11.1, gitoxide-core v0.47.1, gitoxide v0.44.0 ([`e104545`](https://github.com/GitoxideLabs/gitoxide/commit/e104545b78951ca882481d4a58f4425a8bc81c87))
     - Bump all prior pratch levels to majors ([`5f7f805`](https://github.com/GitoxideLabs/gitoxide/commit/5f7f80570e1a5522e76ea58cccbb957249a0dffe))
+    - Merge pull request #1969 from GitoxideLabs/new-release ([`631f07a`](https://github.com/GitoxideLabs/gitoxide/commit/631f07ad0c1cb93d9da42cf2c8499584fe91880a))
 </details>
 
 ## 0.46.0 (2025-04-25)

--- a/gix-traverse/CHANGELOG.md
+++ b/gix-traverse/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.46.2 (2025-05-10)
 
 ### New Features
 
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 6 commits contributed to the release over the course of 14 calendar days.
+ - 7 commits contributed to the release over the course of 14 calendar days.
  - 14 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Prepare changelogs prior to release of `gix-index` ([`bfc4880`](https://github.com/GitoxideLabs/gitoxide/commit/bfc48801bf3ed39cdf7ec02e01aa3cfb6181705f))
     - Merge pull request #1977 from GitoxideLabs/dependabot/cargo/cargo-811d7b929d ([`800738a`](https://github.com/GitoxideLabs/gitoxide/commit/800738a37f3d33926a427edfa294423bbe3f2b66))
     - Bump the cargo group with 12 updates ([`4408166`](https://github.com/GitoxideLabs/gitoxide/commit/4408166bf56197a67419277a4ef8feeba9060fee))
     - Merge pull request #1974 from cruessler/move-commit-time-to-either ([`8be3193`](https://github.com/GitoxideLabs/gitoxide/commit/8be3193eb34ac5deadb0ade60ba01cb3c97f6135))

--- a/gix-traverse/Cargo.toml
+++ b/gix-traverse/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-traverse"
-version = "0.46.1"
+version = "0.46.2"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project"
@@ -18,7 +18,7 @@ doctest = false
 [dependencies]
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
-gix-date = { version = "^0.10.1", path = "../gix-date" }
+gix-date = { version = "^0.10.2", path = "../gix-date" }
 gix-hashtable = { version = "^0.8.1", path = "../gix-hashtable" }
 gix-revwalk = { version = "^0.20.1", path = "../gix-revwalk" }
 gix-commitgraph = { version = "^0.28.0", path = "../gix-commitgraph" }

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -20,7 +20,7 @@ serde = ["dep:serde", "bstr/serde"]
 
 [dependencies]
 gix-features = { version = "^0.42.1", path = "../gix-features" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }
 thiserror = "2.0.0"

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -17,12 +17,12 @@ doctest = false
 
 [dependencies]
 gix-worktree = { version = "^0.41.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }
-gix-index = { version = "^0.40.0", path = "../gix-index" }
+gix-index = { version = "^0.40.1", path = "../gix-index" }
 gix-fs = { version = "^0.15.0", path = "../gix-fs" }
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
 gix-glob = { version = "^0.20.0", path = "../gix-glob" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-features = { version = "^0.42.1", path = "../gix-features" }
 gix-filter = { version = "^0.19.1", path = "../gix-filter" }
 

--- a/gix-worktree-stream/Cargo.toml
+++ b/gix-worktree-stream/Cargo.toml
@@ -20,9 +20,9 @@ gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
 gix-attributes = { version = "^0.26.0", path = "../gix-attributes" }
 gix-filter = { version = "^0.19.1", path = "../gix-filter" }
-gix-traverse = { version = "^0.46.1", path = "../gix-traverse" }
+gix-traverse = { version = "^0.46.2", path = "../gix-traverse" }
 gix-fs = { version = "^0.15.0", path = "../gix-fs" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 
 thiserror = "2.0.0"
 parking_lot = "0.12.1"

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -23,12 +23,12 @@ attributes = ["dep:gix-attributes", "dep:gix-validate"]
 serde = ["dep:serde", "bstr/serde", "gix-index/serde", "gix-hash/serde", "gix-object/serde", "gix-attributes?/serde", "gix-ignore/serde"]
 
 [dependencies]
-gix-index = { version = "^0.40.0", path = "../gix-index" }
+gix-index = { version = "^0.40.1", path = "../gix-index" }
 gix-fs = { version = "^0.15.0", path = "../gix-fs" }
 gix-hash = { version = "^0.18.0", path = "../gix-hash" }
 gix-object = { version = "^0.49.1", path = "../gix-object" }
 gix-glob = { version = "^0.20.0", path = "../gix-glob" }
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-attributes = { version = "^0.26.0", path = "../gix-attributes", optional = true }
 gix-validate = { version = "^0.10.0", path = "../gix-validate", optional = true }
 gix-ignore = { version = "^0.15.0", path = "../gix-ignore" }

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -312,7 +312,7 @@ gix-tempfile = { version = "^17.1.0", path = "../gix-tempfile", default-features
 gix-lock = { version = "^17.1.0", path = "../gix-lock" }
 gix-validate = { version = "^0.10.0", path = "../gix-validate" }
 gix-sec = { version = "^0.11.0", path = "../gix-sec" }
-gix-date = { version = "^0.10.1", path = "../gix-date" }
+gix-date = { version = "^0.10.2", path = "../gix-date" }
 gix-refspec = { version = "^0.30.1", path = "../gix-refspec" }
 gix-filter = { version = "^0.19.1", path = "../gix-filter", optional = true }
 gix-dir = { version = "^0.14.1", path = "../gix-dir", optional = true }
@@ -330,9 +330,9 @@ gix-revision = { version = "^0.34.1", path = "../gix-revision", default-features
 gix-revwalk = { version = "^0.20.1", path = "../gix-revwalk" }
 gix-negotiate = { version = "^0.20.1", path = "../gix-negotiate", optional = true }
 
-gix-path = { version = "^0.10.17", path = "../gix-path" }
+gix-path = { version = "^0.10.18", path = "../gix-path" }
 gix-url = { version = "^0.31.0", path = "../gix-url" }
-gix-traverse = { version = "^0.46.1", path = "../gix-traverse" }
+gix-traverse = { version = "^0.46.2", path = "../gix-traverse" }
 gix-diff = { version = "^0.52.1", path = "../gix-diff", default-features = false }
 gix-merge = { version = "^0.5.1", path = "../gix-merge", default-features = false, optional = true }
 gix-mailmap = { version = "^0.27.1", path = "../gix-mailmap", optional = true }
@@ -345,7 +345,7 @@ gix-trace = { version = "^0.1.12", path = "../gix-trace" }
 gix-glob = { version = "^0.20.0", path = "../gix-glob" }
 gix-credentials = { version = "^0.29.0", path = "../gix-credentials", optional = true }
 gix-prompt = { version = "^0.11.0", path = "../gix-prompt", optional = true }
-gix-index = { version = "^0.40.0", path = "../gix-index", optional = true }
+gix-index = { version = "^0.40.1", path = "../gix-index", optional = true }
 gix-attributes = { version = "^0.26.0", path = "../gix-attributes", optional = true }
 gix-ignore = { version = "^0.15.0", path = "../gix-ignore", optional = true }
 gix-worktree = { version = "^0.41.0", path = "../gix-worktree", optional = true, default-features = false }


### PR DESCRIPTION
- **prepare changelogs prior to release of `gix-index`**
- **Release gix-path v0.10.18, gix-date v0.10.2, gix-traverse v0.46.2, gix-index v0.40.1**
Related to #2005
