### PR TITLE
Make MSRV checks and updates easier and more thorough

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,7 +487,7 @@ jobs:
           sort -m blocking-jobs.txt expected-nonblocking-jobs.txt |
             diff --color=always -U1000 - all-jobs.txt
 
-  # Dummy job to have a stable name for the "all tests pass" requirement
+  # Dummy job to have a stable name for the "all tests pass" requirement.
   tests-pass:
     name: Tests pass
 
@@ -504,7 +504,7 @@ jobs:
       - check-packetline
       - check-blocking
 
-    if: always() # always run even if dependencies fail
+    if: always()  # Always run even if dependencies fail.
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -25,7 +25,6 @@ jobs:
         os:
           - windows-2022
           - ubuntu-latest
-          - macos-15  # FIXME(portability): Remove after testing new justfile changes.
 
     runs-on: ${{ matrix.os }}
 
@@ -39,7 +38,7 @@ jobs:
       - name: Read the MSRV
         run: |
           msrv="$(just msrv)"
-          echo "MSRV=$msrv" >> "$GITHUB_ENV"
+          tee -a "$GITHUB_ENV" <<<"MSRV=$msrv"
       - name: Set up MSRV and nightly toolchains
         run: |
           rustup toolchain install "$MSRV" nightly --profile minimal --no-self-update
@@ -58,12 +57,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
+      - name: Ensure we start out clean
+        run: git diff --exit-code
       - name: Regenerate the MSRV badge
         run: just msrv-badge
       - name: Check for changes
         run: git diff --exit-code
 
-  # Dummy job to have a stable name for the requirement that all MSRV tests pass.
+  # Dummy job to have a stable name for the requirement that all MSRV checks pass.
   msrv-pass:
     name: MSRV checks pass
 

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -25,25 +25,57 @@ jobs:
         os:
           - windows-2022
           - ubuntu-latest
+          - macos-15  # FIXME(portability): Remove after testing new justfile changes.
 
     runs-on: ${{ matrix.os }}
 
-    env:
-      # This is dictated by `firefox` to support the `helix` editor, but now probably effectively
-      # be controlled by `jiff`, which also aligns with `regex`.
-      # IMPORTANT: When adjusting, change all occurrences in `etc/msrv-badge.svg` as well.
-      RUST_VERSION: 1.75.0
+    defaults:
+      run:
+        shell: bash  # Use `bash` even in the Windows job.
 
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
-      - name: Set up ${{ env.RUST_VERSION }} (MSRV) and nightly toolchains
-        run: rustup toolchain install ${{ env.RUST_VERSION }} nightly --profile minimal --no-self-update
-      - name: Set ${{ env.RUST_VERSION }} (MSRV) as default
-        run: rustup default ${{ env.RUST_VERSION }}
+      - name: Read the MSRV
+        run: |
+          msrv="$(just msrv)"
+          echo "MSRV=$msrv" >> "$GITHUB_ENV"
+      - name: Set up MSRV and nightly toolchains
+        run: |
+          rustup toolchain install "$MSRV" nightly --profile minimal --no-self-update
       - name: Downgrade locked dependencies to lowest allowed versions
         run: |
           # TODO(msrv): Use `cargo update --minimal-versions` when `--minimal-versions` is available.
           cargo +nightly update -Zminimal-versions
       - name: Run some `cargo build` commands on `gix`
-        run: just ci-check-msrv
+        run: just check-rust-version "$MSRV"
+
+  check-msrv-badge:
+    name: Check MSRV badge
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v3
+      - name: Regenerate the MSRV badge
+        run: just msrv-badge
+      - name: Check for changes
+        run: git diff --exit-code
+
+  # Dummy job to have a stable name for the requirement that all MSRV tests pass.
+  msrv-pass:
+    name: MSRV checks pass
+
+    needs: [ check-msrv, check-msrv-badge ]
+
+    if: always()  # Always run even if dependencies fail.
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fail if ANY dependency has failed or cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+      - name: OK
+        run: exit 0

--- a/Makefile
+++ b/Makefile
@@ -124,11 +124,6 @@ stress-commitgraph: release-lean $(commit_graphs)
 bench-gix-config:
 	cd gix-config && cargo bench
 
-check-msrv-on-ci: ## Check the minimal support rust version for currently installed Rust version
-	rustc --version
-	cargo build --locked --package gix
-	cargo build --locked --package gix --no-default-features --features async-network-client,max-performance
-
 ##@ Maintenance
 
 baseline_asset_dir = gix/src/assets/baseline-init

--- a/etc/msrv-badge.template.svg
+++ b/etc/msrv-badge.template.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="92" height="20" role="img" aria-label="rustc: {MSRV}+">
+    <title>rustc: {MSRV}+</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="92" height="20" rx="3" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="37" height="20" fill="#555"/>
+        <rect x="37" width="55" height="20" fill="#007ec6"/>
+        <rect width="92" height="20" fill="url(#s)"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="195" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">rustc</text>
+        <text x="195" y="140" transform="scale(.1)" fill="#fff" textLength="270">rustc</text>
+        <text aria-hidden="true" x="635" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">{MSRV}+</text>
+        <text x="635" y="140" transform="scale(.1)" fill="#fff" textLength="450">{MSRV}+</text>
+    </g>
+</svg>

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -9,6 +9,8 @@ version = "0.72.1"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 include = ["src/**/*", "LICENSE-*"]
+# This MSRV is dictated by `firefox` to support the `helix` editor, but is now probably
+# effectively controlled by `jiff`, which also aligns with `regex`.
 rust-version = "1.75"
 
 [lib]

--- a/justfile
+++ b/justfile
@@ -186,14 +186,13 @@ unit-tests-flaky:
 
 # Extract cargo metadata, excluding dependencies, and query it
 [private]
-get-metadata jq-query:
-    cargo metadata --format-version 1 --no-deps | \
-        jq --exit-status --raw-output -- {{ quote(jq-query) }}
+query-meta jq-query:
+    meta="$(cargo metadata --format-version 1 --no-deps)" && \
+        printf '%s\n' "$meta" | jq --exit-status --raw-output -- {{ quote(jq-query) }}
 
 # Get the path to the directory where debug binaries are created during builds
 [private]
-dbg:
-    target_dir="$({{ j }} get-metadata .target_directory)" && echo "$target_dir/debug"
+dbg: (query-meta '.target_directory + "/debug"')
 
 # Run journey tests (`max`)
 journey-tests:
@@ -242,7 +241,7 @@ check-size:
     etc/check-package-size.sh
 
 # Report the Minimum Supported Rust Version (the `rust-version` of `gix`) in X.Y.Z form
-msrv: (get-metadata '''
+msrv: (query-meta '''
     .packages[]
     | select(.name == "gix")
     | .rust_version

--- a/justfile
+++ b/justfile
@@ -242,7 +242,12 @@ check-size:
     etc/check-package-size.sh
 
 # Report the Minimum Supported Rust Version (the `rust-version` of `gix`) in X.Y.Z form
-msrv: (get-metadata '.packages[] | select(.name == "gix") | .rust_version | sub("^\\d+\\.\\d+\\K$"; ".0")')
+msrv: (get-metadata '''
+    .packages[]
+    | select(.name == "gix")
+    | .rust_version
+    | sub("(?<xy>^[0-9]+[.][0-9]+$)"; "\(.xy).0")
+''')
 
 # Regenerate the MSRV badge SVG
 msrv-badge:

--- a/justfile
+++ b/justfile
@@ -242,19 +242,16 @@ check-size:
     etc/check-package-size.sh
 
 # Report the Minimum Supported Rust Version (the `rust-version` of `gix`) in X.Y.Z form
-msrv:
-    set -eu; \
-        query='.packages[] | select(.name == "gix") | .rust_version'; \
-        value="$({{ j }} get-metadata "$query")"; \
-        case "$value" in \
-        *.*.*) \
-            echo "$value" ;; \
-        *.*) \
-            echo "$value.0" ;; \
-        *) \
-            echo "No '.' in gix rust-version '$value'" >&2; \
-            exit 1 ;; \
-        esac
+msrv: (get-metadata '''
+    (.packages[] | select(.name == "gix") | .rust_version | tostring) as $v |
+        if ($v | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) then
+            $v
+        elif ($v | test("^[0-9]+\\.[0-9]+$")) then
+            $v + ".0"
+        else
+            error("Unrecognized rust-version format: " + $v)
+        end
+''')
 
 # Regenerate the MSRV badge SVG
 msrv-badge:

--- a/justfile
+++ b/justfile
@@ -242,16 +242,7 @@ check-size:
     etc/check-package-size.sh
 
 # Report the Minimum Supported Rust Version (the `rust-version` of `gix`) in X.Y.Z form
-msrv: (get-metadata '''
-    (.packages[] | select(.name == "gix") | .rust_version | tostring) as $v |
-        if ($v | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) then
-            $v
-        elif ($v | test("^[0-9]+\\.[0-9]+$")) then
-            $v + ".0"
-        else
-            error("Unrecognized rust-version format: " + $v)
-        end
-''')
+msrv: (get-metadata '.packages[] | select(.name == "gix") | .rust_version | sub("^\\d+\\.\\d+\\K$"; ".0")')
 
 # Regenerate the MSRV badge SVG
 msrv-badge:


### PR DESCRIPTION
This PR could be regarded as a sequel to #2003. Prior to this PR, the MSRV had to be updated manually in `Cargo.toml` for the `gix` crate, in the `msrv.yml` workflow, and in the four occurrences appearing in `msrv-badge.svg`. No mechanism was in place to automate or verify that this had been done correctly.

The changes in this PR make the `rust-version` in `Cargo.toml` for the `gix` crate the single source of truth for the MSRV. This pertains to how the MSRV is validated and the actions that are undertaken to change it, so no change to `STABILITY.md` is made or required; this also does not change how modifying the MSRV will sometimes involve adjusting `rust-version` in other `gix-*` crates.

In the `justfile`, besides makes some minor adjustments for robustness and refactoring for clarity, this makes three external-facing recipe changes:

1. A new `msrv` recipe uses `cargo metadata` and `jq` to retrieve the `rust-version` of `gix` and report it in *major*.*minor*.*patch* format.

2. A new `msrv-badge` recipe calls the `msrv` recipe and writes a badge with the current MSRV to `etc/msrv-badge.svg`.

   This is supported by a new MSRV badge *template* with the literal text `{MSRV}` in place of the MSRV added in `etc`; the `msrv-badge` recipe substitutes those placeholders with the actual MSRV.

3. The old `ci-check-msrv` recipe was confusing, because it didn't do anything MSRV-specific: it checked that `gix` could build in a couple of ways using the current default toolchain. (Comment changes in [#2003](https://github.com/GitoxideLabs/gitoxide/pull/2003) attempted to make this clearer, but I think they managed to lessen the confusion only slightly, if at all.)

   This confusion is mostly fixed here, by renaming the recipe to `check-rust-version` and having it require a `rust-version` argument. Regardless of whatever toolchain is configured as the default, it uses the toolchain specified by the `rust-version` argument (which in ordinary use will be a version number) for the commands it runs.

This facilitates local use, such as running `just msrv-badge` to update the MSRV badge after modifying `gix/Cargo.toml`, but the more important effect is to support changes in the `msrv.yml` workflow:

- The hard-coded `MSRV` environment variable in `msrv.yml` is removed. The `check-msrv` job definition in that workflow instead uses `just msrv` to find out what MSRV toolchain to preinstall, and what argument to pass in `just check-rust-version`. Passing this argument to the `check-rust-version` recipe eliminates the need to set a default toolchain.

  (The main reason the entire MSRV check is not just added as a `check-msrv` recipe in the `justfile`, with the idea that the `check-msrv` jobs could call that, is that `check-msrv` in `msrv.yml` has an intermediate step that downgrades versions in `Cargo.lock`. It might be possible to take a different approach, or to add a `justfile` recipe for that as well, but it's not something that should be done locally by `just` commands that don't clearly advertise it, and it also feels like it doesn't belong in the scope of this PR.)

- A new `check-msrv-badge` job is added to `msrv.yml`. This verifies that `etc/msrv-badge.svg` is correct for the current MSRV, by calling `just msrv-badge`, checking if there are any changes, and failing if so.

  This should make it so that the badge cannot get out of date from forgetting to update it, as well as avoid problems like the `aria-label` bug fixed in dc1d271 ([#2003](https://github.com/GitoxideLabs/gitoxide/pull/2003)) where the badge was in an inconsistent state presenting different MSRVs depending on how it was examined.

  (This is its own job rather than a step in `check-msrv` because it is conceptually separate from that, and also because there are two `check-msrv` jobs--it uses a matrix strategy--but there should only be one `check-msrv-badge` job.)

---

I believe the `check-msrv-badge` job ought to block PR auto-merge--as the `check-msrv` jobs do--since changes to the MSRV may be made in PRs and any resulting inconsistency is most useful to catch immediately when it arises. Currently, the `check-msrv` jobs are listed as required checks (which is not something I can change, via a PR or otherwise).

To support doing that without making branch protection rules more complicated, I've also added an `msrv-pass` job to `msrv.yml` that depends on the jobs in that workflow in the same way that the `tests-pass` job in `ci.yml` depends on most of the other jobs there. (I think it's possible to do this *across* workflows, but more complicated, and it doesn't seem like it would be worthwhile to do for gitoxide's workflows at this time. That is something I am hoping to set up for GitPython, though.) So one option is to remove the current required check(s) for `msrv.yml` and add `msrv-pass` as a required check.

But an alternative is to get rid of the new `msrv-pass` job, and instead merge the `msrv.yml` workflow into `ci.yml`--that is, to put the `check-msrv` and `check-msrv-badge` job definitions in `ci.yml`. I think the workflows have had different triggers in the past, with `msrv.yml` having run on more branches than `ci.yml`. But even if so, that is no longer the case. The `ci.yml` workflow is about 500 lines long, so even if it doubles in size, I don't think it will be too long to read and work in easily. It also contains a wide variety of checks, not limited to running the test suite. Accordingly, it's not obvious that the MSRV checks are more different from the checks that in `ci.yml` than the various checks already in `ci.yml` are from each other.