### PR TITLE
fix: improve version detection fallback in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,22 +6,17 @@ fn main() {
         .output()
         .ok()
         .and_then(|out| {
-            if out.status.success() {
-                parse_describe(&out.stdout)
-            } else {
-                None
+            if !out.status.success() {
+                return None;
             }
+            try_parse_describe(&out.stdout)
         })
         .unwrap_or_else(|| env!("CARGO_PKG_VERSION").into());
     println!("cargo:rustc-env=GIX_VERSION={version}");
 }
 
-fn parse_describe(input: &[u8]) -> Option<String> {
+fn try_parse_describe(input: &[u8]) -> Option<String> {
     let input = std::str::from_utf8(input).ok()?;
     let trimmed = input.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_owned())
-    }
+    (!trimmed.is_empty()).then(|| trimmed.to_owned())
 }

--- a/build.rs
+++ b/build.rs
@@ -5,13 +5,23 @@ fn main() {
         .args(["describe", r"--match=v*\.*\.*"])
         .output()
         .ok()
-        .and_then(|out| parse_describe(&out.stdout))
+        .and_then(|out| {
+            if out.status.success() {
+                parse_describe(&out.stdout)
+            } else {
+                None
+            }
+        })
         .unwrap_or_else(|| env!("CARGO_PKG_VERSION").into());
-
     println!("cargo:rustc-env=GIX_VERSION={version}");
 }
 
 fn parse_describe(input: &[u8]) -> Option<String> {
     let input = std::str::from_utf8(input).ok()?;
-    input.trim().to_owned().into()
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
 }


### PR DESCRIPTION
# Fix version detection in build.rs for cargo-binstall installations

This PR implements improvements suggested in issue #2025.

The main change is fixing the version detection logic in `build.rs` to properly handle cases where Git operations fail or return empty results. Previously, when using `cargo-binstall`, the `gix --version` command would output nothing because the build script was not properly falling back to `CARGO_PKG_VERSION`.

## Changes

- **Improved Git command validation**: Added explicit check for `output.status.success()` to ensure Git command actually succeeded
- **Fixed empty string handling**: Modified `parse_describe()` to return `None` for empty strings instead of `Some("")`, allowing proper fallback to `CARGO_PKG_VERSION`
- **Enhanced error handling**: Build script now properly detects when Git describe fails and falls back to package version

## Issue

When installing via `cargo-binstall`, the pre-built binaries were compiled in environments where:
- Git commands may have failed silently
- Repository tags were not available
- The fallback mechanism was not triggering due to empty strings being treated as valid results

The original `parse_describe` function would return `Some("")` for empty Git output, preventing the `unwrap_or_else` fallback from executing.

## Testing

- Verified that `gix --version` now properly displays version information when installed via `cargo-binstall`
- Confirmed that source builds continue to work as expected
- Version detection now works correctly in both scenarios

Fixes #2025