### PR TITLE
fix: Actually avoid `serde` as dependency, when the serde feature is off

### DIFF
--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -17,13 +17,13 @@ test = false
 
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde = ["dep:serde"]
+serde = ["dep:serde", "faster-hex/serde"]
 
 [dependencies]
 gix-features = { version = "^0.42.1", path = "../gix-features", features = ["progress"] }
 
 thiserror = "2.0.0"
-faster-hex = { version = "0.10.0" }
+faster-hex = { version = "0.10.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 sha1-checked = { version = "0.10.0", default-features = false }
 

--- a/gix-packetline-blocking/Cargo.toml
+++ b/gix-packetline-blocking/Cargo.toml
@@ -26,14 +26,14 @@ async-io = []
 
 #! ### Other
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde = ["dep:serde", "bstr/serde"]
+serde = ["dep:serde", "bstr/serde", "faster-hex/serde"]
 
 [dependencies]
 gix-trace = { version = "^0.1.12", path = "../gix-trace" }
 
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }
 thiserror = "2.0.0"
-faster-hex = { version = "0.10.0" }
+faster-hex = { version = "0.10.0", default-features = false, features = ["std"] }
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 
 document-features = { version = "0.2.0", optional = true }

--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -29,7 +29,7 @@ async-io = ["dep:futures-io", "futures-lite", "dep:pin-project-lite"]
 
 #! ### Other
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde = ["dep:serde", "bstr/serde"]
+serde = ["dep:serde", "bstr/serde", "faster-hex/serde"]
 
 [[test]]
 name = "async-packetline"
@@ -46,7 +46,7 @@ gix-trace = { version = "^0.1.12", path = "../gix-trace" }
 
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }
 thiserror = "2.0.0"
-faster-hex = { version = "0.10.0" }
+faster-hex = { version = "0.10.0", default-features = false, features = ["std"] }
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 # async support
 futures-io = { version = "0.3.16", optional = true }


### PR DESCRIPTION
`faster-hex` has serde as default dependency, and was not marked with `default-features = false`.

I found this while using `gix` with it's default features turned off. 