### PR TITLE
gix-actor docs: document conversions between `Signature` and `SignatureRef`

### DIFF
--- a/gix-actor/src/lib.rs
+++ b/gix-actor/src/lib.rs
@@ -71,6 +71,8 @@ pub struct Signature {
 
 /// An immutable signature that is created by an actor at a certain time.
 ///
+/// Not fully parsed.
+///
 /// Note that this is not a cryptographical signature.
 #[derive(Default, PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -84,6 +86,6 @@ pub struct SignatureRef<'a> {
     ///
     /// Use [SignatureRef::trim()] or trim manually to be able to clean it up.
     pub email: &'a BStr,
-    /// The timestamp at which the signature was performed.
+    /// The timestamp at which the signature was performed, potentially malformed.
     pub time: &'a str,
 }

--- a/gix-actor/src/lib.rs
+++ b/gix-actor/src/lib.rs
@@ -71,7 +71,8 @@ pub struct Signature {
 
 /// An immutable signature that is created by an actor at a certain time.
 ///
-/// Not fully parsed.
+/// All of its fields are references to the backing buffer to allow lossless
+/// round-tripping, as decoding the `time` field could be a lossy transformation.
 ///
 /// Note that this is not a cryptographical signature.
 #[derive(Default, PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
@@ -79,13 +80,16 @@ pub struct Signature {
 pub struct SignatureRef<'a> {
     /// The actors name, potentially with whitespace as parsed.
     ///
-    /// Use [SignatureRef::trim()] or trim manually to be able to clean it up.
+    /// Use [SignatureRef::trim()] or trim manually for cleanup.
     #[cfg_attr(feature = "serde", serde(borrow))]
     pub name: &'a BStr,
     /// The actor's email, potentially with whitespace and garbage as parsed.
     ///
-    /// Use [SignatureRef::trim()] or trim manually to be able to clean it up.
+    /// Use [SignatureRef::trim()] or trim manually for cleanup.
     pub email: &'a BStr,
-    /// The timestamp at which the signature was performed, potentially malformed.
+    /// The timestamp at which the signature was performed,
+    /// potentially malformed due to lenient parsing.
+    ///
+    /// Use [`SignatureRef::time()`] to decode.
     pub time: &'a str,
 }

--- a/gix-actor/src/signature/mod.rs
+++ b/gix-actor/src/signature/mod.rs
@@ -14,7 +14,7 @@ mod _ref {
             decode.parse_next(&mut data)
         }
 
-        /// Create an owned instance from this shared one.
+        /// Try to parse the timestamp and create an owned instance from this shared one.
         pub fn to_owned(&self) -> Result<Signature, gix_date::parse::Error> {
             Ok(Signature {
                 name: self.name.to_owned(),
@@ -71,6 +71,8 @@ mod convert {
 
     impl Signature {
         /// Borrow this instance as immutable, serializing the `time` field into `buf`.
+        ///
+        /// Commonly used as `signature.to_ref(&mut TimeBuf::default())`.
         pub fn to_ref<'a>(&'a self, time_buf: &'a mut TimeBuf) -> SignatureRef<'a> {
             SignatureRef {
                 name: self.name.as_ref(),

--- a/gix-actor/src/signature/mod.rs
+++ b/gix-actor/src/signature/mod.rs
@@ -72,7 +72,7 @@ mod convert {
     impl Signature {
         /// Borrow this instance as immutable, serializing the `time` field into `buf`.
         ///
-        /// Commonly used as `signature.to_ref(&mut TimeBuf::default())`.
+        /// Commonly used as [`signature.to_ref(&mut TimeBuf::default())`](TimeBuf::default).
         pub fn to_ref<'a>(&'a self, time_buf: &'a mut TimeBuf) -> SignatureRef<'a> {
             SignatureRef {
                 name: self.name.as_ref(),
@@ -82,6 +82,7 @@ mod convert {
         }
     }
 
+    /// Note that this conversion is lossy due to the lenient parsing of the [`time`](SignatureRef::time) field.
     impl From<SignatureRef<'_>> for Signature {
         fn from(other: SignatureRef<'_>) -> Signature {
             Signature {


### PR DESCRIPTION
These are some docs that could have been helpful as I am adapting `jj` to https://github.com/GitoxideLabs/gitoxide/pull/1935. Please feel free to edit them further.

I guess a part of this PR is a question: did I figure out correctly how I'm supposed to use these?

See also https://github.com/GitoxideLabs/gitoxide/pull/1935#issuecomment-2946631136. I wonder if some of these classes and methods should be renamed. (Perhaps it's possible to make the old name a deprecated type alias?)