### PR TITLE
fix: `blob::UnifiedDiff` now produces non-overlapping hunks.

### DIFF
--- a/gix-diff/src/blob/unified_diff.rs
+++ b/gix-diff/src/blob/unified_diff.rs
@@ -218,9 +218,7 @@ pub(super) mod _impl {
             if self.err.is_some() {
                 return;
             }
-            if ((self.pos == 0) && (before.start - self.pos > self.ctx_size))
-                || (before.start - self.pos > 2 * self.ctx_size)
-            {
+            if before.start - self.pos > 2 * self.ctx_size {
                 if let Err(err) = self.flush() {
                     self.err = Some(err);
                     return;

--- a/gix-diff/tests/diff/blob/unified_diff.rs
+++ b/gix-diff/tests/diff/blob/unified_diff.rs
@@ -109,6 +109,68 @@ fn removed_modified_added() -> crate::Result {
 }
 
 #[test]
+fn context_overlap_by_one_line_move_up() -> crate::Result {
+    let a = "2\n3\n4\n5\n6\n7\n";
+    let b = "7\n2\n3\n4\n5\n6\n";
+
+    let interner = gix_diff::blob::intern::InternedInput::new(a, b);
+    let actual = gix_diff::blob::diff(
+        Algorithm::Myers,
+        &interner,
+        UnifiedDiff::new(
+            &interner,
+            String::new(),
+            NewlineSeparator::AfterHeaderAndLine("\n"),
+            ContextSize::symmetrical(3),
+        ),
+    )?;
+
+    // merged by context.
+    insta::assert_snapshot!(actual, @r"
+    @@ -1,6 +1,6 @@
+    +7
+     2
+     3
+     4
+     5
+     6
+    -7
+    ");
+    Ok(())
+}
+
+#[test]
+fn context_overlap_by_one_line_move_down() -> crate::Result {
+    let a = "2\n3\n4\n5\n6\n7\n";
+    let b = "7\n2\n3\n4\n5\n6\n";
+
+    let interner = gix_diff::blob::intern::InternedInput::new(b, a);
+    let actual = gix_diff::blob::diff(
+        Algorithm::Myers,
+        &interner,
+        UnifiedDiff::new(
+            &interner,
+            String::new(),
+            NewlineSeparator::AfterHeaderAndLine("\n"),
+            ContextSize::symmetrical(3),
+        ),
+    )?;
+
+    // merged by context.
+    insta::assert_snapshot!(actual, @r"
+    @@ -1,6 +1,6 @@
+    -7
+     2
+     3
+     4
+     5
+     6
+    +7
+    ");
+    Ok(())
+}
+
+#[test]
 fn removed_modified_added_with_newlines_in_tokens() -> crate::Result {
     let a = "1\n2\n3\n4\n5\n6\n7\n8\n9\n10";
     let b = "2\n3\n4\n5\nsix\n7\n8\n9\n10\neleven\ntwelve";


### PR DESCRIPTION
Previously it was possible to see two hunks with overlapping context lines due to an off-by-one error.
