### PR TITLE
fix: username in scp-like url is no longer percent-encoded (#2056)

### DIFF
--- a/gix-url/tests/fixtures/make_baseline.sh
+++ b/gix-url/tests/fixtures/make_baseline.sh
@@ -15,7 +15,7 @@ tests_windows=()
 for path in "repo" "re:po" "re/po"; do
   # normal urls
   for protocol in "ssh+git" "git+ssh" "git" "ssh"; do
-    for host in "host" "user@host" "user@[::1]" "user@::1"; do
+    for host in "host" "user@host" "user_name@host" "user@[::1]" "user@::1"; do
       for port_separator in "" ":"; do
         tests+=("$protocol://$host$port_separator/$path")
 
@@ -42,7 +42,7 @@ for path in "repo" "re:po" "re/po"; do
     tests+=("./$protocol:$host/~$path")
   done
   # SCP like urls
-  for host in "host" "[::1]"; do
+  for host in "user@name@host" "user_name@host" "host" "[::1]"; do
     tests+=("$host:$path")
     tests+=("$host:/~$path")
   done

--- a/gix-url/tests/url/baseline.rs
+++ b/gix-url/tests/url/baseline.rs
@@ -84,7 +84,7 @@ fn run() {
     }
 
     assert!(
-        failure_count_reserialization <= 42,
+        failure_count_reserialization <= 63,
         "the number of reserialization errors should ideally get better, not worse - if this panic is not due to regressions but to new passing test cases, you can set this check to {failure_count_reserialization}"
     );
     assert_eq!(failure_count_roundtrips, 0, "there should be no roundtrip errors");
@@ -185,8 +185,8 @@ mod baseline {
 
         pub fn max_num_failures(&self) -> usize {
             match self {
-                Kind::Unix => 165,
-                Kind::Windows => 171,
+                Kind::Unix => 198,
+                Kind::Windows => 198 + 6,
             }
         }
 


### PR DESCRIPTION
Since Git doesn't percent-decode characters in scp-like URL, we shouldn't encode username at all.

https://github.com/git/git/blob/v2.50.0/connect.c#L1081

I've split write_to() function to clarify that any non-path components that should be separated by ":" cannot be serialized in alternative form. I've made it fall back to the URL syntax if password or port number was set. Maybe we can also check if the user or host includes ":", but I'm not sure how much foolproof we should add here.