### PR TITLE
Get only patch version updates to `imara-diff`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
       prefix: ''
     allow:
       - dependency-type: all
+    ignore:
+      # Keep imara-diff at 0.1.* for now (see comments in #2068).
+      - dependency-name: imara-diff
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
     groups:
       cargo:
         patterns: ['*']


### PR DESCRIPTION
This configures Dependabot version updates to keep `imara-diff` at 0.1.*. It does not affect Dependabot security updates, nor other ways of updating besides Dependabot, nor other crate dependencies if they are unrelated to `imara-diff`. See:

- https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--

This is by the same technique as used in https://github.com/GitoxideLabs/cargo-smart-release/commit/aeb91ee22bcd8aadd64a3261e3de2ed985c99485.

See discussion in #2068 for details for why we are not upgrading `imara-diff` to 0.2 at this time.

---

I've tested this in my fork; see https://github.com/EliahKagan/gitoxide/pull/62 if interested. The configuration works, and no other changes were needed to make CI pass in that test PR. Unless something arises to indicate otherwise, I plan to merge this, then let Dependabot update #2068 or supersede it with a new PR (I expect it to do the latter) and merge it so long as it also passes here.