### PR TITLE
Add explicit accessors to `gix_diff::index::ChangeRef``

### DIFF
--- a/gix-diff/src/index/change.rs
+++ b/gix-diff/src/index/change.rs
@@ -82,6 +82,12 @@ impl ChangeRef<'_, '_> {
     /// Return all shared fields among all variants: `(location, index, entry_mode, id)`
     ///
     /// In case of rewrites, the fields return to the current change.
+    ///
+    /// Note that there are also more specific accessors in case you only need to access to one of
+    /// these fields individually.
+    ///
+    /// See [`ChangeRef::location()`], [`ChangeRef::index()`], [`ChangeRef::entry_mode()`] and
+    /// [`ChangeRef::id()`].
     pub fn fields(&self) -> (&BStr, usize, gix_index::entry::Mode, &gix_hash::oid) {
         match self {
             ChangeRef::Addition {

--- a/gix-diff/src/index/change.rs
+++ b/gix-diff/src/index/change.rs
@@ -114,6 +114,46 @@ impl ChangeRef<'_, '_> {
             } => (location.as_ref(), *index, *entry_mode, id),
         }
     }
+
+    /// Return the `location`, in the case of rewrites referring to the current change.
+    pub fn location(&self) -> &BStr {
+        match self {
+            ChangeRef::Addition { location, .. }
+            | ChangeRef::Deletion { location, .. }
+            | ChangeRef::Modification { location, .. }
+            | ChangeRef::Rewrite { location, .. } => location.as_ref(),
+        }
+    }
+
+    /// Return the `index`, in the case of rewrites referring to the current change.
+    pub fn index(&self) -> usize {
+        match self {
+            ChangeRef::Addition { index, .. }
+            | ChangeRef::Deletion { index, .. }
+            | ChangeRef::Modification { index, .. }
+            | ChangeRef::Rewrite { index, .. } => *index,
+        }
+    }
+
+    /// Return the `entry_mode`, in the case of rewrites referring to the current change.
+    pub fn entry_mode(&self) -> gix_index::entry::Mode {
+        match self {
+            ChangeRef::Addition { entry_mode, .. }
+            | ChangeRef::Deletion { entry_mode, .. }
+            | ChangeRef::Modification { entry_mode, .. }
+            | ChangeRef::Rewrite { entry_mode, .. } => *entry_mode,
+        }
+    }
+
+    /// Return the `id`, in the case of rewrites referring to the current change.
+    pub fn id(&self) -> &gix_hash::oid {
+        match self {
+            ChangeRef::Addition { id, .. }
+            | ChangeRef::Deletion { id, .. }
+            | ChangeRef::Modification { id, .. }
+            | ChangeRef::Rewrite { id, .. } => id,
+        }
+    }
 }
 
 impl rewrites::tracker::Change for ChangeRef<'_, '_> {

--- a/gix-diff/tests/diff/index.rs
+++ b/gix-diff/tests/diff/index.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use gix_diff::{
     index::Change,
     rewrites::{Copies, CopySource},
@@ -313,8 +315,27 @@ fn renames_by_similarity_with_limit() -> crate::Result {
         0,
         "fuzzy tracking is effectively disabled due to limit"
     );
-    let actual: Vec<_> = changes.iter().map(|c| c.fields().0).collect();
-    assert_eq!(actual, ["f1", "f1-renamed", "f2", "f2-renamed"]);
+    let actual_locations: Vec<_> = changes.iter().map(|c| c.location()).collect();
+    assert_eq!(actual_locations, ["f1", "f1-renamed", "f2", "f2-renamed"]);
+
+    let actual_indices: Vec<_> = changes.iter().map(|c| c.index()).collect();
+    assert_eq!(actual_indices, [6, 6, 7, 7]);
+
+    use gix_index::entry::Mode;
+
+    let actual_entry_modes: Vec<_> = changes.iter().map(|c| c.entry_mode()).collect();
+    assert_eq!(actual_entry_modes, [Mode::FILE, Mode::FILE, Mode::FILE, Mode::FILE]);
+
+    let actual_ids: Vec<_> = changes.iter().map(|c| c.id()).collect();
+    assert_eq!(
+        actual_ids,
+        [
+            gix_hash::ObjectId::from_str("f00c965d8307308469e537302baa73048488f162")?,
+            gix_hash::ObjectId::from_str("683cfcc0f47566c332aa45d81c5cc98acb4aab49")?,
+            gix_hash::ObjectId::from_str("3bb459b831ea471b9cd1cbb7c6d54a74251a711b")?,
+            gix_hash::ObjectId::from_str("0a805f8e02d72bd354c1f00607906de2e49e00d6")?,
+        ]
+    );
 
     let out = out.expect("tracking enabled");
     assert_eq!(out.num_similarity_checks, 0);
@@ -481,7 +502,7 @@ fn copies_in_entire_tree_by_similarity() -> crate::Result {
         0,
         "needs --find-copies-harder to detect rewrites here"
     );
-    let actual: Vec<_> = changes.iter().map(|c| c.fields().0).collect();
+    let actual: Vec<_> = changes.iter().map(|c| c.location()).collect();
     assert_eq!(actual, ["b", "c6", "c7", "newly-added"]);
 
     let out = out.expect("tracking enabled");

--- a/gix-diff/tests/diff/index.rs
+++ b/gix-diff/tests/diff/index.rs
@@ -315,18 +315,21 @@ fn renames_by_similarity_with_limit() -> crate::Result {
         0,
         "fuzzy tracking is effectively disabled due to limit"
     );
-    let actual_locations: Vec<_> = changes.iter().map(|c| c.location()).collect();
+
+    use gix_diff::index::ChangeRef;
+
+    let actual_locations: Vec<_> = changes.iter().map(ChangeRef::location).collect();
     assert_eq!(actual_locations, ["f1", "f1-renamed", "f2", "f2-renamed"]);
 
-    let actual_indices: Vec<_> = changes.iter().map(|c| c.index()).collect();
+    let actual_indices: Vec<_> = changes.iter().map(ChangeRef::index).collect();
     assert_eq!(actual_indices, [6, 6, 7, 7]);
 
     use gix_index::entry::Mode;
 
-    let actual_entry_modes: Vec<_> = changes.iter().map(|c| c.entry_mode()).collect();
+    let actual_entry_modes: Vec<_> = changes.iter().map(ChangeRef::entry_mode).collect();
     assert_eq!(actual_entry_modes, [Mode::FILE, Mode::FILE, Mode::FILE, Mode::FILE]);
 
-    let actual_ids: Vec<_> = changes.iter().map(|c| c.id()).collect();
+    let actual_ids: Vec<_> = changes.iter().map(ChangeRef::id).collect();
     assert_eq!(
         actual_ids,
         [
@@ -502,7 +505,7 @@ fn copies_in_entire_tree_by_similarity() -> crate::Result {
         0,
         "needs --find-copies-harder to detect rewrites here"
     );
-    let actual: Vec<_> = changes.iter().map(|c| c.location()).collect();
+    let actual: Vec<_> = changes.iter().map(gix_diff::index::ChangeRef::location).collect();
     assert_eq!(actual, ["b", "c6", "c7", "newly-added"]);
 
     let out = out.expect("tracking enabled");

--- a/gix/src/status/iter/types.rs
+++ b/gix/src/status/iter/types.rs
@@ -135,7 +135,7 @@ impl Item {
     pub fn location(&self) -> &BStr {
         match self {
             Item::IndexWorktree(change) => change.rela_path(),
-            Item::TreeIndex(change) => change.fields().0,
+            Item::TreeIndex(change) => change.location(),
         }
     }
 }


### PR DESCRIPTION
- feat: add explicit accessors for common fields
- Adapt to changes in `gix-diff`

There don’t seem to be any explicit tests specifically for `.fields()` yet, so I extended an existing test that already used `.fields().0`. Let me know if there’s a better way to test this!

This PR is based on an idea in this comment: https://github.com/gitui-org/gitui/pull/2673#discussion_r2174461979
