### PR TITLE
feat: add first debug version of `gix tag list`

### DIFF
--- a/gitoxide-core/src/repository/mod.rs
+++ b/gitoxide-core/src/repository/mod.rs
@@ -44,6 +44,7 @@ pub mod remote;
 pub mod revision;
 pub mod status;
 pub mod submodule;
+pub mod tag;
 pub mod tree;
 pub mod verify;
 pub mod worktree;

--- a/gitoxide-core/src/repository/tag.rs
+++ b/gitoxide-core/src/repository/tag.rs
@@ -5,12 +5,26 @@ pub fn list(repo: gix::Repository, out: &mut dyn std::io::Write) -> anyhow::Resu
         let tag = reference.peel_to_tag();
         let tag_ref = tag.as_ref().map(gix::Tag::decode);
 
-        let name = match tag_ref {
-            Ok(Ok(tag)) => tag.name.to_string(),
-            _ => reference.name().shorten().to_string(),
-        };
+        // `name` is the name of the file in `refs/tags/`. This applies to both lightweight as well
+        // as annotated tags.
+        let name = reference.name().shorten();
 
-        writeln!(out, "{name}")?;
+        match tag_ref {
+            Ok(Ok(tag_ref)) => {
+                // `tag_name` is the name provided by the user via `git tag -a/-s/-u`. It is only
+                // present for annotated tags.
+                let tag_name = tag_ref.name;
+
+                if name == tag_name {
+                    writeln!(out, "{name} *")?;
+                } else {
+                    writeln!(out, "{name} [tag name: {}]", tag_ref.name)?;
+                }
+            }
+            _ => {
+                writeln!(out, "{name}")?;
+            }
+        }
     }
 
     Ok(())

--- a/gitoxide-core/src/repository/tag.rs
+++ b/gitoxide-core/src/repository/tag.rs
@@ -1,0 +1,17 @@
+pub fn list(repo: gix::Repository, out: &mut dyn std::io::Write) -> anyhow::Result<()> {
+    let platform = repo.references()?;
+
+    for mut reference in (platform.tags()?).flatten() {
+        let tag = reference.peel_to_tag();
+        let tag_ref = tag.as_ref().map(gix::Tag::decode);
+
+        let name = match tag_ref {
+            Ok(Ok(tag)) => tag.name.to_string(),
+            _ => reference.name().shorten().to_string(),
+        };
+
+        writeln!(out, "{name}")?;
+    }
+
+    Ok(())
+}

--- a/gitoxide-core/src/repository/tag.rs
+++ b/gitoxide-core/src/repository/tag.rs
@@ -1,25 +1,27 @@
 pub fn list(repo: gix::Repository, out: &mut dyn std::io::Write) -> anyhow::Result<()> {
     let platform = repo.references()?;
 
-    for mut reference in (platform.tags()?).flatten() {
+    for mut reference in platform.tags()?.flatten() {
         let tag = reference.peel_to_tag();
         let tag_ref = tag.as_ref().map(gix::Tag::decode);
 
-        // `name` is the name of the file in `refs/tags/`. This applies to both lightweight as well
-        // as annotated tags.
+        // `name` is the name of the file in `refs/tags/`.
+        // This applies to both lightweight and annotated tags.
         let name = reference.name().shorten();
-
+        let mut fields = Vec::new();
         match tag_ref {
             Ok(Ok(tag_ref)) => {
-                // `tag_name` is the name provided by the user via `git tag -a/-s/-u`. It is only
-                // present for annotated tags.
-                let tag_name = tag_ref.name;
-
-                if name == tag_name {
-                    writeln!(out, "{name} *")?;
-                } else {
-                    writeln!(out, "{name} [tag name: {}]", tag_ref.name)?;
+                // `tag_name` is the name provided by the user via `git tag -a/-s/-u`.
+                // It is only present for annotated tags.
+                fields.push(format!(
+                    "tag name: {}",
+                    if name == tag_ref.name { "*".into() } else { tag_ref.name }
+                ));
+                if tag_ref.pgp_signature.is_some() {
+                    fields.push("signed".into());
                 }
+
+                writeln!(out, "{name} [{fields}]", fields = fields.join(", "))?;
             }
             _ => {
                 writeln!(out, "{name}")?;

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -1304,8 +1304,8 @@ pub fn main() -> Result<()> {
                 },
             ),
         },
-        Subcommands::Tag(cmd) => match cmd {
-            tag::Subcommands::List => prepare_and_run(
+        Subcommands::Tag(platform) => match platform.cmds {
+            Some(tag::Subcommands::List) | None => prepare_and_run(
                 "tag-list",
                 trace,
                 auto_verbose,

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -17,7 +17,7 @@ use crate::{
     plumbing::{
         options::{
             attributes, commit, commitgraph, config, credential, exclude, free, fsck, index, mailmap, merge, odb,
-            revision, tree, Args, Subcommands,
+            revision, tag, tree, Args, Subcommands,
         },
         show_progress,
     },
@@ -1302,6 +1302,17 @@ pub fn main() -> Result<()> {
                         },
                     )
                 },
+            ),
+        },
+        Subcommands::Tag(cmd) => match cmd {
+            tag::Subcommands::List => prepare_and_run(
+                "tag-list",
+                trace,
+                auto_verbose,
+                progress,
+                progress_keep_open,
+                None,
+                move |_progress, out, _err| core::repository::tag::list(repository(Mode::Lenient)?, out),
             ),
         },
         Subcommands::Tree(cmd) => match cmd {

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -100,6 +100,9 @@ pub enum Subcommands {
     /// Interact with commit objects.
     #[clap(subcommand)]
     Commit(commit::Subcommands),
+    /// Interact with tag objects.
+    #[clap(subcommand)]
+    Tag(tag::Subcommands),
     /// Verify the integrity of the entire repository
     Verify {
         #[clap(flatten)]
@@ -925,6 +928,14 @@ pub mod commit {
             /// A specification of the revision to use, or the current `HEAD` if unset.
             rev_spec: Option<String>,
         },
+    }
+}
+
+pub mod tag {
+    #[derive(Debug, clap::Subcommand)]
+    pub enum Subcommands {
+        /// List all tags.
+        List,
     }
 }
 

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -101,8 +101,8 @@ pub enum Subcommands {
     #[clap(subcommand)]
     Commit(commit::Subcommands),
     /// Interact with tag objects.
-    #[clap(subcommand)]
-    Tag(tag::Subcommands),
+    #[clap(visible_alias = "tags")]
+    Tag(tag::Platform),
     /// Verify the integrity of the entire repository
     Verify {
         #[clap(flatten)]
@@ -932,6 +932,12 @@ pub mod commit {
 }
 
 pub mod tag {
+    #[derive(Debug, clap::Parser)]
+    pub struct Platform {
+        #[clap(subcommand)]
+        pub cmds: Option<Subcommands>,
+    }
+
     #[derive(Debug, clap::Subcommand)]
     pub enum Subcommands {
         /// List all tags.


### PR DESCRIPTION
This PR adds a new command: `gix tag list`.

`gix tag list` outputs a list of tags, adding information with respect to whether a tag is lightweight or annotated (the examples are taken from the `gitoxide` repository):

- for a lightweight tag, it will show the name it has in `.git/refs/tags/`: `v0.8.4`.
- for an annotated tag where the name is identical to the filename in `.git/refs/tags/`, it will show an asterisk next to the name: `gix-v0.72.1 *`.
- for an annotated tag where the name is *not* identical to the filename in `.git/refs/tags/`, it will show the tag name in square brackets: `gitoxide-v0.8.1 [tag name: v0.8.1]`.

Feel free to modify this in any way you like, though, in particular if there are already established patterns in other parts of the codebase.
