### PR TITLE
Add `justfile` recipes to help with releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,16 @@ on:
   push:
     # Enable when testing release infrastructure on a branch.
     # branches:
-     #  - fix-releases
+    #   - fix-releases
     tags:
-      - 'v*'
+    # For now, real releases always use `workflow_dispatch`, and running the workflow on tag pushes
+    # is only done in testing. This is because we usually push too many tags at once for the `push`
+    # event to be triggered, since there are usually more than 3 crates tagged together. So the
+    # `push` trigger doesn't usually work. If we allow it, we risk running the workflow twice if
+    # it is also manually triggered based on the assumption that it would not run. See #1970 for
+    # details. See also the `run-release-workflow` and `roll-release` recipes in the `justfile`.
+    # - 'v*'
+      - 'v*-DO-NOT-USE'  # Pattern for tags used to test the workflow (usually done in a fork).
   workflow_dispatch:
 
 permissions:

--- a/etc/unique-v-tag.sh
+++ b/etc/unique-v-tag.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -efu
+IFS=$'\n'
+
+# shellcheck disable=SC2207  # Intentionally splitting. No globbing due to set -f.
+tags=(
+    $(git tag --points-at HEAD -- 'v*')
+)
+
+count="${#tags[@]}"
+if ((count != 1)); then
+    printf '%s: error: Found %d matching v* tags, need exactly 1.\n' "$0" "$count" >&2
+    exit 1
+fi
+
+printf '%s\n' "${tags[0]}"


### PR DESCRIPTION
As described in #1970, the `release.yml` workflow can rarely (if ever) trigger on `push`, because `cargo-smart-release` usually pushes more than three tags at a time, as used here.

This makes two changes:

- e249706a52c372329814dc4437ae46288fb25055 adds recipes in the `justfile` to make it easier to trigger the workflow via `workflow_dispatch`.
- ef5fff179953e846c7073f4d07539529282f4031 prevents the `push` event from triggering the workflow except for testing tags, so it's not accidentally triggered twice when using the new recipes.

There are substantial further details in the commit messages. I have tested everything in my fork, for various scenarios--for example, [here's one of the runs](https://github.com/EliahKagan/gitoxide/actions/runs/16246429827)--except I have only slightly tested `roll-release`. It may be that something like `just roll-release -e` will usually be sufficient when releasing, I am not sure.

I am not sure about the `roll-release` recipe as currently written. If one were to run `just roll-release`, then it would do a dry-run release, but then attempt to run the actual release workflow.

- Maybe there should be a recipe to run `cargo smart-release` for a dry run (even if it would have just one command), with the `roll-release` recipe without passing `-e`/`--execute`, to discourage such usage where it would not make sense to trigger the workflow. Maybe the `roll-release` recipe should pass `-e`/`--execute`.
- On the other hand, maybe running `roll-release` for a dry-run should not be discouraged: if there is no `v*` tag at `HEAD`, then the `run-release-workflow` recipe will look for a unique `v*` tag via the `unique-v-tag` recipe, which will fail, and no `gh workflow` command will be invoked.
- Yet, I am worried about the case where, for some reason, there is a `v*` tag at the tip of a branch before running `cargo smart-release` with the intent that new commits will be created with changelogs and a release will be performed. This seems unlikely, but I don't know of any fundamental reason it could not happen. (For example, a preceding just-completed release of at least one crate could have been yanked due to a SemVer-related problem.) If that happened, then we could wrongly *re*run `release.yml` on a `v*` tag.

In view of my uncertainty as to how safe and usable the current design is, I'll wait for a review before merging.

*Edit:* Clarified and fixed some incorrect wording in the above bullet points.