### PR TITLE
fix: textconf programs are now always run through a shell.

### DIFF
--- a/gix-diff/src/blob/pipeline.rs
+++ b/gix-diff/src/blob/pipeline.rs
@@ -549,7 +549,7 @@ impl Driver {
         let cmd = gix_command::prepare(gix_path::from_bstr(command).into_owned())
             // TODO: Add support for an actual Context, validate it *can* match Git
             .with_context(Default::default())
-            .command_may_be_shell_script()
+            .with_shell()
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())


### PR DESCRIPTION
This is based on what Git does, see https://github.com/git/git/commit/41a457e4f814a0e514548b3178e7692129f0fcfe .

This originally surfaced in https://github.com/gitbutlerapp/gitbutler/issues/9540 .
