### PR TITLE
WIP: gix-date: handling bad offsets

### DIFF
--- a/gix-date/tests/time/format.rs
+++ b/gix-date/tests/time/format.rs
@@ -81,6 +81,14 @@ fn git_default() {
     );
 }
 
+#[test]
+fn bad_offset() {
+    assert_eq!(
+        time_bad_offset().format(gix_date::time::format::DEFAULT),
+        "Wed Jan 24 22:36:22 2018 -3407"
+    );
+}
+
 fn time() -> Time {
     Time {
         seconds: 123456789,
@@ -92,5 +100,12 @@ fn time_dec1() -> Time {
     Time {
         seconds: 123543189,
         offset: 9000,
+    }
+}
+
+fn time_bad_offset() -> Time {
+    Time {
+        seconds: 1516956202,
+        offset: -122820,
     }
 }


### PR DESCRIPTION
This commit from edk2 has an invalid author date offset: https://github.com/tianocore/edk2/commit/630cb8507b2f1d7d7af3ac0f992d40f209dc1cee

```
$ gix cat 630cb8507b2f1d7d7af3ac0f992d40f209dc1cee ...
author Ruiyu Ni <ruiyu.ni@intel.com> 1516956202 -3407

But git show can still display it:
commit 630cb8507b2f1d7d7af3ac0f992d40f209dc1cee
Author: Ray Ni <ray.ni@intel.com>
Date:   Wed Jan 24 22:36:22 2018 -3407
```

How to handle it with gix-date?