### PR TITLE
Change `set +x` to `set -x` in CI `wasm` steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
       - name: 'WASI only: crates without feature toggle'
         if: endsWith(matrix.target, '-wasi')
         run: |
-          set +x
+          set -x
           for crate in gix-sec; do
             cargo build -p "$crate" --target "$TARGET"
           done
@@ -447,19 +447,19 @@ jobs:
             gix-url
             gix-validate
           )
-          set +x
+          set -x
           for crate in "${crates[@]}"; do
             cargo build -p "$crate" --target "$TARGET"
           done
       - name: features of gix-features
         run: |
-          set +x
+          set -x
           for feature in progress parallel io-pipe crc32 zlib cache-efficiency-debug; do
             cargo build -p gix-features --features "$feature" --target "$TARGET"
           done
       - name: crates with 'wasm' feature
         run: |
-          set +x
+          set -x
           for crate in gix-pack; do
             cargo build -p "$crate" --features wasm --target "$TARGET"
           done


### PR DESCRIPTION
These steps benefit from showing the `cargo` command that was run before the resulting build output. Most run multiple `cargo build` commands, sometimes in a loop, such that the output can only be properly understood if the commands are shown. `set +x` is the default (in general, as well as in GitHub Actions unless the value of `shell` is modified with `-x` or `-o xtrace`). It looks like `set -x` was already intended here. Work in #2093 confirms a practical benefit of `-x` for understanding these logs.

`set +x` was part of the original code of these CI steps when they were introduced in 0d4b804 (#735). Its use was preserved and expanded in several changes. In 44ff412 (#1668), `set +x` was preserved and also positioned where it would make sense for `set -x` to be. Thus, it appears this started as a small typo and gradually expanded through misreadings, including my own. This fixes that.

(See EliahKagan#74 for verification that `set +x` had no effect.)

---

This is its own PR rather than being done as part of #2093, because this already confers a benefit, whereas I don't know if or when #2093 will be ready.