### PR TITLE
fix: don't parse any number as timestamp in `parse_header()` (#2095)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,7 +1633,7 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "bstr",
  "document-features",

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 serde = ["dep:serde", "bstr/serde", "gix-date/serde"]
 
 [dependencies]
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 gix-utils = { version = "^0.3.0", path = "../gix-utils" }
 
 thiserror = "2.0.0"

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -30,7 +30,7 @@ zip = ["dep:zip"]
 gix-worktree-stream = { version = "^0.22.0", path = "../gix-worktree-stream" }
 gix-object = { version = "^0.50.0", path = "../gix-object" }
 gix-path = { version = "^0.10.19", path = "../gix-path", optional = true }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 
 flate2 = { version = "1.1.1", optional = true, default-features = false, features = ["zlib-rs"] }
 zip = { version = "4.3.0", optional = true, default-features = false, features = ["deflate-flate2"] }

--- a/gix-blame/Cargo.toml
+++ b/gix-blame/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.70"
 gix-commitgraph = { version = "^0.29.0", path = "../gix-commitgraph" }
 gix-revwalk = { version = "^0.21.0", path = "../gix-revwalk" }
 gix-trace = { version = "^0.1.13", path = "../gix-trace" }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 gix-diff = { version = "^0.53.0", path = "../gix-diff", default-features = false, features = ["blob"] }
 gix-object = { version = "^0.50.0", path = "../gix-object" }
 gix-hash = { version = "^0.19.0", path = "../gix-hash" }

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -25,7 +25,7 @@ gix-path = { version = "^0.10.19", path = "../gix-path" }
 gix-command = { version = "^0.6.2", path = "../gix-command" }
 gix-config-value = { version = "^0.15.1", path = "../gix-config-value" }
 gix-prompt = { version = "^0.11.1", path = "../gix-prompt" }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 gix-trace = { version = "^0.1.13", path = "../gix-trace" }
 
 thiserror = "2.0.0"

--- a/gix-date/CHANGELOG.md
+++ b/gix-date/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.4 (2025-08-03)
+
+### Bug Fixes
+
+ - <csr-id-ad67ab5bdea74f3c90c9670c8043f8b642a274d4/> don't parse any number as timestamp in `parse_header()`
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 3 commits contributed to the release over the course of 19 calendar days.
+ - 19 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 1 unique issue was worked on: [#2095](https://github.com/GitoxideLabs/gitoxide/issues/2095)
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **[#2095](https://github.com/GitoxideLabs/gitoxide/issues/2095)**
+    - Don't parse any number as timestamp in `parse_header()` ([`ad67ab5`](https://github.com/GitoxideLabs/gitoxide/commit/ad67ab5bdea74f3c90c9670c8043f8b642a274d4))
+ * **Uncategorized**
+    - Remove a hack which makes '1979-02-26 18:30:00' special. ([`91b3220`](https://github.com/GitoxideLabs/gitoxide/commit/91b32208dda387916b87fc1d02809a73415a58c0))
+    - Merge pull request #2075 from GitoxideLabs/improvements ([`784c046`](https://github.com/GitoxideLabs/gitoxide/commit/784c0465bf87011fe7dbf71a590d3f9e6c8696a8))
+</details>
+
 ## 0.10.3 (2025-07-15)
 
 A maintenance release without user-facing changes.
@@ -13,7 +41,7 @@ A maintenance release without user-facing changes.
 
 <csr-read-only-do-not-edit/>
 
- - 6 commits contributed to the release over the course of 65 calendar days.
+ - 7 commits contributed to the release over the course of 65 calendar days.
  - 65 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -25,6 +53,7 @@ A maintenance release without user-facing changes.
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-date v0.10.3, gix-actor v0.35.2, gix-trace v0.1.13, gix-path v0.10.19, gix-features v0.43.0, gix-hash v0.19.0, gix-hashtable v0.9.0, gix-object v0.50.0, gix-glob v0.21.0, gix-attributes v0.27.0, gix-command v0.6.2, gix-packetline-blocking v0.19.1, gix-filter v0.20.0, gix-fs v0.16.0, gix-commitgraph v0.29.0, gix-revwalk v0.21.0, gix-traverse v0.47.0, gix-worktree-stream v0.22.0, gix-archive v0.22.0, gix-tempfile v18.0.0, gix-lock v18.0.0, gix-index v0.41.0, gix-config-value v0.15.1, gix-pathspec v0.12.0, gix-ignore v0.16.0, gix-worktree v0.42.0, gix-diff v0.53.0, gix-blame v0.3.0, gix-ref v0.53.0, gix-sec v0.12.0, gix-config v0.46.0, gix-prompt v0.11.1, gix-url v0.32.0, gix-credentials v0.30.0, gix-discover v0.41.0, gix-dir v0.15.0, gix-mailmap v0.27.2, gix-revision v0.35.0, gix-merge v0.6.0, gix-negotiate v0.21.0, gix-pack v0.60.0, gix-odb v0.70.0, gix-refspec v0.31.0, gix-shallow v0.5.0, gix-packetline v0.19.1, gix-transport v0.48.0, gix-protocol v0.51.0, gix-status v0.20.0, gix-submodule v0.20.0, gix-worktree-state v0.20.0, gix v0.73.0, gix-fsck v0.12.0, gitoxide-core v0.48.0, gitoxide v0.45.0, safety bump 43 crates ([`5a919c4`](https://github.com/GitoxideLabs/gitoxide/commit/5a919c48393020d47c7034946108577dd213b80a))
     - Update changelogs prior to release ([`65037b5`](https://github.com/GitoxideLabs/gitoxide/commit/65037b56918b90ac07454a815b0ed136df2fca3b))
     - Merge pull request #2070 from GitoxideLabs/dependabot/cargo/cargo-827bceb7eb ([`dab97f7`](https://github.com/GitoxideLabs/gitoxide/commit/dab97f7618f160421b6e31de8f3e2f3d11dc2ef2))
     - Bump the cargo group across 1 directory with 68 updates ([`a9a8ea1`](https://github.com/GitoxideLabs/gitoxide/commit/a9a8ea1472532dde03bce4e0afdfa82924af1f96))

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-date"
-version = "0.10.3"
+version = "0.10.4"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project parsing dates the way git does"

--- a/gix-date/src/parse.rs
+++ b/gix-date/src/parse.rs
@@ -214,6 +214,9 @@ pub(crate) mod function {
             Some(offset_in_seconds)
         }
 
+        if input.contains(':') {
+            return None;
+        }
         let mut split = input.split_whitespace();
         let seconds = split.next()?;
         let seconds = match seconds.parse::<SecondsSinceUnixEpoch>() {

--- a/gix-date/src/parse.rs
+++ b/gix-date/src/parse.rs
@@ -145,11 +145,6 @@ pub(crate) mod function {
     ///     *   `2 minutes ago` (October 27, 2023 at 09:58:00 UTC)
     ///     *   `3 hours ago` (October 27, 2023 at 07:00:00 UTC)
     pub fn parse(input: &str, now: Option<SystemTime>) -> Result<Time, Error> {
-        // TODO: actual implementation, this is just to not constantly fail
-        if input == "1979-02-26 18:30:00" {
-            return Ok(Time::new(42, 1800));
-        }
-
         Ok(if let Ok(val) = Date::strptime(SHORT.0, input) {
             let val = val
                 .to_zoned(TimeZone::UTC)

--- a/gix-date/tests/time/parse.rs
+++ b/gix-date/tests/time/parse.rs
@@ -3,13 +3,10 @@ use std::time::SystemTime;
 use gix_date::Time;
 
 #[test]
-fn special_time_is_ok_for_now() {
-    assert_eq!(
-        gix_date::parse("1979-02-26 18:30:00", Some(SystemTime::now())).unwrap(),
-        Time {
-            seconds: 42,
-            offset: 1800,
-        }
+fn time_without_offset_is_not_parsed_yet() {
+    assert!(
+        gix_date::parse("1979-02-26 18:30:00", Some(SystemTime::now())).is_err(),
+        "This was a special time with special handling, but it is not  anymore"
     );
 }
 

--- a/gix-date/tests/time/parse.rs
+++ b/gix-date/tests/time/parse.rs
@@ -14,6 +14,21 @@ fn special_time_is_ok_for_now() {
 }
 
 #[test]
+fn parse_header_is_not_too_lenient() {
+    let now = SystemTime::now();
+    for not_a_header_str in ["2005-04-07T22:13:09", "2005-04-07 22:13:09"] {
+        assert!(
+            gix_date::parse_header(not_a_header_str).is_none(),
+            "It's not timestamp-like, despite some leniency"
+        );
+        assert!(
+            gix_date::parse(not_a_header_str, Some(now)).is_err(),
+            "it misses the timezone offset, so can't be parsed"
+        );
+    }
+}
+
+#[test]
 fn short() {
     assert_eq!(
         gix_date::parse("1979-02-26", Some(SystemTime::now())).unwrap(),

--- a/gix-mailmap/Cargo.toml
+++ b/gix-mailmap/Cargo.toml
@@ -20,7 +20,7 @@ serde = ["dep:serde", "bstr/serde", "gix-actor/serde"]
 
 [dependencies]
 gix-actor = { version = "^0.35.2", path = "../gix-actor" }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 bstr = { version = "1.12.0", default-features = false, features = ["std", "unicode"] }
 thiserror = "2.0.0"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }

--- a/gix-negotiate/Cargo.toml
+++ b/gix-negotiate/Cargo.toml
@@ -18,7 +18,7 @@ test = false
 [dependencies]
 gix-hash = { version = "^0.19.0", path = "../gix-hash" }
 gix-object = { version = "^0.50.0", path = "../gix-object" }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 gix-commitgraph = { version = "^0.29.0", path = "../gix-commitgraph" }
 gix-revwalk = { version = "^0.21.0", path = "../gix-revwalk" }
 thiserror = "2.0.0"

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -48,7 +48,7 @@ gix-hash = { version = "^0.19.0", path = "../gix-hash" }
 gix-hashtable = { version = "^0.9.0", path = "../gix-hashtable" }
 gix-validate = { version = "^0.10.0", path = "../gix-validate" }
 gix-actor = { version = "^0.35.2", path = "../gix-actor" }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 gix-path = { version = "^0.10.19", path = "../gix-path" }
 gix-utils = { version = "^0.3.0", path = "../gix-utils" }
 

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -23,7 +23,7 @@ serde = ["dep:serde", "gix-hash/serde", "gix-object/serde", "gix-pack/serde"]
 gix-features = { version = "^0.43.0", path = "../gix-features", features = ["walkdir", "zlib", "crc32"] }
 gix-hashtable = { version = "^0.9.0", path = "../gix-hashtable" }
 gix-hash = { version = "^0.19.0", path = "../gix-hash" }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 gix-path = { version = "^0.10.19", path = "../gix-path" }
 gix-quote = { version = "^0.6.0", path = "../gix-quote" }
 gix-object = { version = "^0.50.0", path = "../gix-object" }

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -74,7 +74,7 @@ gix-features = { version = "^0.43.0", path = "../gix-features", features = [
 gix-transport = { version = "^0.48.0", path = "../gix-transport" }
 gix-hash = { version = "^0.19.0", path = "../gix-hash" }
 gix-shallow = { version = "^0.5.0", path = "../gix-shallow" }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 gix-utils = { version = "^0.3.0", path = "../gix-utils" }
 gix-ref = { version = "^0.53.0", path = "../gix-ref" }
 

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -29,7 +29,7 @@ serde = ["dep:serde", "gix-hash/serde", "gix-object/serde"]
 [dependencies]
 gix-hash = { version = "^0.19.0", path = "../gix-hash" }
 gix-object = { version = "^0.50.0", path = "../gix-object" }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 gix-hashtable = { version = "^0.9.0", path = "../gix-hashtable", optional = true }
 gix-revwalk = { version = "^0.21.0", path = "../gix-revwalk" }
 gix-commitgraph = { version = "^0.29.0", path = "../gix-commitgraph" }

--- a/gix-revision/tests/revision/spec/parse/anchor/at_symbol.rs
+++ b/gix-revision/tests/revision/spec/parse/anchor/at_symbol.rs
@@ -35,7 +35,7 @@ fn reflog_by_entry_for_current_branch() {
 
 #[test]
 fn reflog_by_date_for_current_branch() {
-    let rec = parse("@{1979-02-26 18:30:00}");
+    let rec = parse("@{42 +0030}");
 
     assert!(rec.kind.is_none());
     assert_eq!(rec.find_ref[0], None);
@@ -81,9 +81,9 @@ fn reflog_by_date_with_date_parse_failure() {
 #[test]
 fn reflog_by_date_for_hash_is_invalid() {
     for (spec, full_name) in [
-        ("1234@{1979-02-26 18:30:00}", "1234"),
-        ("abcd-dirty@{1979-02-26 18:30:00}", "abcd-dirty"),
-        ("v1.2.3-0-g1234@{1979-02-26 18:30:00}", "v1.2.3-0-g1234"),
+        ("1234@{42 +0030}", "1234"),
+        ("abcd-dirty@{42 +0030}", "abcd-dirty"),
+        ("v1.2.3-0-g1234@{42 +0030}", "v1.2.3-0-g1234"),
     ] {
         let err = try_parse(spec).unwrap_err();
         assert!(matches!(err, spec::parse::Error::ReflogLookupNeedsRefName {name} if name == full_name));
@@ -93,12 +93,9 @@ fn reflog_by_date_for_hash_is_invalid() {
 #[test]
 fn reflog_by_date_for_given_ref_name() {
     for (spec, expected_ref) in [
-        ("main@{1979-02-26 18:30:00}", "main"),
-        ("refs/heads/other@{1979-02-26 18:30:00}", "refs/heads/other"),
-        (
-            "refs/worktree/feature/a@{1979-02-26 18:30:00}",
-            "refs/worktree/feature/a",
-        ),
+        ("main@{42 +0030}", "main"),
+        ("refs/heads/other@{42 +0030}", "refs/heads/other"),
+        ("refs/worktree/feature/a@{42 +0030}", "refs/worktree/feature/a"),
     ] {
         let rec = parse(spec);
 

--- a/gix-revwalk/Cargo.toml
+++ b/gix-revwalk/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 [dependencies]
 gix-hash = { version = "^0.19.0", path = "../gix-hash" }
 gix-object = { version = "^0.50.0", path = "../gix-object" }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 gix-hashtable = { version = "^0.9.0", path = "../gix-hashtable" }
 gix-commitgraph = { version = "^0.29.0", path = "../gix-commitgraph" }
 

--- a/gix-traverse/Cargo.toml
+++ b/gix-traverse/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 [dependencies]
 gix-hash = { version = "^0.19.0", path = "../gix-hash" }
 gix-object = { version = "^0.50.0", path = "../gix-object" }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 gix-hashtable = { version = "^0.9.0", path = "../gix-hashtable" }
 gix-revwalk = { version = "^0.21.0", path = "../gix-revwalk" }
 gix-commitgraph = { version = "^0.29.0", path = "../gix-commitgraph" }

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -314,7 +314,7 @@ gix-tempfile = { version = "^18.0.0", path = "../gix-tempfile", default-features
 gix-lock = { version = "^18.0.0", path = "../gix-lock" }
 gix-validate = { version = "^0.10.0", path = "../gix-validate" }
 gix-sec = { version = "^0.12.0", path = "../gix-sec" }
-gix-date = { version = "^0.10.3", path = "../gix-date" }
+gix-date = { version = "^0.10.4", path = "../gix-date" }
 gix-refspec = { version = "^0.31.0", path = "../gix-refspec" }
 gix-filter = { version = "^0.20.0", path = "../gix-filter", optional = true }
 gix-dir = { version = "^0.15.0", path = "../gix-dir", optional = true }

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -26,7 +26,7 @@ mod with_overrides {
     #[test]
     #[serial]
     fn order_from_api_and_cli_and_environment() -> gix_testtools::Result {
-        let default_date = "1979-02-26 18:30:00";
+        let default_date = "42 +0030";
         let _env = Env::new()
             .set("GIT_HTTP_USER_AGENT", "agent-from-env")
             .set("GIT_HTTP_LOW_SPEED_LIMIT", "1")

--- a/gix/tests/gix/repository/config/identity.rs
+++ b/gix/tests/gix/repository/config/identity.rs
@@ -141,7 +141,7 @@ fn author_from_different_config_sections() -> crate::Result {
     let _env = Env::new()
         .set("GIT_CONFIG_GLOBAL", work_dir.join("global.config").to_str().unwrap())
         .set("GIT_CONFIG_SYSTEM", work_dir.join("system.config").to_str().unwrap())
-        .set("GIT_AUTHOR_DATE", "1979-02-26 18:30:00")
+        .set("GIT_AUTHOR_DATE", "42 +0030")
         .unset("GIT_AUTHOR_NAME")
         .set("GIT_COMMITTER_DATE", "1980-02-26 18:30:00 +0000")
         .unset("GIT_COMMITTER_NAME")

--- a/gix/tests/gix/revision/spec/from_bytes/reflog.rs
+++ b/gix/tests/gix/revision/spec/from_bytes/reflog.rs
@@ -78,7 +78,7 @@ fn by_index() {
 fn by_date() {
     let repo = repo("complex_graph").unwrap();
 
-    let spec = parse_spec_no_baseline("main@{1979-02-26 18:30:00}", &repo).unwrap();
+    let spec = parse_spec_no_baseline("main@{42 +0030}", &repo).unwrap();
 
     assert_eq!(
         spec,

--- a/gix/tests/gix/util.rs
+++ b/gix/tests/gix/util.rs
@@ -9,7 +9,7 @@ pub fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
 }
 
 pub fn freeze_time() -> gix_testtools::Env<'static> {
-    let frozen_time = "1979-02-26 18:30:00";
+    let frozen_time = "42 +0030";
     gix_testtools::Env::new()
         .unset("GIT_AUTHOR_NAME")
         .unset("GIT_AUTHOR_EMAIL")


### PR DESCRIPTION
Fixes #2095

### Tasks

* [x] reproduction and fix
* [x] `gix-date` patch release
