### PR TITLE
fix(gix): extend lifetime of iterators

### DIFF
--- a/gix-ref/src/store/file/overlay_iter.rs
+++ b/gix-ref/src/store/file/overlay_iter.rs
@@ -189,11 +189,11 @@ impl Iterator for LooseThenPacked<'_, '_> {
     }
 }
 
-impl Platform<'_> {
+impl<'repo> Platform<'repo> {
     /// Return an iterator over all references, loose or packed, sorted by their name.
     ///
     /// Errors are returned similarly to what would happen when loose and packed refs were iterated by themselves.
-    pub fn all(&self) -> std::io::Result<LooseThenPacked<'_, '_>> {
+    pub fn all<'p>(&'p self) -> std::io::Result<LooseThenPacked<'p, 'repo>> {
         self.store.iter_packed(self.packed.as_ref().map(|b| &***b))
     }
 
@@ -205,14 +205,14 @@ impl Platform<'_> {
     /// starts with `foo`, like `refs/heads/foo` and `refs/heads/foobar`.
     ///
     /// Prefixes are relative paths with slash-separated components.
-    pub fn prefixed(&self, prefix: &RelativePath) -> std::io::Result<LooseThenPacked<'_, '_>> {
+    pub fn prefixed<'p>(&'p self, prefix: &RelativePath) -> std::io::Result<LooseThenPacked<'p, 'repo>> {
         self.store
             .iter_prefixed_packed(prefix, self.packed.as_ref().map(|b| &***b))
     }
 
     /// Return an iterator over the pseudo references, like `HEAD` or `FETCH_HEAD`, or anything else suffixed with `HEAD`
     /// in the root of the `.git` directory, sorted by name.
-    pub fn pseudo(&self) -> std::io::Result<LooseThenPacked<'_, '_>> {
+    pub fn pseudo<'p>(&'p self) -> std::io::Result<LooseThenPacked<'p, 'repo>> {
         self.store.iter_pseudo()
     }
 }

--- a/gix/tests/gix/repository/reference.rs
+++ b/gix/tests/gix/repository/reference.rs
@@ -183,6 +183,21 @@ mod iter_references {
         );
         Ok(())
     }
+
+    /// Regression test for https://github.com/GitoxideLabs/gitoxide/issues/2103
+    /// This only ensures we can return a reference, not that the code below is correct
+    #[test]
+    fn tags() -> crate::Result {
+        let repo = repo()?;
+        let actual = repo
+            .references()?
+            .tags()?
+            .filter_map(Result::ok)
+            .max_by_key(|tag| tag.name().shorten().to_owned())
+            .ok_or(std::io::Error::other("latest tag not found"))?;
+        assert_eq!(actual.name().as_bstr(), "refs/tags/t1");
+        Ok(())
+    }
 }
 
 mod head {


### PR DESCRIPTION
Previously the iterators would return references with lifetimes that were shorter than the actual lifetimes of the `gix::Reference` themselves. This was dues to a footgun with `'_` (eliding the lifetime).

When a function returns an elided lifetime, this lifetime usually is the lifetime of the `&self` parameter, but sometimes it is the lifetime of the type itself (e.g. `Iter<'_>`).

I made the lifetimes explicit to ensure we were using the correct ones.

Closes #2103