### PR TITLE
Mark `ReadDataLineFuture` as `#[allow(dead_code)]`

### DIFF
--- a/gix-packetline-blocking/src/read/sidebands/async_io.rs
+++ b/gix-packetline-blocking/src/read/sidebands/async_io.rs
@@ -176,6 +176,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 pub struct ReadDataLineFuture<'a, 'b, T: AsyncRead, F> {
     parent: &'b mut WithSidebands<'a, T, F>,
     buf: &'b mut Vec<u8>,

--- a/gix-packetline/src/read/sidebands/async_io.rs
+++ b/gix-packetline/src/read/sidebands/async_io.rs
@@ -174,6 +174,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 pub struct ReadDataLineFuture<'a, 'b, T: AsyncRead, F> {
     parent: &'b mut WithSidebands<'a, T, F>,
     buf: &'b mut Vec<u8>,


### PR DESCRIPTION
The `ReadDataLineFuture` struct was among the facilities added within `gix-packetline` in 41fdb84 (#634), and it looks like it may have been intended to be used eventually. However, it is unused.

While it is public in `read::sidebands::async_io` module, the only facility from that module that is exposed through `read::sidebands` is `WithSidebands`:

https://github.com/GitoxideLabs/gitoxide/blob/04a18f3a4520dd6f49b5f87fe3782dd1cd1547f2/gix-packetline/src/read/sidebands/mod.rs#L6-L9

This situation appears to be long-standing. However, possibly because it is public in its own directly containing module, it was not detected as dead code by `cargo clippy` until recently.

Specifically, this caused the CI `lint` job to fail starting in the recently released Rust 1.89. This can be observed by rerunning the workflow where it had passed before:

https://github.com/EliahKagan/gitoxide/actions/runs/16739420509/job/47709197815

(The failure only happens in the `lean-async` run of `cargo clippy` because the containing module is not used at all in the `max`, `small`, and `max-pure` builds.)

For now, this PR suppresses the error by adding `#[allow(dead_code)]` to `ReadDataLineFuture`.

---

It may be that a different fix is preferable, maybe even removing `ReadDataLineFuture` altogether. I figured this would be a reasonable fix to start with, because currently this fails the `lint` job in PRs and feature branches, such as [this failure](https://github.com/GitoxideLabs/gitoxide/actions/runs/16823918370/job/47656067995?pr=2106) in #2106. The idea here is to unblock progress in other areas, but I don't claim that this should be permanent.