### PR TITLE
Keep `test-32bit` CI on Debian 12 for the moment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
 
     runs-on: ${{ matrix.runner-os }}
 
-    container: ${{ matrix.container-arch }}/debian:stable-slim
+    container: ${{ matrix.container-arch }}/debian:bookworm-slim
 
     steps:
       - name: Prerequisites


### PR DESCRIPTION
*See https://github.com/GitoxideLabs/gitoxide/issues/1622#issuecomment-3172528683.*

Debian `stable` has moved from Debian 12 `bookworm` to Debian 13 `trixie`. The Debian 12 `git` package is 2.39.5 (with downstream patches), while the Debian 13 `git` package is 2.47.2 (with downstream patches). This brings back #1622 for the `test-32bit` jobs, where the `regex_matches` test fails again, as seen in:

- https://github.com/EliahKagan/gitoxide/actions/runs/16855949428/job/47756506693#step:10:429
- https://github.com/EliahKagan/gitoxide/actions/runs/16843514197/job/47757429000#step:10:429

The `:/` baseline skip was removed in #1993 based on two assumptions. It turns out neither of these was altogether correct:

- Although most CI jobs are expected to have a recent Git because GitHub Actions runner images are expected to have a recent Git, `container` jobs may have an older Git, as is the case here.
- Debian 13 is a release of a prominent distribution that provides Git 2.47.\*. Since Debian is very popular and the time between its stable releases is sometimes long, the scenario of a system provided Git 2.47.\* is now far from obscure.

It may be that a `:/` baseline skip should be reintroduced to work around this. If so, it should possibly be opt-in by a `GIX_TEST_*` environment variable, because some of the reasons for removing it still apply fully. (Such as to avoid: the risk of accidentally committing incorrect regenerated fixture archives; misleading test results, where what it means for the test to pass varies by system in a non-obvious way; and the need to cover other tests that run under other feature combinations and are similarly affected.)

It may (instead, or also) be that we should use a later build of `git` than 2.47.\* in the `test-32bit` jobs, which would have the fix for the bug that underlies #1622 and thus avoid the CI failure, though it would currently involve using either an unofficial build or taking it from Debian `unstable`.

This PR just holds the Docker image back to Debian 12. This is meant as a temporary workaround.

This only modifies the `test-32bit` jobs. The `pure-rust-build` job works on Debian 13 already, because it does not run the tests. (Running the tests without `GIX_TEST_IGNORE_ARCHIVES` would also pass, even with affected versions of Git, as #1622 is not surfaced when pre-generated baselines are used from committed archives.)