### PR TITLE
Persist object refs on disk with a trailing newline

### DIFF
--- a/gix-ref/src/store/file/transaction/prepare.rs
+++ b/gix-ref/src/store/file/transaction/prepare.rs
@@ -182,7 +182,7 @@ impl Transaction<'_, '_> {
                     let mut lock = lock.take().map_or_else(obtain_lock, Ok)?;
 
                     lock.with_mut(|file| match new {
-                        Target::Object(oid) => write!(file, "{oid}"),
+                        Target::Object(oid) => writeln!(file, "{oid}"),
                         Target::Symbolic(name) => writeln!(file, "ref: {}", name.0),
                     })?;
                     Some(lock.close()?)


### PR DESCRIPTION
Match git's behavior. This improves compatibility with alternative Git client programs such as Sublime Merge.