### PR TITLE
Test that loose refs are written with a trailing newline

### DIFF
--- a/gix-ref/tests/refs/file/transaction/prepare_and_commit/create_or_update/mod.rs
+++ b/gix-ref/tests/refs/file/transaction/prepare_and_commit/create_or_update/mod.rs
@@ -755,6 +755,11 @@ fn packed_refs_are_looked_up_when_checking_existing_values() -> crate::Result {
         Some(new_id.as_ref()),
         "the new id was written to the loose ref"
     );
+    assert_eq!(
+        std::fs::read_to_string(store.common_dir_resolved().join("refs/heads/main"))?,
+        format!("{}\n", new_id.to_hex()),
+        "the loose ref is stored on disk as the full OID followed by a newline"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
This adds regression testing for the fix in 6c0cc71 (#2111).

The `packed_refs_are_looked_up_when_checking_existing_values` test case had already asserted that the updated ref is loose and parses as the correct OID. This extends that case with another assertion that the stored file's exact contents are the hex OID followed by a newline.

The added assertion checks the OID, and not just that the file ends with a newline character, partly so that if it somehow opened the wrong file then this would be caught, but more importantly so that it verifies that no extra data beyond this are added. For example, a loose ref should end with a Unix-style LF line ending on all systems; by checking its whole content, this verifies that no CR (`\r`) byte is written even on Windows.

The new assertion was validated by applying it locally at fb78f1e, where it fails in the expected way:

            FAIL [   0.560s] gix-ref-tests::refs file::transaction::prepare_and_commit::create_or_update::packed_refs_are_looked_up_when_checking_existing_values
      stdout ───

        running 1 test
        test file::transaction::prepare_and_commit::create_or_update::packed_refs_are_looked_up_when_checking_existing_values ... FAILED

        failures:

        failures:
            file::transaction::prepare_and_commit::create_or_update::packed_refs_are_looked_up_when_checking_existing_values

        test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 134 filtered out; finished in 0.52s

      stderr ───

        thread 'file::transaction::prepare_and_commit::create_or_update::packed_refs_are_looked_up_when_checking_existing_values' panicked at gix-ref\tests\refs\file\transaction\prepare_and_commit\create_or_update\mod.rs:758:5:
        assertion `left == right` failed: the loose ref is stored on disk as the full OID followed by a newline
          left: "0000000000000000000000000000000000000001"
         right: "0000000000000000000000000000000000000001\n"
        note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

In contrast, when applied at dc7343c, it passes, due to 6c0cc71.