### PR TITLE
perf(gix-utils): add normalization fast path

### DIFF
--- a/gix-utils/src/str.rs
+++ b/gix-utils/src/str.rs
@@ -4,8 +4,8 @@ use std::{borrow::Cow, ffi::OsStr, path::Path};
 ///
 /// At the expense of extra-compute, it does nothing if there is no work to be done, returning the original input without allocating.
 pub fn precompose(s: Cow<'_, str>) -> Cow<'_, str> {
-    use unicode_normalization::UnicodeNormalization;
-    if s.as_ref().nfc().cmp(s.as_ref().chars()).is_eq() {
+    use unicode_normalization::{is_nfc, UnicodeNormalization};
+    if is_nfc(s.as_ref()) {
         s
     } else {
         Cow::Owned(s.as_ref().nfc().collect())
@@ -16,8 +16,8 @@ pub fn precompose(s: Cow<'_, str>) -> Cow<'_, str> {
 ///
 /// At the expense of extra-compute, it does nothing if there is no work to be done, returning the original input without allocating.
 pub fn decompose(s: Cow<'_, str>) -> Cow<'_, str> {
-    use unicode_normalization::UnicodeNormalization;
-    if s.as_ref().nfd().cmp(s.as_ref().chars()).is_eq() {
+    use unicode_normalization::{is_nfd, UnicodeNormalization};
+    if is_nfd(s.as_ref()) {
         s
     } else {
         Cow::Owned(s.as_ref().nfd().collect())


### PR DESCRIPTION
`unicode_normalization` provide fast-paths functions (`is_nfc_quick`/`is_nfd_quick`) for quick-checks to determine if (de-)composition is necessary. These functions may can return an ambiguous results in certain cases (`Maybe`), to avoid this `is_nfc`/`is_nfd` exists which do slow checks if these functions return `Maybe` (matching the current code in `gix-utils`).

For strings that do not require normalisation the `is_nfc`/`is_nfd` are about 75% faster, but 20% slower for strings that do require normalisation. As far as I can tell the slowdown can be avoided by avoiding the slow check e.g `is_nfc_quick(s.chars()) == IsNormalized::Yes`, but this may come at the expense of unnecessary allocations.