### PR TITLE
docs(readme): concise overview, usage boundaries, stability, links — crate: gix-bitmap

### DIFF
--- a/gix-bitmap/Cargo.toml
+++ b/gix-bitmap/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.70"
 exclude = ["CHANGELOG.md"]
+readme = "README.md"
 
 [lib]
 doctest = false

--- a/gix-bitmap/README.md
+++ b/gix-bitmap/README.md
@@ -1,0 +1,23 @@
+# gix-bitmap — README (draft)
+
+## What it is
+Library crate for reading and using Git pack bitmaps to accelerate reachability/object enumeration in packed repositories within the gitoxide stack.
+
+## When to use / When not to
+- **Use when** building tools/services that need faster reachability checks and must scale with large repositories.
+- **Do not use when** you need a CLI or a high‑level package/repository management layer; this is an internal component.
+
+## Stability & MSRV
+Stability: Unspecified — see the project‑wide stability policy (https://github.com/GitoxideLabs/gitoxide/blob/main/STABILITY.md).
+MSRV: Inherits the workspace’s Minimum Supported Rust Version — see MSRV policy for details (https://github.com/GitoxideLabs/gitoxide/blob/main/.github/workflows/msrv.yml).
+
+## Links
+- crates.io: https://crates.io/crates/gix-bitmap
+- docs.rs: https://docs.rs/gix-bitmap/latest/gix_bitmap/
+
+## Related crates
+- `gix-pack` — pack file access and operations.
+- `gix-object` — core Git object types and serialization.
+
+## License
+Dual-licensed under MIT OR Apache-2.0.


### PR DESCRIPTION

## What changed
Add a concise README for **gix-bitmap** with:
- two-line purpose statement,
- “When to use / When not to” boundaries,
- explicit links to crates.io and docs.rs,
- **Stability & MSRV** section with absolute links to the project-wide policies,
- License section (MIT OR Apache-2.0).

No behavioral/API changes. No MSRV or release changes. Documentation only.

## Motivation
Improve package discoverability and trust on crates.io and make the crate’s role within the gitoxide stack explicit.

## Before → After
| Item | Before | After |
|---|---|---|
| crates.io page | README insufficient/unclear | Concise README + docs.rs link + stability/MSRV policy references |

## References
- crates.io: https://crates.io/crates/gix-bitmap  
- docs.rs: https://docs.rs/gix-bitmap/latest/gix_bitmap/  
- Stability policy: https://github.com/GitoxideLabs/gitoxide/blob/main/STABILITY.md  
- MSRV policy: https://github.com/GitoxideLabs/gitoxide/blob/main/README.md#msrv  
- License: MIT — https://github.com/GitoxideLabs/gitoxide/blob/main/LICENSE-MIT  
            Apache-2.0 — https://github.com/GitoxideLabs/gitoxide/blob/main/LICENSE-APACHE

## Scope & exclusions
- Includes: README for **gix-bitmap** only.
- Excludes: code changes, tests, release/version bumps, MSRV changes.

## Verification
- [x] Local build passes (no warnings introduced).
- [x] Links resolve (crates.io, docs.rs, stability/MSRV, licenses).
- [x] Narrow scope aligned with trunk-based workflow.
