### PR TITLE
feat: add first debug version of `gix branch list`

### DIFF
--- a/gitoxide-core/src/repository/branch.rs
+++ b/gitoxide-core/src/repository/branch.rs
@@ -1,0 +1,68 @@
+use crate::OutputFormat;
+
+pub enum Kind {
+    Local,
+    All,
+}
+
+impl Kind {
+    fn includes_local_branches(&self) -> bool {
+        match self {
+            Self::Local | Self::All => true,
+        }
+    }
+
+    fn includes_remote_branches(&self) -> bool {
+        match self {
+            Self::Local => false,
+            Self::All => true,
+        }
+    }
+}
+
+pub struct Options {
+    pub kind: Kind,
+}
+
+pub fn list(
+    repo: gix::Repository,
+    out: &mut dyn std::io::Write,
+    format: OutputFormat,
+    options: Options,
+) -> anyhow::Result<()> {
+    if format != OutputFormat::Human {
+        anyhow::bail!("JSON output isn't supported");
+    }
+
+    let platform = repo.references()?;
+
+    if options.kind.includes_local_branches() {
+        let mut branch_names: Vec<String> = platform
+            .local_branches()?
+            .flatten()
+            .map(|branch| branch.name().shorten().to_string())
+            .collect();
+
+        branch_names.sort();
+
+        for branch_name in branch_names {
+            writeln!(out, "{branch_name}")?;
+        }
+    }
+
+    if options.kind.includes_remote_branches() {
+        let mut branch_names: Vec<String> = platform
+            .remote_branches()?
+            .flatten()
+            .map(|branch| branch.name().shorten().to_string())
+            .collect();
+
+        branch_names.sort();
+
+        for branch_name in branch_names {
+            writeln!(out, "{branch_name}")?;
+        }
+    }
+
+    Ok(())
+}

--- a/gitoxide-core/src/repository/branch.rs
+++ b/gitoxide-core/src/repository/branch.rs
@@ -5,21 +5,6 @@ pub enum Kind {
     All,
 }
 
-impl Kind {
-    fn includes_local_branches(&self) -> bool {
-        match self {
-            Self::Local | Self::All => true,
-        }
-    }
-
-    fn includes_remote_branches(&self) -> bool {
-        match self {
-            Self::Local => false,
-            Self::All => true,
-        }
-    }
-}
-
 pub struct Options {
     pub kind: Kind,
 }
@@ -36,7 +21,12 @@ pub fn list(
 
     let platform = repo.references()?;
 
-    if options.kind.includes_local_branches() {
+    let (show_local, show_remotes) = match options.kind {
+        Kind::Local => (true, false),
+        Kind::All => (true, true),
+    };
+
+    if show_local {
         let mut branch_names: Vec<String> = platform
             .local_branches()?
             .flatten()
@@ -50,7 +40,7 @@ pub fn list(
         }
     }
 
-    if options.kind.includes_remote_branches() {
+    if show_remotes {
         let mut branch_names: Vec<String> = platform
             .remote_branches()?
             .flatten()

--- a/gitoxide-core/src/repository/branch.rs
+++ b/gitoxide-core/src/repository/branch.rs
@@ -1,19 +1,21 @@
 use crate::OutputFormat;
 
-pub enum Kind {
-    Local,
-    All,
-}
+pub mod list {
+    pub enum Kind {
+        Local,
+        All,
+    }
 
-pub struct Options {
-    pub kind: Kind,
+    pub struct Options {
+        pub kind: Kind,
+    }
 }
 
 pub fn list(
     repo: gix::Repository,
     out: &mut dyn std::io::Write,
     format: OutputFormat,
-    options: Options,
+    options: list::Options,
 ) -> anyhow::Result<()> {
     if format != OutputFormat::Human {
         anyhow::bail!("JSON output isn't supported");
@@ -22,8 +24,8 @@ pub fn list(
     let platform = repo.references()?;
 
     let (show_local, show_remotes) = match options.kind {
-        Kind::Local => (true, false),
-        Kind::All => (true, true),
+        list::Kind::Local => (true, false),
+        list::Kind::All => (true, true),
     };
 
     if show_local {

--- a/gitoxide-core/src/repository/mod.rs
+++ b/gitoxide-core/src/repository/mod.rs
@@ -6,6 +6,7 @@ use gix::bstr::BString;
 
 #[cfg(feature = "archive")]
 pub mod archive;
+pub mod branch;
 pub mod cat;
 pub use cat::function::cat;
 pub mod blame;

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -509,16 +509,12 @@ pub fn main() -> Result<()> {
                 )
             },
         ),
-        Subcommands::Branch(platform) => match platform.cmds {
-            Some(branch::Subcommands::List) | None => {
-                use core::repository::branch;
+        Subcommands::Branch(platform) => match platform.cmd {
+            branch::Subcommands::List { all } => {
+                use core::repository::branch::list;
 
-                let kind = if platform.all {
-                    branch::Kind::All
-                } else {
-                    branch::Kind::Local
-                };
-                let options = branch::Options { kind };
+                let kind = if all { list::Kind::All } else { list::Kind::Local };
+                let options = list::Options { kind };
 
                 prepare_and_run(
                     "branch-list",

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -511,10 +511,14 @@ pub fn main() -> Result<()> {
         ),
         Subcommands::Branch(platform) => match platform.cmds {
             Some(branch::Subcommands::List) | None => {
-                use core::repository::branch::{Kind, Options};
+                use core::repository::branch;
 
-                let kind = if platform.all { Kind::All } else { Kind::Local };
-                let options = Options { kind };
+                let kind = if platform.all {
+                    branch::Kind::All
+                } else {
+                    branch::Kind::Local
+                };
+                let options = branch::Options { kind };
 
                 prepare_and_run(
                     "branch-list",

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -16,8 +16,8 @@ use gix::bstr::{io::BufReadExt, BString};
 use crate::{
     plumbing::{
         options::{
-            attributes, commit, commitgraph, config, credential, exclude, free, fsck, index, mailmap, merge, odb,
-            revision, tag, tree, Args, Subcommands,
+            attributes, branch, commit, commitgraph, config, credential, exclude, free, fsck, index, mailmap, merge,
+            odb, revision, tag, tree, Args, Subcommands,
         },
         show_progress,
     },
@@ -509,6 +509,26 @@ pub fn main() -> Result<()> {
                 )
             },
         ),
+        Subcommands::Branch(platform) => match platform.cmds {
+            Some(branch::Subcommands::List) | None => {
+                use core::repository::branch::{Kind, Options};
+
+                let kind = if platform.all { Kind::All } else { Kind::Local };
+                let options = Options { kind };
+
+                prepare_and_run(
+                    "branch-list",
+                    trace,
+                    auto_verbose,
+                    progress,
+                    progress_keep_open,
+                    None,
+                    move |_progress, out, _err| {
+                        core::repository::branch::list(repository(Mode::Lenient)?, out, format, options)
+                    },
+                )
+            }
+        },
         #[cfg(feature = "gitoxide-core-tools-corpus")]
         Subcommands::Corpus(crate::plumbing::options::corpus::Platform { db, path, cmd }) => {
             let reverse_trace_lines = progress;

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -83,6 +83,9 @@ pub enum Subcommands {
     /// Subcommands for creating worktree archives.
     #[cfg(feature = "gitoxide-core-tools-archive")]
     Archive(archive::Platform),
+    /// Interact with branches.
+    #[clap(visible_alias = "branches")]
+    Branch(branch::Platform),
     /// Remove untracked files from the working tree.
     #[cfg(feature = "gitoxide-core-tools-clean")]
     Clean(clean::Command),
@@ -233,6 +236,24 @@ pub mod archive {
         ///
         /// If commit, the commit timestamp will be used as timestamp for each file in the archive.
         pub treeish: Option<String>,
+    }
+}
+
+pub mod branch {
+    #[derive(Debug, clap::Parser)]
+    pub struct Platform {
+        #[clap(subcommand)]
+        pub cmds: Option<Subcommands>,
+
+        /// List remote-tracking as well as local branches.
+        #[clap(long, short = 'a')]
+        pub all: bool,
+    }
+
+    #[derive(Debug, clap::Subcommand)]
+    pub enum Subcommands {
+        /// List all tags.
+        List,
     }
 }
 

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -248,7 +248,7 @@ pub mod branch {
 
     #[derive(Debug, clap::Subcommand)]
     pub enum Subcommands {
-        /// List all tags.
+        /// List branches.
         List {
             /// List remote-tracking as well as local branches.
             #[clap(long, short = 'a')]

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -243,17 +243,17 @@ pub mod branch {
     #[derive(Debug, clap::Parser)]
     pub struct Platform {
         #[clap(subcommand)]
-        pub cmds: Option<Subcommands>,
-
-        /// List remote-tracking as well as local branches.
-        #[clap(long, short = 'a')]
-        pub all: bool,
+        pub cmd: Subcommands,
     }
 
     #[derive(Debug, clap::Subcommand)]
     pub enum Subcommands {
         /// List all tags.
-        List,
+        List {
+            /// List remote-tracking as well as local branches.
+            #[clap(long, short = 'a')]
+            all: bool,
+        },
     }
 }
 

--- a/tests/it/src/commands/blame_copy_royal.rs
+++ b/tests/it/src/commands/blame_copy_royal.rs
@@ -217,7 +217,7 @@ git commit -m {commit_id}
             // history’s root being the last element. We reverse the order in place so that all
             // methods can rely on the assumption that the root comes first, followed by its
             // descendants. That way, we can use a simple `for` loop to iterate through
-            // `self.blame_path` below.
+            // `self.blame_infos` below.
             self.blame_infos.reverse();
 
             for blame_path_entry in self.blame_infos.clone() {


### PR DESCRIPTION
This is a draft PR even though I feel it is already 95 % done. I mainly want to get CI feedback early.

This PR adds `gix branch list` and `gix branch`, supporting `--all` as the only flag.

I copied the way `gix tag list` and `gix tags` work, but I’m less sure this is a good idea in this case as passing arguments seems to become trickier. Given the current code, `gix branch list --all` does not work, but `gix branch --all list` does which seems sub-optimal to me. What do you think?
