### PR TITLE
fix: consider a Windows resource untrusted if security information could not be retrieved (#2128)

### DIFF
--- a/gix-sec/src/identity.rs
+++ b/gix-sec/src/identity.rs
@@ -123,9 +123,9 @@ mod impl_ {
                 );
 
                 if result != ERROR_SUCCESS {
-                    // We cannot determine ownership, so we default to reduced trust (false) rather
-                    // than failing completely.
                     if result == ERROR_INVALID_FUNCTION {
+                        // We cannot obtain security information, so we default to reduced trust
+                        // (false) rather than failing completely.
                         return Ok(false);
                     }
                     let inner = io::Error::from_raw_os_error(result as _);

--- a/gix-sec/src/identity.rs
+++ b/gix-sec/src/identity.rs
@@ -82,7 +82,7 @@ mod impl_ {
 
     pub fn is_path_owned_by_current_user(path: &Path) -> io::Result<bool> {
         use windows_sys::Win32::{
-            Foundation::{GetLastError, LocalFree, ERROR_INSUFFICIENT_BUFFER, ERROR_SUCCESS},
+            Foundation::{GetLastError, LocalFree, ERROR_INSUFFICIENT_BUFFER, ERROR_INVALID_FUNCTION, ERROR_SUCCESS},
             Security::{
                 Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT},
                 CheckTokenMembership, EqualSid, GetTokenInformation, IsWellKnownSid, TokenOwner,
@@ -123,6 +123,11 @@ mod impl_ {
                 );
 
                 if result != ERROR_SUCCESS {
+                    // We cannot determine ownership, so we default to reduced trust (false) rather
+                    // than failing completely.
+                    if result == ERROR_INVALID_FUNCTION {
+                        return Ok(false);
+                    }
                     let inner = io::Error::from_raw_os_error(result as _);
                     error!(
                         inner,


### PR DESCRIPTION
Fixes #2128 .

Related to https://github.com/gitbutlerapp/gitbutler/issues/9913