### PR TITLE
fix `gix-blame` performance regresion

### DIFF
--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -246,8 +246,8 @@ pack-cache-lru-static = ["gix-pack/pack-cache-lru-static"]
 ## Provide a hash-map based LRU cache whose eviction is based a memory cap calculated from object data.
 pack-cache-lru-dynamic = ["gix-pack/pack-cache-lru-dynamic"]
 
-## Enable all features required for performance. Currently, this is equivalent to `max-control`, as gix always uses zlib-rs.
-max-performance = ["max-control"]
+## Enable all features required for performance.
+max-performance = ["max-performance-safe"]
 
 ## Deprecated: gix always uses zlib-rs.
 zlib-ng = ["gix-features/zlib"]


### PR DESCRIPTION
fixes https://github.com/GitoxideLabs/gitoxide/issues/2148

The issue was introduced in https://github.com/GitoxideLabs/gitoxide/pull/1963, where it was incorrectly assumed that the `max-performance-safe` feature flag was only used to enable other feature flags. But this feature flag is itself used in various places, so failing to enable it leads to worse codegen. This issue was discussed/found in https://github.com/GitoxideLabs/gitoxide/issues/2148