### PR TITLE
feat: ability to change the fetch url of a remote

### DIFF
--- a/gix/src/remote/build.rs
+++ b/gix/src/remote/build.rs
@@ -2,6 +2,31 @@ use crate::{bstr::BStr, remote, Remote};
 
 /// Builder methods
 impl Remote<'_> {
+    /// Set the `url` to be used when fetching data from a remote.
+    pub fn with_url<Url, E>(self, url: Url) -> Result<Self, remote::init::Error>
+    where
+        Url: TryInto<gix_url::Url, Error = E>,
+        gix_url::parse::Error: From<E>,
+    {
+        self.url_inner(
+            url.try_into().map_err(|err| remote::init::Error::Url(err.into()))?,
+            true,
+        )
+    }
+
+    /// Set the `url` to be used when fetching data from a remote, without applying rewrite rules in case these could be faulty,
+    /// eliminating one failure mode.
+    pub fn with_url_without_url_rewrite<Url, E>(self, url: Url) -> Result<Self, remote::init::Error>
+    where
+        Url: TryInto<gix_url::Url, Error = E>,
+        gix_url::parse::Error: From<E>,
+    {
+        self.url_inner(
+            url.try_into().map_err(|err| remote::init::Error::Url(err.into()))?,
+            false,
+        )
+    }
+
     /// Set the `url` to be used when pushing data to a remote.
     pub fn push_url<Url, E>(self, url: Url) -> Result<Self, remote::init::Error>
     where
@@ -46,6 +71,19 @@ impl Remote<'_> {
             Ok((None, None))
         }?;
         self.push_url_alias = push_url_alias;
+
+        Ok(self)
+    }
+
+    fn url_inner(mut self, url: gix_url::Url, should_rewrite_urls: bool) -> Result<Self, remote::init::Error> {
+        self.url = url.into();
+
+        let (fetch_url_alias, _) = if should_rewrite_urls {
+            remote::init::rewrite_urls(&self.repo.config, self.url.as_ref(), None)
+        } else {
+            Ok((None, None))
+        }?;
+        self.url_alias = fetch_url_alias;
 
         Ok(self)
     }

--- a/gix/src/remote/build.rs
+++ b/gix/src/remote/build.rs
@@ -2,7 +2,9 @@ use crate::{bstr::BStr, remote, Remote};
 
 /// Builder methods
 impl Remote<'_> {
-    /// Set the `url` to be used when fetching data from a remote.
+    /// Override the `url` to be used when fetching data from a remote.
+    ///
+    /// Note that this URL is typically set during instantiation with [`crate::Repository::remote_at()`].
     pub fn with_url<Url, E>(self, url: Url) -> Result<Self, remote::init::Error>
     where
         Url: TryInto<gix_url::Url, Error = E>,
@@ -16,6 +18,8 @@ impl Remote<'_> {
 
     /// Set the `url` to be used when fetching data from a remote, without applying rewrite rules in case these could be faulty,
     /// eliminating one failure mode.
+    ///
+    /// Note that this URL is typically set during instantiation with [`crate::Repository::remote_at_without_url_rewrite()`].
     pub fn with_url_without_url_rewrite<Url, E>(self, url: Url) -> Result<Self, remote::init::Error>
     where
         Url: TryInto<gix_url::Url, Error = E>,
@@ -28,7 +32,17 @@ impl Remote<'_> {
     }
 
     /// Set the `url` to be used when pushing data to a remote.
+    #[deprecated = "Use `with_push_url()` instead"]
     pub fn push_url<Url, E>(self, url: Url) -> Result<Self, remote::init::Error>
+    where
+        Url: TryInto<gix_url::Url, Error = E>,
+        gix_url::parse::Error: From<E>,
+    {
+        self.with_push_url(url)
+    }
+
+    /// Set the `url` to be used when pushing data to a remote.
+    pub fn with_push_url<Url, E>(self, url: Url) -> Result<Self, remote::init::Error>
     where
         Url: TryInto<gix_url::Url, Error = E>,
         gix_url::parse::Error: From<E>,
@@ -41,7 +55,18 @@ impl Remote<'_> {
 
     /// Set the `url` to be used when pushing data to a remote, without applying rewrite rules in case these could be faulty,
     /// eliminating one failure mode.
+    #[deprecated = "Use `with_push_url_without_rewrite()` instead"]
     pub fn push_url_without_url_rewrite<Url, E>(self, url: Url) -> Result<Self, remote::init::Error>
+    where
+        Url: TryInto<gix_url::Url, Error = E>,
+        gix_url::parse::Error: From<E>,
+    {
+        self.with_push_url_without_url_rewrite(url)
+    }
+
+    /// Set the `url` to be used when pushing data to a remote, without applying rewrite rules in case these could be faulty,
+    /// eliminating one failure mode.
+    pub fn with_push_url_without_url_rewrite<Url, E>(self, url: Url) -> Result<Self, remote::init::Error>
     where
         Url: TryInto<gix_url::Url, Error = E>,
         gix_url::parse::Error: From<E>,

--- a/gix/tests/gix/remote/save.rs
+++ b/gix/tests/gix/remote/save.rs
@@ -63,7 +63,7 @@ mod save_as_to {
         let repo = basic_repo()?;
         let mut remote = repo
             .remote_at("https://example.com/path")?
-            .push_url("https://ein.hub/path")?
+            .with_push_url("https://ein.hub/path")?
             .with_fetch_tags(gix::remote::fetch::Tags::All)
             .with_refspecs(
                 [

--- a/gix/tests/gix/repository/remote.rs
+++ b/gix/tests/gix/repository/remote.rs
@@ -13,7 +13,7 @@ mod remote_at {
         assert_eq!(remote.url(Direction::Fetch).unwrap().to_bstring(), fetch_url);
         assert_eq!(remote.url(Direction::Push).unwrap().to_bstring(), fetch_url);
 
-        let mut remote = remote.push_url("user@host.xz:./relative")?;
+        let mut remote = remote.with_push_url("user@host.xz:./relative")?;
         assert_eq!(
             remote.url(Direction::Push).unwrap().to_bstring(),
             "user@host.xz:./relative"
@@ -75,7 +75,7 @@ mod remote_at {
 
         let remote = repo
             .remote_at("https://github.com/foobar/gitoxide".to_owned())?
-            .push_url("file://dev/null".to_owned())?;
+            .with_push_url("file://dev/null".to_owned())?;
         assert_eq!(remote.url(Direction::Fetch).unwrap().to_bstring(), rewritten_fetch_url);
         assert_eq!(
             remote.url(Direction::Push).unwrap().to_bstring(),
@@ -117,7 +117,7 @@ mod remote_at {
 
         let remote = repo
             .remote_at_without_url_rewrite("https://github.com/foobar/gitoxide".to_owned())?
-            .push_url_without_url_rewrite("file://dev/null".to_owned())?;
+            .with_push_url_without_url_rewrite("file://dev/null".to_owned())?;
         assert_eq!(remote.url(Direction::Fetch).unwrap().to_bstring(), fetch_url);
         assert_eq!(
             remote.url(Direction::Push).unwrap().to_bstring(),
@@ -127,7 +127,7 @@ mod remote_at {
 
         let remote = remote
             .with_url_without_url_rewrite("https://github.com/foobaz/gitoxide".to_owned())?
-            .push_url_without_url_rewrite("file://dev/null".to_owned())?;
+            .with_push_url_without_url_rewrite("file://dev/null".to_owned())?;
         assert_eq!(
             remote.url(Direction::Fetch).unwrap().to_bstring(),
             "https://github.com/foobaz/gitoxide"

--- a/gix/tests/gix/repository/remote.rs
+++ b/gix/tests/gix/repository/remote.rs
@@ -20,6 +20,10 @@ mod remote_at {
         );
         assert_eq!(remote.url(Direction::Fetch).unwrap().to_bstring(), fetch_url);
 
+        let new_fetch_url = "https://host.xz/byron/gitoxide";
+        remote = remote.with_url(new_fetch_url)?;
+        assert_eq!(remote.url(Direction::Fetch).unwrap().to_bstring(), new_fetch_url);
+
         for (spec, direction) in [
             ("refs/heads/push", Direction::Push),
             ("refs/heads/fetch", Direction::Fetch),
@@ -46,6 +50,18 @@ mod remote_at {
 
         assert_eq!(remote.name(), None, "anonymous remotes are unnamed");
         let rewritten_fetch_url = "https://github.com/byron/gitoxide";
+        assert_eq!(
+            remote.url(Direction::Fetch).unwrap().to_bstring(),
+            rewritten_fetch_url,
+            "fetch was rewritten"
+        );
+        assert_eq!(
+            remote.url(Direction::Push).unwrap().to_bstring(),
+            rewritten_fetch_url,
+            "push is the same as fetch was rewritten"
+        );
+
+        let remote = remote.with_url("https://github.com/foobar/gitoxide")?;
         assert_eq!(
             remote.url(Direction::Fetch).unwrap().to_bstring(),
             rewritten_fetch_url,
@@ -87,10 +103,35 @@ mod remote_at {
             "push is the same as fetch was rewritten"
         );
 
+        let remote = remote.with_url_without_url_rewrite("https://github.com/foobaz/gitoxide")?;
+        assert_eq!(
+            remote.url(Direction::Fetch).unwrap().to_bstring(),
+            "https://github.com/foobaz/gitoxide",
+            "fetch was rewritten"
+        );
+        assert_eq!(
+            remote.url(Direction::Push).unwrap().to_bstring(),
+            "https://github.com/foobaz/gitoxide",
+            "push is the same as fetch was rewritten"
+        );
+
         let remote = repo
             .remote_at_without_url_rewrite("https://github.com/foobar/gitoxide".to_owned())?
             .push_url_without_url_rewrite("file://dev/null".to_owned())?;
         assert_eq!(remote.url(Direction::Fetch).unwrap().to_bstring(), fetch_url);
+        assert_eq!(
+            remote.url(Direction::Push).unwrap().to_bstring(),
+            "file://dev/null",
+            "push-url rewrite rules are not applied"
+        );
+
+        let remote = remote
+            .with_url_without_url_rewrite("https://github.com/foobaz/gitoxide".to_owned())?
+            .push_url_without_url_rewrite("file://dev/null".to_owned())?;
+        assert_eq!(
+            remote.url(Direction::Fetch).unwrap().to_bstring(),
+            "https://github.com/foobaz/gitoxide"
+        );
         assert_eq!(
             remote.url(Direction::Push).unwrap().to_bstring(),
             "file://dev/null",


### PR DESCRIPTION
The remote has a couple of "builder" methods to change is fields, e.g. `push_url` for setting the push url.

A builder method for changing the fetch url of a remote was missing. This makes it impossible to fully replicate  the functionality of `git remote set-url` (e.g. look at the lengths I'm trying to workaround this (imperfectly) in a PR to replicate `git remote set-url --push`) in `jj`: https://github.com/metlos/jj/blob/8ec7cd1f68a5279e6aff2faea248a4978d46d17a/lib/src/git.rs#L2024)