### PR TITLE
fix: submodule worktree incorrect with symlinked `.git` dir (#2052)

### DIFF
--- a/gix/tests/fixtures/generated-archives/.gitignore
+++ b/gix/tests/fixtures/generated-archives/.gitignore
@@ -9,3 +9,4 @@
 /make_diff_repos.tar
 /make_submodule_with_worktree.tar
 /repo_with_untracked_files.tar
+/make_submodule_with_symlinked_git_dir.tar

--- a/gix/tests/fixtures/make_submodule_with_symlinked_git_dir.sh
+++ b/gix/tests/fixtures/make_submodule_with_symlinked_git_dir.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+git init -q module1
+(cd module1
+  touch this
+  mkdir subdir
+  touch subdir/that
+  git add .
+  git commit -q -m c1
+  echo hello >> this
+  git commit -q -am c2
+  touch untracked
+)
+
+mkdir symlinked-git-dir
+(cd symlinked-git-dir
+  git init -q r1
+  (cd r1
+    git commit -q --allow-empty -m "init"
+  )
+
+  git config -f r1/.git/config core.worktree "$(pwd)"
+  ln -s r1/.git .git
+
+  git -c protocol.file.allow=always submodule add ../module1 m1
+  git commit -m "add module 1"
+)

--- a/gix/tests/gix/status.rs
+++ b/gix/tests/gix/status.rs
@@ -311,6 +311,27 @@ mod index_worktree {
         }
 
         #[test]
+        fn submodule_in_symlinked_dir() -> crate::Result {
+            use crate::util::named_subrepo_opts;
+            let repo = named_subrepo_opts(
+                "make_submodule_with_symlinked_git_dir.sh",
+                "symlinked-git-dir",
+                gix::open::Options::isolated(),
+            )?;
+            let status = repo
+                .status(gix::progress::Discard)?
+                .index_worktree_options_mut(|opts| {
+                    opts.sorting =
+                        Some(gix::status::plumbing::index_as_worktree_with_renames::Sorting::ByPathCaseSensitive);
+                })
+                .into_index_worktree_iter(None)?;
+            for change in status {
+                change?;
+            }
+            Ok(())
+        }
+
+        #[test]
         fn submodule_modification() -> crate::Result {
             let repo = submodule_repo("modified-untracked-and-submodule-head-changed-and-modified")?;
             let mut status = repo


### PR DESCRIPTION
fixes https://github.com/GitoxideLabs/gitoxide/issues/2052

My fix introduced a regression. Looks like we never return relative paths for `repo.workdir()`. One way I see to fix this is by making the path relative to `cwd`, but not sure if this is desired. Any thoughts on how we can work around this?

```
failures:

---- repository::open::submodules::by_their_worktree_checkout_and_git_modules_dir stdout ----
[gix/src/open/repository.rs:308:17] &git_dir = "tests/fixtures/generated-do-not-edit/make_submodules/1482069896-unix/with-submodules/.git/modules/m1"
[gix/src/open/repository.rs:308:17] &wt_path = "tests/fixtures/generated-do-not-edit/make_submodules/1482069896-unix/with-submodules/.git/modules/m1/../../../m1"

thread 'repository::open::submodules::by_their_worktree_checkout_and_git_modules_dir' panicked at gix/tests/gix/repository/open.rs:338:17:
assertion `left == right` failed
  left: "/home/aru/oss/gitoxide/gix/tests/fixtures/generated-do-not-edit/make_submodules/1482069896-unix/with-submodules/m1"
 right: "tests/fixtures/generated-do-not-edit/make_submodules/1482069896-unix/with-submodules/m1"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- repository::worktree::with_core_worktree_config::relative stdout ----
[gix/src/open/repository.rs:308:17] &git_dir = "tests/fixtures/generated-do-not-edit/make_core_worktree_repo/4038243702-unix/absolute-worktree/.git"
[gix/src/open/repository.rs:308:17] &wt_path = "/home/aru/oss/gitoxide/gix/tests/fixtures/generated-do-not-edit/make_core_worktree_repo/4038243702-unix/worktree"
[gix/src/open/repository.rs:308:17] &git_dir = "tests/fixtures/generated-do-not-edit/make_core_worktree_repo/4038243702-unix/relative-worktree/.git"
[gix/src/open/repository.rs:308:17] &wt_path = "tests/fixtures/generated-do-not-edit/make_core_worktree_repo/4038243702-unix/relative-worktree/.git/../../worktree"

thread 'repository::worktree::with_core_worktree_config::relative' panicked at gix/tests/gix/repository/worktree.rs:51:17:
assertion `left == right` failed: relative-worktree|true: work_dir is set to core.worktree config value, relative paths are appended to `git_dir() and made absolute`
  left: "/home/aru/oss/gitoxide/gix/tests/fixtures/generated-do-not-edit/make_core_worktree_repo/4038243702-unix/worktree"
 right: "tests/fixtures/generated-do-not-edit/make_core_worktree_repo/4038243702-unix/worktree"


failures:
    repository::open::submodules::by_their_worktree_checkout_and_git_modules_dir
    repository::worktree::with_core_worktree_config::relative
```
