### PR TITLE
Build Intel Mac releases on Intel runner to fix missing `openssl` for target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
           - target: s390x-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc


### PR DESCRIPTION
This changes the runner in the `release.yml` workflow for the job that builds the `x86_64-apple-darwin` target from `macos-latest` (which currently aliases the `macos-15` runner, an Apple Silicon system) to the recently introduced `macos-15-intel` runner. This is to fix recent build failures for the `lean` and `max` feature jobs with that target, which happen when the `openssl-sys` dependency attempts to find the installed `openssl` library for the target architecture.

The new failures can be seen in these runs:

- https://github.com/EliahKagan/gitoxide/actions/runs/17895976664/job/50882669073
- https://github.com/EliahKagan/gitoxide/actions/runs/17895976664/job/50882669084

I'm not sure why the failures happened, since they did not occur in the `macos-15` experiments with `release.yml` done as part of #2078.

Regarding the new `macos-15-intel` runner, see [this recent post on the GitHub blog](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/#what-you-need-to-do).

To verify that the changes here fix the failures, see:

- https://github.com/EliahKagan/gitoxide/actions/runs/17897891645/job/50886931822
- https://github.com/EliahKagan/gitoxide/actions/runs/17897891645/job/50886931809