### PR TITLE
Note that the `small` feature doesn't include `clone`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ lean = ["fast", "tracing", "pretty-cli", "http-client-curl", "gitoxide-core-tool
 
 ## The smallest possible build, best suitable for small single-core machines.
 ##
-## This build is essentially limited to local operations without any fanciness.
+## This build is essentially limited to local operations without any fanciness. It does not have `gix clone`.
 ##
 ## Optimized for size, no parallelism thus much slower, progress line rendering.
 small = ["pretty-cli", "prodash-render-line", "is-terminal"]


### PR DESCRIPTION
Closes #2185

The `small` feature of the `gitoxide` crate does not directly or indirectly include the `gitoxide-core-blocking-client` feature, and therefore does not provide `gix clone`. Although it was documented to provide only local operations, this was ambiguous: in the sense of local and remote repository operations, cloning is arguably a remote operation even when one clones from a filesystem path, or file URL. But in the broader meaning of "local," this could mean merely that network transport is omitted and that local cloning is included.

This adds a short explicit note that `small` does not include `gix clone`. This is a minimal fix for #2185 and it may make sense to improve the description further (unless `small` is to change).