### PR TITLE
Don't persist GitHub authentication token in `.git/config` on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: extractions/setup-just@v3
       - name: Read the MSRV
         run: |
@@ -60,6 +62,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: extractions/setup-just@v3
       - name: Ensure we start out clean
         run: git diff --exit-code
@@ -75,6 +79,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Prerequisites
         run: |
           prerequisites=(
@@ -177,6 +183,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Setup dependencies
@@ -197,6 +205,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: extractions/setup-just@v3
@@ -221,6 +231,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: cargo check default features
@@ -268,6 +280,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
@@ -339,6 +353,8 @@ jobs:
           apt-get install --no-install-recommends -y -- "${prerequisites[@]}"
         shell: bash  # This step needs `bash`, and the default in container jobs is `sh`.
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install Rust via Rustup
         run: |
           # Specify toolchain to avoid possible misdetection based on the 64-bit running kernel.
@@ -365,6 +381,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ env.TARGET }}
@@ -382,6 +400,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
@@ -412,6 +432,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check advisories
@@ -422,6 +444,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check bans licenses sources
@@ -441,6 +465,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install Rust
         run: |
           rustup update stable
@@ -520,6 +546,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Check that working tree is initially clean
         run: |
           set -x
@@ -557,6 +585,7 @@ jobs:
           echo "WORKFLOW_PATH=${relative_workflow_with_ref%@*}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           sparse-checkout: ${{ env.WORKFLOW_PATH }}
       - name: Get all jobs
         run: yq '.jobs | keys.[]' -- "$WORKFLOW_PATH" | sort | tee all-jobs.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,6 +561,33 @@ jobs:
           git status
           git diff --exit-code
 
+  # Check that all `actions/checkout` in CI jobs have `persist-credentials: false`.
+  check-no-persist-credentials:
+    runs-on: ubuntu-latest
+
+    env:
+      GLOB: .github/workflows/*.@(yaml|yml)
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          sparse-checkout: '.github/workflows'
+      - name: List workflows to be scanned
+        run: |
+          shopt -s extglob
+          printf '%s\n' ${{ env.GLOB }}
+      - name: Scan workflows
+        run: |
+          shopt -s extglob
+          yq '.jobs.*.steps[]
+            | select(.uses == "actions/checkout@*" and .with.["persist-credentials"]? != false)
+            | {"file": filename, "line": line, "name": (.name // .uses)}
+            | .file + ":" + (.line | tostring) + ": " + .name
+          ' -- ${{ env.GLOB }} >query-output.txt
+          cat query-output.txt
+          test -z "$(<query-output.txt)"  # Report failure if we found anything.
+
   # Check that only jobs intended not to block PR auto-merge are omitted as
   # dependencies of the `tests-pass` job below, so that whenever a job is
   # added, a decision is made about whether it must pass for PRs to merge.
@@ -615,6 +642,7 @@ jobs:
       - lint
       - cargo-deny
       - check-packetline
+      - check-no-persist-credentials
       - check-blocking
 
     if: always()  # Always run even if dependencies fail.

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: Swatinem/rust-cache@v2
       - name: stress
         run: make stress

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Get the release version from the tag
         if: env.VERSION == ''
@@ -234,6 +236,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Install packages (Ubuntu)
         # Because openssl doesn't work on musl by default, we resort to max-pure.
@@ -537,6 +541,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
When `actions/checkout` is used to check out the repository on CI, it persists credentials related to the GitHub token in the local scope configuration at `.git/config`, unless `persist-credentials` is explicitly set to `false`. This facilitates subsequent remote operations on the repository that could otherwise fail, but we have no such operations in any of our workflows.

As an added layer of protection to keep these credentials from leaking into logs (or otherwise being displayed or subject to exfiltration) in case there is ever unintended coupling between the operation of the test suite (or any step subsequent to checkout that is used to prepare or run tests or other checks) and the cloned `gitoxide` repository itself, this:

- Adds `persist-credentials: false` in a `with` mapping on every step that uses `actions/checkout`.
- Adds a new CI job that checks that every `actions/checkout` step in any job in any workflow sets `persist-credentials` to `false`.

In addition to usual testing on CI, the `release.yml` workflow is among the workflows changed here, and it has also been tested: https://github.com/EliahKagan/gitoxide/actions/runs/17899238656

See also:

- https://github.com/actions/checkout/blob/main/README.md
  (covers what happens with/without `persist-credentials: false`)
- https://github.com/actions/checkout/issues/485