### PR TITLE
Switch to CodeQL "advanced" setup so it can run on all PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,15 +9,20 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL Advanced"
+name: CodeQL
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+      - 'run-ci/**'
+      - '**/run-ci/**'
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
   schedule:
     - cron: '32 3 * * 6'
+  workflow_dispatch:
 
 jobs:
   analyze:
@@ -33,11 +38,11 @@ jobs:
       security-events: write
 
       # required to fetch internal or private CodeQL packs
-      packages: read
+      # packages: read
 
       # only required for workflows in private repositories
-      actions: read
-      contents: read
+      # actions: read
+      # contents: read
 
     strategy:
       fail-fast: false
@@ -57,7 +62,9 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
+      with:
+        persist-credentials: false
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`


### PR DESCRIPTION
Fixes #2193

See the individual commits for details, and #2193 for rationale.

This intentionally does not make or recommend that the CodeQL checks be made blocking for PR auto-merge, just as we have deliberately not blocked PRs on the dynamic CodeQL checks from the default setup. (We may of course sometimes wait to see what the outcome is before merging a PR about which there is concern, or which is substantial in ways relevant to something we hope CodeQL to check.)

**Testing:** I've tested this in https://github.com/EliahKagan/gitoxide/pull/107, and temporarily on the main branch of my fork (since rewound). Of course, that doesn't test it with a PR originating from outside of my fork. I'll revisit this configuration later to verify that it is working properly with such PRs.

**Outscoped:** I think we should enable more CodeQL queries such as extended queries, and possibly also make it so forks whose operators want to run CodeQL within the fork can use this configuration rather than overriding it while still changing what queries are run, such as by adjusting per-repo [variable](https://docs.github.com/en/actions/reference/workflows-and-actions/variables). But this PR deliberately does not include any of that. To be clear, the CodeQL configuration introduced here *does* scan with all the queries that were in use previously in this upstream repository (just not all the ones I had been testing out in my fork).

~~This is a draft while I wait for the CodeQL checks in this PR itself to complete.~~ Done.