### PR TITLE
Tell Dependabot to keep `expectrl` and `getrandom` back for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,19 @@ updates:
     allow:
       - dependency-type: all
     ignore:
-      # Keep imara-diff at 0.1.* for now (see comments in #2068).
+      # Keep `expectrl` at 0.7.* for now. See https://github.com/GitoxideLabs/gitoxide/pull/2200.
+      - dependency-name: expectrl
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+      # Some `getrandom` dependencies are at 0.2.*. Keep them there for now. (Some are at 0.3.*.
+      # This allows them to remain there but keeps them from going to a future 0.4.*.) This is
+      # hopefully temporary. See https://github.com/GitoxideLabs/gitoxide/pull/2093.
+      - dependency-name: getrandom
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+     # Keep `imara-diff` at 0.1.* for now. See https://github.com/GitoxideLabs/gitoxide/pull/2068.
       - dependency-name: imara-diff
         update-types:
           - 'version-update:semver-major'


### PR DESCRIPTION
This allows them to have patch version updates but not major and minor version updates. Becuase they are not yet at 1.0.0, this has the effect of allowing SemVer-compatible but not SemVer-breaking updates to them via Dependabot version update PRs.

This may be temporary and, in the case of `getrandom`, is intended to be temporary. For details, see comments in `dependabot.yml`, and:

- https://github.com/GitoxideLabs/gitoxide/pull/2200#issuecomment-3361407300
- https://github.com/GitoxideLabs/gitoxide/pull/2093#issuecomment-3361449228

This also expands the comment for holding back `imara-diff` (all referenced PRs in the file now have full URLs, not just numbers).

The effect of keeping back `expectrl` was tested and verified to be the only new hold needed to allow version updates to work, in: https://github.com/EliahKagan/gitoxide/pull/111