### PR TITLE
hash: Future Proofing - rewritten commits of #2213

### DIFF
--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -16,6 +16,9 @@ doctest = false
 test = false
 
 [features]
+default = ["sha1"]
+## Support for SHA-1 digests.
+sha1 = []
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde = ["dep:serde", "faster-hex/serde"]
 

--- a/gix-hash/src/lib.rs
+++ b/gix-hash/src/lib.rs
@@ -12,7 +12,7 @@
 // Remove this once other hashes (e.g., SHA-256, and potentially others)
 // are supported, and this crate can build without [`ObjectId::Sha1`].
 #[cfg(not(feature = "sha1"))]
-compile_error!("The feature `sha1` feature is required.");
+compile_error!("Please set the `sha1` feature flag");
 
 #[path = "oid.rs"]
 mod borrowed;

--- a/gix-hash/src/lib.rs
+++ b/gix-hash/src/lib.rs
@@ -9,6 +9,11 @@
 #![cfg_attr(all(doc, feature = "document-features"), feature(doc_cfg, doc_auto_cfg))]
 #![deny(missing_docs, rust_2018_idioms, unsafe_code)]
 
+// Remove this once other hashes (e.g., SHA-256, and potentially others)
+// are supported, and this crate can build without [`ObjectId::Sha1`].
+#[cfg(not(feature = "sha1"))]
+compile_error!("The feature `sha1` feature is required.");
+
 #[path = "oid.rs"]
 mod borrowed;
 pub use borrowed::{oid, Error};

--- a/gix-hash/src/object_id.rs
+++ b/gix-hash/src/object_id.rs
@@ -9,6 +9,7 @@ use crate::{borrowed::oid, Kind, SIZE_OF_SHA1_DIGEST};
 /// An owned hash identifying objects, most commonly `Sha1`
 #[derive(PartialEq, Eq, Ord, PartialOrd, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum ObjectId {
     /// A SHA 1 hash digest
     Sha1([u8; SIZE_OF_SHA1_DIGEST]),


### PR DESCRIPTION
For the original, see https://github.com/GitoxideLabs/gitoxide/pull/2213.
It wasn't allowed to push into the existing branch.
