### PR TITLE
Replace `split_at_pos` by `split_at_checked`

### DIFF
--- a/gix-bitmap/src/ewah.rs
+++ b/gix-bitmap/src/ewah.rs
@@ -25,9 +25,11 @@ pub fn decode(data: &[u8]) -> Result<(Vec, &[u8]), decode::Error> {
     // NOTE: git does this by copying all bytes first, and then it will change the endianness in a separate loop.
     //       Maybe it's faster, but we can't do it without unsafe. Let's leave it to the optimizer and maybe
     //       one day somebody will find out that it's worth it to use unsafe here.
-    let (mut bits, data) = decode::split_at_pos(data, len * std::mem::size_of::<u64>()).ok_or(Error::Corrupt {
-        message: "eof while reading bit data",
-    })?;
+    let (mut bits, data) = data
+        .split_at_checked(len * std::mem::size_of::<u64>())
+        .ok_or(Error::Corrupt {
+            message: "eof while reading bit data",
+        })?;
     let mut buf = std::vec::Vec::<u64>::with_capacity(len);
     for _ in 0..len {
         let (bit_num, rest) = bits.split_at(std::mem::size_of::<u64>());

--- a/gix-bitmap/src/lib.rs
+++ b/gix-bitmap/src/lib.rs
@@ -8,15 +8,8 @@ pub mod ewah;
 
 pub(crate) mod decode {
     #[inline]
-    pub(crate) fn split_at_pos(data: &[u8], pos: usize) -> Option<(&[u8], &[u8])> {
-        if data.len() < pos {
-            return None;
-        }
-        data.split_at(pos).into()
-    }
-
-    #[inline]
     pub(crate) fn u32(data: &[u8]) -> Option<(u32, &[u8])> {
-        split_at_pos(data, 4).map(|(num, data)| (u32::from_be_bytes(num.try_into().unwrap()), data))
+        data.split_at_checked(4)
+            .map(|(num, data)| (u32::from_be_bytes(num.try_into().unwrap()), data))
     }
 }

--- a/gix-index/src/extension/link.rs
+++ b/gix-index/src/extension/link.rs
@@ -1,7 +1,4 @@
-use crate::{
-    extension::{Link, Signature},
-    util::split_at_pos,
-};
+use crate::extension::{Link, Signature};
 
 /// The signature of the link extension.
 pub const SIGNATURE: Signature = *b"link";
@@ -39,7 +36,8 @@ pub mod decode {
 }
 
 pub(crate) fn decode(data: &[u8], object_hash: gix_hash::Kind) -> Result<Link, decode::Error> {
-    let (id, data) = split_at_pos(data, object_hash.len_in_bytes())
+    let (id, data) = data
+        .split_at_checked(object_hash.len_in_bytes())
         .ok_or(decode::Error::Corrupt(
             "link extension too short to read share index checksum",
         ))

--- a/gix-index/src/extension/resolve_undo.rs
+++ b/gix-index/src/extension/resolve_undo.rs
@@ -1,10 +1,7 @@
 use bstr::BString;
 use gix_hash::ObjectId;
 
-use crate::{
-    extension::Signature,
-    util::{split_at_byte_exclusive, split_at_pos},
-};
+use crate::{extension::Signature, util::split_at_byte_exclusive};
 
 pub type Paths = Vec<ResolvePath>;
 
@@ -47,7 +44,7 @@ pub fn decode(mut data: &[u8], object_hash: gix_hash::Kind) -> Option<Paths> {
             if *mode == 0 {
                 continue;
             }
-            let (hash, rest) = split_at_pos(data, hash_len)?;
+            let (hash, rest) = data.split_at_checked(hash_len)?;
             data = rest;
             *stage = Some(Stage {
                 mode: *mode,

--- a/gix-index/src/extension/tree/decode.rs
+++ b/gix-index/src/extension/tree/decode.rs
@@ -1,9 +1,6 @@
 use gix_hash::ObjectId;
 
-use crate::{
-    extension::Tree,
-    util::{split_at_byte_exclusive, split_at_pos},
-};
+use crate::{extension::Tree, util::split_at_byte_exclusive};
 
 /// A recursive data structure
 pub fn decode(data: &[u8], object_hash: gix_hash::Kind) -> Option<Tree> {
@@ -26,7 +23,7 @@ fn one_recursive(data: &[u8], hash_len: usize) -> Option<(Tree, &[u8])> {
     let subtree_count: usize = gix_utils::btoi::to_unsigned(subtree_count).ok()?;
 
     let (id, mut data) = if num_entries >= 0 {
-        let (hash, data) = split_at_pos(data, hash_len)?;
+        let (hash, data) = data.split_at_checked(hash_len)?;
         (ObjectId::from_bytes_or_panic(hash), data)
     } else {
         (

--- a/gix-index/src/extension/untracked_cache.rs
+++ b/gix-index/src/extension/untracked_cache.rs
@@ -4,7 +4,7 @@ use gix_hash::ObjectId;
 use crate::{
     entry,
     extension::{Signature, UntrackedCache},
-    util::{read_u32, split_at_byte_exclusive, split_at_pos, var_int},
+    util::{read_u32, split_at_byte_exclusive, var_int},
 };
 
 /// A structure to track filesystem stat information along with an object id, linking a worktree file with what's in our ODB.
@@ -44,7 +44,7 @@ pub fn decode(data: &[u8], object_hash: gix_hash::Kind) -> Option<UntrackedCache
         return None;
     }
     let (identifier_len, data) = var_int(data)?;
-    let (identifier, data) = split_at_pos(data, identifier_len.try_into().ok()?)?;
+    let (identifier, data) = data.split_at_checked(identifier_len.try_into().ok()?)?;
 
     let hash_len = object_hash.len_in_bytes();
     let (info_exclude, data) = decode_oid_stat(data, hash_len)?;
@@ -96,7 +96,7 @@ pub fn decode(data: &[u8], object_hash: gix_hash::Kind) -> Option<UntrackedCache
         Some(())
     });
     hash_valid.for_each_set_bit(|index| {
-        let (hash, rest) = split_at_pos(data, hash_len)?;
+        let (hash, rest) = data.split_at_checked(hash_len)?;
         data = rest;
         directories[index].exclude_file_oid = ObjectId::from_bytes_or_panic(hash).into();
         Some(())
@@ -143,7 +143,7 @@ fn decode_directory_block<'a>(data: &'a [u8], directories: &mut Vec<Directory>) 
 
 fn decode_oid_stat(data: &[u8], hash_len: usize) -> Option<(OidStat, &[u8])> {
     let (stat, data) = crate::decode::stat(data)?;
-    let (hash, data) = split_at_pos(data, hash_len)?;
+    let (hash, data) = data.split_at_checked(hash_len)?;
     Some((
         OidStat {
             stat,

--- a/gix-index/src/lib.rs
+++ b/gix-index/src/lib.rs
@@ -198,12 +198,14 @@ pub(crate) mod util {
 
     #[inline]
     pub fn read_u32(data: &[u8]) -> Option<(u32, &[u8])> {
-        split_at_pos(data, 4).map(|(num, data)| (u32::from_be_bytes(num.try_into().unwrap()), data))
+        data.split_at_checked(4)
+            .map(|(num, data)| (u32::from_be_bytes(num.try_into().unwrap()), data))
     }
 
     #[inline]
     pub fn read_u64(data: &[u8]) -> Option<(u64, &[u8])> {
-        split_at_pos(data, 8).map(|(num, data)| (u64::from_be_bytes(num.try_into().unwrap()), data))
+        data.split_at_checked(8)
+            .map(|(num, data)| (u64::from_be_bytes(num.try_into().unwrap()), data))
     }
 
     #[inline]
@@ -226,13 +228,5 @@ pub(crate) mod util {
                 }
             })
         })
-    }
-
-    #[inline]
-    pub fn split_at_pos(data: &[u8], pos: usize) -> Option<(&[u8], &[u8])> {
-        if data.len() < pos {
-            return None;
-        }
-        data.split_at(pos).into()
     }
 }


### PR DESCRIPTION
Now that #2217 has been merged, this is a follow-up to replace `split_at_pos` by `split_at_checked` which was stabilized in 1.80. This does not change behaviour, it just replaces a custom function by the equivalent one from `std`.
