### PR TITLE
fix!: move TransportWithoutIO::request() method to I/O-specific traits

### DIFF
--- a/gix-protocol/tests/protocol/fetch/arguments.rs
+++ b/gix-protocol/tests/protocol/fetch/arguments.rs
@@ -34,15 +34,6 @@ mod impls {
             self.inner.set_identity(identity)
         }
 
-        fn request(
-            &mut self,
-            write_mode: WriteMode,
-            on_into_read: MessageKind,
-            trace: bool,
-        ) -> Result<RequestWriter<'_>, Error> {
-            self.inner.request(write_mode, on_into_read, trace)
-        }
-
         fn to_url(&self) -> Cow<'_, BStr> {
             self.inner.to_url()
         }
@@ -71,6 +62,15 @@ mod impls {
         ) -> Result<SetServiceResponse<'_>, Error> {
             self.inner.handshake(service, extra_parameters)
         }
+
+        fn request(
+            &mut self,
+            write_mode: WriteMode,
+            on_into_read: MessageKind,
+            trace: bool,
+        ) -> Result<RequestWriter<'_>, Error> {
+            self.inner.request(write_mode, on_into_read, trace)
+        }
     }
 }
 
@@ -90,15 +90,6 @@ mod impls {
     impl<T: client::TransportWithoutIO + Send> client::TransportWithoutIO for Transport<T> {
         fn set_identity(&mut self, identity: client::Account) -> Result<(), Error> {
             self.inner.set_identity(identity)
-        }
-
-        fn request(
-            &mut self,
-            write_mode: WriteMode,
-            on_into_read: MessageKind,
-            trace: bool,
-        ) -> Result<RequestWriter<'_>, Error> {
-            self.inner.request(write_mode, on_into_read, trace)
         }
 
         fn to_url(&self) -> Cow<'_, BStr> {
@@ -129,6 +120,15 @@ mod impls {
             extra_parameters: &'a [(&'a str, Option<&'a str>)],
         ) -> Result<SetServiceResponse<'_>, Error> {
             self.inner.handshake(service, extra_parameters).await
+        }
+
+        fn request(
+            &mut self,
+            write_mode: WriteMode,
+            on_into_read: MessageKind,
+            trace: bool,
+        ) -> Result<RequestWriter<'_>, Error> {
+            self.inner.request(write_mode, on_into_read, trace)
         }
     }
 }

--- a/gix-transport/src/client/blocking_io/file.rs
+++ b/gix-transport/src/client/blocking_io/file.rs
@@ -108,18 +108,6 @@ impl client::TransportWithoutIO for SpawnProcessOnDemand {
         }
     }
 
-    fn request(
-        &mut self,
-        write_mode: WriteMode,
-        on_into_read: MessageKind,
-        trace: bool,
-    ) -> Result<RequestWriter<'_>, client::Error> {
-        self.connection
-            .as_mut()
-            .ok_or(client::Error::MissingHandshake)?
-            .request(write_mode, on_into_read, trace)
-    }
-
     fn to_url(&self) -> Cow<'_, BStr> {
         Cow::Owned(self.url.to_bstring())
     }
@@ -280,6 +268,18 @@ impl client::blocking_io::Transport for SpawnProcessOnDemand {
             .as_mut()
             .expect("connection to be there right after setting it")
             .handshake(service, extra_parameters)
+    }
+
+    fn request(
+        &mut self,
+        write_mode: WriteMode,
+        on_into_read: MessageKind,
+        trace: bool,
+    ) -> Result<RequestWriter<'_>, client::Error> {
+        self.connection
+            .as_mut()
+            .ok_or(client::Error::MissingHandshake)?
+            .request(write_mode, on_into_read, trace)
     }
 }
 

--- a/gix-transport/src/client/blocking_io/traits.rs
+++ b/gix-transport/src/client/blocking_io/traits.rs
@@ -4,7 +4,7 @@ use bstr::BString;
 
 use crate::{
     client::{
-        blocking_io::{ExtendedBufRead, ReadlineBufRead},
+        blocking_io::{request::RequestWriter, ExtendedBufRead, ReadlineBufRead},
         Capabilities, Error, MessageKind, TransportWithoutIO, WriteMode,
     },
     Protocol, Service,
@@ -42,6 +42,18 @@ pub trait Transport: TransportWithoutIO {
         service: Service,
         extra_parameters: &'a [(&'a str, Option<&'a str>)],
     ) -> Result<SetServiceResponse<'_>, Error>;
+
+    /// Get a writer for sending data and obtaining the response. It can be configured in various ways
+    /// to support the task at hand.
+    /// `write_mode` determines how calls to the `write(…)` method are interpreted, and `on_into_read` determines
+    /// which message to write when the writer is turned into the response reader using [`into_read()`][RequestWriter::into_read()].
+    /// If `trace` is `true`, then all packetlines written and received will be traced using facilities provided by the `gix_trace` crate.
+    fn request(
+        &mut self,
+        write_mode: WriteMode,
+        on_into_read: MessageKind,
+        trace: bool,
+    ) -> Result<RequestWriter<'_>, Error>;
 }
 
 // Would be nice if the box implementation could auto-forward to all implemented traits.
@@ -53,6 +65,15 @@ impl<T: Transport + ?Sized> Transport for Box<T> {
     ) -> Result<SetServiceResponse<'_>, Error> {
         self.deref_mut().handshake(service, extra_parameters)
     }
+
+    fn request(
+        &mut self,
+        write_mode: WriteMode,
+        on_into_read: MessageKind,
+        trace: bool,
+    ) -> Result<RequestWriter<'_>, Error> {
+        self.deref_mut().request(write_mode, on_into_read, trace)
+    }
 }
 
 impl<T: Transport + ?Sized> Transport for &mut T {
@@ -62,6 +83,15 @@ impl<T: Transport + ?Sized> Transport for &mut T {
         extra_parameters: &'a [(&'a str, Option<&'a str>)],
     ) -> Result<SetServiceResponse<'_>, Error> {
         self.deref_mut().handshake(service, extra_parameters)
+    }
+
+    fn request(
+        &mut self,
+        write_mode: WriteMode,
+        on_into_read: MessageKind,
+        trace: bool,
+    ) -> Result<RequestWriter<'_>, Error> {
+        self.deref_mut().request(write_mode, on_into_read, trace)
     }
 }
 

--- a/gix-transport/src/client/git/async_io.rs
+++ b/gix-transport/src/client/git/async_io.rs
@@ -51,21 +51,6 @@ where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
-    fn request(
-        &mut self,
-        write_mode: client::WriteMode,
-        on_into_read: client::MessageKind,
-        trace: bool,
-    ) -> Result<RequestWriter<'_>, client::Error> {
-        Ok(RequestWriter::new_from_bufread(
-            &mut self.writer,
-            Box::new(self.line_provider.as_read_without_sidebands()),
-            write_mode,
-            on_into_read,
-            trace,
-        ))
-    }
-
     fn to_url(&self) -> Cow<'_, BStr> {
         self.state.custom_url.as_ref().map_or_else(
             || {
@@ -122,6 +107,21 @@ where
             capabilities,
             refs,
         })
+    }
+
+    fn request(
+        &mut self,
+        write_mode: client::WriteMode,
+        on_into_read: client::MessageKind,
+        trace: bool,
+    ) -> Result<RequestWriter<'_>, client::Error> {
+        Ok(RequestWriter::new_from_bufread(
+            &mut self.writer,
+            Box::new(self.line_provider.as_read_without_sidebands()),
+            write_mode,
+            on_into_read,
+            trace,
+        ))
     }
 }
 

--- a/gix-transport/src/client/git/blocking_io.rs
+++ b/gix-transport/src/client/git/blocking_io.rs
@@ -49,21 +49,6 @@ where
     R: std::io::Read,
     W: std::io::Write,
 {
-    fn request(
-        &mut self,
-        write_mode: client::WriteMode,
-        on_into_read: client::MessageKind,
-        trace: bool,
-    ) -> Result<RequestWriter<'_>, client::Error> {
-        Ok(RequestWriter::new_from_bufread(
-            &mut self.writer,
-            Box::new(self.line_provider.as_read_without_sidebands()),
-            write_mode,
-            on_into_read,
-            trace,
-        ))
-    }
-
     fn to_url(&self) -> Cow<'_, BStr> {
         self.state.custom_url.as_ref().map_or_else(
             || {
@@ -117,6 +102,21 @@ where
             capabilities,
             refs,
         })
+    }
+
+    fn request(
+        &mut self,
+        write_mode: client::WriteMode,
+        on_into_read: client::MessageKind,
+        trace: bool,
+    ) -> Result<RequestWriter<'_>, client::Error> {
+        Ok(RequestWriter::new_from_bufread(
+            &mut self.writer,
+            Box::new(self.line_provider.as_read_without_sidebands()),
+            write_mode,
+            on_into_read,
+            trace,
+        ))
     }
 }
 

--- a/gix-transport/src/client/traits.rs
+++ b/gix-transport/src/client/traits.rs
@@ -6,12 +6,6 @@ use std::{
 
 use bstr::BStr;
 
-#[cfg(all(feature = "async-client", not(feature = "blocking-client")))]
-use crate::client::async_io::RequestWriter;
-#[cfg(feature = "blocking-client")]
-use crate::client::blocking_io::RequestWriter;
-#[cfg(any(feature = "blocking-client", feature = "async-client"))]
-use crate::client::{MessageKind, WriteMode};
 use crate::{client::Error, Protocol};
 
 /// This trait represents all transport related functions that don't require any input/output to be done which helps
@@ -26,18 +20,6 @@ pub trait TransportWithoutIO {
     fn set_identity(&mut self, _identity: gix_sec::identity::Account) -> Result<(), Error> {
         Err(Error::AuthenticationUnsupported)
     }
-    /// Get a writer for sending data and obtaining the response. It can be configured in various ways
-    /// to support the task at hand.
-    /// `write_mode` determines how calls to the `write(…)` method are interpreted, and `on_into_read` determines
-    /// which message to write when the writer is turned into the response reader using [`into_read()`][RequestWriter::into_read()].
-    /// If `trace` is `true`, then all packetlines written and received will be traced using facilities provided by the `gix_trace` crate.
-    #[cfg(any(feature = "blocking-client", feature = "async-client"))]
-    fn request(
-        &mut self,
-        write_mode: WriteMode,
-        on_into_read: MessageKind,
-        trace: bool,
-    ) -> Result<RequestWriter<'_>, Error>;
 
     /// Returns the canonical URL pointing to the destination of this transport.
     fn to_url(&self) -> Cow<'_, BStr>;
@@ -75,16 +57,6 @@ impl<T: TransportWithoutIO + ?Sized> TransportWithoutIO for Box<T> {
         self.deref_mut().set_identity(identity)
     }
 
-    #[cfg(any(feature = "blocking-client", feature = "async-client"))]
-    fn request(
-        &mut self,
-        write_mode: WriteMode,
-        on_into_read: MessageKind,
-        trace: bool,
-    ) -> Result<RequestWriter<'_>, Error> {
-        self.deref_mut().request(write_mode, on_into_read, trace)
-    }
-
     fn to_url(&self) -> Cow<'_, BStr> {
         self.deref().to_url()
     }
@@ -105,16 +77,6 @@ impl<T: TransportWithoutIO + ?Sized> TransportWithoutIO for Box<T> {
 impl<T: TransportWithoutIO + ?Sized> TransportWithoutIO for &mut T {
     fn set_identity(&mut self, identity: gix_sec::identity::Account) -> Result<(), Error> {
         self.deref_mut().set_identity(identity)
-    }
-
-    #[cfg(any(feature = "blocking-client", feature = "async-client"))]
-    fn request(
-        &mut self,
-        write_mode: WriteMode,
-        on_into_read: MessageKind,
-        trace: bool,
-    ) -> Result<RequestWriter<'_>, Error> {
-        self.deref_mut().request(write_mode, on_into_read, trace)
     }
 
     fn to_url(&self) -> Cow<'_, BStr> {


### PR DESCRIPTION
The `RequestWriter` type is specific to the I/O mode, so this should not live in the I/O-generic trait.