### PR TITLE
Update documentation for msrv.yml change

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ cave resolve -x gitoxide
 `cargo` is the Rust package manager which can easily be obtained through [rustup]. With it, you can build your own binary
 effortlessly and for your particular CPU for additional performance gains.
 
-The minimum supported Rust version is [documented in the CI configuration](https://github.com/GitoxideLabs/gitoxide/blob/main/.github/workflows/msrv.yml#L23),
+The minimum supported Rust version is [documented in the Cargo package](https://github.com/GitoxideLabs/gitoxide/blob/main/gix/Cargo.toml#L12-L14),
 the latest stable one will work as well.
 
 There are various build configurations, all of them are [documented here](https://docs.rs/crate/gitoxide/latest). The documentation should also be useful

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -127,7 +127,7 @@ Minor version updates for new features can be released when needed assuming ther
 ## The _Minimal Supported Rust Version_ (->MSRV)
 
 The MSRV is automatically assumed to be the latest stable version for all crates with the following exception: `gix` and all it's dependencies must
-adhere to an MSRV, as validated by the `msrv.yml` GitHub workflow.
+adhere to an MSRV, as validated by the `ci.yml` GitHub workflow.
 
 Increasing the MSRV is *not* considered a breaking change like is the case for most other crates in the community.
 


### PR DESCRIPTION
The `msrv.yml` file was removed in https://github.com/GitoxideLabs/gitoxide/pull/2027. However, there were some remaining references that didn't get updated.