### PR TITLE
fix: use `std::env::home_dir()` and remove the `home` crate from dependencies. (#2234)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,6 @@ dependencies = [
  "gix-testtools",
  "gix-trace",
  "gix-validate",
- "home",
  "serial_test",
  "thiserror 2.0.17",
  "windows 0.62.1",
@@ -2739,15 +2738,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "http"

--- a/gix-path/Cargo.toml
+++ b/gix-path/Cargo.toml
@@ -20,9 +20,6 @@ gix-validate = { version = "^0.10.1", path = "../gix-validate" }
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 thiserror = "2.0.17"
 
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
-home = "0.5.5"
-
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }
 serial_test = { version = "3.1.0", default-features = false }

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -199,7 +199,7 @@ pub fn home_dir() -> Option<PathBuf> {
 }
 
 /// Tries to obtain the home directory from `HOME` on all platforms, but falls back to
-/// [`home::home_dir()`] for more complex ways of obtaining a home directory, particularly useful
+/// [`std::env::home_dir()`] for more complex ways of obtaining a home directory, particularly useful
 /// on Windows.
 ///
 /// The reason `HOME` is tried first is to allow Windows users to have a custom location for their
@@ -207,7 +207,7 @@ pub fn home_dir() -> Option<PathBuf> {
 /// inconvenient and perceived as clutter.
 #[cfg(not(target_family = "wasm"))]
 pub fn home_dir() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(Into::into).or_else(home::home_dir)
+    std::env::var_os("HOME").map(Into::into).or_else(std::env::home_dir)
 }
 
 /// Returns the contents of an environment variable of `name` with some special handling for


### PR DESCRIPTION
Let's hope this works with WASM.
