### PR TITLE
Move worktree_branches call out of loop in ref update

### DIFF
--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -76,6 +76,7 @@ pub(crate) fn update(
     let mut updates = Vec::new();
     let mut edit_indices_to_validate = Vec::new();
 
+    let mut checked_out_branches = worktree_branches(repo)?;
     let implicit_tag_refspec = fetch_tags
         .to_refspec()
         .filter(|_| matches!(fetch_tags, crate::remote::fetch::Tags::Included));
@@ -110,7 +111,6 @@ pub(crate) fn update(
                 continue;
             }
         }
-        let mut checked_out_branches = worktree_branches(repo)?;
         let (mode, edit_index, type_change) = match local {
             Some(name) => {
                 let (mode, reflog_message, name, previous_value) = match repo.try_find_reference(name)? {


### PR DESCRIPTION
`worktree_branches` opens every worktree as a `Repository` to resolve its `HEAD`. This is currently getting called in the loop over ref mappings, but I do not see why it needs to be. Moving it outside the loop results in a pretty significant performance increase (~10x in my case) for fetch when worktree(s) are present, dependent on how many refs exist in the repository and the value configured for `object_store_slots`. In my case, `object_store_slots` was set relatively high, resulting in slow drop for `gix_odb::Store` and hence `gix::Repository`.