### PR TITLE
Exclude `expectrl` and `imara-diff` from grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
     groups:
       cargo:
         patterns: ['*']
+        exclude-patterns:
+          - expectrl
+          - imara-diff
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
Dependabot is working again for cargo dependencies: #2245 was due to https://github.com/dependabot/dependabot-core/issues/13345, fixed in https://github.com/dependabot/dependabot-core/pull/13359.

However, now we get an analogous problem in here in `gitoxide` with `expectrl` and `imara-diff` to the problem previously encountered in `cargo-smart-release` with `pulldown-cmark`. That was seen in https://github.com/GitoxideLabs/cargo-smart-release/pull/85, where even though it is held back in `dependabot.yml`, Dependabot proposed updates to it in `Cargo.toml`. The analogous problem here can be seen in #2268, which includes `expectrl` and `imara-diff`.

In https://github.com/GitoxideLabs/cargo-smart-release/pull/86, we worked around the problem in `cargo-smart-release` by explicitly excluding `pulldown-cmark` from grouped updates, so that PRs would be made without it even of Dependabot were to wrongly detect that it should attempt to upgrade it. That was even more effective than anticipated, in that Dependabot also refrained from opening extra non-grouped PRs for it (it heeded the version restrictions again).

This attempts an analogous change here in `dependabot.yml` for `gitoxide`, excluding `expectrl` and `imara-diff` from grouped version updates. Hopefully this will at least allow Dependabot grouped version update PRs to be made that don't bump those crates.