### PR TITLE
Report number of non-matching diffs in slider test

### DIFF
--- a/gix-diff/tests/diff/blob/slider.rs
+++ b/gix-diff/tests/diff/blob/slider.rs
@@ -95,11 +95,13 @@ fn baseline() -> gix_testtools::Result {
         .filter(|(_, _, actual_matches_baseline, _)| *actual_matches_baseline)
         .count();
 
-    assert!(
-        matching_diffs == total_diffs,
-        "assertion failed: total diffs {} == matching diffs {}\n\n{}",
-        total_diffs,
+    assert_eq!(
         matching_diffs,
+        total_diffs,
+        "matching diffs {} == total diffs {} [{:.2} %]\n\n{}",
+        matching_diffs,
+        total_diffs,
+        ((matching_diffs as f32) / (total_diffs as f32) * 100.0),
         {
             let first_non_matching_diff = diffs
                 .iter()


### PR DESCRIPTION
This PR improves the test reporting for the diff slider test.

In addition to the first non-matching diff, the test now also reports the fixture it came from and the number of total as well as non-matching diffs. This makes the slider test more suitable as a benchmark for comparing different slider heuristics.

This is a follow-up to #2197.

Comparison of new test report (above) vs. old test report (below):

<img width="731" height="875" alt="Screenshot 2025-12-01 at 10 15 00" src="https://github.com/user-attachments/assets/0c9ed614-0355-4b92-8f4f-58810218b3b0" />
