### PR TITLE
gix-mailmap: Derive `std::hash::Hash` for `Snapshot`

### DIFF
--- a/gix-mailmap/src/lib.rs
+++ b/gix-mailmap/src/lib.rs
@@ -43,7 +43,7 @@ pub mod snapshot;
 /// something that should be very rare but is possible, we decided to not expose this fallibility in the API.
 /// Hence, the user may separately check for the correctness of `time`, which we replace with [`gix_date::Time::default()`]
 /// in case of parse errors.
-#[derive(Default, Clone, Debug, Eq, PartialEq, std::hash::Hash)]
+#[derive(Default, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Snapshot {
     /// Sorted by `old_email`
     entries_by_old_email: Vec<snapshot::EmailEntry>,

--- a/gix-mailmap/src/snapshot/entry.rs
+++ b/gix-mailmap/src/snapshot/entry.rs
@@ -2,14 +2,14 @@ use bstr::BString;
 
 use crate::snapshot::util::{EncodedString, EncodedStringRef};
 
-#[derive(Clone, Debug, Eq, PartialEq, std::hash::Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) struct NameEntry {
     pub(crate) new_name: Option<BString>,
     pub(crate) new_email: Option<BString>,
     pub(crate) old_name: EncodedString,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, std::hash::Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) struct EmailEntry {
     pub(crate) new_name: Option<BString>,
     pub(crate) new_email: Option<BString>,

--- a/gix-mailmap/src/snapshot/util.rs
+++ b/gix-mailmap/src/snapshot/util.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, ops::Deref};
 
 use bstr::{BStr, BString, ByteSlice};
 
-#[derive(Clone, Debug, Eq, PartialEq, std::hash::Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum EncodedString {
     Utf8(String),
     Unknown(BString),


### PR DESCRIPTION
Hello!

I'd like to cache output that relies on mailmaps.

Using the object id or a hash of the raw bytes is an alternative but the format allows for comments and whatnot. At present, the best alternative I think is newtyping and implementing Hash through `Snapshot::iter()`. Having hash on `Snapshot` lets me avoid that.