### PR TITLE
fix tar feature in gix-archive

### DIFF
--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -33,7 +33,7 @@ gix-path = { version = "^0.10.22", path = "../gix-path", optional = true }
 gix-date = { version = "^0.11.0", path = "../gix-date" }
 
 flate2 = { version = "1.1.1", optional = true, default-features = false, features = ["zlib-rs"] }
-zip = { version = "6.0.0", optional = true, default-features = false, features = ["deflate-flate2"] }
+zip = { version = "6.0.0", optional = true, default-features = false, features = ["deflate-flate2-zlib-rs"] }
 jiff = { version = "0.2.15", default-features = false, features = ["std"] }
 
 thiserror = "2.0.17"

--- a/gix-archive/src/write.rs
+++ b/gix-archive/src/write.rs
@@ -247,7 +247,7 @@ fn tar_entry_type(mode: gix_object::tree::EntryMode) -> tar::EntryType {
     }
 }
 
-#[cfg(any(feature = "tar", feature = "tar_gz"))]
+#[cfg(any(feature = "tar", feature = "tar_gz", feature = "zip"))]
 fn add_prefix<'a>(relative_path: &'a bstr::BStr, prefix: Option<&bstr::BString>) -> std::borrow::Cow<'a, bstr::BStr> {
     use std::borrow::Cow;
     match prefix {

--- a/justfile
+++ b/justfile
@@ -149,9 +149,9 @@ unit-tests:
     cargo nextest run -p gix-testtools --no-fail-fast
     cargo nextest run -p gix-testtools --features xz --no-fail-fast
     cargo nextest run -p gix-archive --no-default-features --no-fail-fast
-    cargo nextest run -p gix-archive --features tar --no-fail-fast
-    cargo nextest run -p gix-archive --features tar_gz --no-fail-fast
-    cargo nextest run -p gix-archive --features zip --no-fail-fast
+    cargo nextest run -p gix-archive --no-default-features --features tar --no-fail-fast
+    cargo nextest run -p gix-archive --no-default-features --features tar_gz --no-fail-fast
+    cargo nextest run -p gix-archive --no-default-features --features zip --no-fail-fast
     cargo nextest run -p gix-status-tests --features gix-features-parallel --no-fail-fast
     cargo nextest run -p gix-worktree-state-tests --features gix-features-parallel --no-fail-fast
     cargo nextest run -p gix-worktree-tests --features gix-features-parallel --no-fail-fast


### PR DESCRIPTION
Currently it is not possible to only choose the `tar` feature in `gix-archive`, also `Format::TarGz` was not correctly instantiated and throw an additional error.