### PR TITLE
Also call `configure_connection` callback for the initial connection in shallow clones

### DIFF
--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -121,6 +121,9 @@ impl PrepareFetch {
                 // For shallow clones without a specified ref, we need to determine the default branch.
                 // We'll connect to get HEAD information. For Protocol V2, we need to explicitly list refs.
                 let mut connection = remote.connect(remote::Direction::Fetch).await?;
+                if let Some(f) = self.configure_connection.as_mut() {
+                    f(&mut connection).map_err(Error::RemoteConnection)?;
+                }
 
                 // Perform handshake and try to get HEAD from it (works for Protocol V1)
                 let _ = connection.ref_map_by_ref(&mut progress, Default::default()).await?;


### PR DESCRIPTION
I was wondering why I was being asked for credentials and why my callback wasn't being called. This bug pretty much breaks injected credentials for shallow clones.