### PR TITLE
feat: add `Prefix::from_hex_nonempty()` to allow creating short prefixes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0dfe5e9e71bdcf4e4954f7d14da74d1cdb92a3a07686452d1509652684b1aab"
+checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
 dependencies = [
  "alloca",
  "anes",
@@ -684,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de36c2bee19fba779808f92bf5d9b0fa5a40095c277aba10c458a12b35d21d6"
+checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -2681,11 +2681,12 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
+ "fnv",
  "itoa",
 ]
 
@@ -4043,9 +4044,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4756,9 +4757,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
@@ -5780,18 +5781,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/gix-hash/src/prefix.rs
+++ b/gix-hash/src/prefix.rs
@@ -93,12 +93,23 @@ impl Prefix {
     }
 
     /// Create an instance from the given hexadecimal prefix `value`, e.g. `35e77c16` would yield a `Prefix` with `hex_len()` = 8.
+    /// Note that the minimum hex length is `4` - use [`Self::from_hex_nonempty()`].
     pub fn from_hex(value: &str) -> Result<Self, from_hex::Error> {
+        let hex_len = value.len();
+        if hex_len < Self::MIN_HEX_LEN {
+            return Err(from_hex::Error::TooShort { hex_len });
+        }
+        Self::from_hex_nonempty(value)
+    }
+
+    /// Create an instance from the given hexadecimal prefix `value`, e.g. `35e` would yield a `Prefix` with `hex_len()` = 3.
+    /// Note that this function supports all non-empty hex input - for a more typical implementation, use [`Self::from_hex()`].
+    pub fn from_hex_nonempty(value: &str) -> Result<Self, from_hex::Error> {
         let hex_len = value.len();
 
         if hex_len > crate::Kind::longest().len_in_hex() {
             return Err(from_hex::Error::TooLong { hex_len });
-        } else if hex_len < Self::MIN_HEX_LEN {
+        } else if hex_len == 0 {
             return Err(from_hex::Error::TooShort { hex_len });
         }
 

--- a/gix-hash/tests/hash/prefix.rs
+++ b/gix-hash/tests/hash/prefix.rs
@@ -80,7 +80,7 @@ mod try_from {
     use crate::hex_to_id;
 
     #[test]
-    fn id_8_chars() {
+    fn id_6_chars() {
         let oid_hex = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
         let input = "abcdef";
 
@@ -90,7 +90,7 @@ mod try_from {
     }
 
     #[test]
-    fn id_9_chars() {
+    fn id_7_chars() {
         let oid_hex = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
         let input = "abcdefa";
 
@@ -107,7 +107,7 @@ mod try_from {
     }
 
     #[test]
-    fn id_to_long() {
+    fn id_too_long() {
         let input = "abcdefabcdefabcdefabcdefabcdefabcdefabcd123123123123123123";
         let expected = Error::TooLong { hex_len: 58 };
         let actual = Prefix::try_from(input).unwrap_err();
@@ -119,6 +119,62 @@ mod try_from {
         let input = "abcdfOsd";
         let expected = Error::Invalid;
         let actual = Prefix::try_from(input).unwrap_err();
+        assert_eq!(actual, expected);
+    }
+}
+
+mod from_hex_nonempty {
+    use std::cmp::Ordering;
+
+    use gix_hash::{prefix::from_hex::Error, Prefix};
+
+    use crate::hex_to_id;
+
+    #[test]
+    fn id_6_chars() {
+        let oid_hex = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+        let input = "abcdef";
+
+        let expected = hex_to_id(oid_hex);
+        let actual = Prefix::from_hex_nonempty(input).expect("No errors");
+        assert_eq!(actual.cmp_oid(&expected), Ordering::Equal);
+    }
+
+    #[test]
+    fn id_7_chars() {
+        let oid_hex = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+        let input = "abcdefa";
+
+        let expected = hex_to_id(oid_hex);
+        let actual = Prefix::from_hex_nonempty(input).expect("No errors");
+        assert_eq!(actual.cmp_oid(&expected), Ordering::Equal);
+    }
+
+    #[test]
+    fn id_2_chars_and_less() {
+        let oid_hex = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+
+        let oid = hex_to_id(oid_hex);
+        let actual = Prefix::from_hex_nonempty("ab").expect("no errors");
+        assert_eq!(actual.cmp_oid(&oid), Ordering::Equal);
+
+        let actual = Prefix::from_hex_nonempty("a").expect("no errors");
+        assert_eq!(actual.cmp_oid(&oid), Ordering::Equal);
+    }
+
+    #[test]
+    fn id_empty() {
+        let input = "";
+        let expected = Error::TooShort { hex_len: 0 };
+        let actual = Prefix::from_hex_nonempty(input).unwrap_err();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn id_too_long() {
+        let input = "abcdefabcdefabcdefabcdefabcdefabcdefabcd123123123123123123";
+        let expected = Error::TooLong { hex_len: 58 };
+        let actual = Prefix::from_hex_nonempty(input).unwrap_err();
         assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
This can be useful in certain situations where the set of candidate object ids is very small.
