### PR TITLE
update to zlib-rs 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5847,6 +5847,6 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f936044d677be1a1168fae1d03b583a285a5dd9d8cbf7b24c23aa1fc775235"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"

--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -108,7 +108,7 @@ bytesize = { version = "2.3.1", optional = true }
 bytes = { version = "1.0.0", optional = true }
 
 # zlib module
-zlib-rs = { version = "0.5.4", optional = true }
+zlib-rs = { version = "0.5.5", optional = true }
 thiserror = { version = "2.0.17", optional = true }
 
 # Note: once_cell is kept for OnceCell type because std::sync::OnceLock::get_or_try_init() is not yet stable.


### PR DESCRIPTION
fixes https://github.com/GitoxideLabs/gitoxide/issues/2265

zlib-rs now correctly handles an input/output buffer size larger than `c_uint`. Internally `c_uint::MAX` is now used as the length of the buffer. The caller is responsible for handing the (unlikely) case of zlib actually using that full buffer and not having found the logical end of the input.