### PR TITLE
Add feature flag `blame-experimental` to `gix`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,6 @@ lean = ["fast", "tracing", "pretty-cli", "http-client-curl", "gitoxide-core-tool
 ## Optimized for size, no parallelism thus much slower, progress line rendering.
 small = ["pretty-cli", "prodash-render-line", "is-terminal"]
 
-## An experimental use of the v0.2 branch of `imara-diff` in `gix-diff` and `gix-blame`, to allow trying the new diff algorithm.
-blame-experimental = ["gitoxide-core/blame-experimental"]
-
 ## Like lean, but uses Rusts async implementations for networking.
 ##
 ## This build is more of a demonstration showing how async can work with `gitoxide`, which generally is blocking. This also means that the selection of async transports
@@ -150,6 +147,11 @@ http-client-reqwest = ["gix/blocking-http-transport-reqwest-rust-tls"]
 #!
 ## Use async client networking.
 gitoxide-core-async-client = ["gitoxide-core/async-client", "futures-lite"]
+
+#! ### Experimental Features
+#!
+## An experimental use of the v0.2 branch of `imara-diff` in `gix-diff` and `gix-blame`, to allow trying the new diff algorithm.
+blame-experimental = ["gitoxide-core/blame-experimental"]
 
 [dependencies]
 anyhow = "1.0.98"

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -46,6 +46,7 @@ async-client = ["gix/async-network-client-async-std", "gix-transport-configurati
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde = ["gix/serde", "dep:serde_json", "dep:serde", "bytesize/serde"]
 
+#! ### Experimental
 ## An experimental use of the v0.2 branch of `imara-diff` in `gix-diff` and `gix-blame`, to allow trying the new diff algorithm.
 blame-experimental = ["gix/blame-experimental"]
 

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -147,9 +147,6 @@ merge = ["tree-editor", "blob-diff", "dep:gix-merge", "attributes"]
 ## Add blame command similar to `git blame`.
 blame = ["dep:gix-blame", "blob-diff"]
 
-## Use the v0.2 branch of `imara-diff` in `gix-diff` and `gix-blame`, to allow trying the new diff algorithm.
-blame-experimental = ["dep:gix-blame", "gix-blame/blob-experimental"]
-
 ## Make it possible to turn a tree into a stream of bytes, which can be decoded to entries and turned into various other formats.
 worktree-stream = ["gix-worktree-stream", "attributes"]
 
@@ -307,6 +304,10 @@ progress-tree = ["prodash/progress-tree"]
 
 ## Print debugging information about usage of object database caches, useful for tuning cache sizes.
 cache-efficiency-debug = ["gix-features/cache-efficiency-debug"]
+
+#! #### Experimental Features
+## Use the v0.2 branch of `imara-diff` in `gix-diff` and `gix-blame`, to allow trying the new diff algorithm.
+blame-experimental = ["blame", "gix-blame/blob-experimental"]
 
 
 [dependencies]


### PR DESCRIPTION
The proposed feature flag makes it easier to run tests comparing the output of `gix blame` using `imara-diff` 0.1 vs. 0.2.
