### PR TITLE
docs: using PrepareFetch::with_ref_name with non-branch refs causes panics

### DIFF
--- a/gix/src/clone/access.rs
+++ b/gix/src/clone/access.rs
@@ -49,8 +49,10 @@ impl PrepareFetch {
     /// Note that `name` should be a partial name like `main` or `feat/one`, but can be a full ref name.
     /// If a branch on the remote matches, it will automatically be retrieved even without a refspec.
     ///
-    /// **Warning**: Calling this method with a valid refspec that is not a branch name currently causes
-    /// subsequent calls to [`PrepareFetch::fetch_only`] or [`PrepareFetch::fetch_then_checkout`] to panic.
+    /// # Panics
+    ///
+    /// Calling this method with a valid refspec that is not a branch name, like an object-id as hex-hash,
+    /// currently causes subsequent calls to [`PrepareFetch::fetch_only`] or [`PrepareFetch::fetch_then_checkout`] to panic.
     pub fn with_ref_name<'a, Name, E>(mut self, name: Option<Name>) -> Result<Self, E>
     where
         Name: TryInto<&'a gix_ref::PartialNameRef, Error = E>,


### PR DESCRIPTION
see discussion in https://github.com/GitoxideLabs/gitoxide/discussions/2309
