### PR TITLE
improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           ! GREP_COLORS='ms=30;48;5;214' grep --color=always -Ex -C 1000000 -e "$pattern" tree.txt
         continue-on-error: true
       - name: Check for unrecognized *-sys dependencies
+        # TODO: remove `libz-rs|` once https://github.com/rust-lang/flate2-rs/pull/520 is merged.
         run: |
           ! grep -qP '(?<!\b(linux-raw|libz-rs|aws-lc))-sys\b' tree.txt
       - name: Wrap cc1 (and cc1plus if present) to record calls


### PR DESCRIPTION
Remove `libz-rs-sys` crate from allow-list for pure Rust build

Follow-up of #2328.