### PR TITLE
improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "gix-command"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "bstr",
  "gix-path",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "bstr",
  "document-features",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "gix-transport"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "async-std",
  "async-trait",

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -54,7 +54,7 @@ blame-experimental = ["gix/blame-experimental"]
 # deselect everything else (like "performance") as this should be controllable by the parent application.
 gix = { version = "^0.77.0", path = "../gix", default-features = false, features = ["merge", "blob-diff", "blame", "revision", "mailmap", "excludes", "attributes", "worktree-mutation", "credentials", "interrupt", "status", "dirwalk"] }
 gix-pack-for-configuration-only = { package = "gix-pack", version = "^0.64.0", path = "../gix-pack", default-features = false, features = ["pack-cache-lru-dynamic", "pack-cache-lru-static", "generate", "streaming-input"] }
-gix-transport-configuration-only = { package = "gix-transport", version = "^0.52.0", path = "../gix-transport", default-features = false }
+gix-transport-configuration-only = { package = "gix-transport", version = "^0.52.1", path = "../gix-transport", default-features = false }
 gix-archive-for-configuration-only = { package = "gix-archive", version = "^0.26.0", path = "../gix-archive", optional = true, features = ["tar", "tar_gz"] }
 gix-status = { version = "^0.24.0", path = "../gix-status" }
 gix-fsck = { version = "^0.16.0", path = "../gix-fsck" }

--- a/gix-command/CHANGELOG.md
+++ b/gix-command/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.6.4 (2026-01-02)
 
 A maintenance release without user-facing changes.
 
@@ -13,9 +13,9 @@ A maintenance release without user-facing changes.
 
 <csr-read-only-do-not-edit/>
 
- - 9 commits contributed to the release.
+ - 10 commits contributed to the release.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
+ - 1 unique issue was worked on: [#2328](https://github.com/GitoxideLabs/gitoxide/issues/2328)
 
 ### Commit Details
 
@@ -23,6 +23,8 @@ A maintenance release without user-facing changes.
 
 <details><summary>view details</summary>
 
+ * **[#2328](https://github.com/GitoxideLabs/gitoxide/issues/2328)**
+    - Update changelogs prior to `gix-transport` release ([`ae8c9d3`](https://github.com/GitoxideLabs/gitoxide/commit/ae8c9d3ff56a38f2cd92c6f5afa9e93434939fe0))
  * **Uncategorized**
     - Merge pull request #2324 from EliahKagan/run-ci/cred-test-sh ([`0b1a7b7`](https://github.com/GitoxideLabs/gitoxide/commit/0b1a7b7914fe2bffdea2fd8628cabb7a6edbe262))
     - Don't run `shell_builtin_or_command_in_path*` on Windows ([`81fa44c`](https://github.com/GitoxideLabs/gitoxide/commit/81fa44c645988521cd36d6282814bc75817e7fe3))

--- a/gix-command/Cargo.toml
+++ b/gix-command/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-command"
-version = "0.6.3"
+version = "0.6.4"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project handling internal git command execution"

--- a/gix-credentials/CHANGELOG.md
+++ b/gix-credentials/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.34.1 (2026-01-02)
 
 A maintenance release without user-facing changes.
 
@@ -13,10 +13,10 @@ A maintenance release without user-facing changes.
 
 <csr-read-only-do-not-edit/>
 
- - 6 commits contributed to the release over the course of 1 calendar day.
+ - 7 commits contributed to the release over the course of 1 calendar day.
  - 1 day passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
+ - 1 unique issue was worked on: [#2328](https://github.com/GitoxideLabs/gitoxide/issues/2328)
 
 ### Commit Details
 
@@ -24,6 +24,8 @@ A maintenance release without user-facing changes.
 
 <details><summary>view details</summary>
 
+ * **[#2328](https://github.com/GitoxideLabs/gitoxide/issues/2328)**
+    - Update changelogs prior to `gix-transport` release ([`ae8c9d3`](https://github.com/GitoxideLabs/gitoxide/commit/ae8c9d3ff56a38f2cd92c6f5afa9e93434939fe0))
  * **Uncategorized**
     - Merge pull request #2324 from EliahKagan/run-ci/cred-test-sh ([`0b1a7b7`](https://github.com/GitoxideLabs/gitoxide/commit/0b1a7b7914fe2bffdea2fd8628cabb7a6edbe262))
     - Adjust misleading `gix-credentials` shell script fixture shebangs ([`e7f5910`](https://github.com/GitoxideLabs/gitoxide/commit/e7f5910a7b90eb89f22325d0e87fd8669cf8e8ec))

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-credentials"
-version = "0.34.0"
+version = "0.34.1"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project to interact with git credentials helpers"
@@ -22,7 +22,7 @@ serde = ["dep:serde", "bstr/serde", "gix-sec/serde"]
 gix-sec = { version = "^0.12.2", path = "../gix-sec" }
 gix-url = { version = "^0.34.0", path = "../gix-url" }
 gix-path = { version = "^0.10.22", path = "../gix-path" }
-gix-command = { version = "^0.6.3", path = "../gix-command" }
+gix-command = { version = "^0.6.4", path = "../gix-command" }
 gix-config-value = { version = "^0.16.0", path = "../gix-config-value" }
 gix-prompt = { version = "^0.12.0", path = "../gix-prompt" }
 gix-date = { version = "^0.12.0", path = "../gix-date" }

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -47,7 +47,7 @@ gix-hash = { version = "^0.21.1", path = "../gix-hash" }
 gix-object = { version = "^0.54.0", path = "../gix-object" }
 gix-filter = { version = "^0.24.0", path = "../gix-filter", optional = true }
 gix-worktree = { version = "^0.46.0", path = "../gix-worktree", default-features = false, features = ["attributes"], optional = true }
-gix-command = { version = "^0.6.3", path = "../gix-command", optional = true }
+gix-command = { version = "^0.6.4", path = "../gix-command", optional = true }
 gix-path = { version = "^0.10.22", path = "../gix-path", optional = true }
 gix-fs = { version = "^0.18.1", path = "../gix-fs", optional = true }
 gix-tempfile = { version = "^20.0.0", path = "../gix-tempfile", optional = true }

--- a/gix-filter/Cargo.toml
+++ b/gix-filter/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 gix-hash = { version = "^0.21.1", path = "../gix-hash" }
 gix-trace = { version = "^0.1.16", path = "../gix-trace" }
 gix-object = { version = "^0.54.0", path = "../gix-object" }
-gix-command = { version = "^0.6.3", path = "../gix-command" }
+gix-command = { version = "^0.6.4", path = "../gix-command" }
 gix-quote = { version = "^0.6.1", path = "../gix-quote" }
 gix-utils = { version = "^0.3.1", path = "../gix-utils" }
 gix-path = { version = "^0.10.22", path = "../gix-path" }

--- a/gix-merge/Cargo.toml
+++ b/gix-merge/Cargo.toml
@@ -23,7 +23,7 @@ gix-hash = { version = "^0.21.1", path = "../gix-hash" }
 gix-object = { version = "^0.54.0", path = "../gix-object" }
 gix-filter = { version = "^0.24.0", path = "../gix-filter" }
 gix-worktree = { version = "^0.46.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }
-gix-command = { version = "^0.6.3", path = "../gix-command" }
+gix-command = { version = "^0.6.4", path = "../gix-command" }
 gix-path = { version = "^0.10.22", path = "../gix-path" }
 gix-fs = { version = "^0.18.1", path = "../gix-fs" }
 gix-tempfile = { version = "^20.0.0", path = "../gix-tempfile" }

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -71,7 +71,7 @@ required-features = ["async-client"]
 gix-features = { version = "^0.45.1", path = "../gix-features", features = [
     "progress",
 ] }
-gix-transport = { version = "^0.52.0", path = "../gix-transport" }
+gix-transport = { version = "^0.52.1", path = "../gix-transport" }
 gix-hash = { version = "^0.21.1", path = "../gix-hash" }
 gix-shallow = { version = "^0.7.0", path = "../gix-shallow" }
 gix-date = { version = "^0.12.0", path = "../gix-date" }
@@ -82,7 +82,7 @@ gix-trace = { version = "^0.1.16", path = "../gix-trace", optional = true }
 gix-negotiate = { version = "^0.25.0", path = "../gix-negotiate", optional = true }
 gix-object = { version = "^0.54.0", path = "../gix-object", optional = true }
 gix-revwalk = { version = "^0.25.0", path = "../gix-revwalk", optional = true }
-gix-credentials = { version = "^0.34.0", path = "../gix-credentials", optional = true }
+gix-credentials = { version = "^0.34.1", path = "../gix-credentials", optional = true }
 gix-refspec = { version = "^0.35.0", path = "../gix-refspec", optional = true }
 gix-lock = { version = "^20.0.0", path = "../gix-lock", optional = true }
 

--- a/gix-transport/CHANGELOG.md
+++ b/gix-transport/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.52.1 (2026-01-02)
 
 Update to the latest version of `reqwest` for improved dependencies.
 
@@ -13,10 +13,10 @@ Update to the latest version of `reqwest` for improved dependencies.
 
 <csr-read-only-do-not-edit/>
 
- - 3 commits contributed to the release over the course of 1 calendar day.
+ - 4 commits contributed to the release over the course of 1 calendar day.
  - 1 day passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
- - 0 issues like '(#ID)' were seen in commit messages
+ - 1 unique issue was worked on: [#2328](https://github.com/GitoxideLabs/gitoxide/issues/2328)
 
 ### Commit Details
 
@@ -24,6 +24,8 @@ Update to the latest version of `reqwest` for improved dependencies.
 
 <details><summary>view details</summary>
 
+ * **[#2328](https://github.com/GitoxideLabs/gitoxide/issues/2328)**
+    - Update changelogs prior to `gix-transport` release ([`ae8c9d3`](https://github.com/GitoxideLabs/gitoxide/commit/ae8c9d3ff56a38f2cd92c6f5afa9e93434939fe0))
  * **Uncategorized**
     - Merge pull request #2328 from NobodyXu/patch-1 ([`5de660e`](https://github.com/GitoxideLabs/gitoxide/commit/5de660e0779b51288c443d6d44a5ae89519b499c))
     - Bump reqwest to 0.13.1 ([`c8196c6`](https://github.com/GitoxideLabs/gitoxide/commit/c8196c6f7f55328b2518e94c982a93f620515211))

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-transport"
-version = "0.52.0"
+version = "0.52.1"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dedicated to implementing the git transport layer"
@@ -79,12 +79,12 @@ path = "tests/async-transport.rs"
 required-features = ["async-client"]
 
 [dependencies]
-gix-command = { version = "^0.6.3", path = "../gix-command" }
+gix-command = { version = "^0.6.4", path = "../gix-command" }
 gix-features = { version = "^0.45.1", path = "../gix-features" }
 gix-url = { version = "^0.34.0", path = "../gix-url" }
 gix-sec = { version = "^0.12.2", path = "../gix-sec" }
 gix-packetline = { version = "^0.20.0", path = "../gix-packetline" }
-gix-credentials = { version = "^0.34.0", path = "../gix-credentials", optional = true }
+gix-credentials = { version = "^0.34.1", path = "../gix-credentials", optional = true }
 gix-quote = { version = "^0.6.1", path = "../gix-quote" }
 
 serde = { version = "1.0.114", optional = true, default-features = false, features = [

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -350,7 +350,7 @@ gix-features = { version = "^0.45.1", path = "../gix-features", features = [
 gix-trace = { version = "^0.1.16", path = "../gix-trace" }
 
 gix-glob = { version = "^0.23.0", path = "../gix-glob" }
-gix-credentials = { version = "^0.34.0", path = "../gix-credentials", optional = true }
+gix-credentials = { version = "^0.34.1", path = "../gix-credentials", optional = true }
 gix-prompt = { version = "^0.12.0", path = "../gix-prompt", optional = true }
 gix-index = { version = "^0.45.0", path = "../gix-index", optional = true }
 gix-attributes = { version = "^0.29.0", path = "../gix-attributes", optional = true }
@@ -364,7 +364,7 @@ gix-submodule = { version = "^0.24.0", path = "../gix-submodule", optional = tru
 gix-status = { version = "^0.24.0", path = "../gix-status", optional = true, features = [
     "worktree-rewrites",
 ] }
-gix-command = { version = "^0.6.3", path = "../gix-command", optional = true }
+gix-command = { version = "^0.6.4", path = "../gix-command", optional = true }
 
 gix-worktree-stream = { version = "^0.26.0", path = "../gix-worktree-stream", optional = true }
 gix-archive = { version = "^0.26.0", path = "../gix-archive", default-features = false, optional = true }
@@ -372,7 +372,7 @@ gix-blame = { version = "^0.7.0", path = "../gix-blame", optional = true }
 
 # For communication with remotes
 gix-protocol = { version = "^0.55.0", path = "../gix-protocol" }
-gix-transport = { version = "^0.52.0", path = "../gix-transport", optional = true }
+gix-transport = { version = "^0.52.1", path = "../gix-transport", optional = true }
 
 # Just to get the progress-tree feature
 prodash = { version = "30.0.1", optional = true, features = ["progress-tree"] }


### PR DESCRIPTION
Release `gix-transport` for https://github.com/GitoxideLabs/gitoxide/pull/2328.
