### PR TITLE
Revert "Fix rusqlite 0.38.0 compatibility: cast usize/u64 to i64 for database operations"

### DIFF
--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -22,7 +22,7 @@ organize = ["dep:gix-url", "dep:jwalk"]
 ## Derive the amount of time invested into a git repository akin to [git-hours](https://github.com/kimmobrunfeldt/git-hours).
 estimate-hours = ["dep:fs-err", "dep:crossbeam-channel", "dep:smallvec"]
 ## Gather information about repositories and store it in a database for easy querying.
-query = ["dep:rusqlite", "dep:crossbeam-channel"]
+query = ["dep:rusqlite"]
 ## Run algorithms on a corpus of repositories and store their results for later comparison and intelligence gathering.
 ## *Note that* `organize` we need for finding git repositories fast.
 corpus = ["dep:rusqlite", "dep:sysinfo", "organize", "dep:crossbeam-channel", "dep:serde_json", "dep:tracing-forest", "dep:tracing-subscriber", "tracing", "dep:parking_lot"]

--- a/gitoxide-core/src/corpus/db.rs
+++ b/gitoxide-core/src/corpus/db.rs
@@ -58,11 +58,10 @@ pub fn create(path: impl AsRef<std::path::Path>) -> anyhow::Result<rusqlite::Con
         version int
     )"#;
     con.execute_batch(meta_table)?;
-    let version: Option<i64> = con.query_row("SELECT version FROM meta", [], |r| r.get(0)).optional()?;
-    let version = version.map(|v| v as usize);
+    let version: Option<usize> = con.query_row("SELECT version FROM meta", [], |r| r.get(0)).optional()?;
     match version {
         None => {
-            con.execute("INSERT into meta(version) values(?)", params![VERSION as i64])?;
+            con.execute("INSERT into meta(version) values(?)", params![VERSION])?;
         }
         Some(version) if version != VERSION => match con.close() {
             Ok(()) => {
@@ -213,7 +212,7 @@ impl Engine {
         repository: Id,
     ) -> anyhow::Result<Run> {
         let insertion_time = std::time::UNIX_EPOCH.elapsed()?.as_secs();
-        let id = con.query_row("INSERT INTO run (gitoxide_version, runner, task, repository, insertion_time) VALUES (?1, ?2, ?3, ?4, ?5) RETURNING id", params![gitoxide_version, runner, task, repository, insertion_time as i64], |r| r.get(0))?;
+        let id = con.query_row("INSERT INTO run (gitoxide_version, runner, task, repository, insertion_time) VALUES (?1, ?2, ?3, ?4, ?5) RETURNING id", params![gitoxide_version, runner, task, repository, insertion_time], |r| r.get(0))?;
         Ok(Run {
             id,
             duration: Default::default(),

--- a/gitoxide-core/src/corpus/engine.rs
+++ b/gitoxide-core/src/corpus/engine.rs
@@ -255,9 +255,9 @@ impl Engine {
                 Ok(db::Repo {
                     id: r.get(0)?,
                     path: corpus_path.join(r.get::<_, String>(1)?),
-                    odb_size: ByteSize(r.get::<_, i64>(2)? as u64),
-                    num_objects: r.get::<_, i64>(3)? as u64,
-                    num_references: r.get::<_, i64>(4)? as usize,
+                    odb_size: ByteSize(r.get(2)?),
+                    num_objects: r.get(3)?,
+                    num_references: r.get(4)?,
                 })
             })?
             .inspect(|_| self.state.progress.inc())
@@ -313,7 +313,7 @@ impl Engine {
                         match repo_res {
                             Ok(mut repo) => {
                                 let rela_path = repo.path.strip_prefix(corpus_path)?;
-                                repo.id = statement.query_row(params![rela_path.to_str().context("only valid UTF8 is allowed for repository paths")?, corpus_id, repo.odb_size.as_u64() as i64, repo.num_objects as i64, repo.num_references as i64], |r| r.get(0))?;
+                                repo.id = statement.query_row(params![rela_path.to_str().context("only valid UTF8 is allowed for repository paths")?, corpus_id, repo.odb_size.as_u64(), repo.num_objects, repo.num_references], |r| r.get(0))?;
                                 out.push(repo);
                                 progress.inc();
                             }

--- a/gitoxide-core/src/query/db.rs
+++ b/gitoxide-core/src/query/db.rs
@@ -12,11 +12,10 @@ pub fn create(path: impl AsRef<std::path::Path>) -> anyhow::Result<rusqlite::Con
             version int
         )"#;
     con.execute_batch(meta_table)?;
-    let version: Option<i64> = con.query_row("SELECT version FROM meta", [], |r| r.get(0)).optional()?;
-    let version = version.map(|v| v as usize);
+    let version: Option<usize> = con.query_row("SELECT version FROM meta", [], |r| r.get(0)).optional()?;
     match version {
         None => {
-            con.execute("INSERT into meta(version) values(?)", params![VERSION as i64])?;
+            con.execute("INSERT into meta(version) values(?)", params![VERSION])?;
         }
         Some(version) if version != VERSION => match con.close() {
             Ok(()) => {
@@ -28,7 +27,7 @@ pub fn create(path: impl AsRef<std::path::Path>) -> anyhow::Result<rusqlite::Con
                 })?;
                 con = rusqlite::Connection::open(path)?;
                 con.execute_batch(meta_table)?;
-                con.execute("INSERT into meta(version) values(?)", params![VERSION as i64])?;
+                con.execute("INSERT into meta(version) values(?)", params![VERSION])?;
             }
             Err((_, err)) => return Err(err.into()),
         },


### PR DESCRIPTION
This reverts GitoxideLabs/gitoxide#2331.

See https://github.com/GitoxideLabs/gitoxide/pull/2331#issuecomment-3705769461 for context.

---

#2331 was a PR against the Dependabot feature branch for #2330, as is this. This will be followed up the alternative fix discussed at https://github.com/GitoxideLabs/gitoxide/pull/2331#pullrequestreview-3623510730. There are also some other changes I may make before merging that Dependabot PR or a similar one, related to https://github.com/GitoxideLabs/gitoxide/pull/2330#issuecomment-3705744385 and the conversation at https://github.com/GitoxideLabs/gitoxide/pull/2275#issuecomment-3591510707. I may end up merging the history including the original fix from #2331, or omitting it. See also https://github.com/EliahKagan/gitoxide/commit/6adf3bde6633fa3a70cd1baa416b40a60fe87456, which tests the alternative fix by itself.