### PR TITLE
Replace `dtolnay/rust-toolchain` with manual `rustup`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,10 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust
+        run: |
+          rustup update stable
+          rustup default stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -211,7 +214,10 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust
+        run: |
+          rustup update stable
+          rustup default stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -239,7 +245,11 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust
+        shell: bash
+        run: |
+          rustup update stable
+          rustup default stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -297,7 +307,11 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust
+        shell: bash
+        run: |
+          rustup update stable
+          rustup default stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -408,9 +422,12 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ env.TARGET }}
+      - name: Install Rust
+        shell: bash
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup target add "$TARGET"
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -429,10 +446,11 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          components: clippy,rustfmt
+      - name: Install Rust
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add clippy rustfmt
       - uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Run cargo clippy
         run: just clippy -D warnings -A unknown-lints --no-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,10 +248,12 @@ jobs:
           sudo apt-get install -y --no-install-recommends xz-utils liblz4-tool musl-tools
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-          targets: ${{ matrix.target }}
+        env:
+          RUST: ${{ matrix.rust }}
+        run: |
+          rustup update "$RUST"
+          rustup default "$RUST"
+          rustup target add "$TARGET"
 
       - name: Use Cross
         if: matrix.os == 'ubuntu-latest'
@@ -539,24 +541,25 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      RUST: ${{ matrix.rust }}
+      TARGET: ${{ matrix.target }}
+
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
-          targets: ${{ matrix.target }}
+        run: |
+          rustup update "$RUST"
+          rustup default "$RUST"
+          rustup target add "$TARGET"
       - uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2.30.0
         with:
           msystem: MINGW${{ startsWith(matrix.target, 'i686-') && '32' || '64' }}
           pacboy: cc:p
           path-type: inherit
       - name: 'Installation from crates.io: gitoxide'
-        env:
-          RUST: ${{ matrix.rust }}
-          TARGET: ${{ matrix.target }}
         run: |
           cargo +"$RUST" install --target "$TARGET" --no-default-features \
             --features max-pure --target-dir install-artifacts --debug --force gitoxide


### PR DESCRIPTION
This builds on #2337 by replacing all uses of `dtolnay/rust-toolchain` with `rustup` commands, as described in the "Plan" section there. See the commit message here (dc980b24ed5ede328394d5aa976f513c22af404e) for considerable details including background, rationale, and why an alternative action was not as good of a choice.

I first attempted to do this change (within my fork) via a Copilot PR. An error occurred, but the generated prompt in https://github.com/EliahKagan/gitoxide/pull/141 (if one expands the details) is potentially a useful alternative summary. The diff here is the same as what Copilot would've done.

Analogous to [that release test](https://github.com/EliahKagan/gitoxide/actions/runs/20691845377) of changes to `release.yml` in #2337, a release test achieved by cherry-picking the commit used there onto this branch was done in [this release test](https://github.com/EliahKagan/gitoxide/actions/runs/20691893860). (That was before rebasing this, but the rebase was just to bring this ahead of the merge commit--it didn't change the contents of `release.yml` or anything else.) Based on that, this seems not to break `release.yml` (so it should work again once some production-suitable fix/workaround for #2338 is devised).

However, this PR remains a draft until I check that the expected security scanning alerts, for both CodeQL and Zizmor, have appeared in the Security tab due to #2337. (Most of them should then go away as a result of this PR.)