### PR TITLE
Fix CI regression `test-fast` skipped tests except on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,6 @@ jobs:
         with:
           tool: nextest
       - name: Test (nextest)
-        if: startsWith(matrix.os, 'windows')
         env:
           GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI: '1'
         run: |  # zizmor: ignore[template-injection]


### PR DESCRIPTION
I had failed to remove an `if` guard that was meant to be removed in a refactoring, in c1a3a99 (#2337). That made it so `test-fast` skips running the tests on non-Windows systems and just reports success!

This fixes that serious CI bug by removing the left-over `if:`.

---

I noticed this in #2341 by observing that some tests passed when they shouldn't have been able to, and very fast.

As for this PR, I think everything should pass, but the bug also made it so that the changes to `test-fast` was not adequately tested before merging #2337, so that's not guaranteed.