### PR TITLE
[not intended for merging] experiment: use `git diff` in `blob_changes`

### DIFF
--- a/gitoxide-core/src/repository/blame.rs
+++ b/gitoxide-core/src/repository/blame.rs
@@ -39,6 +39,7 @@ pub fn blame_file(
     let cache: Option<gix::commitgraph::Graph> = repo.commit_graph_if_enabled()?;
     let mut resource_cache = repo.diff_resource_cache_for_tree_diff()?;
     let outcome = gix::blame::file(
+        repo.workdir().expect("TODO").to_path_buf(),
         &repo.objects,
         suspect,
         cache,

--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -981,6 +981,7 @@ fn blob_changes(
 #[allow(clippy::too_many_arguments)]
 #[cfg(feature = "blob-experimental")]
 fn blob_changes(
+    _worktree_path: PathBuf,
     odb: impl gix_object::Find + gix_object::FindHeader,
     resource_cache: &mut gix_diff::blob::Platform,
     oid: ObjectId,

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -222,6 +222,7 @@ macro_rules! mktest {
             let source_file_name: gix_object::bstr::BString = format!("{}.txt", $case).into();
 
             let lines_blamed = gix_blame::file(
+                fixture_path()?,
                 &odb,
                 suspect,
                 None,
@@ -297,7 +298,6 @@ mktest!(
 ///
 /// Context: https://github.com/Byron/gitoxide/pull/1453#issuecomment-2371013904
 #[test]
-#[should_panic = "empty-lines-myers"]
 #[cfg(not(feature = "blob-experimental"))]
 fn diff_disparity_imara_diff_v1() {
     diff_disparity_base();
@@ -323,6 +323,7 @@ fn diff_disparity_base() {
         let source_file_name: gix_object::bstr::BString = format!("{case}.txt").into();
 
         let lines_blamed = gix_blame::file(
+            fixture_path().expect("TODO"),
             &odb,
             suspect,
             None,
@@ -360,6 +361,7 @@ fn file_that_was_added_in_two_branches() -> gix_testtools::Result {
 
     let source_file_name = "file-with-two-roots.txt";
     let lines_blamed = gix_blame::file(
+        worktree_path.clone(),
         &odb,
         suspect,
         None,
@@ -390,6 +392,7 @@ fn since() -> gix_testtools::Result {
     let source_file_name: gix_object::bstr::BString = "simple.txt".into();
 
     let lines_blamed = gix_blame::file(
+        fixture_path()?,
         &odb,
         suspect,
         None,
@@ -430,6 +433,7 @@ mod blame_ranges {
         let source_file_name: gix_object::bstr::BString = "simple.txt".into();
 
         let lines_blamed = gix_blame::file(
+            fixture_path()?,
             &odb,
             suspect,
             None,
@@ -473,6 +477,7 @@ mod blame_ranges {
         let source_file_name: gix_object::bstr::BString = "simple.txt".into();
 
         let lines_blamed = gix_blame::file(
+            fixture_path()?,
             &odb,
             suspect,
             None,
@@ -514,6 +519,7 @@ mod blame_ranges {
         let source_file_name: gix_object::bstr::BString = "simple.txt".into();
 
         let lines_blamed = gix_blame::file(
+            fixture_path()?,
             &odb,
             suspect,
             None,
@@ -560,6 +566,7 @@ mod rename_tracking {
 
         let source_file_name = "after-rename.txt";
         let lines_blamed = gix_blame::file(
+            worktree_path.clone(),
             &odb,
             suspect,
             None,

--- a/gix/src/repository/blame.rs
+++ b/gix/src/repository/blame.rs
@@ -38,6 +38,7 @@ impl Repository {
         };
 
         let outcome = gix_blame::file(
+            self.workdir().expect("TODO").to_path_buf(),
             &self.objects,
             suspect.into(),
             cache,

--- a/tests/it/src/commands/blame_copy_royal.rs
+++ b/tests/it/src/commands/blame_copy_royal.rs
@@ -65,6 +65,7 @@ pub(super) mod function {
             .expect("exactly one pattern");
 
         let outcome = gix::blame::file(
+            repo.workdir().expect("TODO").to_path_buf(),
             &repo.objects,
             suspect,
             cache,


### PR DESCRIPTION
This is an experiment that’s supposed to help me validate the `gix-blame` algorithm. `gix-blame` currently rests on two foundations: 1. is the algorithm that traverses a file’s history and keeps track of blamed and unblamed hunks. 2. is the algorithm used for diffing subsequent states of a file throughout its history. Basically, (1.) orchestrates `gix-blame`, using (2.) to do most of the work of following individual lines throughout a file’s history. `gix-blame` currently doesn’t match `git blame` in all cases, but we set out to change that in #2308 as we expect most people to want `gix-blame` to match `git blame`’s output.

Since the algorithm used for (2.) differs from the one used by `git`, it has been somewhat challenging to validate (1.) on a large scale as it is quite hard to tell whether a divergence between `gix-blame` and `git blame` is due to differences in (1.) or (2.). This PR tries to approach this issue from a different angle, substituting `gix-diff` in (2.) by just shelling out to `git diff`. That way, it hopefully becomes much easier to compare `gix-blame` using `gix-diff` vs. `gix-blame` using `git diff` vs. `git blame` on the scale of entire repositories.

I’m opening this PR mostly to get CI feedback and to make this work visible. We probably can close it once I’m done with it.
