### PR TITLE
fix[pack]: Don't decompress the delta when decompressing base objects.

### DIFF
--- a/gix-pack/src/data/file/decode/entry.rs
+++ b/gix-pack/src/data/file/decode/entry.rs
@@ -345,7 +345,8 @@ impl File {
                 let base_entry = cursor;
                 debug_assert!(!base_entry.header.is_delta());
                 object_kind = base_entry.header.as_kind();
-                self.decompress_entry_from_data_offset(base_entry.data_offset, inflate, out)?;
+                let out_base = &mut out[..out_size - total_delta_data_size];
+                self.decompress_entry_from_data_offset(base_entry.data_offset, inflate, out_base)?;
             }
 
             (first_buffer_size, second_buffer_end)


### PR DESCRIPTION
It was already decompressed on line 285, so attempting to decompress it again turns the delta stream into garbage.

Unfortunately I don't know enough about the git file format to make a test, the best I was able to do was to compare it to a reference implementation and see what was going wrong.

Fixes #2344