### PR TITLE
Set default-features to false for curl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,8 @@ checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
 dependencies = [
  "curl-sys",
  "libc",
+ "openssl-probe",
+ "openssl-sys",
  "schannel",
  "socket2 0.6.1",
  "windows-sys 0.59.0",
@@ -825,6 +827,7 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
  "rustls-ffi",
  "vcpkg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,12 @@ default = ["max"]
 ##
 ## As fast as possible, tracing, with TUI progress, progress line rendering with autoconfiguration, all transports based on their most mature implementation (HTTP), all `ein` tools, CLI colors and local-time support, JSON output, regex support for rev-specs.
 ## Can be amended with the `http-client-curl-rustls` feature to avoid `openssl` as backend.
-max = ["max-control", "fast", "gitoxide-core-tools-query", "gitoxide-core-tools-corpus", "gitoxide-core-blocking-client", "http-client-curl"]
+##
+## ### Note
+##
+## When used in conjunction with `http-client-curl-rustls`, the `openssl` crates will still be compiled, but won't be used. To bypass this, disable
+## default dependencies and specify the features yourself.
+max = ["max-control", "fast", "gitoxide-core-tools-query", "gitoxide-core-tools-corpus", "gitoxide-core-blocking-client", "http-client-curl-openssl"]
 
 ## Like `max`, but only Rust is allowed.
 ##
@@ -54,7 +59,7 @@ max-control = ["tracing", "fast", "pretty-cli", "gitoxide-core-tools", "prodash-
 ## All the good stuff, with less fanciness for smaller binaries.
 ##
 ## As fast as possible, progress line rendering, all transports based on their most mature implementation (HTTP), all `ein` tools, CLI colors and local-time support, JSON output.
-lean = ["fast", "tracing", "pretty-cli", "http-client-curl", "gitoxide-core-tools-query", "gitoxide-core-tools-corpus", "gitoxide-core-tools", "gitoxide-core-blocking-client", "prodash-render-line"]
+lean = ["fast", "tracing", "pretty-cli", "http-client-curl-openssl", "gitoxide-core-tools-query", "gitoxide-core-tools-corpus", "gitoxide-core-tools", "gitoxide-core-blocking-client", "prodash-render-line"]
 
 ## The smallest possible build, best suitable for small single-core machines.
 ##
@@ -140,6 +145,8 @@ gitoxide-core-blocking-client = ["gitoxide-core/blocking-client"]
 http-client-curl = ["gix/blocking-http-transport-curl"]
 ## Implies `http-client-curl` and configures `curl` to use the `rust-tls` backend.
 http-client-curl-rustls = ["gix/blocking-http-transport-curl-rustls"]
+## Implies `http-client-curl` and configures `curl` to use the `openssl` backend.
+http-client-curl-openssl = ["gix/blocking-http-transport-curl-openssl"]
 ## Support synchronous 'http' and 'https' transports (e.g. for clone, fetch and push) using **reqwest**.
 http-client-reqwest = ["gix/blocking-http-transport-reqwest-rust-tls"]
 

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -190,9 +190,15 @@ blocking-http-transport-curl = [
     "gix-transport/http-client-curl",
 ]
 ## Stacks with `blocking-http-transport-curl` and also enables the `rustls` backend to avoid `openssl`.
+## This feature takes precedence over `http-client-curl-rust-ssl`.
 blocking-http-transport-curl-rustls = [
     "blocking-http-transport-curl",
     "gix-transport/http-client-curl-rust-tls",
+]
+## Stacks with `blocking-http-transport-curl` and also enables the `openssl` backend.
+blocking-http-transport-curl-openssl = [
+    "blocking-http-transport-curl",
+    "gix-transport/http-client-curl-openssl",
 ]
 ## Stacks with `blocking-network-client` to provide support for HTTP/S using **reqwest**, and implies blocking networking as a whole, making the `https://` transport available.
 blocking-http-transport-reqwest = [


### PR DESCRIPTION
curl pulls in openssl by default, and even specifying rustls will cause this.

This enables a pure rustls build.