### PR TITLE
Don't build powerpc64le `max-pure` release asset, for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           - aarch64-unknown-linux-gnu
           - arm-unknown-linux-musleabihf
           - arm-unknown-linux-gnueabihf
-          - powerpc64le-unknown-linux-gnu
+          # - powerpc64le-unknown-linux-gnu  # Omit as temporary workaround for #2338.
           - riscv64gc-unknown-linux-gnu
           - s390x-unknown-linux-gnu
           - x86_64-apple-darwin
@@ -127,8 +127,8 @@ jobs:
             os: ubuntu-latest
           - target: arm-unknown-linux-gnueabihf
             os: ubuntu-latest
-          - target: powerpc64le-unknown-linux-gnu
-            os: ubuntu-latest
+          # - target: powerpc64le-unknown-linux-gnu  # Omit as temporary workaround for #2338.
+          #   os: ubuntu-latest
           - target: riscv64gc-unknown-linux-gnu
             os: ubuntu-latest
           - target: s390x-unknown-linux-gnu


### PR DESCRIPTION
This is a temporary workaround for #2338, to let the rest of the release process work to build and attach other release assets.

Effectiveness is checked in [this test job](https://github.com/EliahKagan/gitoxide/actions/runs/20909432687/job/60069289069). This has been rebase since then, but there are no intervening changes to `release.yml`. I recommend we keep #2338 open until a more long-term solution is in place, preferably one that lets powerpc64le build again.