### PR TITLE
Clean up some CI loose ends related to recent changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust
-        shell: bash
+        shell: bash  # Use `bash` on all OSes, for `set -e` behavior.
         run: |
           rustup update stable
           rustup default stable
@@ -274,6 +274,12 @@ jobs:
       - name: Test (nextest)
         env:
           GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI: '1'
+        # We deliberately let this step use different shells on different OSes, each the runner
+        # default: `bash` on Ubuntu and macOS, but `pwsh` on Windows. `bash` on Windows runners
+        # would use a modified ("Git Bash") environment that is in some ways nicer for our tests,
+        # due to being more in line with some Unix-oriented assumptions. So we need to verify that
+        # the test suite is compatible with being run even outside that environment, including that
+        # `gix-testtools` is still able to run fixture scripts with the `bash` shell as intended.
         run: |  # zizmor: ignore[template-injection]
           cargo nextest run --workspace --no-fail-fast -- ${{ matrix.test-args }}
       - name: Check that tracked archives are up to date
@@ -319,7 +325,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust
-        shell: bash
+        shell: bash  # Use `bash` (not `pwsh`), for `set -e` behavior.
         run: |
           rustup update stable
           rustup default stable
@@ -434,7 +440,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Rust
-        shell: bash
+        shell: bash  # Use `bash` (not `pwsh`), for `$` expansion and `set -e` behavior.
         run: |
           rustup update stable
           rustup default stable


### PR DESCRIPTION
This makes some changes that build on, clarify, or are unblocked by recent changes.

- c97ef4e62be7723a5eb078db07cd96a6f9c7e981
  Delist `libz-rs-sys` from "pure" builds' `*-sys` allowlist
  Relates to: [#2370](https://github.com/GitoxideLabs/gitoxide/pull/2370)

- 1c74b91c925d93104d9982317ae290dcd3d82f19
  Add missing `shell: bash` comments as well as a conceptual comment
  Relates to: [#2340](https://github.com/GitoxideLabs/gitoxide/pull/2340)

See commit messages for full details.