### PR TITLE
Use `ubuntu-slim` runner where `ubuntu-latest` confers no benefit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,7 +592,7 @@ jobs:
 
   # Check that all `actions/checkout` in CI jobs have `persist-credentials: false`.
   check-no-persist-credentials:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     env:
       GLOB: .github/workflows/*.@(yaml|yml)
@@ -621,7 +621,7 @@ jobs:
   # dependencies of the `tests-pass` job below, so that whenever a job is
   # added, a decision is made about whether it must pass for PRs to merge.
   check-blocking:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     env:
       # List all jobs that are intended NOT to block PR auto-merge here.
@@ -658,6 +658,8 @@ jobs:
   tests-pass:
     name: Tests pass
 
+    permissions: {}
+
     needs:
       - msrv
       - msrv-badge
@@ -675,7 +677,7 @@ jobs:
 
     if: always()  # Always run even if dependencies fail.
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Fail if ANY dependency has failed or cancelled

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ defaults:
 jobs:
   # Create a draft release, initially with no binary assets attached.
   create-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     permissions:
       contents: write  # Allows the use of `gh release create`.
@@ -373,7 +373,7 @@ jobs:
 
   # Check for some problems, consolidate checksum files into one, and mark the release non-draft.
   publish-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     needs: [ create-release, build-release, build-macos-universal2-release ]
 
@@ -442,7 +442,7 @@ jobs:
 
   # Comment in a locked discussion that notifies about only `gitoxide` (e.g. not `gix-*`) releases.
   announce-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     needs: [ create-release, publish-release ]
 


### PR DESCRIPTION
Most GitHub-hosted runners are virtual machines: a new VM is spun up for each job, and destroyed at the end. In contrast, in October 2025, an `ubuntu-slim` runner label was added. `ubuntu-slim` runners are containers that do not (or do not necessarily) have their own VM. They are designed to be isolated enough nonetheless.

https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/

Usually, it is better to use `ubuntu-latest` (or `ubuntu-*` where `*` is a specific version), rather than the recently introduced `ubuntu-slim`. But `ubuntu-slim` should be at least as good for jobs that can't take advantage of multiple processor cores, use very little RAM, always complete quickly, and don't use Docker in any way (no job-wide container, container steps, action steps using container actions or composite actions that use container actions, nor any explicit `docker` commands).

We have a few jobs like that. Running them in `ubuntu-slim` instead of `ubuntu-latest` may make them run slightly faster because `ubuntu-slim` runners are created and destroyed faster (because they are containers), and it seems like it may avoid some rate limiting (fewer runs toward the concurrent maximum number of full Ubuntu runners).

While the `cargo-deny` and `zizmor` jobs are fast, single threaded, and use very little RAM, they remain on `ubuntu-latest` because they use container actions, preventing them from running on `ubuntu-slim`. While linting jobs are sometimes given as an example of jobs that make sense to run on `ubuntu-slim`, this advice is not applicable to our linting job, which is much less lightweight and makes use of parallel builds (at least in the `clippy` step).

The `msrv-badge` job is fairly lightweight, but uses `cargo`. No Rust toolchain is preinstalled on `ubuntu-slim` runners. At least for now, this doesn't try to move `msrv-badge` to `ubuntu-slim`.

---

Changes to the main CI workflow is tested by the `push` and `pull_request` event triggers. Changes to the release workflow are not, but I've tested them [in my fork](https://github.com/EliahKagan/gitoxide/actions/runs/21115340655/job/60720041909).