### PR TITLE
fix: correct typo in error message for gix-fs directory creation

### DIFF
--- a/gix-fs/src/dir/create.rs
+++ b/gix-fs/src/dir/create.rs
@@ -52,7 +52,7 @@ mod error {
             match self {
                 Error::Intermediate { dir, kind } => write!(
                     f,
-                    "Intermediae failure creating {:?} with error: {:?}",
+                    "Intermediate failure creating {:?} with error: {:?}",
                     dir.display(),
                     kind
                 ),


### PR DESCRIPTION
Corrects typo `Intermediae` -> `Intermediate`