### PR TITLE
Clarify that `blocking-http-transport-reqwest` doesn't enable `reqwest`'s default features

### DIFF
--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -201,7 +201,7 @@ blocking-http-transport-curl-openssl = [
     "gix-transport/http-client-curl-openssl",
 ]
 ## Stacks with `blocking-network-client` to provide support for HTTP/S using **reqwest**, and implies blocking networking as a whole, making the `https://` transport available.
-## This does not enable `reqwest`'s default features, allowing custom configuration of e.g. the TLS backend.
+## Note that `reqwest`'s default features are not enabled, allowing custom configuration of e.g. the TLS backend by adding it as explicit dependency.
 blocking-http-transport-reqwest = [
     "blocking-network-client",
     "gix-transport/http-client-reqwest",


### PR DESCRIPTION
As suggested in #2388.