### PR TITLE
fix(gix-index): handle loongarch64-musl stat struct field names

### DIFF
--- a/gix-index/src/fs.rs
+++ b/gix-index/src/fs.rs
@@ -54,14 +54,30 @@ impl Metadata {
     pub fn modified(&self) -> Option<SystemTime> {
         #[cfg(not(windows))]
         {
-            #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "hurd",
+                all(target_arch = "loongarch64", target_env = "musl")
+            )))]
             let seconds = self.0.st_mtime;
-            #[cfg(any(target_os = "aix", target_os = "hurd"))]
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "hurd",
+                all(target_arch = "loongarch64", target_env = "musl")
+            ))]
             let seconds = self.0.st_mtim.tv_sec;
 
-            #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "hurd",
+                all(target_arch = "loongarch64", target_env = "musl")
+            )))]
             let nanoseconds = self.0.st_mtime_nsec;
-            #[cfg(any(target_os = "aix", target_os = "hurd"))]
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "hurd",
+                all(target_arch = "loongarch64", target_env = "musl")
+            ))]
             let nanoseconds = self.0.st_mtim.tv_nsec;
 
             // All operating systems treat the seconds as offset from unix epoch, hence it must
@@ -81,14 +97,30 @@ impl Metadata {
     pub fn created(&self) -> Option<SystemTime> {
         #[cfg(not(windows))]
         {
-            #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "hurd",
+                all(target_arch = "loongarch64", target_env = "musl")
+            )))]
             let seconds = self.0.st_ctime;
-            #[cfg(any(target_os = "aix", target_os = "hurd"))]
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "hurd",
+                all(target_arch = "loongarch64", target_env = "musl")
+            ))]
             let seconds = self.0.st_ctim.tv_sec;
 
-            #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
+            #[cfg(not(any(
+                target_os = "aix",
+                target_os = "hurd",
+                all(target_arch = "loongarch64", target_env = "musl")
+            )))]
             let nanoseconds = self.0.st_ctime_nsec;
-            #[cfg(any(target_os = "aix", target_os = "hurd"))]
+            #[cfg(any(
+                target_os = "aix",
+                target_os = "hurd",
+                all(target_arch = "loongarch64", target_env = "musl")
+            ))]
             let nanoseconds = self.0.st_ctim.tv_nsec;
 
             // All operating systems treat the seconds as offset from unix epoch, hence it must


### PR DESCRIPTION
This follows the same pattern already used for AIX and Hurd targets.

On this target with musl 1.2.3+,
musl switched to POSIX timespec structs for time64 support.
Loongarch in 0.2.180 was changed accordingly.

See [libc 0.2.180](https://github.com/rust-lang/libc/compare/0.2.178...0.2.180), which added [proper time64 support for `loongarch64-unknown-linux-musl` with musl 1.2.3+](https://github.com/rust-lang/libc/blob/0.2.180/src/unix/linux_like/linux/musl/b64/loongarch64/mod.rs#L29-L43)

Found through:

- Failed PR: https://github.com/rust-lang/rust/pull/152240
- Failed GHA run: https://github.com/rust-lang/rust/actions/runs/21809002005/job/62917474088]]]]
- libc change: https://github.com/rust-lang/libc/pull/4463