### PR TITLE
diff: skip subtrees with identical oids

### DIFF
--- a/gix-pack/tests/pack/data/output/count_and_entries.rs
+++ b/gix-pack/tests/pack/data/output/count_and_entries.rs
@@ -146,7 +146,7 @@ fn traversals() -> crate::Result {
                 output::count::objects::Outcome {
                     input_objects: 1,
                     expanded_objects: 102,
-                    decoded_objects: 18,
+                    decoded_objects: 10,
                     total_objects: 103,
                 },
                 output::entry::iter_from_counts::Outcome {
@@ -179,7 +179,7 @@ fn traversals() -> crate::Result {
                 output::count::objects::Outcome {
                     input_objects: 1,
                     expanded_objects: 102,
-                    decoded_objects: 18,
+                    decoded_objects: 10,
                     total_objects: 103,
                 },
                 output::entry::iter_from_counts::Outcome {
@@ -221,7 +221,7 @@ fn traversals() -> crate::Result {
                 output::count::objects::Outcome {
                     input_objects: 16,
                     expanded_objects: 866,
-                    decoded_objects: 208,
+                    decoded_objects: 74,
                     total_objects: 868,
                 },
                 output::entry::iter_from_counts::Outcome {


### PR DESCRIPTION
Add a short-circuit check to the core gix-diff algorithm to skip identical subtrees based on oid. This substantially improves diff performance on large repos by avoiding loading & diffing objects from unchanged subtrees.

This appears to have reduced the number of objects which need to be decoded by `gix-pack` as well.