### PR TITLE
docs: fix incorrect feature name references in gix-transport

### DIFF
--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -36,18 +36,20 @@ http-client-curl-rust-tls = ["http-client-curl", "curl/rustls"]
 ## Implies `http-client-curl` and enables `ssl` for creating `https://` connections.
 ## If used in conjunction with `http-client-curl-rust-tls`, the `rust-tls` feature will take precedence.
 http-client-curl-openssl = ["http-client-curl", "curl/ssl"]
-## Implies `http-client` and adds support for http and https transports using the blocking version of `reqwest`.
+## Implies `http-client` and adds support for http transports using the blocking version of `reqwest`.
+## NOTE: `https://` is NOT supported by default. You must enable one of the `http-client-reqwest-rust-tls`
+## or `http-client-reqwest-native-tls` features to enable HTTPS support.
 http-client-reqwest = ["reqwest", "http-client"]
-## Stacks with `blocking-http-transport-reqwest` and enables `https://` via the `rustls` crate.
+## Stacks with `http-client-reqwest` and enables `https://` via the `rustls` crate.
 http-client-reqwest-rust-tls = ["http-client-reqwest", "reqwest/rustls"]
-## Stacks with `blocking-http-transport-reqwest` and enables `https://` via the `rustls` crate.
-## This also makes use of `hickory-dns` to avoid `getaddrinfo`, but note it comes with its own problems.
+## Stacks with `http-client-reqwest` and enables `https://` via the `rustls` crate.
+## This also makes use of `trust-dns` to avoid `getaddrinfo`, but note it comes with its own problems.
 http-client-reqwest-rust-tls-trust-dns = [
     "http-client-reqwest",
     "reqwest/rustls",
     "reqwest/hickory-dns",
 ]
-## Stacks with `blocking-http-transport-reqwest` and enables `https://` via the `native-tls` crate.
+## Stacks with `http-client-reqwest` and enables `https://` via the `native-tls` crate.
 http-client-reqwest-native-tls = ["http-client-reqwest", "reqwest/native-tls"]
 ## Allows sending credentials over cleartext HTTP. For testing purposes only.
 http-client-insecure-credentials = []


### PR DESCRIPTION
## Summary

This PR fixes documentation issues in `gix-transport/Cargo.toml` related to the `reqwest` feature names:

1. **Incorrect feature name references**: Replaced `blocking-http-transport-reqwest` with the correct `http-client-reqwest` in the feature documentation comments. These incorrect references were carried over from a March 2024 PR (#1329) that migrated the `rustls` feature into `gix-transport`.

2. **Clarified HTTPS support**: Added a note to the `http-client-reqwest` feature documentation that HTTPS is **NOT** supported by default. Users must enable one of:
   - `http-client-reqwest-rust-tls`
   - `http-client-reqwest-native-tls`

   This addresses user confusion where HTTPS requests would fail with an unhelpful error message when only `http-client-reqwest` was enabled.

## Related

Fixes #2425

## Changes

```diff
-## Implies `http-client` and adds support for http and https transports using the blocking version of `reqwest`.
+## Implies `http-client` and adds support for http transports using the blocking version of `reqwest`.
+## NOTE: `https://` is NOT supported by default. You must enable one of the `http-client-reqwest-rust-tls`
+## or `http-client-reqwest-native-tls` features to enable HTTPS support.
 http-client-reqwest = ["reqwest", "http-client"]
-## Stacks with `blocking-http-transport-reqwest` and enables `https://` via the `rustls` crate.
+## Stacks with `http-client-reqwest` and enables `https://` via the `rustls` crate.
```