### PR TITLE
Revert "fix(gix-index): handle loongarch64-musl stat struct field names"

### DIFF
--- a/gix-index/src/fs.rs
+++ b/gix-index/src/fs.rs
@@ -54,30 +54,14 @@ impl Metadata {
     pub fn modified(&self) -> Option<SystemTime> {
         #[cfg(not(windows))]
         {
-            #[cfg(not(any(
-                target_os = "aix",
-                target_os = "hurd",
-                all(target_arch = "loongarch64", target_env = "musl")
-            )))]
+            #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
             let seconds = self.0.st_mtime;
-            #[cfg(any(
-                target_os = "aix",
-                target_os = "hurd",
-                all(target_arch = "loongarch64", target_env = "musl")
-            ))]
+            #[cfg(any(target_os = "aix", target_os = "hurd"))]
             let seconds = self.0.st_mtim.tv_sec;
 
-            #[cfg(not(any(
-                target_os = "aix",
-                target_os = "hurd",
-                all(target_arch = "loongarch64", target_env = "musl")
-            )))]
+            #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
             let nanoseconds = self.0.st_mtime_nsec;
-            #[cfg(any(
-                target_os = "aix",
-                target_os = "hurd",
-                all(target_arch = "loongarch64", target_env = "musl")
-            ))]
+            #[cfg(any(target_os = "aix", target_os = "hurd"))]
             let nanoseconds = self.0.st_mtim.tv_nsec;
 
             // All operating systems treat the seconds as offset from unix epoch, hence it must
@@ -97,30 +81,14 @@ impl Metadata {
     pub fn created(&self) -> Option<SystemTime> {
         #[cfg(not(windows))]
         {
-            #[cfg(not(any(
-                target_os = "aix",
-                target_os = "hurd",
-                all(target_arch = "loongarch64", target_env = "musl")
-            )))]
+            #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
             let seconds = self.0.st_ctime;
-            #[cfg(any(
-                target_os = "aix",
-                target_os = "hurd",
-                all(target_arch = "loongarch64", target_env = "musl")
-            ))]
+            #[cfg(any(target_os = "aix", target_os = "hurd"))]
             let seconds = self.0.st_ctim.tv_sec;
 
-            #[cfg(not(any(
-                target_os = "aix",
-                target_os = "hurd",
-                all(target_arch = "loongarch64", target_env = "musl")
-            )))]
+            #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
             let nanoseconds = self.0.st_ctime_nsec;
-            #[cfg(any(
-                target_os = "aix",
-                target_os = "hurd",
-                all(target_arch = "loongarch64", target_env = "musl")
-            ))]
+            #[cfg(any(target_os = "aix", target_os = "hurd"))]
             let nanoseconds = self.0.st_ctim.tv_nsec;
 
             // All operating systems treat the seconds as offset from unix epoch, hence it must


### PR DESCRIPTION
This reverts commit 7e25c3426b382493007fa6982873f76baa9d020d.

The [issue](https://github.com/rust-lang/libc/issues/4939) was fixed in libc: https://github.com/rust-lang/libc/pull/4958