### PR TITLE
fix(tree): peel to the final tree entry

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,6 +66,7 @@ Follow "purposeful conventional commits" style:
 - Follow existing patterns in the codebase
 - No `.unwrap()` - use `.expect("context")` if you are sure this can't fail.
 - Prefer references in plumbing crates to avoid expensive clones
+- Avoid calling `.detach()` unless an owned value is explicitly required. Many `gix` APIs accept attached ids and references directly, so prefer keeping repository-backed handles like `gix::Id` when possible.
 - Use `gix_features::threading::*` for interior mutability primitives
 
 ### Path Handling

--- a/gix/src/object/tree/mod.rs
+++ b/gix/src/object/tree/mod.rs
@@ -88,15 +88,14 @@ impl<'repo> Tree<'repo> {
 
     /// Follow a sequence of `path` components starting from this instance, and look them up one by one until the last component
     /// is looked up and its tree entry is returned, while changing this instance to point to the last seen tree.
-    /// Note that if the lookup fails, it may be impossible to continue making lookups through this tree.
+    /// If the returned entry itself is a tree, this instance is updated to point to it as well.
     /// It's useful to have this function to be able to reuse the internal buffer of the tree.
     ///
     /// # Performance Notes
     ///
-    /// Searching tree entries is currently done in sequence, which allows to the search to be allocation free. It would be possible
-    /// to reuse a vector and use a binary search instead, which might be able to improve performance over all.
-    /// However, a benchmark should be created first to have some data and see which trade-off to choose here.
-    ///
+    /// Searching tree entries is currently done in sequence, which allows to the search to be allocation free.
+    /// This is beneficial for most 'common' repositiries, but for other cases an allocation might be preferable
+    /// to allow a bisect.
     pub fn peel_to_entry<I, P>(&mut self, path: I) -> Result<Option<Entry<'repo>>, find::existing::Error>
     where
         I: IntoIterator<Item = P>,
@@ -107,14 +106,23 @@ impl<'repo> Tree<'repo> {
 
         loop {
             data = match next_entry(&mut iter, data) {
-                ControlFlow::Continue(oid) => {
-                    let res = self.repo.find(&oid, &mut self.data)?;
-                    self.id = oid;
+                ControlFlow::Continue(id) => {
+                    let res = self.repo.find(&id, &mut self.data)?;
+                    if res.kind.is_tree() {
+                        self.id = id;
+                    }
                     res
                 }
                 ControlFlow::Break(entry) => {
-                    let repo = self.repo;
-                    let mapped = entry.map(|e| Entry { inner: e.into(), repo });
+                    let mapped = entry.map(|e| Entry {
+                        inner: e.into(),
+                        repo: self.repo,
+                    });
+                    if let Some(entry) = &mapped {
+                        if entry.mode().is_tree() {
+                            self.id = entry.object_id();
+                        }
+                    }
                     break Ok(mapped);
                 }
             }

--- a/gix/src/object/tree/mod.rs
+++ b/gix/src/object/tree/mod.rs
@@ -103,13 +103,15 @@ impl<'repo> Tree<'repo> {
     {
         let mut iter = path.into_iter().peekable();
         let mut data = gix_object::Data::new(gix_object::Kind::Tree, &self.data);
+        let mut data_id = self.id;
 
         loop {
             data = match next_entry(&mut iter, data) {
                 ControlFlow::Continue(id) => {
                     let res = self.repo.find(&id, &mut self.data)?;
+                    data_id = id;
                     if res.kind.is_tree() {
-                        self.id = id;
+                        self.id = data_id;
                     }
                     res
                 }
@@ -120,8 +122,15 @@ impl<'repo> Tree<'repo> {
                     });
                     if let Some(entry) = &mapped {
                         if entry.mode().is_tree() {
-                            self.id = entry.object_id();
+                            let id = entry.object_id();
+                            self.repo.find(&id, &mut self.data)?;
+                            data_id = id;
+                            self.id = data_id;
                         }
+                    }
+                    if data_id != self.id {
+                        // Ensure that our data always matches our id, even if this means an extra lookup.
+                        self.repo.find(&self.id, &mut self.data)?;
                     }
                     break Ok(mapped);
                 }

--- a/gix/tests/gix/object/tree/mod.rs
+++ b/gix/tests/gix/object/tree/mod.rs
@@ -3,6 +3,10 @@ use crate::util::{named_repo, named_subrepo_opts};
 #[cfg(all(feature = "blob-diff", feature = "revision"))]
 mod diff;
 
+fn worktree_repo() -> Result<gix::Repository, gix::open::Error> {
+    named_subrepo_opts("make_worktree_repo.sh", "repo", gix::open::Options::isolated())
+}
+
 #[test]
 fn find_entry() -> crate::Result {
     let repo = named_repo("make_basic_repo.sh")?;
@@ -15,8 +19,114 @@ fn find_entry() -> crate::Result {
 
 #[test]
 fn lookup_entry_by_path() -> crate::Result {
-    let repo = named_subrepo_opts("make_worktree_repo.sh", "repo", gix::open::Options::isolated())?;
+    let repo = worktree_repo()?;
     let tree = repo.head_commit()?.tree()?;
     assert_eq!(tree.lookup_entry_by_path("dir/c")?.expect("present").filename(), "c");
     Ok(())
+}
+
+mod peel_to_entry {
+    #[test]
+    fn top_level_file_keeps_the_current_tree() -> crate::Result {
+        let repo = super::worktree_repo()?;
+        let mut tree = repo.head_commit()?.tree()?;
+        let root_id = tree.id();
+
+        let entry = tree.peel_to_entry(["a"])?.expect("file entry");
+
+        assert!(!entry.mode().is_tree());
+        assert_eq!(tree.id(), root_id);
+        Ok(())
+    }
+
+    #[test]
+    fn nested_file_moves_to_the_last_seen_tree() -> crate::Result {
+        let repo = super::worktree_repo()?;
+        let mut tree = repo.head_commit()?.tree()?;
+        let dir_id = tree.lookup_entry(["dir"])?.expect("tree entry").object_id();
+
+        let entry = tree.peel_to_entry(["dir", "c"])?.expect("file entry");
+
+        assert!(!entry.mode().is_tree());
+        assert_eq!(tree.id(), dir_id);
+        Ok(())
+    }
+
+    #[test]
+    fn tree_leaf_moves_to_the_returned_tree() -> crate::Result {
+        let repo = super::worktree_repo()?;
+        let mut tree = repo.head_commit()?.tree()?;
+        let dir_id = tree.lookup_entry(["dir"])?.expect("tree entry").object_id();
+
+        let entry = tree.peel_to_entry(["dir"])?.expect("tree entry");
+
+        assert!(entry.mode().is_tree());
+        assert_eq!(tree.id(), dir_id);
+        Ok(())
+    }
+
+    #[test]
+    fn missing_top_level_entry_keeps_the_current_tree() -> crate::Result {
+        let repo = super::worktree_repo()?;
+        let mut tree = repo.head_commit()?.tree()?;
+        let root_id = tree.id();
+
+        let entry = tree.peel_to_entry(["missing"])?;
+
+        assert!(entry.is_none());
+        assert_eq!(tree.id(), root_id);
+        Ok(())
+    }
+
+    #[test]
+    fn missing_nested_entry_moves_to_the_last_seen_tree() -> crate::Result {
+        let repo = super::worktree_repo()?;
+        let mut tree = repo.head_commit()?.tree()?;
+        let dir_id = tree.lookup_entry(["dir"])?.expect("tree entry").object_id();
+
+        let entry = tree.peel_to_entry(["dir", "missing"])?;
+
+        assert!(entry.is_none());
+        assert_eq!(tree.id(), dir_id);
+        Ok(())
+    }
+
+    #[test]
+    fn path_continuing_past_a_top_level_file_keeps_the_current_tree() -> crate::Result {
+        let repo = super::worktree_repo()?;
+        let mut tree = repo.head_commit()?.tree()?;
+        let root_id = tree.id();
+
+        let entry = tree.peel_to_entry(["a", "missing"])?;
+
+        assert!(entry.is_none());
+        assert_eq!(tree.id(), root_id);
+        Ok(())
+    }
+
+    #[test]
+    fn path_continuing_past_a_nested_file_keeps_the_last_seen_tree() -> crate::Result {
+        let repo = super::worktree_repo()?;
+        let mut tree = repo.head_commit()?.tree()?;
+        let dir_id = tree.lookup_entry(["dir"])?.expect("tree entry").object_id();
+
+        let entry = tree.peel_to_entry(["dir", "c", "missing"])?;
+
+        assert!(entry.is_none());
+        assert_eq!(tree.id(), dir_id);
+        Ok(())
+    }
+
+    #[test]
+    fn by_path_has_the_same_tree_leaf_behavior() -> crate::Result {
+        let repo = super::worktree_repo()?;
+        let mut tree = repo.head_commit()?.tree()?;
+        let dir_id = tree.lookup_entry(["dir"])?.expect("tree entry").object_id();
+
+        let entry = tree.peel_to_entry_by_path("dir")?.expect("tree entry");
+
+        assert!(entry.mode().is_tree());
+        assert_eq!(tree.id(), dir_id);
+        Ok(())
+    }
 }

--- a/gix/tests/gix/object/tree/mod.rs
+++ b/gix/tests/gix/object/tree/mod.rs
@@ -62,6 +62,11 @@ mod peel_to_entry {
 
         assert!(entry.mode().is_tree());
         assert_eq!(tree.id(), dir_id);
+        assert_eq!(
+            tree.find_entry("c").expect("subtree entry").filename(),
+            "c",
+            "the data matches the id"
+        );
         Ok(())
     }
 
@@ -101,6 +106,11 @@ mod peel_to_entry {
 
         assert!(entry.is_none());
         assert_eq!(tree.id(), root_id);
+        assert_eq!(
+            tree.find_entry("dir").expect("root tree entry").filename(),
+            "dir",
+            "the data matches the id"
+        );
         Ok(())
     }
 
@@ -114,6 +124,11 @@ mod peel_to_entry {
 
         assert!(entry.is_none());
         assert_eq!(tree.id(), dir_id);
+        assert_eq!(
+            tree.find_entry("c").expect("nested tree entry").filename(),
+            "c",
+            "the data matches the id"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- update `Tree::peel_to_entry{_by_path}` to move `self` to the final tree entry when the leaf entry is a tree
- clarify the behavior in the API docs
- add a regression test for peeling to a tree leaf

## Testing
- `cargo test -p gix --test gix object::tree::`

Refs #2456
Context: https://github.com/GitoxideLabs/gitoxide/issues/2456#issuecomment-4126248450