### PR TITLE
feat: use the IOUC (UNTR extension) to speed up directory walks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,7 @@ dependencies = [
  "gix-utils",
  "gix-worktree",
  "pretty_assertions",
+ "rustix",
  "thiserror 2.0.18",
 ]
 

--- a/crate-status.md
+++ b/crate-status.md
@@ -843,7 +843,7 @@ A git directory walk.
 * [x] pathspec based filtering
 * [ ] multi-threaded initialization of icase hash table is always used to accelerate index lookups, even if ignoreCase = false for performance
 * [ ] special handling of submodules (for now, submodules or nested repositories are detected, but they can't be walked into naturally)
-* [ ] accelerated walk with `untracked`-cache (as provided by `UNTR` extension of `gix_index::File`)
+* [x] accelerated walk with `untracked`-cache (as provided by `UNTR` extension of `gix_index::File`)
 
 ### gix-index
 

--- a/gix-dir/Cargo.toml
+++ b/gix-dir/Cargo.toml
@@ -20,6 +20,8 @@ test = false
 sha1 = ["gix-index/sha1"]
 ## Enable support for the SHA-256 hash by forwarding the feature to dependencies.
 sha256 = ["gix-index/sha256"]
+## Enable support for handling attributes, forwarding the feature to dependencies.
+attributes = ["gix-worktree/attributes"]
 
 [dependencies]
 gix-trace = { version = "^0.1.20", path = "../gix-trace" }
@@ -35,6 +37,9 @@ gix-utils = { version = "^0.3.3", path = "../gix-utils", features = ["bstr"] }
 
 bstr = { version = "1.12.0", default-features = false }
 thiserror = "2.0.18"
+
+[target.'cfg(unix)'.dependencies]
+rustix = { version = "1.1.2", default-features = false, features = ["std", "system"] }
 
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }

--- a/gix-dir/src/walk/function.rs
+++ b/gix-dir/src/walk/function.rs
@@ -7,7 +7,7 @@ use bstr::{BStr, BString, ByteSlice};
 
 use crate::{
     EntryRef, entry,
-    walk::{Action, Context, Delegate, Error, ForDeletionMode, Options, Outcome, classify, readdir},
+    walk::{Action, Context, Delegate, Error, ForDeletionMode, Options, Outcome, classify, readdir, untracked_cache},
 };
 
 /// A function to perform a git-style, unsorted, directory walk.
@@ -105,6 +105,10 @@ pub fn walk(
     }
 
     let mut state = readdir::State::new(worktree_root, ctx.current_dir, options.for_deletion.is_some());
+    let untracked_cache = options
+        .use_untracked_cache
+        .then(|| untracked_cache::validate(worktree_root, ctx.index, &ctx, options))
+        .flatten();
     let may_collapse = root != worktree_root && state.may_collapse(&current);
     let (action, _) = readdir::recursive(
         may_collapse,
@@ -116,6 +120,10 @@ pub fn walk(
         delegate,
         &mut out,
         &mut state,
+        untracked_cache.as_ref(),
+        untracked_cache
+            .as_ref()
+            .map(|cache: &untracked_cache::Validated<'_>| cache.root_dir()),
     )?;
     if action.is_continue() {
         state.emit_remaining(may_collapse, options, &mut out, delegate);

--- a/gix-dir/src/walk/mod.rs
+++ b/gix-dir/src/walk/mod.rs
@@ -190,6 +190,10 @@ pub struct Options<'a> {
     ///
     /// In other words, for Git compatibility this flag should be `false`, the default, for `git2` compatibility it should be `true`.
     pub symlinks_to_directories_are_ignored_like_directories: bool,
+    /// If `true`, consult the untracked cache if it is present and otherwise applicable.
+    ///
+    /// Defaults to `false`; the higher-level `gix` layer opts in based on `core.untrackedCache`.
+    pub use_untracked_cache: bool,
     /// A set of all git worktree checkouts that are located within the main worktree directory.
     ///
     /// They will automatically be detected as 'tracked', but without providing index information (as there is no actual index entry).
@@ -271,6 +275,12 @@ pub struct Outcome {
     pub returned_entries: usize,
     /// The amount of entries, prior to pathspecs filtering them out or otherwise excluding them.
     pub seen_entries: u32,
+    /// The number of directories whose contents were served entirely from the untracked cache,
+    /// avoiding a `read_dir` syscall.
+    pub untracked_cache_hits: u32,
+    /// The number of directories skipped by the untracked cache due to a failed per-directory
+    /// stat validation, falling back to a real `read_dir` call instead.
+    pub untracked_cache_misses: u32,
 }
 
 /// The error returned by [`walk()`](function::walk()).

--- a/gix-dir/src/walk/mod.rs
+++ b/gix-dir/src/walk/mod.rs
@@ -318,3 +318,4 @@ pub enum Error {
 mod classify;
 pub(crate) mod function;
 mod readdir;
+mod untracked_cache;

--- a/gix-dir/src/walk/readdir.rs
+++ b/gix-dir/src/walk/readdir.rs
@@ -32,9 +32,37 @@ pub(super) fn recursive(
     delegate: &mut dyn Delegate,
     out: &mut Outcome,
     state: &mut State,
+    untracked_cache: Option<&walk::untracked_cache::Validated<'_>>,
+    untracked_cache_dir: Option<usize>,
 ) -> Result<(Action, bool), Error> {
     if ctx.should_interrupt.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
         return Err(Error::Interrupted);
+    }
+    let cache_attempted = untracked_cache.zip(untracked_cache_dir);
+    let cache_valid = cache_attempted.filter(|(cache, dir)| cache.is_dir_valid(*dir, current));
+    if cache_attempted.is_some() && cache_valid.is_none() {
+        out.untracked_cache_misses += 1;
+    }
+    if let Some((action, prevent_collapse)) = cache_valid
+        .map(|(cache, dir)| {
+            recursive_from_untracked_cache(
+                dir,
+                may_collapse,
+                current,
+                current_bstr,
+                current_info,
+                ctx,
+                opts,
+                delegate,
+                out,
+                state,
+                cache,
+            )
+        })
+        .transpose()?
+    {
+        out.untracked_cache_hits += 1;
+        return Ok((action, prevent_collapse));
     }
     out.read_dir_calls += 1;
     let entries = gix_fs::read_dir(current, opts.precompose_unicode).map_err(|err| Error::ReadDir {
@@ -94,6 +122,15 @@ pub(super) fn recursive(
                 delegate,
                 out,
                 state,
+                untracked_cache,
+                untracked_cache_dir.and_then(|dir| {
+                    untracked_cache.and_then(|cache| {
+                        let component = current_bstr
+                            .rfind_byte(b'/')
+                            .map_or(current_bstr.as_bstr(), |pos| current_bstr[pos + 1..].as_bstr());
+                        cache.child_dir(dir, component)
+                    })
+                }),
             )?;
             prevent_collapse |= subdir_prevent_collapse;
             if action.is_break() {
@@ -118,6 +155,150 @@ pub(super) fn recursive(
                 if action.is_break() {
                     return Ok((action, prevent_collapse));
                 }
+            }
+        }
+        current_bstr.truncate(prev_len);
+        current.pop();
+    }
+
+    let res = mark.reduce_held_entries(
+        num_entries,
+        state,
+        &mut prevent_collapse,
+        current,
+        current_bstr.as_bstr(),
+        current_info,
+        opts,
+        out,
+        ctx,
+        delegate,
+    );
+    Ok((res, prevent_collapse))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn recursive_from_untracked_cache(
+    cache_dir: usize,
+    may_collapse: bool,
+    current: &mut PathBuf,
+    current_bstr: &mut BString,
+    current_info: classify::Outcome,
+    ctx: &mut Context<'_>,
+    opts: Options<'_>,
+    delegate: &mut dyn Delegate,
+    out: &mut Outcome,
+    state: &mut State,
+    untracked_cache: &walk::untracked_cache::Validated<'_>,
+) -> Result<(Action, bool), Error> {
+    let Some(cached) = untracked_cache.directory(cache_dir) else {
+        return Ok((std::ops::ControlFlow::Continue(()), false));
+    };
+
+    let mut num_entries = 0;
+    let mark = state.mark(may_collapse);
+    let mut prevent_collapse = current_info.status == Status::Tracked;
+
+    // Build the set of sub-directory names so we can skip their `"<name>/"` entries in
+    // `untracked_entries` — those are handled (with proper stat validation) below.
+    let subdir_names: std::collections::HashSet<&[u8]> = cached
+        .sub_directories()
+        .iter()
+        .filter_map(|&i| untracked_cache.directory(i))
+        .map(|d| d.name().as_bytes())
+        .collect();
+
+    for &subdir_idx in cached.sub_directories() {
+        let Some(subdir) = untracked_cache.directory(subdir_idx) else {
+            continue;
+        };
+        let prev_len = current_bstr.len();
+        if prev_len != 0 {
+            current_bstr.push(b'/');
+        }
+        current_bstr.extend_from_slice(subdir.name());
+        current.push(gix_path::from_bstr(subdir.name()));
+
+        let info = classify::path(
+            current,
+            current_bstr,
+            if prev_len == 0 { 0 } else { prev_len + 1 },
+            Some(entry::Kind::Directory),
+            || Some(entry::Kind::Directory),
+            opts,
+            ctx,
+        )?;
+        num_entries += 1;
+        if can_recurse(current_bstr.as_bstr(), info, opts.for_deletion, false, delegate) {
+            let subdir_may_collapse = state.may_collapse(current);
+            let (action, subdir_prevent_collapse) = recursive(
+                subdir_may_collapse,
+                current,
+                current_bstr,
+                info,
+                ctx,
+                opts,
+                delegate,
+                out,
+                state,
+                Some(untracked_cache),
+                Some(subdir_idx),
+            )?;
+            prevent_collapse |= subdir_prevent_collapse;
+            if action.is_break() {
+                return Ok((action, prevent_collapse));
+            }
+        } else if !state.held_for_directory_collapse(current_bstr.as_bstr(), info, &opts) {
+            let action = emit_entry(Cow::Borrowed(current_bstr.as_bstr()), info, None, opts, out, delegate);
+            if action.is_break() {
+                return Ok((action, prevent_collapse));
+            }
+        }
+        current_bstr.truncate(prev_len);
+        current.pop();
+    }
+
+    for file in cached.untracked_entries() {
+        // Git stores collapsed untracked directories in BOTH `sub_directories` AND as
+        // `"<name>/"` in `untracked_entries`. Skip the `untracked_entries` copy — the
+        // sub_directories loop above handles it (with proper per-directory stat
+        // validation via `recursive()`). Emitting from here would bypass the stat check
+        // and serve stale cache entries (e.g. if files inside were deleted).
+        let (file_name, is_collapsed_dir) = file
+            .as_slice()
+            .strip_suffix(b"/")
+            .map_or((file.as_slice(), false), |s| (s, true));
+        if is_collapsed_dir && subdir_names.contains(file_name) {
+            continue;
+        }
+
+        num_entries += 1;
+        let prev_len = current_bstr.len();
+        if prev_len != 0 {
+            current_bstr.push(b'/');
+        }
+        current_bstr.extend_from_slice(file_name);
+        current.push(gix_path::from_bstr(bstr::BStr::new(file_name)));
+
+        // The cache doesn't record an entry's kind, so we still need a single `lstat` to tell files,
+        // symlinks and directories apart. Doing it eagerly lets us pass the kind in directly, avoiding
+        // a per-entry clone of `current` that a borrow-conflicting on-demand closure would require.
+        let disk_kind = std::fs::symlink_metadata(&*current)
+            .ok()
+            .map(|meta| meta.file_type().into());
+
+        let info = classify::path(
+            current,
+            current_bstr,
+            if prev_len == 0 { 0 } else { prev_len + 1 },
+            disk_kind,
+            || None,
+            opts,
+            ctx,
+        )?;
+        if !state.held_for_directory_collapse(current_bstr.as_bstr(), info, &opts) {
+            let action = emit_entry(Cow::Borrowed(current_bstr.as_bstr()), info, None, opts, out, delegate);
+            if action.is_break() {
+                return Ok((action, prevent_collapse));
             }
         }
         current_bstr.truncate(prev_len);

--- a/gix-dir/src/walk/untracked_cache.rs
+++ b/gix-dir/src/walk/untracked_cache.rs
@@ -1,0 +1,293 @@
+use std::path::Path;
+
+use bstr::{BStr, ByteSlice};
+
+use crate::walk::{Context, Options};
+
+const DIR_SHOW_OTHER_DIRECTORIES: u32 = 1 << 1;
+
+pub(crate) struct Validated<'a> {
+    cache: &'a gix_index::extension::UntrackedCache,
+    object_hash: gix_index::hash::Kind,
+}
+
+impl<'a> Validated<'a> {
+    pub(crate) fn root_dir(&self) -> usize {
+        0
+    }
+
+    pub(crate) fn child_dir(&self, parent: usize, name: &BStr) -> Option<usize> {
+        self.directory(parent)?
+            .sub_directories()
+            .iter()
+            .copied()
+            .find(|idx| self.directory(*idx).is_some_and(|dir| dir.name() == name))
+    }
+
+    pub(crate) fn directory(&self, idx: usize) -> Option<&'a gix_index::extension::untracked_cache::Directory> {
+        self.cache.directories().get(idx)
+    }
+
+    pub(crate) fn is_dir_valid(&self, idx: usize, absolute_dir: &Path) -> bool {
+        let Some(dir) = self.directory(idx) else {
+            return false;
+        };
+        let Some(expected) = dir.stat() else {
+            return false;
+        };
+        let actual = match gix_index::fs::Metadata::from_path_no_follow(absolute_dir)
+            .and_then(|meta| gix_index::entry::Stat::from_fs(&meta).map_err(std::io::Error::other))
+        {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let use_nsec = expected.mtime.nsecs != 0;
+        let opts = gix_index::entry::stat::Options {
+            use_nsec,
+            ..Default::default()
+        };
+        if !expected.matches(&actual, opts) {
+            return false;
+        }
+        // If the IOUC recorded a .gitignore OID, verify the current file matches it.
+        // If no OID was recorded, trust the directory stat — git skips the .gitignore
+        // check entirely when exclude_oid is null and the directory stat is valid (see
+        // valid_cached_dir() / prep_exclude() in git's dir.c). A newly-added .gitignore
+        // would change the directory stat, which is already checked above.
+        if let Some(expected_oid) = dir.exclude_file_oid() {
+            let ignore_path = absolute_dir.join(gix_path::from_bstr(self.cache.exclude_filename_per_dir()));
+            gitignore_matches(&expected_oid, &ignore_path, self.object_hash)
+        } else {
+            true
+        }
+    }
+}
+
+pub(crate) fn validate<'a>(
+    worktree_root: &Path,
+    index: &'a gix_index::State,
+    ctx: &Context<'_>,
+    opts: Options<'_>,
+) -> Option<Validated<'a>> {
+    let cache = index.untracked()?;
+    if !cache_is_applicable(worktree_root, opts, ctx, cache.dir_flags())? {
+        return None;
+    }
+
+    let ident = cache.identifier().split_str("\0").next().unwrap_or(cache.identifier());
+    if !ident.starts_with(expected_ident(worktree_root, ctx.current_dir).as_bytes()) {
+        return None;
+    }
+
+    #[allow(unreachable_patterns)]
+    let ignore = match ctx.excludes.as_deref()?.state() {
+        gix_worktree::stack::State::IgnoreStack(ignore) => ignore,
+        #[cfg(feature = "attributes")]
+        gix_worktree::stack::State::AttributesAndIgnoreStack { ignore, .. } => ignore,
+        _ => return None,
+    };
+    if !matches!(
+        ignore.source(),
+        gix_worktree::stack::state::ignore::Source::WorktreeThenIdMappingIfNotSkipped
+    ) {
+        return None;
+    }
+    if !ignore.overrides().patterns.is_empty() {
+        return None;
+    }
+    if ignore.exclude_file_name_for_directories() != cache.exclude_filename_per_dir() {
+        return None;
+    }
+    let info_exclude_path = ctx.git_dir_realpath.join("info").join("exclude");
+    let excludes_file = ignore
+        .globals()
+        .patterns
+        .iter()
+        .filter_map(|list| list.source.as_deref())
+        .find(|path| gix_path::realpath(*path).ok().as_deref() != Some(info_exclude_path.as_path()));
+    let object_hash = index.object_hash();
+    // Validate the configured `core.excludesFile` by stat *and* content hash. An in-place edit that
+    // preserves size and mtime-second (ctime is ignored) would slip past the stat check alone even
+    // though its ignore rules changed, so also compare the stored OID — the cache records one for
+    // this file exactly as it does for `.git/info/exclude`.
+    match (cache.excludes_file(), excludes_file) {
+        (Some(expected), Some(path))
+            if validate_cached_stat(expected, path) && gitignore_matches(&expected.id(), path, object_hash) => {}
+        (None, None) => {}
+        _ => return None,
+    }
+    // Also validate the cached .git/info/exclude stat and OID. If info/exclude changed since
+    // the UNTR snapshot was written, cached ignore decisions for directories could be stale.
+    // We verify the content hash in addition to the stat to catch same-second, same-size edits.
+    // A `None` cache entry means the file was absent when the snapshot was written; if it exists
+    // now, global ignore rules changed without altering any worktree directory stat, so the cache
+    // must be treated as a miss.
+    match cache.info_exclude() {
+        Some(expected)
+            if !validate_cached_stat(expected, &info_exclude_path)
+                || !gitignore_matches(&expected.id(), &info_exclude_path, object_hash) =>
+        {
+            return None;
+        }
+        None if info_exclude_path.exists() => return None,
+        _ => {}
+    }
+
+    Some(Validated {
+        cache,
+        object_hash: index.object_hash(),
+    })
+}
+
+fn cache_is_applicable(
+    worktree_root: &Path,
+    opts: Options<'_>,
+    ctx: &Context<'_>,
+    cache_dir_flags: u32,
+) -> Option<bool> {
+    if opts.emit_ignored.is_some()
+        || opts.for_deletion.is_some()
+        || opts.emit_tracked
+        || opts.recurse_repositories
+        || opts.classify_untracked_bare_repositories
+        || opts.symlinks_to_directories_are_ignored_like_directories
+        || opts.worktree_relative_worktree_dirs.is_some()
+        || ctx.explicit_traversal_root.is_some_and(|root| root != worktree_root)
+        || ctx.pathspec.patterns().len() != 0
+    {
+        return Some(false);
+    }
+    // Git only records nested untracked files when it descended into untracked directories, which it
+    // does for `-uall` and signals by leaving `DIR_SHOW_OTHER_DIRECTORIES` unset. A collapsed
+    // (`-unormal`) cache instead stores each fully-untracked directory as a single `dir/` entry and
+    // never records its contents.
+    let cache_is_collapsed = cache_dir_flags & DIR_SHOW_OTHER_DIRECTORIES != 0;
+    match opts.emit_untracked {
+        // A collapsed request can be reproduced from either cache: a `-unormal` cache already holds
+        // the collapsed entries, and a `-uall` cache's expanded entries get re-collapsed by the walk.
+        crate::walk::EmissionMode::CollapseDirectory if !opts.emit_empty_directories => {}
+        // A matching (`-uall`) request needs the nested untracked files, so the cache itself must
+        // have been written by a non-collapsing traversal; a collapsed cache would omit them.
+        crate::walk::EmissionMode::Matching if !cache_is_collapsed => {}
+        _ => return Some(false),
+    }
+    // Note on Git's per-directory `check_only` flag, which we intentionally do not consult:
+    // Git sets it on the collapsed, fully-untracked directories of a `-unormal` cache and rejects a
+    // cached directory whose `check_only` disagrees with the current request (`dir.c`). We don't need
+    // that gate because we never serve a cached directory's shape verbatim: `Matching` only ever uses a
+    // non-collapsed cache (rejected above otherwise), where no directory is `check_only`, and
+    // `CollapseDirectory` reconstructs its output by descending and re-collapsing, so an entry list that
+    // Git recorded only for an existence check is still sufficient. See the `gix-dir` test
+    // `untracked_cache_with_check_only_dirs_matches_git_and_uncached`.
+    Some(true)
+}
+
+/// Check whether the `.gitignore` file at `path` matches the `expected_oid` stored in the IOUC.
+///
+/// Git's `add_patterns()` in `dir.c` always appends `'\n'` to the buffer before hashing
+/// (to ensure the last pattern is terminated), but it uses the index entry OID directly
+/// when the file is tracked and uptodate in the index. This means the IOUC may contain
+/// either `hash(content)` or `hash(content + '\n')` depending on whether the file's
+/// index stat was current at the time of the last `git status` run. We accept both.
+fn gitignore_matches(
+    expected_oid: &gix_index::hash::ObjectId,
+    path: &Path,
+    object_hash: gix_index::hash::Kind,
+) -> bool {
+    let Ok(data) = std::fs::read(path) else { return false };
+    if let Ok(oid) = gix_object::compute_hash(object_hash, gix_object::Kind::Blob, &data) {
+        if oid == *expected_oid {
+            return true;
+        }
+    }
+    // Also try with appended '\n' (git's condition-3 hashing path)
+    let mut data_plus_nl = data;
+    data_plus_nl.push(b'\n');
+    gix_object::compute_hash(object_hash, gix_object::Kind::Blob, &data_plus_nl).is_ok_and(|oid| oid == *expected_oid)
+}
+
+fn validate_cached_stat(expected: &gix_index::extension::untracked_cache::OidStat, path: &Path) -> bool {
+    let Ok(actual) = gix_index::fs::Metadata::from_path_no_follow(path)
+        .and_then(|meta| gix_index::entry::Stat::from_fs(&meta).map_err(std::io::Error::other))
+    else {
+        return false;
+    };
+    expected.stat().matches(
+        &actual,
+        gix_index::entry::stat::Options {
+            trust_ctime: false,
+            ..Default::default()
+        },
+    )
+}
+
+fn expected_ident(worktree_root: &Path, _current_dir: &Path) -> String {
+    let path = normalize_ident_path(worktree_root);
+    format!("Location {path}, system {}", system_name())
+}
+
+#[cfg(not(windows))]
+fn normalize_ident_path(path: &Path) -> String {
+    gix_path::realpath(path)
+        .unwrap_or_else(|_| path.to_owned())
+        .display()
+        .to_string()
+}
+
+#[cfg(windows)]
+fn normalize_ident_path(path: &Path) -> String {
+    // Use canonicalize to resolve symlinks and expand 8.3 short names (via
+    // GetFinalPathNameByHandleW), matching how git normalizes paths in the IOUC
+    // identifier on Windows.
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_owned());
+    // canonicalize on Windows may return a verbatim path (\\?\C:\...), strip it.
+    let s = canonical.to_string_lossy();
+    let s = s.strip_prefix("\\\\?\\").unwrap_or(&*s);
+    // git uses forward slashes in the ident.
+    s.replace('\\', "/")
+}
+
+#[cfg(unix)]
+fn system_name() -> String {
+    rustix::system::uname().sysname().to_string_lossy().into_owned()
+}
+
+#[cfg(not(unix))]
+fn system_name() -> String {
+    // std::env::consts::OS returns "windows" (lowercase), but git writes "Windows".
+    let os = std::env::consts::OS;
+    let mut chars = os.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gix_testtools::tempfile;
+    use std::fs;
+
+    #[test]
+    #[cfg(unix)]
+    fn expected_ident_resolves_symlinks() -> Result<(), Box<dyn std::error::Error>> {
+        let tmp = tempfile::tempdir()?;
+        let real_dir = tmp.path().join("real");
+        fs::create_dir(&real_dir)?;
+        let symlink_dir = tmp.path().join("symlink");
+        std::os::unix::fs::symlink(&real_dir, &symlink_dir)?;
+
+        let current_dir = std::env::current_dir()?;
+        let ident_real = expected_ident(&real_dir, &current_dir);
+        let ident_symlink = expected_ident(&symlink_dir, &current_dir);
+
+        assert_eq!(
+            ident_real, ident_symlink,
+            "identifiers must be identical for the same physical location"
+        );
+        assert!(ident_real.contains("real"), "it must contain the resolved path");
+        assert!(!ident_real.contains("symlink"), "it must not contain the symlink path");
+        Ok(())
+    }
+}

--- a/gix-dir/tests/dir/walk.rs
+++ b/gix-dir/tests/dir/walk.rs
@@ -64,6 +64,7 @@ fn one_top_level_fifo() {
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 2,
+            ..Default::default()
         }
     );
 
@@ -96,6 +97,7 @@ fn fifo_in_traversal() {
             read_dir_calls: 3,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         }
     );
 
@@ -132,6 +134,7 @@ fn symlink_to_dir_can_be_excluded() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 9,
+            ..Default::default()
         }
     );
 
@@ -167,6 +170,7 @@ fn symlink_to_dir_can_be_excluded() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 9,
+            ..Default::default()
         }
     );
 
@@ -265,6 +269,7 @@ fn assume_unchanged_submodule_replaced_with_symlink_is_hidden() -> crate::Result
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         }
     );
     assert!(
@@ -295,6 +300,7 @@ fn submodule_replaced_with_symlink_without_assume_unchanged_is_untracked() -> cr
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -333,6 +339,7 @@ fn empty_root() -> crate::Result {
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -358,6 +365,7 @@ fn empty_root() -> crate::Result {
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -378,6 +386,7 @@ fn complex_empty() -> crate::Result {
             read_dir_calls: 9,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -409,6 +418,7 @@ fn complex_empty() -> crate::Result {
             read_dir_calls: 9,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -435,6 +445,7 @@ fn complex_empty() -> crate::Result {
             read_dir_calls: 9,
             returned_entries: entries.len(),
             seen_entries: 9,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -496,6 +507,7 @@ fn ignored_with_prefix_pathspec_collapses_just_like_untracked() -> crate::Result
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 6,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -529,6 +541,7 @@ fn ignored_with_prefix_pathspec_collapses_just_like_untracked() -> crate::Result
             read_dir_calls: 4,
             returned_entries: entries.len(),
             seen_entries: 8,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -569,6 +582,7 @@ fn ignored_collapse_of_empty_directories_is_not_classified_as_empty_directory() 
             read_dir_calls: 5,
             returned_entries: entries.len(),
             seen_entries: 6,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -607,6 +621,7 @@ fn ignored_dir_with_cwd_handling() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -641,6 +656,7 @@ fn ignored_dir_with_cwd_handling() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 2,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -675,7 +691,8 @@ fn ignored_dir_with_cwd_handling() -> crate::Result {
         walk::Outcome {
             read_dir_calls: 8,
             returned_entries: entries.len(),
-            seen_entries: 26
+            seen_entries: 26,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -720,6 +737,7 @@ fn ignored_with_cwd_handling() -> crate::Result {
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         }
     );
 
@@ -755,6 +773,7 @@ fn ignored_with_cwd_handling() -> crate::Result {
             read_dir_calls: 5,
             returned_entries: entries.len(),
             seen_entries: 7,
+            ..Default::default()
         }
     );
 
@@ -799,6 +818,7 @@ fn only_untracked_with_cwd_handling() -> crate::Result {
             read_dir_calls: 3,
             returned_entries: entries.len(),
             seen_entries: 9,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -837,6 +857,7 @@ fn only_untracked_with_cwd_handling() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -871,6 +892,7 @@ fn only_untracked_with_cwd_handling() -> crate::Result {
             read_dir_calls: 3,
             returned_entries: entries.len(),
             seen_entries: 8,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -911,6 +933,7 @@ fn only_untracked_with_cwd_handling() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 4,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -953,6 +976,7 @@ fn only_untracked_with_pathspec() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -985,6 +1009,7 @@ fn only_untracked_with_pathspec() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -1017,6 +1042,7 @@ fn only_untracked_with_prefix_deletion() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -1043,6 +1069,7 @@ fn only_untracked_with_prefix_deletion() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -1063,6 +1090,7 @@ fn only_untracked() -> crate::Result {
             read_dir_calls: 3,
             returned_entries: entries.len(),
             seen_entries: 7,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -1085,6 +1113,7 @@ fn only_untracked() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -1113,6 +1142,7 @@ fn only_untracked() -> crate::Result {
             read_dir_calls: 3,
             returned_entries: entries.len(),
             seen_entries: 7 + 2,
+            ..Default::default()
         },
         "There are 2 extra directories that we fold into, but ultimately discard"
     );
@@ -1153,6 +1183,7 @@ fn only_untracked_explicit_pathspec_selection() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         },
     );
     assert_eq!(
@@ -1187,6 +1218,7 @@ fn only_untracked_explicit_pathspec_selection() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         },
         "no collapsing happens"
     );
@@ -1223,6 +1255,7 @@ fn only_untracked_explicit_pathspec_selection() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 2 + 3,
+            ..Default::default()
         },
         "collapsing happens just like Git"
     );
@@ -1244,6 +1277,7 @@ fn expendable_and_precious() {
             read_dir_calls: 6,
             returned_entries: entries.len(),
             seen_entries: 18,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -1289,6 +1323,7 @@ fn expendable_and_precious() {
             read_dir_calls: 6,
             returned_entries: entries.len(),
             seen_entries: 18 + 2,
+            ..Default::default()
         }
     );
 
@@ -1334,6 +1369,7 @@ fn expendable_and_precious() {
             read_dir_calls: 6,
             returned_entries: entries.len(),
             seen_entries: 16 + 2,
+            ..Default::default()
         }
     );
 
@@ -1357,6 +1393,7 @@ fn subdir_untracked() -> crate::Result {
             read_dir_calls: 3,
             returned_entries: entries.len(),
             seen_entries: 7,
+            ..Default::default()
         }
     );
     assert_eq!(entries, [entry("d/d/a", Untracked, File)]);
@@ -1376,6 +1413,7 @@ fn subdir_untracked() -> crate::Result {
             read_dir_calls: 3,
             returned_entries: entries.len(),
             seen_entries: 7,
+            ..Default::default()
         },
         "pruning has no actual effect here as there is no extra directories that could be avoided"
     );
@@ -1398,6 +1436,7 @@ fn subdir_untracked() -> crate::Result {
             read_dir_calls: 3,
             returned_entries: entries.len(),
             seen_entries: 7 + 1,
+            ..Default::default()
         },
         "there is a folded directory we added"
     );
@@ -1416,6 +1455,7 @@ fn only_untracked_from_subdir() -> crate::Result {
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -1453,6 +1493,7 @@ fn untracked_and_ignored_pathspec_guidance() -> crate::Result {
                 read_dir_calls: 1,
                 returned_entries: entries.len(),
                 seen_entries: 1,
+                ..Default::default()
             },
             "we have to read the parent directory, just like git, as we can't assume a directory"
         );
@@ -1493,6 +1534,7 @@ fn untracked_and_ignored_for_deletion_negative_wildcard_spec() -> crate::Result 
             read_dir_calls: 5,
             returned_entries: entries.len(),
             seen_entries: 23,
+            ..Default::default()
         },
     );
     assert_eq!(
@@ -1548,6 +1590,7 @@ fn untracked_and_ignored_for_deletion_positive_wildcard_spec() -> crate::Result 
             read_dir_calls: 8,
             returned_entries: entries.len(),
             seen_entries: 27,
+            ..Default::default()
         },
     );
     assert_eq!(
@@ -1601,6 +1644,7 @@ fn untracked_and_ignored_for_deletion_nonmatching_wildcard_spec() -> crate::Resu
             read_dir_calls: 8,
             returned_entries: entries.len(),
             seen_entries: 28,
+            ..Default::default()
         },
     );
     assert_eq!(
@@ -1747,6 +1791,7 @@ fn expendable_and_precious_in_ignored_dir_with_pathspec() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         },
     );
 
@@ -1789,6 +1834,7 @@ fn expendable_and_precious_in_ignored_dir_with_pathspec() -> crate::Result {
             read_dir_calls: 9,
             returned_entries: entries.len(),
             seen_entries: 19,
+            ..Default::default()
         },
     );
 
@@ -1843,6 +1889,7 @@ fn expendable_and_precious_in_ignored_dir_with_pathspec() -> crate::Result {
             read_dir_calls: 9,
             returned_entries: entries.len(),
             seen_entries: 19,
+            ..Default::default()
         },
     );
 
@@ -1891,6 +1938,7 @@ fn untracked_and_ignored() -> crate::Result {
             read_dir_calls: 5,
             returned_entries: entries.len(),
             seen_entries: 21,
+            ..Default::default()
         },
         "some untracked ones are hidden by default"
     );
@@ -1937,6 +1985,7 @@ fn untracked_and_ignored() -> crate::Result {
             read_dir_calls: 5,
             returned_entries: entries.len(),
             seen_entries: 21,
+            ..Default::default()
         },
         "basically the same result…"
     );
@@ -1969,6 +2018,7 @@ fn untracked_and_ignored() -> crate::Result {
             read_dir_calls: 5,
             returned_entries: entries.len(),
             seen_entries: 21 + 1,
+            ..Default::default()
         },
         "we still encounter the same amount of entries, and 1 folded directory"
     );
@@ -1995,6 +2045,7 @@ fn untracked_and_ignored() -> crate::Result {
             read_dir_calls: 5,
             returned_entries: entries.len(),
             seen_entries: 21 + 2,
+            ..Default::default()
         },
         "some untracked ones are hidden by default, folded directories"
     );
@@ -2037,6 +2088,7 @@ fn untracked_and_ignored() -> crate::Result {
             read_dir_calls: 5,
             returned_entries: entries.len(),
             seen_entries: 21 + 3,
+            ..Default::default()
         },
         "some untracked ones are hidden by default, and folded directories"
     );
@@ -2092,6 +2144,7 @@ fn untracked_and_ignored_collapse_handling_mixed() -> crate::Result {
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 4,
+            ..Default::default()
         },
         "it has to read 'd/d' as 'd/d/b.o' isn't a directory candidate"
     );
@@ -2130,6 +2183,7 @@ fn untracked_and_ignored_collapse_handling_mixed() -> crate::Result {
                 read_dir_calls: 4,
                 returned_entries: entries.len(),
                 seen_entries: 21,
+                ..Default::default()
             },
         );
 
@@ -2180,7 +2234,8 @@ fn untracked_and_ignored_collapse_handling_mixed_with_prefix() -> crate::Result 
         walk::Outcome {
             read_dir_calls: 3,
             returned_entries: entries.len(),
-            seen_entries: 11
+            seen_entries: 11,
+            ..Default::default()
         },
         "this is not a directory, so the prefix is only 'd', not 'd/d'"
     );
@@ -2222,6 +2277,7 @@ fn untracked_and_ignored_collapse_handling_mixed_with_prefix() -> crate::Result 
                 read_dir_calls: 2,
                 returned_entries: entries.len(),
                 seen_entries: 6,
+                ..Default::default()
             },
         );
 
@@ -2272,7 +2328,8 @@ fn untracked_and_ignored_collapse_handling_for_deletion_with_wildcards() -> crat
         walk::Outcome {
             read_dir_calls: 8,
             returned_entries: entries.len(),
-            seen_entries: 26
+            seen_entries: 26,
+            ..Default::default()
         },
     );
     assert_eq!(
@@ -2318,7 +2375,8 @@ fn untracked_and_ignored_collapse_handling_for_deletion_with_wildcards() -> crat
         walk::Outcome {
             read_dir_calls: 8,
             returned_entries: entries.len(),
-            seen_entries: 28
+            seen_entries: 28,
+            ..Default::default()
         },
     );
     assert_eq!(
@@ -2376,6 +2434,7 @@ fn untracked_and_ignored_collapse_handling_for_deletion_with_prefix_wildcards() 
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 2,
+            ..Default::default()
         },
     );
     assert_eq!(
@@ -2408,6 +2467,7 @@ fn untracked_and_ignored_collapse_handling_for_deletion_mixed() -> crate::Result
             read_dir_calls: 5,
             returned_entries: entries.len(),
             seen_entries: 21,
+            ..Default::default()
         },
     );
 
@@ -2437,6 +2497,7 @@ fn untracked_and_ignored_collapse_handling_for_deletion_mixed() -> crate::Result
             read_dir_calls: 5,
             returned_entries: entries.len(),
             seen_entries: 24,
+            ..Default::default()
         },
     );
 
@@ -2485,6 +2546,7 @@ fn untracked_and_ignored_collapse_handling_for_deletion_mixed() -> crate::Result
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 6,
+            ..Default::default()
         },
     );
 
@@ -2533,6 +2595,7 @@ fn untracked_and_ignored_collapse_handling_for_deletion_mixed() -> crate::Result
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         },
     );
 
@@ -2572,6 +2635,7 @@ fn untracked_and_ignored_collapse_handling_for_deletion_mixed() -> crate::Result
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         },
     );
 
@@ -2609,6 +2673,7 @@ fn untracked_and_ignored_collapse_handling_for_deletion_mixed() -> crate::Result
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 6,
+            ..Default::default()
         },
     );
 
@@ -2648,6 +2713,7 @@ fn untracked_and_ignored_collapse_handling_for_deletion_mixed() -> crate::Result
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 4,
+            ..Default::default()
         },
     );
 
@@ -2708,6 +2774,7 @@ fn precious_are_not_expendable() {
             read_dir_calls: 3,
             returned_entries: entries.len(),
             seen_entries: 10,
+            ..Default::default()
         },
     );
 
@@ -2750,6 +2817,7 @@ fn precious_are_not_expendable() {
             read_dir_calls: 3,
             returned_entries: entries.len(),
             seen_entries: 10,
+            ..Default::default()
         },
         "'d' is assumed to be a file, hence it's stripped to its base '', yielding one more call."
     );
@@ -2789,6 +2857,7 @@ fn precious_are_not_expendable() {
                 read_dir_calls: 2,
                 returned_entries: entries.len(),
                 seen_entries: 7,
+                ..Default::default()
             },
             "{equivalent_pathspec}: should yield same result, they also see the 'd' prefix directory"
         );
@@ -2824,6 +2893,7 @@ fn precious_are_not_expendable() {
             read_dir_calls: 3,
             returned_entries: entries.len(),
             seen_entries: 9,
+            ..Default::default()
         },
     );
 
@@ -2872,6 +2942,7 @@ fn decomposed_unicode_in_directory_is_returned_precomposed() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -2898,6 +2969,7 @@ fn decomposed_unicode_in_directory_is_returned_precomposed() -> crate::Result {
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         },
         "note how it starts directly in the right repository"
     );
@@ -2932,6 +3004,7 @@ fn worktree_root_can_be_symlink() -> crate::Result {
             read_dir_calls: 0,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -2941,7 +3014,6 @@ fn worktree_root_can_be_symlink() -> crate::Result {
     );
     Ok(())
 }
-
 #[test]
 fn root_may_not_go_through_dot_git() -> crate::Result {
     let root = fixture("with-nested-dot-git");
@@ -2956,6 +3028,7 @@ fn root_may_not_go_through_dot_git() -> crate::Result {
                 read_dir_calls: 0,
                 returned_entries: entries.len(),
                 seen_entries: 1,
+                ..Default::default()
             }
         );
         assert_eq!(
@@ -3001,6 +3074,7 @@ fn root_at_submodule_repository_allows_walk() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         }
     );
 
@@ -3042,6 +3116,7 @@ fn root_in_submodule_repository_allows_walk() -> crate::Result {
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
 
@@ -3083,6 +3158,7 @@ fn root_in_submodule_from_superproject_repository_allows_walk() -> crate::Result
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
 
@@ -3124,6 +3200,7 @@ fn root_enters_directory_with_dot_git_in_reconfigured_worktree_tracked() -> crat
             read_dir_calls: 0,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
 
@@ -3158,6 +3235,7 @@ fn root_enters_directory_with_dot_git_in_reconfigured_worktree_tracked() -> crat
             read_dir_calls: 0,
             returned_entries: 0,
             seen_entries: 1,
+            ..Default::default()
         }
     );
 
@@ -3228,6 +3306,7 @@ fn root_may_not_go_through_nested_repository_unless_enabled() -> crate::Result {
             read_dir_calls: 0,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -3256,6 +3335,7 @@ fn root_may_not_go_through_submodule() -> crate::Result {
             read_dir_calls: 0,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         },
     );
     assert_eq!(
@@ -3277,6 +3357,7 @@ fn walk_with_submodule() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 4,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -3310,6 +3391,7 @@ fn root_that_is_tracked_file_is_returned() -> crate::Result {
             read_dir_calls: 0,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
 
@@ -3339,6 +3421,7 @@ fn root_that_is_untracked_file_is_returned() -> crate::Result {
             read_dir_calls: 0,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
 
@@ -3375,6 +3458,7 @@ fn root_can_be_pruned_early_with_pathspec() -> crate::Result {
             read_dir_calls: 0,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
 
@@ -3396,6 +3480,7 @@ fn submodules() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         }
     );
     let expected_content = [
@@ -3533,6 +3618,7 @@ fn file_root_is_shown_if_pathspec_matches_exactly() -> crate::Result {
             read_dir_calls: 0,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         },
     );
 
@@ -3564,6 +3650,7 @@ fn root_that_is_tracked_and_ignored_is_considered_tracked() -> crate::Result {
             read_dir_calls: 0,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
 
@@ -3598,6 +3685,7 @@ fn root_with_dir_that_is_tracked_and_ignored() -> crate::Result {
                 read_dir_calls: 2,
                 returned_entries: entries.len(),
                 seen_entries: 3,
+                ..Default::default()
             }
         );
 
@@ -3639,6 +3727,7 @@ fn empty_and_nested_untracked() -> crate::Result {
                 read_dir_calls: 3,
                 returned_entries: entries.len(),
                 seen_entries: 2,
+                ..Default::default()
             }
         );
 
@@ -3669,6 +3758,7 @@ fn empty_and_nested_untracked() -> crate::Result {
                 read_dir_calls: 3,
                 returned_entries: entries.len(),
                 seen_entries: 3,
+                ..Default::default()
             }
         );
 
@@ -3715,6 +3805,7 @@ fn root_that_is_ignored_is_listed_for_files_and_directories() -> crate::Result {
                     read_dir_calls: 0,
                     returned_entries: entries.len(),
                     seen_entries: 1,
+                    ..Default::default()
                 }
             );
 
@@ -3877,6 +3968,7 @@ fn nested_repos_in_ignored_directories() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 4,
+            ..Default::default()
         }
     );
 
@@ -3908,6 +4000,7 @@ fn nested_repos_in_ignored_directories() -> crate::Result {
             read_dir_calls: 4,
             returned_entries: entries.len(),
             seen_entries: 6,
+            ..Default::default()
         }
     );
 
@@ -3941,6 +4034,7 @@ fn nested_repos_in_ignored_directories() -> crate::Result {
             read_dir_calls: 4,
             returned_entries: entries.len(),
             seen_entries: 7,
+            ..Default::default()
         }
     );
 
@@ -3996,6 +4090,7 @@ fn decomposed_unicode_in_root_is_returned_precomposed() -> crate::Result {
             read_dir_calls: 0,
             returned_entries: entries.len(),
             seen_entries: 1,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4053,6 +4148,7 @@ fn untracked_and_ignored_collapse_mix() {
             read_dir_calls: 4,
             returned_entries: entries.len(),
             seen_entries: 7,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4087,6 +4183,7 @@ fn untracked_and_ignored_collapse_mix() {
             read_dir_calls: 4,
             returned_entries: entries.len(),
             seen_entries: 8,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4121,6 +4218,7 @@ fn untracked_and_ignored_collapse_mix() {
             read_dir_calls: 4,
             returned_entries: entries.len(),
             seen_entries: 8,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4161,6 +4259,7 @@ fn root_cannot_pass_through_case_altered_capital_dot_git_if_case_insensitive() -
                 read_dir_calls: 0,
                 returned_entries: entries.len(),
                 seen_entries: 1,
+                ..Default::default()
             }
         );
         assert_eq!(
@@ -4223,6 +4322,7 @@ fn partial_checkout_cone_and_non_one() -> crate::Result {
                 read_dir_calls: 0,
                 returned_entries: entries.len(),
                 seen_entries: 1,
+                ..Default::default()
             }
         );
         assert_eq!(
@@ -4268,6 +4368,7 @@ fn type_mismatch() {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         }
     );
 
@@ -4310,6 +4411,7 @@ fn type_mismatch() {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 3 + 1,
+            ..Default::default()
         }
     );
 
@@ -4355,6 +4457,7 @@ fn type_mismatch_ignore_case() {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4395,6 +4498,7 @@ fn type_mismatch_ignore_case() {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 3 + 1,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4439,6 +4543,7 @@ fn type_mismatch_ignore_case_clash_dir_is_file() {
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 2,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4480,6 +4585,7 @@ fn type_mismatch_ignore_case_clash_file_is_dir() {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 2,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4501,6 +4607,7 @@ fn top_level_slash_with_negations() -> crate::Result {
                 read_dir_calls: 2,
                 returned_entries: entries.len(),
                 seen_entries: 5,
+                ..Default::default()
             }
         );
         assert_eq!(
@@ -4533,6 +4640,7 @@ fn top_level_slash_with_negations() -> crate::Result {
                 read_dir_calls: 2,
                 returned_entries: entries.len(),
                 seen_entries: 5,
+                ..Default::default()
             }
         );
         assert_eq!(
@@ -4558,6 +4666,7 @@ fn subdir_slash_with_negations() -> crate::Result {
                 read_dir_calls: 3,
                 returned_entries: entries.len(),
                 seen_entries: 5,
+                ..Default::default()
             }
         );
         assert_eq!(
@@ -4590,6 +4699,7 @@ fn subdir_slash_with_negations() -> crate::Result {
                 read_dir_calls: 3,
                 returned_entries: entries.len(),
                 seen_entries: 5,
+                ..Default::default()
             }
         );
         assert_eq!(
@@ -4614,6 +4724,7 @@ fn one_ignored_submodule() -> crate::Result {
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 5,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4637,7 +4748,8 @@ fn one_ignored_submodule() -> crate::Result {
         walk::Outcome {
             read_dir_calls: 0,
             returned_entries: entries.len(),
-            seen_entries: 1
+            seen_entries: 1,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4658,6 +4770,7 @@ fn ignored_sub_repo() -> crate::Result {
             read_dir_calls: 1,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4692,6 +4805,7 @@ fn ignored_sub_repo() -> crate::Result {
                     read_dir_calls: 1,
                     returned_entries: entries.len(),
                     seen_entries: 3,
+                    ..Default::default()
                 }
             );
             assert_eq!(
@@ -4717,6 +4831,7 @@ fn in_repo_worktree() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 4,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4747,6 +4862,7 @@ fn in_repo_worktree() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 4,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4773,6 +4889,7 @@ fn in_repo_hidden_worktree() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 4,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4804,6 +4921,7 @@ fn in_repo_hidden_worktree() -> crate::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 4,
+            ..Default::default()
         }
     );
     assert_eq!(
@@ -4842,6 +4960,7 @@ fn in_repo_hidden_worktree() -> crate::Result {
                     read_dir_calls: 4,
                     returned_entries: entries.len(),
                     seen_entries: 5,
+                    ..Default::default()
                 }
             );
             assert_eq!(

--- a/gix-dir/tests/dir/walk.rs
+++ b/gix-dir/tests/dir/walk.rs
@@ -1,5 +1,6 @@
-use std::{collections::BTreeSet, sync::atomic::AtomicBool};
+use std::{collections::BTreeSet, process::Command, sync::atomic::AtomicBool};
 
+use bstr::ByteSlice;
 use gix_dir::{
     EntryRef, entry,
     entry::{Kind::*, PathspecMatch::*, Property::*, Status::*},
@@ -3014,6 +3015,703 @@ fn worktree_root_can_be_symlink() -> crate::Result {
     );
     Ok(())
 }
+
+#[test]
+#[cfg_attr(windows, ignore)] // NTFS async metadata flush causes flaky mtime mismatches
+fn untracked_cache_can_avoid_read_dir_calls() -> crate::Result {
+    let (_tmp, root) = repo_with_untracked_cache()?;
+    let opts = gix_dir::walk::Options {
+        emit_untracked: CollapseDirectory,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals(&root, opts, true)?;
+    let ((uncached_out, _root), uncached_entries) = collect_with_repo_globals(&root, opts, false)?;
+
+    assert_eq!(
+        out.read_dir_calls, 0,
+        "a valid UNTR cache should satisfy the walk without opening directories"
+    );
+    assert_ne!(
+        uncached_out.read_dir_calls, 0,
+        "the fallback implementation should still hit the filesystem"
+    );
+    assert_eq!(
+        entries, uncached_entries,
+        "cached and uncached walks should produce identical output"
+    );
+    assert_eq!(
+        untracked_paths(&entries),
+        git_untracked_paths(&root, GitUntrackedMode::Collapsed, &[])?,
+        "collapsed untracked entries should match git status"
+    );
+    Ok(())
+}
+
+#[test]
+fn invalidated_untracked_cache_falls_back_to_the_filesystem() -> crate::Result {
+    let (_tmp, root) = repo_with_untracked_cache()?;
+    std::fs::write(root.join("later"), "later")?;
+
+    let opts = gix_dir::walk::Options {
+        emit_untracked: CollapseDirectory,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals(&root, opts, true)?;
+
+    assert_ne!(
+        out.read_dir_calls, 0,
+        "changing the root directory contents must invalidate the cache"
+    );
+    assert!(
+        entries.iter().any(|(entry, _)| entry.rela_path.as_bstr() == "later"),
+        "the fallback traversal should see newly added files"
+    );
+    assert_eq!(
+        untracked_paths(&entries),
+        git_untracked_paths(&root, GitUntrackedMode::Collapsed, &[])?,
+        "fallback output should still match git status after invalidation"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(windows, ignore)] // NTFS async metadata flush causes flaky mtime mismatches
+fn global_excludes_change_disables_untracked_cache() -> crate::Result {
+    let (_tmp, root) = repo_with_untracked_cache()?;
+    let excludes_file = root.join("global-excludes");
+    std::fs::write(&excludes_file, "global-ignored/\n")?;
+    git(
+        &root,
+        [
+            std::ffi::OsStr::new("config"),
+            std::ffi::OsStr::new("core.excludesFile"),
+            excludes_file.as_os_str(),
+        ],
+    )?;
+    std::fs::create_dir_all(root.join("global-ignored"))?;
+    std::fs::write(root.join("global-ignored/file"), "ignored")?;
+    refresh_untracked_cache(&root)?;
+
+    std::fs::write(&excludes_file, "")?;
+    let opts = gix_dir::walk::Options {
+        emit_untracked: CollapseDirectory,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals_opts(&root, opts, true, Some(&excludes_file), &[])?;
+
+    assert_ne!(
+        out.read_dir_calls, 0,
+        "changing core.excludesFile contents must disable the UNTR fast path"
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|(entry, _)| entry.rela_path.as_bstr() == "global-ignored"),
+        "the filesystem fallback should see entries that were formerly hidden by a global exclude"
+    );
+    assert_eq!(
+        untracked_paths(&entries),
+        git_untracked_paths(&root, GitUntrackedMode::Collapsed, &[])?,
+        "global exclude changes should still produce git-compatible output"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(windows, ignore)] // NTFS async metadata flush causes flaky mtime mismatches
+fn info_exclude_change_disables_untracked_cache() -> crate::Result {
+    let (_tmp, root) = repo_with_untracked_cache()?;
+    let info_dir = root.join(".git/info");
+    std::fs::create_dir_all(&info_dir)?;
+    let info_exclude = info_dir.join("exclude");
+    std::fs::write(&info_exclude, "info-excluded/\n")?;
+    std::fs::create_dir_all(root.join("info-excluded"))?;
+    std::fs::write(root.join("info-excluded/file"), "excluded")?;
+    refresh_untracked_cache(&root)?;
+
+    // Now change info/exclude so the cache's recorded stat+OID no longer matches.
+    std::fs::write(&info_exclude, "")?;
+    let opts = gix_dir::walk::Options {
+        emit_untracked: CollapseDirectory,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals(&root, opts, true)?;
+
+    assert_ne!(
+        out.read_dir_calls, 0,
+        "changing .git/info/exclude contents must disable the UNTR fast path"
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|(entry, _)| entry.rela_path.as_bstr() == "info-excluded"),
+        "the filesystem fallback should see entries that were formerly hidden by info/exclude"
+    );
+    assert_eq!(
+        untracked_paths(&entries),
+        git_untracked_paths(&root, GitUntrackedMode::Collapsed, &[])?,
+        "info/exclude changes should still produce git-compatible output"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(windows, ignore)] // NTFS async metadata flush causes flaky mtime mismatches
+fn global_excludes_file_present_and_unchanged_allows_untracked_cache() -> crate::Result {
+    let (_tmp, root) = repo_with_untracked_cache()?;
+    let excludes_file = root.join("global-excludes");
+    std::fs::write(&excludes_file, "global-ignored/\n")?;
+    std::fs::create_dir_all(root.join("global-ignored"))?;
+    std::fs::write(root.join("global-ignored/file"), "ignored")?;
+    git(
+        &root,
+        [
+            std::ffi::OsStr::new("config"),
+            std::ffi::OsStr::new("core.excludesFile"),
+            excludes_file.as_os_str(),
+        ],
+    )?;
+    refresh_untracked_cache(&root)?;
+
+    let opts = gix_dir::walk::Options {
+        emit_untracked: CollapseDirectory,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals_opts(&root, opts, true, Some(&excludes_file), &[])?;
+
+    assert_eq!(
+        out.read_dir_calls, 0,
+        "cache must serve all directories without read_dir when excludes_file is present but unchanged"
+    );
+    assert!(
+        out.untracked_cache_hits > 0,
+        "expected cache hits but got 0 — the UNTR decode or excludes_file stat validation is broken"
+    );
+    assert!(
+        !entries
+            .iter()
+            .any(|(entry, _)| entry.rela_path.as_bstr() == "global-ignored"),
+        "globally-ignored directory must not appear in output"
+    );
+    assert_eq!(
+        untracked_paths(&entries),
+        git_untracked_paths(&root, GitUntrackedMode::Collapsed, &[])?,
+        "output with unchanged global excludes should match git status"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(windows, ignore)] // NTFS async metadata flush causes flaky mtime mismatches
+fn nested_gitignore_change_invalidates_cached_subtree() -> crate::Result {
+    let (_tmp, root) = repo_with_untracked_cache()?;
+    std::fs::write(root.join("tracked/.gitignore"), "")?;
+    git(&root, ["add", "tracked/.gitignore"])?;
+    git(&root, ["commit", "-m", "tracked ignore"])?;
+    refresh_untracked_cache(&root)?;
+
+    std::fs::write(root.join("tracked/.gitignore"), "new/\n")?;
+    let opts = gix_dir::walk::Options {
+        emit_untracked: CollapseDirectory,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals(&root, opts, true)?;
+
+    assert_ne!(
+        out.read_dir_calls, 0,
+        "changing a nested .gitignore should invalidate the cached subtree"
+    );
+    assert!(
+        !entries
+            .iter()
+            .any(|(entry, _)| entry.rela_path.as_bstr() == "tracked/new"),
+        "the fallback traversal should honor the updated ignore file"
+    );
+    assert_eq!(
+        untracked_paths(&entries),
+        git_untracked_paths(&root, GitUntrackedMode::Collapsed, &[])?,
+        "nested .gitignore invalidation should still agree with git status"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(windows, ignore)] // NTFS async metadata flush causes flaky mtime mismatches
+fn non_empty_pathspec_never_uses_untracked_cache() -> crate::Result {
+    let (_tmp, root) = repo_with_untracked_cache()?;
+    let opts = gix_dir::walk::Options {
+        emit_untracked: CollapseDirectory,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals_opts(&root, opts, true, None, &["tracked/"])?;
+    let ((uncached_out, _root), uncached_entries) =
+        collect_with_repo_globals_opts(&root, opts, false, None, &["tracked/"])?;
+
+    assert_ne!(
+        out.read_dir_calls, 0,
+        "a non-empty pathspec should disable the UNTR fast path"
+    );
+    assert_ne!(
+        uncached_out.read_dir_calls, 0,
+        "the uncached comparison should still traverse the filesystem"
+    );
+    assert_eq!(
+        entries, uncached_entries,
+        "pathspec filtering should match the uncached traversal"
+    );
+    assert_eq!(
+        untracked_paths(&entries),
+        git_untracked_paths(&root, GitUntrackedMode::Collapsed, &["tracked/"])?,
+        "pathspec-filtered collapsed output should match git status"
+    );
+    Ok(())
+}
+
+#[test]
+// On Windows, NTFS flushes directory metadata asynchronously. A directory that was
+// recently modified (like `tracked` here, after `tracked/new` was created) may report
+// a different `LastWriteTime` via different APIs or at different instants. This causes
+// the IOUC stat check for `tracked` to fail even after two `git status` runs, making
+// `read_dir_calls` flaky. Skip rather than accept a racy assertion.
+#[cfg_attr(windows, ignore)]
+fn matching_mode_with_tracked_intermediate_dirs_matches_uncached() -> crate::Result {
+    let (_tmp, root) = repo_with_untracked_cache()?;
+    let opts = gix_dir::walk::Options {
+        emit_untracked: Matching,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals(&root, opts, true)?;
+    let ((uncached_out, _root), uncached_entries) = collect_with_repo_globals(&root, opts, false)?;
+
+    assert_eq!(
+        out.read_dir_calls, 0,
+        "matching mode should still use a valid UNTR cache"
+    );
+    assert_ne!(
+        uncached_out.read_dir_calls, 0,
+        "the comparison path should still hit the filesystem"
+    );
+    assert_eq!(
+        entries, uncached_entries,
+        "matching mode output should match the uncached traversal"
+    );
+    assert_eq!(
+        untracked_paths(&entries),
+        git_untracked_paths(&root, GitUntrackedMode::Matching, &[])?,
+        "matching-mode untracked entries should match git status -uall"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(windows, ignore)] // NTFS async metadata flush causes flaky mtime mismatches
+fn collapsed_cache_is_not_used_for_matching_walk() -> crate::Result {
+    // The UNTR cache here was written by a collapsing `-unormal` status, so a fully-untracked
+    // directory is stored as a single `dir/` entry without its contents. A `-uall`/Matching walk
+    // must therefore not be served from it — doing so would omit the nested untracked files — and
+    // has to fall back to the filesystem instead.
+    let (_tmp, root) = repo_with_untracked_cache_mode("normal")?;
+    let opts = gix_dir::walk::Options {
+        emit_untracked: Matching,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals(&root, opts, true)?;
+
+    assert_ne!(
+        out.read_dir_calls, 0,
+        "a collapsed cache must not serve a matching walk from memory"
+    );
+    assert_eq!(
+        out.untracked_cache_hits, 0,
+        "no directory may be served from a collapsed cache in matching mode"
+    );
+    assert_eq!(
+        untracked_paths(&entries),
+        git_untracked_paths(&root, GitUntrackedMode::Matching, &[])?,
+        "matching-mode output must still list every nested untracked file"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(windows, ignore)] // NTFS async metadata flush causes flaky mtime mismatches
+fn collapsed_cache_still_serves_collapsed_walk() -> crate::Result {
+    // The counterpart to the test above: a collapsed (`-unormal`) cache can and should still serve a
+    // collapsed walk from memory without touching the filesystem.
+    let (_tmp, root) = repo_with_untracked_cache_mode("normal")?;
+    let opts = gix_dir::walk::Options {
+        emit_untracked: CollapseDirectory,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals(&root, opts, true)?;
+
+    assert_eq!(
+        out.read_dir_calls, 0,
+        "a collapsed cache should satisfy a collapsed walk without opening directories"
+    );
+    assert_eq!(
+        untracked_paths(&entries),
+        git_untracked_paths(&root, GitUntrackedMode::Collapsed, &[])?,
+        "collapsed output should match git status"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(windows, ignore)] // NTFS async metadata flush causes flaky mtime mismatches
+fn emit_tracked_true_bypasses_untracked_cache() -> crate::Result {
+    let (_tmp, root) = repo_with_untracked_cache()?;
+    let opts = gix_dir::walk::Options {
+        emit_untracked: CollapseDirectory,
+        emit_tracked: true,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals(&root, opts, true)?;
+
+    assert_ne!(
+        out.read_dir_calls, 0,
+        "emit_tracked=true must disable the UNTR fast path since the cache only records untracked entries"
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|(entry, _)| entry.rela_path.as_bstr() == "tracked/keep"),
+        "tracked file must appear in output when emit_tracked=true"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(windows, ignore)] // NTFS async metadata flush causes flaky mtime mismatches
+fn cached_subdir_becoming_repository_is_emitted() -> crate::Result {
+    let (_tmp, root) = repo_with_untracked_cache()?;
+    // Turn `new/` (a regular untracked dir in the cache) into a nested repo.
+    // This changes `new/`'s mtime but not root's, so root's cache entry stays valid.
+    git(&root, ["init", "new"])?;
+    let opts = gix_dir::walk::Options {
+        emit_untracked: CollapseDirectory,
+        ..options()
+    };
+    let ((out, _root), entries) = collect_with_repo_globals(&root, opts, true)?;
+
+    assert!(
+        entries.iter().any(|(entry, _)| {
+            entry.rela_path.as_bstr() == "new" && entry.disk_kind == Some(gix_dir::entry::Kind::Repository)
+        }),
+        "a cached subdir that became a repository must still appear in output, but entries were: {:?}",
+        entries
+            .iter()
+            .map(|(e, _)| e.rela_path.as_bstr().to_owned())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        untracked_paths(&entries),
+        git_untracked_paths(&root, GitUntrackedMode::Collapsed, &[])?,
+        "output must match git status after subdir becomes a repository"
+    );
+    let _ = out;
+    Ok(())
+}
+
+/// Git records `check_only` directories in the UNTR cache for the collapsed, fully-untracked
+/// subtrees written under `-unormal` (here: `a/sub`, `a/sub/deeper`, `b`, `b/deep`). We
+/// deliberately never consult `check_only` when serving the cache — see the note in
+/// `untracked_cache::cache_is_applicable`. This test locks in that ignoring it is safe by
+/// asserting the cached walk equals both `git status` and the uncached walk for every
+/// mode/cache combination, including `Matching` against a collapsed cache (which must fall
+/// back to the filesystem rather than serve incomplete `check_only` data).
+#[test]
+#[cfg_attr(windows, ignore)] // NTFS async metadata flush causes flaky mtime mismatches
+fn untracked_cache_with_check_only_dirs_matches_git_and_uncached() -> crate::Result {
+    for cache_mode in ["all", "normal"] {
+        let (_tmp, root) = repo_with_nested_untracked_cache(cache_mode)?;
+        for emit in [CollapseDirectory, Matching] {
+            let opts = gix_dir::walk::Options {
+                emit_untracked: emit,
+                ..options()
+            };
+            let ((_out, _root), entries) = collect_with_repo_globals(&root, opts, true)?;
+            let ((_uncached_out, _root), uncached) = collect_with_repo_globals(&root, opts, false)?;
+            assert_eq!(
+                entries, uncached,
+                "cache_mode={cache_mode} emit={emit:?}: cached walk must match the uncached walk"
+            );
+            let gmode = if matches!(emit, Matching) {
+                GitUntrackedMode::Matching
+            } else {
+                GitUntrackedMode::Collapsed
+            };
+            assert_eq!(
+                untracked_paths(&entries),
+                git_untracked_paths(&root, gmode, &[])?,
+                "cache_mode={cache_mode} emit={emit:?}: untracked output must match git status"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn repo_with_nested_untracked_cache(
+    show_untracked_files: &str,
+) -> crate::Result<(gix_testtools::tempfile::TempDir, std::path::PathBuf)> {
+    let tmp = gix_testtools::tempfile::tempdir()?;
+    let root = tmp.path().join("repo");
+    std::fs::create_dir(&root)?;
+    git(&root, ["init"])?;
+    git(&root, ["config", "status.showUntrackedFiles", show_untracked_files])?;
+    git(&root, ["config", "user.name", "a"])?;
+    git(&root, ["config", "user.email", "a@example.com"])?;
+    let excludes = root.join("excludes");
+    std::fs::write(&excludes, "")?;
+    git(
+        &root,
+        [
+            std::ffi::OsStr::new("config"),
+            std::ffi::OsStr::new("core.excludesFile"),
+            excludes.as_os_str(),
+        ],
+    )?;
+    // Tracked baseline in `a/` and `c/`.
+    std::fs::create_dir_all(root.join("a"))?;
+    std::fs::write(root.join("a/t"), "t")?;
+    std::fs::create_dir_all(root.join("c"))?;
+    std::fs::write(root.join("c/t"), "t")?;
+    git(&root, ["add", "a/t", "c/t"])?;
+    git(&root, ["commit", "-m", "init"])?;
+    // `a`: tracked file + an untracked file + a fully-untracked nested subtree.
+    // `b`: a fully-untracked nested subtree (a collapse candidate, so its dirs become `check_only`).
+    // `c`: tracked-only (recorded as a subdirectory with no untracked entries).
+    std::fs::write(root.join("a/u"), "u")?;
+    std::fs::create_dir_all(root.join("a/sub/deeper"))?;
+    std::fs::write(root.join("a/sub/deeper/f"), "f")?;
+    std::fs::create_dir_all(root.join("b/deep"))?;
+    std::fs::write(root.join("b/x"), "x")?;
+    std::fs::write(root.join("b/deep/z"), "z")?;
+    refresh_untracked_cache(&root)?;
+    Ok((tmp, root))
+}
+
+fn repo_with_untracked_cache() -> crate::Result<(gix_testtools::tempfile::TempDir, std::path::PathBuf)> {
+    repo_with_untracked_cache_mode("all")
+}
+
+fn repo_with_untracked_cache_mode(
+    show_untracked_files: &str,
+) -> crate::Result<(gix_testtools::tempfile::TempDir, std::path::PathBuf)> {
+    let tmp = gix_testtools::tempfile::tempdir()?;
+    let root = tmp.path().join("repo");
+    std::fs::create_dir(&root)?;
+    git(&root, ["init"])?;
+    git(&root, ["config", "status.showUntrackedFiles", show_untracked_files])?;
+    git(&root, ["config", "user.name", "a"])?;
+    git(&root, ["config", "user.email", "a@example.com"])?;
+    std::fs::create_dir(root.join("tracked"))?;
+    std::fs::write(root.join("tracked/keep"), "keep")?;
+    git(&root, ["add", "tracked/keep"])?;
+    git(&root, ["commit", "-m", "init"])?;
+    std::fs::create_dir_all(root.join("tracked/new"))?;
+    std::fs::create_dir_all(root.join("new"))?;
+    std::fs::write(root.join("tracked/new/file"), "tracked-new")?;
+    std::fs::write(root.join("new/file"), "new")?;
+    refresh_untracked_cache(&root)?;
+    Ok((tmp, root))
+}
+
+fn git(cwd: &std::path::Path, args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>) -> crate::Result {
+    let status = Command::new("git").args(args).current_dir(cwd).status()?;
+    assert!(status.success());
+    Ok(())
+}
+
+fn git_output(
+    cwd: &std::path::Path,
+    args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
+) -> crate::Result<std::process::Output> {
+    Ok(Command::new("git").args(args).current_dir(cwd).output()?)
+}
+
+fn effective_excludes_file(root: &std::path::Path) -> crate::Result<Option<std::path::PathBuf>> {
+    let output = git_output(
+        root,
+        [
+            std::ffi::OsStr::new("config"),
+            std::ffi::OsStr::new("--path"),
+            std::ffi::OsStr::new("core.excludesFile"),
+        ],
+    )?;
+    if output.status.success() {
+        let path = gix_path::try_from_bstr(output.stdout.as_bstr().trim().as_bstr())
+            .ok()
+            .map(std::borrow::Cow::into_owned);
+        return Ok(path);
+    }
+    // No core.excludesFile configured — fall back to the XDG default, matching gix's
+    // `assemble_exclude_globals` which calls `xdg_config_path("ignore")`.
+    let xdg_ignore = std::env::var_os("XDG_CONFIG_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| std::path::PathBuf::from(h).join(".config")))
+        .map(|base| base.join("git").join("ignore"));
+    Ok(xdg_ignore.filter(|p| p.exists()))
+}
+
+fn refresh_untracked_cache(root: &std::path::Path) -> crate::Result {
+    git(root, ["update-index", "--force-untracked-cache"])?;
+    git(root, ["status", "--porcelain"])?;
+    // Run a second time so git validates the recorded directory stats and sets the valid
+    // bitmap. Some git versions only populate the structure on the first run and mark
+    // entries valid on the second. The double-run also lets the filesystem settle so the
+    // recorded stats match what gix will read.
+    git(root, ["status", "--porcelain"])?;
+    assert!(
+        index_has_untracked_cache(root),
+        "test repository must have a UNTR extension"
+    );
+    Ok(())
+}
+
+fn index_has_untracked_cache(root: &std::path::Path) -> bool {
+    std::fs::read(root.join(".git/index"))
+        .ok()
+        .and_then(|bytes| {
+            gix_index::State::from_bytes(
+                &bytes,
+                std::time::UNIX_EPOCH.into(),
+                gix_index::hash::Kind::Sha1,
+                Default::default(),
+            )
+            .ok()
+            .map(|(state, _)| state.untracked().is_some())
+        })
+        .unwrap_or(false)
+}
+
+type CollectedEntries = Vec<(gix_dir::Entry, Option<entry::Status>)>;
+type CollectOutcome = ((gix_dir::walk::Outcome, std::path::PathBuf), CollectedEntries);
+
+#[derive(Clone, Copy)]
+enum GitUntrackedMode {
+    Collapsed,
+    Matching,
+}
+
+fn git_untracked_paths(
+    root: &std::path::Path,
+    mode: GitUntrackedMode,
+    pathspecs: &[&str],
+) -> crate::Result<BTreeSet<String>> {
+    let mut cmd = Command::new("git");
+    cmd.current_dir(root).arg("status").arg("--porcelain").arg(match mode {
+        GitUntrackedMode::Collapsed => "--untracked-files=normal",
+        GitUntrackedMode::Matching => "--untracked-files=all",
+    });
+    if !pathspecs.is_empty() {
+        cmd.arg("--");
+        cmd.args(pathspecs);
+    }
+    let output = cmd.output()?;
+    assert!(output.status.success());
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.strip_prefix("?? "))
+        .map(|path| path.trim_end_matches('/').to_owned())
+        .collect())
+}
+
+fn untracked_paths(entries: &[(gix_dir::Entry, Option<entry::Status>)]) -> BTreeSet<String> {
+    entries
+        .iter()
+        .filter(|(entry, _)| entry.status == Untracked)
+        .map(|(entry, _)| entry.rela_path.to_string())
+        .collect()
+}
+
+fn collect_with_repo_globals(
+    root: &std::path::Path,
+    opts: gix_dir::walk::Options<'static>,
+    use_cache: bool,
+) -> crate::Result<CollectOutcome> {
+    collect_with_repo_globals_opts(root, opts, use_cache, None, &[])
+}
+
+fn collect_with_repo_globals_opts(
+    root: &std::path::Path,
+    opts: gix_dir::walk::Options<'static>,
+    use_cache: bool,
+    excludes_file: Option<&std::path::Path>,
+    pathspecs: &[&str],
+) -> crate::Result<CollectOutcome> {
+    let git_dir = root.join(".git");
+    let bytes = std::fs::read(git_dir.join("index"))?;
+    let (mut index, _) = gix_index::State::from_bytes(
+        &bytes,
+        std::time::UNIX_EPOCH.into(),
+        gix_index::hash::Kind::Sha1,
+        Default::default(),
+    )
+    .expect("valid index");
+    for entry in index
+        .entries_mut()
+        .iter_mut()
+        .filter(|entry| !entry.flags.contains(gix_index::entry::Flags::SKIP_WORKTREE))
+    {
+        entry.flags |= gix_index::entry::Flags::UPTODATE;
+    }
+
+    let parse = gix_ignore::search::Ignore { support_precious: true };
+    let mut buf = Vec::new();
+    let excludes_file = match excludes_file {
+        Some(path) => Some(path.to_owned()),
+        None => effective_excludes_file(root)?,
+    };
+    let globals = gix_ignore::Search::from_git_dir(&git_dir, excludes_file, &mut buf, parse)?;
+    let mut stack = gix_worktree::Stack::from_state_and_ignore_case(
+        root,
+        false,
+        gix_worktree::stack::State::IgnoreStack(gix_worktree::stack::state::Ignore::new(
+            Default::default(),
+            globals,
+            None,
+            gix_worktree::stack::state::ignore::Source::WorktreeThenIdMappingIfNotSkipped,
+            parse,
+        )),
+        &index,
+        index.path_backing(),
+    );
+    let pathspecs = pathspecs
+        .iter()
+        .map(|pattern| {
+            gix_pathspec::Pattern::from_bytes(pattern.as_bytes(), Default::default()).expect("valid pathspec")
+        })
+        .collect::<Vec<_>>();
+    let mut search =
+        gix_pathspec::Search::from_specs(pathspecs, None::<&std::path::Path>, root).expect("empty pathspec is valid");
+    let git_dir_realpath = gix_path::realpath_opts(&git_dir, root, gix_path::realpath::MAX_SYMLINKS)?;
+    let lookup = index.prepare_icase_backing();
+    let mut collect = gix_dir::walk::delegate::Collect::default();
+    let opts = gix_dir::walk::Options {
+        use_untracked_cache: use_cache,
+        ..opts
+    };
+    let out = walk(
+        root,
+        gix_dir::walk::Context {
+            should_interrupt: None,
+            git_dir_realpath: &git_dir_realpath,
+            current_dir: root,
+            index: &index,
+            ignore_case_index_lookup: Some(&lookup),
+            pathspec: &mut search,
+            pathspec_attributes: &mut |_, _, _, _| false,
+            excludes: Some(&mut stack),
+            objects: &gix_object::find::Never,
+            explicit_traversal_root: None,
+        },
+        opts,
+        &mut collect,
+    )?;
+    Ok((out, collect.into_entries_by_path()))
+}
+
 #[test]
 fn root_may_not_go_through_dot_git() -> crate::Result {
     let root = fixture("with-nested-dot-git");

--- a/gix-dir/tests/dir_cwd.rs
+++ b/gix-dir/tests/dir_cwd.rs
@@ -24,6 +24,7 @@ fn prefixes_work_as_expected() -> gix_testtools::Result {
             read_dir_calls: 2,
             returned_entries: entries.len(),
             seen_entries: 3,
+            ..Default::default()
         }
     );
     assert_eq!(

--- a/gix-dir/tests/walk_utils/mod.rs
+++ b/gix-dir/tests/walk_utils/mod.rs
@@ -36,6 +36,7 @@ pub fn options_emit_all() -> walk::Options<'static> {
         emit_empty_directories: true,
         emit_collapsed: None,
         symlinks_to_directories_are_ignored_like_directories: false,
+        use_untracked_cache: true,
         worktree_relative_worktree_dirs: None,
     }
 }

--- a/gix-status/tests/status/index_as_worktree_with_renames.rs
+++ b/gix-status/tests/status/index_as_worktree_with_renames.rs
@@ -197,6 +197,7 @@ fn changed_and_untracked() {
             read_dir_calls: 3,
             returned_entries: 2,
             seen_entries: 8,
+            ..Default::default()
         }
     );
     assert_eq!(out.rewrites, None, "rewrites are still not configured");
@@ -244,6 +245,7 @@ fn unreadable_untracked() {
             read_dir_calls: 1,
             returned_entries: 1,
             seen_entries: 3,
+            ..Default::default()
         }
     );
 }

--- a/gix-worktree/src/stack/state/ignore.rs
+++ b/gix-worktree/src/stack/state/ignore.rs
@@ -81,6 +81,27 @@ impl Ignore {
         self.matched_directory_patterns_stack.pop().expect("something to pop");
         self.stack.patterns.pop().expect("something to pop");
     }
+
+    /// Return the override patterns that are consulted last and typically originate from explicit user input.
+    pub fn overrides(&self) -> &IgnoreMatchGroup {
+        &self.overrides
+    }
+
+    /// Return the global ignore patterns, usually loaded from `core.excludesFile` and `$GIT_DIR/info/exclude`.
+    pub fn globals(&self) -> &IgnoreMatchGroup {
+        &self.globals
+    }
+
+    /// Return the per-directory ignore filename, typically `.gitignore`.
+    pub fn exclude_file_name_for_directories(&self) -> &BStr {
+        self.exclude_file_name_for_directories.as_ref()
+    }
+
+    /// Return where per-directory ignore files are loaded from.
+    pub fn source(&self) -> Source {
+        self.source
+    }
+
     /// The match groups from lowest priority to highest.
     pub(crate) fn match_groups(&self) -> [&IgnoreMatchGroup; 3] {
         [&self.globals, &self.stack, &self.overrides]

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -120,7 +120,7 @@ interrupt = ["dep:signal-hook", "gix-tempfile/signals", "dep:parking_lot"]
 index = ["dep:gix-index"]
 
 ## Support directory walks with Git-style annoations.
-dirwalk = ["dep:gix-dir", "attributes", "excludes"]
+dirwalk = ["dep:gix-dir", "gix-dir?/attributes", "attributes", "excludes"]
 
 ## Access to credential helpers, which provide credentials for URLs.
 # Note that `gix-negotiate` just piggibacks here, as 'credentials' is equivalent to 'fetch & push' right now.

--- a/gix/src/config/mod.rs
+++ b/gix/src/config/mod.rs
@@ -480,6 +480,12 @@ pub mod boolean {
 }
 
 ///
+pub mod untracked_cache {
+    /// The error produced when failing to parse `core.untrackedCache` from configuration.
+    pub type Error = super::key::GenericErrorWithValue;
+}
+
+///
 pub mod unsigned_integer {
     /// The error produced when failing to parse a signed integer from configuration.
     pub type Error = super::key::Error<gix_config::value::Error, 'k', 'u'>;

--- a/gix/src/config/tree/sections/core.rs
+++ b/gix/src/config/tree/sections/core.rs
@@ -57,6 +57,9 @@ impl Core {
     pub const SYMLINKS: keys::Boolean = keys::Boolean::new_boolean("symlinks", &config::Tree::CORE);
     /// The `core.trustCTime` key.
     pub const TRUST_C_TIME: keys::Boolean = keys::Boolean::new_boolean("trustCTime", &config::Tree::CORE);
+    /// The `core.untrackedCache` key.
+    pub const UNTRACKED_CACHE: UntrackedCache =
+        UntrackedCache::new_with_validate("untrackedCache", &config::Tree::CORE, validate::UntrackedCache);
     /// The `core.worktree` key.
     pub const WORKTREE: keys::Any = keys::Any::new("worktree", &config::Tree::CORE)
         .with_environment_override("GIT_WORK_TREE")
@@ -122,6 +125,7 @@ impl Section for Core {
             &Self::REPOSITORY_FORMAT_VERSION,
             &Self::SYMLINKS,
             &Self::TRUST_C_TIME,
+            &Self::UNTRACKED_CACHE,
             &Self::WORKTREE,
             &Self::PROTECT_HFS,
             &Self::PROTECT_NTFS,
@@ -154,6 +158,9 @@ pub type LogAllRefUpdates = keys::Any<validate::LogAllRefUpdates>;
 
 /// The `core.disambiguate` key.
 pub type Disambiguate = keys::Any<validate::Disambiguate>;
+
+/// The `core.untrackedCache` key.
+pub type UntrackedCache = keys::Any<validate::UntrackedCache>;
 
 #[cfg(feature = "attributes")]
 mod filter {
@@ -360,6 +367,33 @@ mod log_all_ref_updates {
     }
 }
 
+mod untracked_cache {
+    use crate::{config, config::tree::core::UntrackedCache};
+
+    impl UntrackedCache {
+        /// Returns `Some(true)` to use the untracked cache, `Some(false)` to disable it,
+        /// or `None` when the value is `keep` (preserve existing state) or absent.
+        ///
+        /// `value` is expected to be provided by [`gix_config::File::boolean()`].
+        pub fn try_into_untracked_cache(
+            &'static self,
+            value: Option<Result<bool, gix_config::value::Error>>,
+        ) -> Result<Option<bool>, config::key::GenericErrorWithValue> {
+            match value {
+                Some(Ok(b)) => Ok(Some(b)),
+                Some(Err(err)) => {
+                    if err.input.eq_ignore_ascii_case(b"keep") {
+                        Ok(None)
+                    } else {
+                        Err(config::key::GenericErrorWithValue::from_value(self, err.input))
+                    }
+                }
+                None => Ok(None),
+            }
+        }
+    }
+}
+
 mod check_stat {
     use std::borrow::Cow;
 
@@ -471,6 +505,16 @@ mod validate {
     impl keys::Validate for CheckStat {
         fn validate(&self, value: &BStr) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
             super::Core::CHECK_STAT.try_into_checkstat(value.into())?;
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct UntrackedCache;
+    impl keys::Validate for UntrackedCache {
+        fn validate(&self, value: &BStr) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+            super::Core::UNTRACKED_CACHE
+                .try_into_untracked_cache(Some(gix_config::Boolean::try_from(value).map(|b| b.0)))?;
             Ok(())
         }
     }

--- a/gix/src/dirwalk/mod.rs
+++ b/gix/src/dirwalk/mod.rs
@@ -4,7 +4,8 @@ use gix_dir::walk::{CollapsedEntriesEmissionMode, EmissionMode, ForDeletionMode}
 
 use crate::{AttributeStack, Pathspec, config};
 
-mod options;
+///
+pub mod options;
 
 ///
 pub mod iter;
@@ -71,6 +72,16 @@ pub struct Outcome<'repo> {
     pub dirwalk: gix_dir::walk::Outcome,
 }
 
+/// Control whether the untracked cache should be consulted during directory walks.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub enum UntrackedCache {
+    /// Consult the untracked cache when it is present and otherwise applicable.
+    #[default]
+    Use,
+    /// Ignore the untracked cache even if it is present.
+    Ignore,
+}
+
 /// Options for use in the [`Repository::dirwalk()`](crate::Repository::dirwalk()) function.
 ///
 /// Note that all values start out disabled.
@@ -89,5 +100,6 @@ pub struct Options {
     classify_untracked_bare_repositories: bool,
     emit_collapsed: Option<CollapsedEntriesEmissionMode>,
     symlinks_to_directories_are_ignored_like_directories: bool,
+    untracked_cache: UntrackedCache,
     pub(crate) empty_patterns_match_prefix: bool,
 }

--- a/gix/src/dirwalk/options.rs
+++ b/gix/src/dirwalk/options.rs
@@ -39,6 +39,7 @@ impl From<Options> for gix_dir::walk::Options<'static> {
             emit_collapsed: v.emit_collapsed,
             symlinks_to_directories_are_ignored_like_directories: v
                 .symlinks_to_directories_are_ignored_like_directories,
+            use_untracked_cache: false,
             worktree_relative_worktree_dirs: None,
         }
     }

--- a/gix/src/dirwalk/options.rs
+++ b/gix/src/dirwalk/options.rs
@@ -1,6 +1,16 @@
 use gix_dir::walk::{CollapsedEntriesEmissionMode, EmissionMode, ForDeletionMode};
 
-use crate::dirwalk::Options;
+use crate::dirwalk::{Options, UntrackedCache};
+
+/// The error returned by [`Repository::dirwalk_options()`](crate::Repository::dirwalk_options()).
+#[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
+pub enum Error {
+    #[error(transparent)]
+    UntrackedCache(#[from] crate::config::untracked_cache::Error),
+    #[error(transparent)]
+    FilesystemOptions(#[from] crate::config::boolean::Error),
+}
 
 /// Construction
 impl Options {
@@ -19,6 +29,7 @@ impl Options {
             emit_collapsed: None,
             empty_patterns_match_prefix: false,
             symlinks_to_directories_are_ignored_like_directories: false,
+            untracked_cache: UntrackedCache::Ignore,
         }
     }
 }
@@ -39,7 +50,7 @@ impl From<Options> for gix_dir::walk::Options<'static> {
             emit_collapsed: v.emit_collapsed,
             symlinks_to_directories_are_ignored_like_directories: v
                 .symlinks_to_directories_are_ignored_like_directories,
-            use_untracked_cache: false,
+            use_untracked_cache: v.untracked_cache == UntrackedCache::Use,
             worktree_relative_worktree_dirs: None,
         }
     }
@@ -184,6 +195,18 @@ impl Options {
     /// but only requires a mutably borrowed instance.
     pub fn set_symlinks_to_directories_are_ignored_like_directories(&mut self, toggle: bool) -> &mut Self {
         self.symlinks_to_directories_are_ignored_like_directories = toggle;
+        self
+    }
+
+    /// Control whether to consult the untracked cache if it is present and applicable.
+    pub fn untracked_cache(mut self, value: UntrackedCache) -> Self {
+        self.untracked_cache = value;
+        self
+    }
+
+    /// Like [`untracked_cache()`](Self::untracked_cache), but only requires a mutably borrowed instance.
+    pub fn set_untracked_cache(&mut self, value: UntrackedCache) -> &mut Self {
+        self.untracked_cache = value;
         self
     }
 }

--- a/gix/src/repository/dirwalk.rs
+++ b/gix/src/repository/dirwalk.rs
@@ -12,8 +12,21 @@ impl Repository {
     /// Return default options suitable for performing a directory walk on this repository.
     ///
     /// Used in conjunction with [`dirwalk()`](Self::dirwalk())
-    pub fn dirwalk_options(&self) -> Result<dirwalk::Options, config::boolean::Error> {
-        Ok(dirwalk::Options::from_fs_caps(self.filesystem_options()?))
+    pub fn dirwalk_options(&self) -> Result<dirwalk::Options, dirwalk::options::Error> {
+        let use_untracked_cache = self
+            .config
+            .apply_leniency(Some(config::tree::Core::UNTRACKED_CACHE.try_into_untracked_cache(
+                self.config.resolved.boolean(config::tree::Core::UNTRACKED_CACHE),
+            )))?
+            .flatten();
+        let fs_caps = self.filesystem_options()?;
+        Ok(
+            dirwalk::Options::from_fs_caps(fs_caps).untracked_cache(if use_untracked_cache.unwrap_or(false) {
+                dirwalk::UntrackedCache::Use
+            } else {
+                dirwalk::UntrackedCache::Ignore
+            }),
+        )
     }
 
     /// Perform a directory walk configured with `options` under control of the `delegate`. Use `patterns` to
@@ -59,6 +72,7 @@ impl Repository {
         let fs_caps = self.filesystem_options()?;
         let accelerate_lookup = fs_caps.ignore_case.then(|| index.prepare_icase_backing());
         let mut opts = gix_dir::walk::Options::from(options);
+        let has_pathspecs = pathspec.search.patterns().len() != 0;
         let worktree_relative_worktree_dirs_storage;
         if let Some(workdir) = self.workdir().filter(|_| opts.for_deletion.is_some()) {
             let linked_worktrees = self.worktrees()?;
@@ -100,7 +114,7 @@ impl Repository {
                 },
                 excludes: Some(&mut excludes.inner),
                 objects: &self.objects,
-                explicit_traversal_root: (!options.empty_patterns_match_prefix).then_some(workdir),
+                explicit_traversal_root: (!options.empty_patterns_match_prefix && has_pathspecs).then_some(workdir),
             },
             opts,
             delegate,

--- a/gix/src/status/mod.rs
+++ b/gix/src/status/mod.rs
@@ -68,7 +68,7 @@ impl Default for Submodule {
 #[allow(missing_docs)]
 pub enum Error {
     #[error(transparent)]
-    DirwalkOptions(#[from] config::boolean::Error),
+    DirwalkOptions(#[from] crate::dirwalk::options::Error),
     #[error(transparent)]
     ConfigureUntrackedFiles(#[from] config::key::GenericErrorWithValue),
 }

--- a/gix/tests/gix/repository/mod.rs
+++ b/gix/tests/gix/repository/mod.rs
@@ -80,9 +80,11 @@ mod index {
 
 #[cfg(feature = "dirwalk")]
 mod dirwalk {
-    use std::sync::atomic::AtomicBool;
+    use std::{process::Command, sync::atomic::AtomicBool};
 
+    use gix::config::tree::Core;
     use gix_dir::{entry::Kind::*, walk::EmissionMode};
+    use gix_testtools::tempfile;
 
     #[test]
     fn basics() -> crate::Result {
@@ -139,6 +141,135 @@ mod dirwalk {
             "just a minor sanity check, assuming everything else works as well"
         );
         Ok(())
+    }
+
+    #[test]
+    fn untracked_cache_keep_config_does_not_error() -> crate::Result {
+        let (_tmp, mut repo) = repo_with_untracked_cache()?;
+        // `core.untrackedCache=keep` is git's documented default and a valid tri-state
+        // value. Parsing it as a boolean returned an error, making `dirwalk_options()`
+        // fail on any repo with this setting.
+        repo.config_snapshot_mut()
+            .set_raw_value_by("core", None, "untrackedCache", "keep")?;
+        let opts = repo.dirwalk_options();
+        assert!(
+            opts.is_ok(),
+            "core.untrackedCache=keep must not cause a parse error, got: {:?}",
+            opts.err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    // On Windows, NTFS flushes directory metadata asynchronously. Directories modified
+    // very recently can report slightly different `LastWriteTime` values depending on
+    // when the stat is read, causing the IOUC stat check to fail unpredictably.
+    #[cfg_attr(windows, ignore)]
+    fn untracked_cache_respects_config_and_allows_overrides() -> crate::Result {
+        let (_tmp, mut repo) = repo_with_untracked_cache()?;
+        let index = repo.index()?;
+
+        repo.config_snapshot_mut().set_value(&Core::UNTRACKED_CACHE, "true")?;
+        let out = run_dirwalk(
+            &repo,
+            &index,
+            repo.dirwalk_options()?.emit_untracked(EmissionMode::CollapseDirectory),
+        )?;
+        assert_eq!(
+            out.dirwalk.read_dir_calls, 0,
+            "core.untrackedCache=true should enable the fast path"
+        );
+
+        let out = run_dirwalk(
+            &repo,
+            &index,
+            repo.dirwalk_options()?
+                .emit_untracked(EmissionMode::CollapseDirectory)
+                .untracked_cache(gix::dirwalk::UntrackedCache::Ignore),
+        )?;
+        assert_ne!(
+            out.dirwalk.read_dir_calls, 0,
+            "callers can explicitly disable the untracked cache"
+        );
+
+        repo.config_snapshot_mut().set_value(&Core::UNTRACKED_CACHE, "false")?;
+        let out = run_dirwalk(
+            &repo,
+            &index,
+            repo.dirwalk_options()?.emit_untracked(EmissionMode::CollapseDirectory),
+        )?;
+        assert_ne!(
+            out.dirwalk.read_dir_calls, 0,
+            "core.untrackedCache=false should disable the fast path"
+        );
+
+        let out = run_dirwalk(
+            &repo,
+            &index,
+            repo.dirwalk_options()?
+                .emit_untracked(EmissionMode::CollapseDirectory)
+                .untracked_cache(gix::dirwalk::UntrackedCache::Use),
+        )?;
+        assert_eq!(
+            out.dirwalk.read_dir_calls, 0,
+            "callers can override config to force use of the untracked cache"
+        );
+        Ok(())
+    }
+
+    fn repo_with_untracked_cache() -> crate::Result<(tempfile::TempDir, gix::Repository)> {
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path().join("repo");
+        std::fs::create_dir(&root)?;
+        git(&root, ["init"])?;
+        git(&root, ["config", "status.showUntrackedFiles", "all"])?;
+        git(&root, ["config", "user.name", "a"])?;
+        git(&root, ["config", "user.email", "a@example.com"])?;
+        git(&root, ["config", "core.untrackedCache", "true"])?;
+        // Pin a local excludesFile so git and gix (isolated mode, reads local config) agree on
+        // which global-excludes file was used when the UNTR cache was written. Without this,
+        // users with a core.excludesFile in their ~/.gitconfig would have it written into the
+        // cache, but gix (isolated) wouldn't know about it, causing cache validation to fail.
+        let excludes = root.join("global-excludes");
+        std::fs::write(&excludes, "")?;
+        git(
+            &root,
+            [
+                std::ffi::OsStr::new("config"),
+                std::ffi::OsStr::new("core.excludesFile"),
+                excludes.as_os_str(),
+            ],
+        )?;
+        std::fs::create_dir(root.join("tracked"))?;
+        std::fs::write(root.join("tracked/keep"), "keep")?;
+        git(&root, ["add", "tracked/keep"])?;
+        git(&root, ["commit", "-m", "init"])?;
+        std::fs::create_dir_all(root.join("tracked/new"))?;
+        std::fs::create_dir_all(root.join("new"))?;
+        std::fs::write(root.join("tracked/new/file"), "tracked-new")?;
+        std::fs::write(root.join("new/file"), "new")?;
+        git(&root, ["update-index", "--force-untracked-cache"])?;
+        git(&root, ["status", "--porcelain"])?;
+        // Run status a second time so git validates the recorded directory stats and sets
+        // the valid bitmap in the IOUC. Some git versions only populate the structure on
+        // the first run and mark entries valid on the second.
+        git(&root, ["status", "--porcelain"])?;
+        Ok((tmp, gix::open_opts(&root, gix::open::Options::isolated())?))
+    }
+
+    fn git(cwd: &std::path::Path, args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>) -> crate::Result {
+        let status = Command::new("git").args(args).current_dir(cwd).status()?;
+        assert!(status.success());
+        Ok(())
+    }
+
+    fn run_dirwalk<'repo>(
+        repo: &'repo gix::Repository,
+        index: &gix::worktree::Index,
+        options: gix::dirwalk::Options,
+    ) -> crate::Result<gix::dirwalk::Outcome<'repo>> {
+        let mut collect = gix::dir::walk::delegate::Collect::default();
+        Ok(repo.dirwalk(index, None::<&str>, &AtomicBool::default(), options, &mut collect)?)
     }
 }
 

--- a/src/plumbing/progress.rs
+++ b/src/plumbing/progress.rs
@@ -122,7 +122,7 @@ static GIT_CONFIG: &[Record] = &[
     },
     Record {
         config: "core.untrackedCache",
-        usage: Planned("Needed for fast worktree operation"),
+        usage: InUse("Consulted for repository dirwalk defaults, with API overrides available"),
     },
     Record {
         config: "checkout.guess",


### PR DESCRIPTION
When `core.untrackedCache` is true, `gix-dir` now consults the index `UNTR` extension before opening each directory. Directories whose stat and exclude-file OID still match the cache are served from memory, avoiding `read_dir` syscalls for unchanged trees.

~As part of verifying the change, I discovered ctime/mtime decoding was incorrect. The stat decoder assigned `ctime_secs/nsecs` to the `mtime` field and vice versa. The binary format stores ctime first then mtime; correcting the swap fixes IOUC stat comparisons for directories where ctime ≠ mtime.~ Landed separately

--- 

Per CONTRIBUTING.md, disclosing (heavy) AI use in these changes (and have done so in the commit trailers). I went through a number of iterations and have manually tested that things "seem to work on my machine" (installing gix locally and using gix status / playing around with --statistics and adding untracked files and making sure they reflect with minimal directory crawling), but acknowledging I have large gaps in my understanding of this codebase and also git's. 

Thanks in advance if you spend the time to review this. I'm very happy to take feedback and fix things up. 