### PR TITLE
upgrade getrandom to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,10 +1299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1659,7 +1661,7 @@ dependencies = [
  "bstr",
  "criterion",
  "document-features",
- "getrandom 0.2.17",
+ "getrandom 0.4.2",
  "gix-attributes",
  "gix-command",
  "gix-filter",

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -65,7 +65,7 @@ thiserror = "2.0.18"
 imara-diff = { version = "0.1.8", optional = true }
 imara-diff-v2 = { version = "0.2.0", optional = true, package = "imara-diff" }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
-getrandom = { version = "0.2.17", optional = true, default-features = false, features = ["js"] }
+getrandom = { version = "0.4", optional = true, default-features = false, features = ["wasm_js"] }
 bstr = { version = "1.12.0", default-features = false }
 
 document-features = { version = "0.2.0", optional = true }


### PR DESCRIPTION
from: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/gix-diff/debian/patches/getrandom-0.4.patch?ref_type=heads