### PR TITLE
fix: make `gix-sec` identity check on Windows similar to Git for Windows

### DIFF
--- a/gitoxide-core/src/lib.rs
+++ b/gitoxide-core/src/lib.rs
@@ -84,6 +84,16 @@ pub mod repository;
 mod discover;
 pub use discover::discover;
 
+pub fn trust(paths: &[std::path::PathBuf], mut out: impl std::io::Write) -> anyhow::Result<()> {
+    let trust_width = "Reduced".len();
+    for path in paths {
+        let trust = gix::sec::Trust::from_path_ownership(path)?;
+        let trust = format!("{trust:?}");
+        writeln!(out, "{trust:<trust_width$} {}", path.display())?;
+    }
+    Ok(())
+}
+
 pub fn env(mut out: impl std::io::Write, format: OutputFormat) -> anyhow::Result<()> {
     if format != OutputFormat::Human {
         bail!("JSON output isn't supported");

--- a/gix-sec/src/identity.rs
+++ b/gix-sec/src/identity.rs
@@ -63,9 +63,9 @@ mod impl_ {
 #[cfg(windows)]
 mod impl_ {
     use std::{
-        io,
+        io, mem,
         mem::MaybeUninit,
-        os::windows::io::{FromRawHandle as _, OwnedHandle},
+        os::windows::io::{AsRawHandle as _, FromRawHandle as _, OwnedHandle},
         path::Path,
         ptr,
     };
@@ -80,14 +80,46 @@ mod impl_ {
         }};
     }
 
+    fn token_information(token: windows_sys::Win32::Foundation::HANDLE, class: i32) -> io::Result<Vec<u8>> {
+        use windows_sys::Win32::{
+            Foundation::{GetLastError, ERROR_INSUFFICIENT_BUFFER},
+            Security::GetTokenInformation,
+        };
+
+        #[allow(unsafe_code)]
+        unsafe {
+            let mut buffer_size = 36;
+            let mut heap_buf = vec![0; 36];
+
+            loop {
+                if GetTokenInformation(
+                    token,
+                    class,
+                    heap_buf.as_mut_ptr().cast(),
+                    heap_buf.len() as _,
+                    &mut buffer_size,
+                ) != 0
+                {
+                    return Ok(heap_buf);
+                }
+
+                if GetLastError() != ERROR_INSUFFICIENT_BUFFER {
+                    error!("Couldn't acquire token information");
+                }
+
+                heap_buf.resize(buffer_size as _, 0);
+            }
+        }
+    }
+
     pub fn is_path_owned_by_current_user(path: &Path) -> io::Result<bool> {
         use windows_sys::Win32::{
-            Foundation::{GetLastError, LocalFree, ERROR_INSUFFICIENT_BUFFER, ERROR_INVALID_FUNCTION, ERROR_SUCCESS},
+            Foundation::{LocalFree, ERROR_INVALID_FUNCTION, ERROR_SUCCESS},
             Security::{
                 Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT},
-                CheckTokenMembership, EqualSid, GetTokenInformation, IsWellKnownSid, TokenOwner,
-                WinBuiltinAdministratorsSid, OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, TOKEN_OWNER,
-                TOKEN_QUERY,
+                CheckTokenMembership, EqualSid, IsWellKnownSid, TokenElevationType, TokenElevationTypeLimited,
+                TokenLinkedToken, TokenUser, WinBuiltinAdministratorsSid, OWNER_SECURITY_INFORMATION,
+                PSECURITY_DESCRIPTOR, TOKEN_ELEVATION_TYPE, TOKEN_LINKED_TOKEN, TOKEN_QUERY, TOKEN_USER,
             },
             System::Threading::{GetCurrentProcess, GetCurrentThread, OpenProcessToken, OpenThreadToken},
         };
@@ -169,46 +201,48 @@ mod impl_ {
 
             let _owned_token = OwnedHandle::from_raw_handle(token as _);
 
-            let buf = 'token_buf: {
-                let mut buffer_size = 36;
-                let mut heap_buf = vec![0; 36];
+            let user_info = token_information(token, TokenUser)?;
+            let token_user = (*user_info.as_ptr().cast::<TOKEN_USER>()).User.Sid;
 
-                loop {
-                    if GetTokenInformation(
-                        token,
-                        TokenOwner,
-                        heap_buf.as_mut_ptr().cast(),
-                        heap_buf.len() as _,
-                        &mut buffer_size,
-                    ) != 0
-                    {
-                        break 'token_buf heap_buf;
-                    }
-
-                    if GetLastError() != ERROR_INSUFFICIENT_BUFFER {
-                        error!("Couldn't acquire token ownership");
-                    }
-
-                    heap_buf.resize(buffer_size as _, 0);
-                }
-            };
-
-            let token_owner = (*buf.as_ptr().cast::<TOKEN_OWNER>()).Owner;
-
-            // If the current user is the owner of the parent folder then they also
-            // own this file
-            if EqualSid(folder_owner, token_owner) != 0 {
+            if EqualSid(folder_owner, token_user) != 0 {
                 return Ok(true);
             }
 
-            // Admin-group owned folders are considered owned by the current user, if they are in the admin group
-            if IsWellKnownSid(token_owner, WinBuiltinAdministratorsSid) == 0 {
+            // Admin-group owned folders are considered owned by the current user, if they are in the admin group.
+            if IsWellKnownSid(folder_owner, WinBuiltinAdministratorsSid) == 0 {
                 return Ok(false);
             }
 
             let mut is_member = 0;
-            if CheckTokenMembership(std::ptr::null_mut(), token_owner, &mut is_member) == 0 {
+            if CheckTokenMembership(std::ptr::null_mut(), folder_owner, &mut is_member) == 0 {
                 error!("Couldn't check if user is an administrator");
+            }
+
+            if is_member != 0 {
+                return Ok(true);
+            }
+
+            let mut elevation_type = TokenElevationTypeLimited;
+            let mut elevation_type_size = 0;
+            if windows_sys::Win32::Security::GetTokenInformation(
+                token,
+                TokenElevationType,
+                (&mut elevation_type as *mut TOKEN_ELEVATION_TYPE).cast(),
+                mem::size_of::<TOKEN_ELEVATION_TYPE>() as u32,
+                &mut elevation_type_size,
+            ) == 0
+                || elevation_type != TokenElevationTypeLimited
+            {
+                return Ok(false);
+            }
+
+            let linked_token_info = token_information(token, TokenLinkedToken)?;
+            let linked_token = (*linked_token_info.as_ptr().cast::<TOKEN_LINKED_TOKEN>()).LinkedToken;
+            let linked_token = OwnedHandle::from_raw_handle(linked_token as _);
+
+            let mut is_member = 0;
+            if CheckTokenMembership(linked_token.as_raw_handle() as _, folder_owner, &mut is_member) == 0 {
+                error!("Couldn't check if elevated user is an administrator");
             }
 
             Ok(is_member != 0)

--- a/gix-sec/src/identity.rs
+++ b/gix-sec/src/identity.rs
@@ -76,11 +76,17 @@ mod impl_ {
             error!(inner, $msg);
         }};
         ($inner:expr, $msg:expr) => {{
-            return Err(io::Error::new($inner.kind(), $msg));
+            return Err(io::Error::new($inner.kind(), format!("{}: {}", $msg, $inner)));
         }};
     }
 
-    fn token_information(token: windows_sys::Win32::Foundation::HANDLE, class: i32) -> io::Result<Vec<u8>> {
+    fn token_information(
+        token: windows_sys::Win32::Foundation::HANDLE,
+        class: i32,
+        class_name: &'static str,
+        subject: &'static str,
+        path: &Path,
+    ) -> io::Result<Vec<u8>> {
         use windows_sys::Win32::{
             Foundation::{GetLastError, ERROR_INSUFFICIENT_BUFFER},
             Security::GetTokenInformation,
@@ -104,7 +110,10 @@ mod impl_ {
                 }
 
                 if GetLastError() != ERROR_INSUFFICIENT_BUFFER {
-                    error!("Couldn't acquire token information");
+                    error!(format!(
+                        "Couldn't acquire {class_name} for the {subject} while checking ownership of '{}'",
+                        path.display()
+                    ));
                 }
 
                 heap_buf.resize(buffer_size as _, 0);
@@ -163,10 +172,7 @@ mod impl_ {
                     let inner = io::Error::from_raw_os_error(result as _);
                     error!(
                         inner,
-                        format!(
-                            "Couldn't get security information for path '{}' with err {inner}",
-                            path.display()
-                        )
+                        format!("Couldn't get security information for path '{}'", path.display())
                     );
                 }
 
@@ -194,14 +200,17 @@ mod impl_ {
                 if OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, 1, token.as_mut_ptr()) == 0
                     && OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, token.as_mut_ptr()) == 0
                 {
-                    error!("Couldn't acquire thread or process token");
+                    error!(format!(
+                        "Couldn't acquire a thread or process token while checking ownership of '{}'",
+                        path.display()
+                    ));
                 }
                 token.assume_init()
             };
 
             let _owned_token = OwnedHandle::from_raw_handle(token as _);
 
-            let user_info = token_information(token, TokenUser)?;
+            let user_info = token_information(token, TokenUser, "TokenUser", "current token", path)?;
             let token_user = (*user_info.as_ptr().cast::<TOKEN_USER>()).User.Sid;
 
             if EqualSid(folder_owner, token_user) != 0 {
@@ -215,7 +224,10 @@ mod impl_ {
 
             let mut is_member = 0;
             if CheckTokenMembership(std::ptr::null_mut(), folder_owner, &mut is_member) == 0 {
-                error!("Couldn't check if user is an administrator");
+                error!(format!(
+                    "Couldn't check whether the current token is in the Administrators group while checking ownership of '{}'",
+                    path.display()
+                ));
             }
 
             if is_member != 0 {
@@ -236,13 +248,22 @@ mod impl_ {
                 return Ok(false);
             }
 
-            let linked_token_info = token_information(token, TokenLinkedToken)?;
+            let linked_token_info = token_information(
+                token,
+                TokenLinkedToken,
+                "TokenLinkedToken",
+                "limited current token",
+                path,
+            )?;
             let linked_token = (*linked_token_info.as_ptr().cast::<TOKEN_LINKED_TOKEN>()).LinkedToken;
             let linked_token = OwnedHandle::from_raw_handle(linked_token as _);
 
             let mut is_member = 0;
             if CheckTokenMembership(linked_token.as_raw_handle() as _, folder_owner, &mut is_member) == 0 {
-                error!("Couldn't check if elevated user is an administrator");
+                error!(format!(
+                    "Couldn't check whether the linked elevated token is in the Administrators group while checking ownership of '{}'",
+                    path.display()
+                ));
             }
 
             Ok(is_member != 0)

--- a/gix-sec/src/identity.rs
+++ b/gix-sec/src/identity.rs
@@ -210,8 +210,9 @@ mod impl_ {
 
             let _owned_token = OwnedHandle::from_raw_handle(token as _);
 
-            let user_info = token_information(token, TokenUser, "TokenUser", "current token", path)?;
-            let token_user = (*user_info.as_ptr().cast::<TOKEN_USER>()).User.Sid;
+            let user_info_buf = token_information(token, TokenUser, "TokenUser", "current token", path)?;
+            let token_user_info = ptr::read_unaligned(user_info_buf.as_ptr().cast::<TOKEN_USER>());
+            let token_user = token_user_info.User.Sid;
 
             if EqualSid(folder_owner, token_user) != 0 {
                 return Ok(true);
@@ -255,7 +256,8 @@ mod impl_ {
                 "limited current token",
                 path,
             )?;
-            let linked_token = (*linked_token_info.as_ptr().cast::<TOKEN_LINKED_TOKEN>()).LinkedToken;
+            let linked_token_info = ptr::read_unaligned(linked_token_info.as_ptr().cast::<TOKEN_LINKED_TOKEN>());
+            let linked_token = linked_token_info.LinkedToken;
             let linked_token = OwnedHandle::from_raw_handle(linked_token as _);
 
             let mut is_member = 0;

--- a/gix-sec/src/identity.rs
+++ b/gix-sec/src/identity.rs
@@ -121,6 +121,40 @@ mod impl_ {
         }
     }
 
+    /// Read a fixed-size token information record of type `T` with `GetTokenInformation`.
+    ///
+    /// Use this for token information classes whose result fits exactly into `T`, unlike
+    /// [`sized_token_information`] which resizes a buffer dynamically.
+    fn fixed_size_token_information<T: Copy>(
+        token: windows_sys::Win32::Foundation::HANDLE,
+        class: i32,
+        class_name: &'static str,
+        subject: &'static str,
+        path: &Path,
+    ) -> io::Result<T> {
+        use windows_sys::Win32::Security::GetTokenInformation;
+
+        #[allow(unsafe_code)]
+        unsafe {
+            let mut info = MaybeUninit::<T>::uninit();
+            let mut returned_size = 0;
+            if GetTokenInformation(
+                token,
+                class,
+                info.as_mut_ptr().cast(),
+                mem::size_of::<T>() as u32,
+                &mut returned_size,
+            ) == 0
+            {
+                error!(format!(
+                    "Couldn't acquire {class_name} for the {subject} while checking ownership of '{}'",
+                    path.display()
+                ));
+            }
+            Ok(info.assume_init())
+        }
+    }
+
     pub fn is_path_owned_by_current_user(path: &Path) -> io::Result<bool> {
         use windows_sys::Win32::{
             Foundation::{LocalFree, ERROR_INVALID_FUNCTION, ERROR_SUCCESS},
@@ -235,28 +269,24 @@ mod impl_ {
                 return Ok(true);
             }
 
-            let mut elevation_type = TokenElevationTypeLimited;
-            let mut elevation_type_size = 0;
-            if windows_sys::Win32::Security::GetTokenInformation(
+            let elevation_type = fixed_size_token_information::<TOKEN_ELEVATION_TYPE>(
                 token,
                 TokenElevationType,
-                (&mut elevation_type as *mut TOKEN_ELEVATION_TYPE).cast(),
-                mem::size_of::<TOKEN_ELEVATION_TYPE>() as u32,
-                &mut elevation_type_size,
-            ) == 0
-                || elevation_type != TokenElevationTypeLimited
-            {
+                "TokenElevationType",
+                "current token",
+                path,
+            )?;
+            if elevation_type != TokenElevationTypeLimited {
                 return Ok(false);
             }
 
-            let linked_token_info = token_information(
+            let linked_token_info = fixed_size_token_information::<TOKEN_LINKED_TOKEN>(
                 token,
                 TokenLinkedToken,
                 "TokenLinkedToken",
                 "limited current token",
                 path,
             )?;
-            let linked_token_info = ptr::read_unaligned(linked_token_info.as_ptr().cast::<TOKEN_LINKED_TOKEN>());
             let linked_token = linked_token_info.LinkedToken;
             let linked_token = OwnedHandle::from_raw_handle(linked_token as _);
 

--- a/gix-sec/src/identity.rs
+++ b/gix-sec/src/identity.rs
@@ -123,8 +123,7 @@ mod impl_ {
 
     /// Read a fixed-size token information record of type `T` with `GetTokenInformation`.
     ///
-    /// Use this for token information classes whose result fits exactly into `T`, unlike
-    /// [`sized_token_information`] which resizes a buffer dynamically.
+    /// Use this for token information classes whose result fits exactly into `T`.
     fn fixed_size_token_information<T: Copy>(
         token: windows_sys::Win32::Foundation::HANDLE,
         class: i32,

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -758,6 +758,15 @@ pub fn main() -> Result<()> {
                 None,
                 move |_progress, out, _err| core::discover(&repository_path, out),
             ),
+            free::Subcommands::Trust { paths } => prepare_and_run(
+                "trust",
+                trace,
+                verbose,
+                progress,
+                progress_keep_open,
+                None,
+                move |_progress, out, _err| core::trust(&paths, out),
+            ),
             free::Subcommands::CommitGraph(cmd) => match cmd {
                 free::commitgraph::Subcommands::Verify { path, statistics } => prepare_and_run(
                     "commitgraph-verify",

--- a/src/plumbing/options/free.rs
+++ b/src/plumbing/options/free.rs
@@ -16,6 +16,12 @@ pub enum Subcommands {
     Index(index::Platform),
     /// Show information about repository discovery and when opening a repository at the current path.
     Discover,
+    /// Show the trust level implied by the ownership of one or more paths.
+    Trust {
+        /// The paths whose ownership-derived trust should be shown.
+        #[clap(required = true)]
+        paths: Vec<std::path::PathBuf>,
+    },
 }
 
 ///


### PR DESCRIPTION
Related to https://github.com/gitbutlerapp/gitbutler/issues/13278 and based Codex analysis.

### Tasks

* [x] refackview
* [x] get Eliah's review -> hard failure
* [x] re-review by Eliah -> hard failure, but better error message
    - Also I (re?-)gained the shared understanding that this is too broken to ship as UAC is common
* [x] reproduce on VM and fix it

----

`gix-sec` is not doing the same Windows ownership check as Git.

**Comparison**
- `gix-sec` reads the path owner SID with `GetNamedSecurityInfoW(...)`, but then compares it to the token’s `TokenOwner` SID, not the current user SID. See [identity.rs](/Users/byron/dev/github.com/GitoxideLabs/gitoxide.gix-error/gix-sec/src/identity.rs:83), especially lines 177-214.
- Upstream Git reads the path owner SID, then compares it to the process `TokenUser` SID. See [compat/mingw.c](/Users/byron/dev/github.com/git/git/compat/mingw.c:3219). In your local upstream checkout, `get_current_user_sid()` uses `TokenUser`, and there is also a `TokenLinkedToken` fallback for limited admin tokens at [compat/mingw.c](/Users/byron/dev/github.com/git/git/compat/mingw.c:3145).
- Git for Windows `windows/main` still uses `TokenUser`, not `TokenOwner`; it just dropped the linked-token fallback. I compared `windows/main:compat/mingw.c`, and the ownership function there is still fundamentally Git’s model, not `gix-sec`’s.

There are two concrete bugs in `gix-sec`’s Windows path:
- It compares `folder_owner` against `token_owner`, where Git compares `path owner` against `current user`.
- Its Administrators exception checks `IsWellKnownSid(token_owner, WinBuiltinAdministratorsSid)`, but Git checks whether the **path owner SID** is `WinBuiltinAdministratorsSid`.

That second one matters a lot: if the repository is owned by `BUILTIN\\Administrators`, Git will accept it for an admin user, but `gix-sec` only accepts it if the token’s default owner SID also happens to be `Administrators`.

**Why Issue 13278 behaves differently**
- In `gix`, repo-local config is filtered by trust: [config/mod.rs](/Users/byron/dev/github.com/GitoxideLabs/gitoxide.gix-error/gix/src/config/mod.rs:48) and [repository/config/mod.rs](/Users/byron/dev/github.com/GitoxideLabs/gitoxide.gix-error/gix/src/repository/config/mod.rs:157).
- If the repo stays at reduced trust, `[remote "origin"]` from `.git/config` is ignored, which explains “The remote named `origin` did not exist”.
- Git instead decides repo safety at the repository level in [setup.c](/Users/byron/dev/github.com/git/git/setup.c:1413), and for this case its ownership logic likely passed, so `git push` could still read `origin`.

So the likely explanation for issue `#13278` is:
- Git and `gix` disagreed on whether the repo or `.git/config` was “owned by the current user”.
- The disagreement comes from `gix-sec` using `TokenOwner` and checking the Administrators exemption against the wrong SID.
- Once `gix` marked the repo config untrusted, it filtered out the remote section, which surfaced as “origin did not exist”.

The issue comment you referenced matches that diagnosis: <https://github.com/gitbutlerapp/gitbutler/issues/13278#issuecomment-4231545470>

If you want, I can turn this into a minimal patch for `gix-sec` that matches Git’s Windows logic more closely.
