### PR TITLE
Implement `TokenSource` for `BStr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,6 +1922,7 @@ dependencies = [
 name = "gix-imara-diff"
 version = "0.2.0"
 dependencies = [
+ "bstr",
  "cov-mark",
  "expect-test",
  "hashbrown 0.16.1",

--- a/gix-diff/tests/diff/blob/v2.rs
+++ b/gix-diff/tests/diff/blob/v2.rs
@@ -1,5 +1,6 @@
 //! We can consider to move some of these tests to the actual imara-diff test-suite as well.
 use gix_diff::blob::{diff_with_slider_heuristics, v2};
+use gix_object::bstr::BStr;
 
 /// Test that the UnifiedDiffPrinter can be used with the v0.2 API
 #[test]
@@ -21,6 +22,39 @@ fn unified_diff_printer_usage() -> crate::Result {
     let diff = diff_with_slider_heuristics(v2::Algorithm::Histogram, &input);
 
     let printer = v2::BasicLineDiffPrinter(&input.interner);
+    insta::assert_snapshot!(util::unidiff(&diff, &input, &printer), @r#"
+    @@ -2,1 +2,1 @@
+    -    let x = 1;
+    +    let x = 2;
+    @@ -4,0 +4,1 @@
+    +    println!("done");
+    "#);
+    Ok(())
+}
+
+/// Test that the `UnifiedDiffPrinter` can be used with `BStr` and the v0.2 API
+#[test]
+fn unified_diff_with_bstr_printer_usage() -> crate::Result {
+    let before: &BStr = r#"fn foo() {
+    let x = 1;
+    println!("x = {}", x);
+}
+"#
+    .into();
+
+    let after: &BStr = r#"fn foo() {
+    let x = 2;
+    println!("x = {}", x);
+    println!("done");
+}
+"#
+    .into();
+
+    let input = v2::InternedInput::new(before, after);
+    let diff = diff_with_slider_heuristics(v2::Algorithm::Histogram, &input);
+
+    let printer = v2::BasicLineDiffPrinter(&input.interner);
+
     insta::assert_snapshot!(util::unidiff(&diff, &input, &printer), @r#"
     @@ -2,1 +2,1 @@
     -    let x = 1;
@@ -265,13 +299,16 @@ fn indent_heuristic_available() -> crate::Result {
 }
 
 mod util {
+    use std::fmt::Display;
+    use std::hash::Hash;
+
     use gix_diff::blob::v2;
 
-    pub fn unidiff<'a>(
+    pub fn unidiff<'a, T: AsRef<[u8]> + ?Sized + Hash + Eq + Display>(
         diff: &'a v2::Diff,
-        input: &'a v2::InternedInput<&str>,
-        printer: &'a v2::BasicLineDiffPrinter<'_, str>,
-    ) -> v2::UnifiedDiff<'a, v2::BasicLineDiffPrinter<'a, str>> {
+        input: &'a v2::InternedInput<&T>,
+        printer: &'a v2::BasicLineDiffPrinter<'_, T>,
+    ) -> v2::UnifiedDiff<'a, v2::BasicLineDiffPrinter<'a, T>> {
         let mut config = v2::UnifiedDiffConfig::default();
         config.context_len(0);
         diff.unified_diff(printer, config, input)

--- a/gix-imara-diff/Cargo.toml
+++ b/gix-imara-diff/Cargo.toml
@@ -17,6 +17,7 @@ exclude = [
 ]
 
 [dependencies]
+bstr = { version = "1.12.0", default-features = false }
 hashbrown = { version = ">=0.15,<=0.16", default-features = false, features = ["default-hasher", "inline-more"] }
 memchr = "2.7.4"
 

--- a/gix-imara-diff/src/sources.rs
+++ b/gix-imara-diff/src/sources.rs
@@ -29,6 +29,14 @@ pub fn words(data: &str) -> Words<'_> {
 /// separator (`\r\n` or `\n`) is included in the emitted tokens. This means that changing
 /// the newline separator from `\r\n` to `\n` (or omitting it fully on the last line) is
 /// detected when computing a [`Diff`](crate::Diff).
+pub fn bstr_lines(data: &bstr::BStr) -> BStrLines<'_> {
+    BStrLines(data)
+}
+
+/// Returns a [`TokenSource`] that uses the lines in `data` as Tokens. The newline
+/// separator (`\r\n` or `\n`) is included in the emitted tokens. This means that changing
+/// the newline separator from `\r\n` to `\n` (or omitting it fully on the last line) is
+/// detected when computing a [`Diff`](crate::Diff).
 pub fn byte_lines(data: &[u8]) -> ByteLines<'_> {
     ByteLines(data)
 }
@@ -45,6 +53,21 @@ impl<'a> TokenSource for &'a str {
 
     fn estimate_tokens(&self) -> u32 {
         lines(self).estimate_tokens()
+    }
+}
+
+/// By default, a line diff is produced for a string
+impl<'a> TokenSource for &'a bstr::BStr {
+    type Token = Self;
+
+    type Tokenizer = BStrLines<'a>;
+
+    fn tokenize(&self) -> Self::Tokenizer {
+        bstr_lines(self)
+    }
+
+    fn estimate_tokens(&self) -> u32 {
+        bstr_lines(self).estimate_tokens()
     }
 }
 
@@ -136,6 +159,43 @@ impl<'a> TokenSource for Words<'a> {
 
     fn estimate_tokens(&self) -> u32 {
         (self.0.len() / 3) as u32
+    }
+}
+
+/// A [`TokenSource`] that returns the lines of a `BStr` as tokens. See [`bstr_lines`] for details.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct BStrLines<'a>(&'a bstr::BStr);
+
+impl<'a> Iterator for BStrLines<'a> {
+    type Item = &'a bstr::BStr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0.is_empty() {
+            return None;
+        }
+        let line_len = memchr(b'\n', self.0).map_or(self.0.len(), |len| len + 1);
+        let (line, rem) = self.0.split_at(line_len);
+        self.0 = rem.into();
+        Some(line.into())
+    }
+}
+
+impl<'a> TokenSource for BStrLines<'a> {
+    type Token = &'a bstr::BStr;
+
+    type Tokenizer = Self;
+
+    fn tokenize(&self) -> Self::Tokenizer {
+        *self
+    }
+
+    fn estimate_tokens(&self) -> u32 {
+        let len: usize = self.take(20).map(|line| line.len()).sum();
+        if len == 0 {
+            100
+        } else {
+            (self.0.len() * 20 / len) as u32
+        }
     }
 }
 


### PR DESCRIPTION
This PR implements `TokenSource` for `BStr`. This makes the following code work:

```rust
let before: &BStr = "...";
let after: &BStr = "...";

let input = v2::InternedInput::new(before, after);
let printer = v2::BasicLineDiffPrinter(&input.interner);
```