### PR TITLE
various improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 version = "0.52.0"
 rust-version = "1.82"
 default-run = "gix"
-include = ["src/**/*", "/build.rs", "LICENSE-*", "README.md"]
+include = ["/src/**/*", "/build.rs", "/LICENSE-*", "/README.md"]
 resolver = "2"
 
 [[bin]]

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.55.0"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -9,7 +9,7 @@ description = "archive generation from of a worktree stream"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing .gitattributes files"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-bitmap/Cargo.toml
+++ b/gix-bitmap/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project dedicated implementing the standa
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-exclude = ["CHANGELOG.md"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = true

--- a/gix-blame/Cargo.toml
+++ b/gix-blame/Cargo.toml
@@ -9,6 +9,7 @@ description = "A crate of the gitoxide project dedicated to implementing a 'blam
 authors = ["Christoph Rüßler <christoph.ruessler@mailbox.org>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
+include = ["/src/**/*", "/LICENSE-*"]
 
 [features]
 ## Enable support for the SHA-1 hash by forwarding the feature to dependencies.

--- a/gix-chunk/Cargo.toml
+++ b/gix-chunk/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/GitoxideLabs/gitoxide"
 documentation = "https://github.com/git/git/blob/seen/Documentation/technical/chunk-format.txt"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-command/Cargo.toml
+++ b/gix-command/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project handling internal git command exe
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/lib.rs", "LICENSE-*"]
+include = ["/src/lib.rs", "/LICENSE-*"]
 
 [lib]
 doctest = true

--- a/gix-commitgraph/Cargo.toml
+++ b/gix-commitgraph/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 description = "Read-only access to the git commitgraph file format"
 authors = ["Conor Davis <gitoxide@conor.fastmail.fm>", "Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-config-value/Cargo.toml
+++ b/gix-config-value/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project providing git-config value parsin
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = true

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Edward Shen <code@eddie.sh>"]
 edition = "2021"
 keywords = ["git-config", "git", "config", "gitoxide"]
 categories = ["config", "parser-implementations"]
-include = ["src/**/*", "LICENSE-*", "README.md"]
+include = ["/src/**/*", "/LICENSE-*", "/README.md"]
 rust-version = "1.82"
 autotests = false
 

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project to interact with git credentials 
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project parsing dates the way git does"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "Calculate differences between various git objects"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 autotests = false
 

--- a/gix-dir/Cargo.toml
+++ b/gix-dir/Cargo.toml
@@ -9,6 +9,7 @@ description = "A crate of the gitoxide project dealing with directory walks"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-discover/Cargo.toml
+++ b/gix-discover/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "Discover git repositories and check if a directory is a git repository"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-error/Cargo.toml
+++ b/gix-error/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project to provide common errors and error-handling utilities"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [features]
@@ -41,4 +41,3 @@ insta = "1.46.3"
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-

--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-fetchhead/Cargo.toml
+++ b/gix-fetchhead/Cargo.toml
@@ -9,6 +9,7 @@ description = "A crate of the gitoxide project to read and write .git/FETCH_HEAD
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-filter/Cargo.toml
+++ b/gix-filter/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project implementing git filters"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate providing file system specific utilities to `gitoxide`"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = true

--- a/gix-fsck/Cargo.toml
+++ b/gix-fsck/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Cameron Esfahani <cesfahani@gmail.com>", "Sebastian Thiel <sebastian
 license = "MIT OR Apache-2.0"
 description = "Verifies the connectivity and validity of objects in the database"
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-glob/Cargo.toml
+++ b/gix-glob/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project dealing with pattern matching"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = true

--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-hashtable/Cargo.toml
+++ b/gix-hashtable/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate that provides hashtable based data structures optimized to utilize ObjectId keys"
 authors = ["Pascal Kuthe <pascal.kuthe@semimod.de>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-ignore/Cargo.toml
+++ b/gix-ignore/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing .gitignore files"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A work-in-progress crate of the gitoxide project dedicated implementing the git index file"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*", "README.md"]
+include = ["/src/**/*", "/LICENSE-*", "/README.md"]
 rust-version = "1.82"
 autotests = false
 

--- a/gix-lfs/Cargo.toml
+++ b/gix-lfs/Cargo.toml
@@ -9,6 +9,7 @@ description = "A crate of the gitoxide project dealing with handling git large f
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-lock/Cargo.toml
+++ b/gix-lock/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A git-style lock-file implementation"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*", "README.md"]
+include = ["/src/**/*", "/LICENSE-*", "/README.md"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-macros/Cargo.toml
+++ b/gix-macros/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-mailmap/Cargo.toml
+++ b/gix-mailmap/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project for parsing mailmap files"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = true

--- a/gix-merge/Cargo.toml
+++ b/gix-merge/Cargo.toml
@@ -7,6 +7,7 @@ description = "A crate of the gitoxide project implementing merge algorithms"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lints]
 workspace = true

--- a/gix-negotiate/Cargo.toml
+++ b/gix-negotiate/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project implementing negotiation algorith
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-note/Cargo.toml
+++ b/gix-note/Cargo.toml
@@ -9,6 +9,7 @@ description = "A crate of the gitoxide project dealing with git notes"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 description = "Implements various git object databases"
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 autotests = false
 

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 description = "Implements git packs and related data structures"
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 autotests = false
 

--- a/gix-pack/tests/Cargo.toml
+++ b/gix-pack/tests/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 description = "Tests for the gix-pack crate"
 edition = "2021"
 rust-version = "1.82"
+publish = false
 
 [features]
 gix-features-parallel = ["gix-features/parallel"]

--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing the pkt-line serialization format"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-path/Cargo.toml
+++ b/gix-path/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing paths and their conversions"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-pathspec/Cargo.toml
+++ b/gix-pathspec/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project dealing magical pathspecs"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*", "README.md"]
+include = ["/src/**/*", "/LICENSE-*", "/README.md"]
 
 [lib]
 doctest = true

--- a/gix-prompt/Cargo.toml
+++ b/gix-prompt/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project for handling prompts in the terminal"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*", "README.md"]
+include = ["/src/**/*", "/LICENSE-*", "/README.md"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project for implementing git protocols"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*", "!**/tests/**/*"]
+include = ["/src/**/*", "/LICENSE-*", "!/tests/**/*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-quote/Cargo.toml
+++ b/gix-quote/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project dealing with various quotations u
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = true

--- a/gix-rebase/Cargo.toml
+++ b/gix-rebase/Cargo.toml
@@ -9,6 +9,7 @@ description = "A crate of the gitoxide project dealing rebases"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate to handle git references"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 autotests = false
 

--- a/gix-refspec/Cargo.toml
+++ b/gix-refspec/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project for parsing and representing refspecs"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*", "README.md"]
+include = ["/src/**/*", "/LICENSE-*", "/README.md"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing with finding names for revisions and parsing specifications"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*", "README.md"]
+include = ["/src/**/*", "/LICENSE-*", "/README.md"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-revwalk/Cargo.toml
+++ b/gix-revwalk/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate providing utilities for walking the revision graph"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-sec/Cargo.toml
+++ b/gix-sec/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project providing a shared trust model"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-sequencer/Cargo.toml
+++ b/gix-sequencer/Cargo.toml
@@ -9,6 +9,7 @@ description = "A crate of the gitoxide project handling sequences of human-aided
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-shallow/Cargo.toml
+++ b/gix-shallow/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 description = "Handle files specifying the shallow boundary"
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing with 'git status'-like functionality"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>", "Pascal Kuthe <pascal.kuthe@semimod.de>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 autotests = false
 

--- a/gix-submodule/Cargo.toml
+++ b/gix-submodule/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate of the gitoxide project dealing git submodules"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-tempfile/Cargo.toml
+++ b/gix-tempfile/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A tempfile implementation with a global registry to assure cleanup"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*", "README.md"]
+include = ["/src/**/*", "/LICENSE-*", "/README.md"]
 rust-version = "1.82"
 
 [[example]]

--- a/gix-tix/Cargo.toml
+++ b/gix-tix/Cargo.toml
@@ -9,6 +9,7 @@ description = "A tool like `tig`, but minimal, fast and efficient"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-trace/Cargo.toml
+++ b/gix-trace/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dedicated to implementing the git transport layer"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-traverse/Cargo.toml
+++ b/gix-traverse/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 autotests = false
 

--- a/gix-traverse/tests/Cargo.toml
+++ b/gix-traverse/tests/Cargo.toml
@@ -9,6 +9,7 @@ description = "Integration tests for the gix-traverse crate"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
+publish = false
 
 [[test]]
 name = "traverse"

--- a/gix-tui/Cargo.toml
+++ b/gix-tui/Cargo.toml
@@ -9,6 +9,7 @@ description = "A crate of the gitoxide project dedicated to a terminal user inte
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
+include = ["/src/**/*", "/LICENSE-*"]
 
 [[bin]]
 name = "gixi"

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing parsing and serialization of gix-url"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*", "tests/baseline/**/*"]
+include = ["/src/**/*", "/LICENSE-*", "/tests/baseline/**/*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-utils/Cargo.toml
+++ b/gix-utils/Cargo.toml
@@ -9,7 +9,7 @@ description = "A crate with `gitoxide` utilities that don't need feature toggles
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = true

--- a/gix-validate/Cargo.toml
+++ b/gix-validate/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "Validation functions for various kinds of names in git"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 
 [lib]

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing setting the worktree to a particular state"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 autotests = false
 

--- a/gix-worktree-stream/Cargo.toml
+++ b/gix-worktree-stream/Cargo.toml
@@ -9,7 +9,7 @@ description = "generate a byte-stream from a git-tree"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
 rust-version = "1.82"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project for shared worktree related types and utilities."
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 rust-version = "1.82"
 autotests = false
 

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 version = "0.81.0"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2021"
-include = ["src/**/*", "LICENSE-*"]
+include = ["/src/**/*", "/LICENSE-*"]
 # This MSRV is dictated by `firefox` to support the `helix` editor, but is now probably
 # effectively controlled by `jiff`, which also aligns with `regex`.
 rust-version = "1.82"


### PR DESCRIPTION
### Tasks

* [x] more specific package includes, see https://github.com/rust-lang/cargo/issues/16872#issuecomment-4246667678
    - double-checked with `cargo package --list` before and after, which showed that the top-level package picked up more README files than it should. Everything else is equal.
* [x] cleanup package manifests further with proper includes, which should fix publishing failures do to generated fixtures.