### PR TITLE
Use `GIX_TEST_FIXTURE_HASH` for `gix-diff`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,6 +1715,7 @@ dependencies = [
  "gix-path",
  "gix-pathspec",
  "gix-tempfile",
+ "gix-testtools",
  "gix-trace",
  "gix-traverse",
  "gix-worktree",

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -69,7 +69,8 @@ document-features = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.8.2"
-gix-hash = { path = "../gix-hash", features = ["sha1"] }
+gix-hash = { path = "../gix-hash", features = ["sha1", "sha256"] }
+gix-testtools = { path = "../tests/tools" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gix-diff/src/tree/function.rs
+++ b/gix-diff/src/tree/function.rs
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn compare_select_samples() {
-        let null = gix_hash::ObjectId::null(gix_testtools::hash_kind_from_env().unwrap_or_default());
+        let null = gix_testtools::hash_kind_from_env().unwrap_or_default().null();
         let actual = compare(
             &EntryRef {
                 mode: EntryKind::Blob.into(),

--- a/gix-diff/src/tree/function.rs
+++ b/gix-diff/src/tree/function.rs
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn compare_select_samples() {
-        let null = gix_hash::ObjectId::null(gix_hash::Kind::Sha1);
+        let null = gix_hash::ObjectId::null(gix_testtools::hash_kind_from_env().unwrap_or_default());
         let actual = compare(
             &EntryRef {
                 mode: EntryKind::Blob.into(),

--- a/gix-diff/tests/diff/blob/platform.rs
+++ b/gix-diff/tests/diff/blob/platform.rs
@@ -48,7 +48,11 @@ fn resources_of_worktree_and_odb_and_check_link() -> crate::Result {
     assert_eq!(new.data.as_slice().expect("present").as_bstr(), a_content);
     assert_eq!(new.driver_index, Some(0));
     assert_eq!(new.mode, EntryKind::BlobExecutable);
-    assert_eq!(new.id, hex_to_id("4c469b6c8c4486fdc9ded9d597d8f6816a455707"));
+    let new_id = hex_to_id(
+        "4c469b6c8c4486fdc9ded9d597d8f6816a455707",
+        "061557fb6e67e1be5d41f8e83962699fce2a7d168ccfb2b5743d27ab06038da8",
+    );
+    assert_eq!(new.id, new_id);
     assert_eq!(new.rela_path, "a", "location is kept directly as provided");
 
     let out = platform.prepare_diff()?;
@@ -70,7 +74,14 @@ fn resources_of_worktree_and_odb_and_check_link() -> crate::Result {
             2,
             3
         )),
-        format!("{}test a <tmp-path> 0000000000000000000000000000000000000000 100644 <tmp-path> 4c469b6c8c4486fdc9ded9d597d8f6816a455707 100755", if !cfg!(windows) { "GIT_DIFF_PATH_COUNTER=3 GIT_DIFF_PATH_TOTAL=3 GIT_DIR=. " } else { Default::default() }),
+        format!(
+            "{}test a <tmp-path> 0000000000000000000000000000000000000000 100644 <tmp-path> {new_id} 100755",
+            if !cfg!(windows) {
+                "GIT_DIFF_PATH_COUNTER=3 GIT_DIFF_PATH_TOTAL=3 GIT_DIR=. "
+            } else {
+                Default::default()
+            }
+        ),
         "in this case, there is no rename-to field as last argument, it's based on the resource paths being different"
     );
 
@@ -95,7 +106,7 @@ fn resources_of_worktree_and_odb_and_check_link() -> crate::Result {
         a_content,
         "despite the same content"
     );
-    assert_eq!(new.id, hex_to_id("4c469b6c8c4486fdc9ded9d597d8f6816a455707"));
+    assert_eq!(new.id, new_id);
     assert_eq!(new.rela_path, "a");
 
     let out = platform.prepare_diff()?;
@@ -117,7 +128,14 @@ fn resources_of_worktree_and_odb_and_check_link() -> crate::Result {
             0,
             1
         )),
-        format!("{}test a <tmp-path> 0000000000000000000000000000000000000000 100644 <tmp-path> 4c469b6c8c4486fdc9ded9d597d8f6816a455707 120000", if !cfg!(windows) { r#"GIT_DIFF_PATH_COUNTER=1 GIT_DIFF_PATH_TOTAL=1 GIT_DIR=. "# } else { Default::default() }),
+        format!(
+            "{}test a <tmp-path> 0000000000000000000000000000000000000000 100644 <tmp-path> {new_id} 120000",
+            if !cfg!(windows) {
+                r#"GIT_DIFF_PATH_COUNTER=1 GIT_DIFF_PATH_TOTAL=1 GIT_DIR=. "#
+            } else {
+                Default::default()
+            }
+        ),
         "Also obvious that symlinks are definitely special, but it's what git does as well"
     );
 

--- a/gix-diff/tests/diff/blob/platform.rs
+++ b/gix-diff/tests/diff/blob/platform.rs
@@ -79,7 +79,7 @@ fn resources_of_worktree_and_odb_and_check_link() -> crate::Result {
             if !cfg!(windows) {
                 "GIT_DIFF_PATH_COUNTER=3 GIT_DIFF_PATH_TOTAL=3 GIT_DIR=. "
             } else {
-                Default::default()
+                ""
             }
         ),
         "in this case, there is no rename-to field as last argument, it's based on the resource paths being different"
@@ -133,7 +133,7 @@ fn resources_of_worktree_and_odb_and_check_link() -> crate::Result {
             if !cfg!(windows) {
                 r#"GIT_DIFF_PATH_COUNTER=1 GIT_DIFF_PATH_TOTAL=1 GIT_DIR=. "#
             } else {
-                Default::default()
+                ""
             }
         ),
         "Also obvious that symlinks are definitely special, but it's what git does as well"

--- a/gix-diff/tests/diff/index.rs
+++ b/gix-diff/tests/diff/index.rs
@@ -328,21 +328,24 @@ fn renames_by_similarity_with_limit() -> crate::Result {
     assert_eq!(actual_entry_modes, [Mode::FILE, Mode::FILE, Mode::FILE, Mode::FILE]);
 
     let actual_ids: Vec<_> = changes.iter().map(ChangeRef::id).collect();
-    let expected_ids = match crate::fixture_hash_kind() {
-        gix_hash::Kind::Sha1 => [
-            crate::hex_to_id("f00c965d8307308469e537302baa73048488f162"),
-            crate::hex_to_id("683cfcc0f47566c332aa45d81c5cc98acb4aab49"),
-            crate::hex_to_id("3bb459b831ea471b9cd1cbb7c6d54a74251a711b"),
-            crate::hex_to_id("0a805f8e02d72bd354c1f00607906de2e49e00d6"),
-        ],
-        gix_hash::Kind::Sha256 => [
-            crate::hex_to_id("300fc9db3fb50e3794eb4013cfe2c9f6c0fa1d8db7f9e3a4f6f0158b3b62cc69"),
-            crate::hex_to_id("b863f94555dd058a680cca6d4afa1bad30b5f9c36122c7089f853081aa1c5a28"),
-            crate::hex_to_id("19ebb6b2c2f3a64e6578013f680ec39330ce158af5977a1b17be0d551185fbab"),
-            crate::hex_to_id("6271a9ad76b692e75a96d260cf02c4cd89e1d2071256447ff50e8a8f443299b4"),
-        ],
-        _ => unreachable!("tests only support sha1 and sha256 fixtures"),
-    };
+    let expected_ids = [
+        crate::hex_to_id(
+            "f00c965d8307308469e537302baa73048488f162",
+            "300fc9db3fb50e3794eb4013cfe2c9f6c0fa1d8db7f9e3a4f6f0158b3b62cc69",
+        ),
+        crate::hex_to_id(
+            "683cfcc0f47566c332aa45d81c5cc98acb4aab49",
+            "b863f94555dd058a680cca6d4afa1bad30b5f9c36122c7089f853081aa1c5a28",
+        ),
+        crate::hex_to_id(
+            "3bb459b831ea471b9cd1cbb7c6d54a74251a711b",
+            "19ebb6b2c2f3a64e6578013f680ec39330ce158af5977a1b17be0d551185fbab",
+        ),
+        crate::hex_to_id(
+            "0a805f8e02d72bd354c1f00607906de2e49e00d6",
+            "6271a9ad76b692e75a96d260cf02c4cd89e1d2071256447ff50e8a8f443299b4",
+        ),
+    ];
     assert_eq!(actual_ids, expected_ids);
 
     let out = out.expect("tracking enabled");

--- a/gix-diff/tests/diff/main.rs
+++ b/gix-diff/tests/diff/main.rs
@@ -174,11 +174,7 @@ mod util {
     impl ObjectDb {
         /// Insert `data` and return its hash. That can be used to find it again.
         pub fn insert(&mut self, data: &str) -> Result<gix_hash::ObjectId, Error> {
-            let id = gix_object::compute_hash(
-                gix_testtools::hash_kind_from_env().unwrap_or_default(),
-                gix_object::Kind::Blob,
-                data.as_bytes(),
-            )?;
+            let id = gix_object::compute_hash(super::fixture_hash_kind(), gix_object::Kind::Blob, data.as_bytes())?;
             self.data_by_id.insert(id, data.into());
             Ok(id)
         }

--- a/gix-diff/tests/diff/main.rs
+++ b/gix-diff/tests/diff/main.rs
@@ -180,7 +180,11 @@ mod util {
     impl ObjectDb {
         /// Insert `data` and return its hash. That can be used to find it again.
         pub fn insert(&mut self, data: &str) -> Result<gix_hash::ObjectId, Error> {
-            let id = gix_object::compute_hash(gix_hash::Kind::Sha1, gix_object::Kind::Blob, data.as_bytes())?;
+            let id = gix_object::compute_hash(
+                gix_testtools::hash_kind_from_env().unwrap_or_default(),
+                gix_object::Kind::Blob,
+                data.as_bytes(),
+            )?;
             self.data_by_id.insert(id, data.into());
             Ok(id)
         }

--- a/gix-diff/tests/diff/main.rs
+++ b/gix-diff/tests/diff/main.rs
@@ -1,8 +1,12 @@
 use gix_testtools::Result;
 use std::collections::HashMap;
 
-fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
-    gix_hash::ObjectId::from_hex(hex.as_bytes()).expect("valid hex id")
+fn hex_to_id(hex_sha1: &str, hex_sha256: &str) -> gix_hash::ObjectId {
+    match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+        gix_hash::Kind::Sha1 => gix_hash::ObjectId::from_hex(hex_sha1.as_bytes()).expect("40 bytes hex"),
+        gix_hash::Kind::Sha256 => gix_hash::ObjectId::from_hex(hex_sha256.as_bytes()).expect("64 bytes hex"),
+        _ => unimplemented!(),
+    }
 }
 
 fn fixture_hash_kind() -> gix_hash::Kind {
@@ -119,16 +123,6 @@ fn normalize_patch_snapshot(input: &str) -> String {
 
 fn assert_hash_agnostic_patch_eq(actual: &str, expected: &str) {
     pretty_assertions::assert_eq!(normalize_patch_snapshot(expected), normalize_patch_snapshot(actual));
-}
-
-macro_rules! assert_hash_agnostic_eq {
-    ($left:expr, $right:expr $(, $($arg:tt)+)?) => {{
-        pretty_assertions::assert_eq!(
-            crate::normalize_debug_snapshot(&($left)),
-            crate::normalize_debug_snapshot(&($right))
-            $(, $($arg)+)?
-        );
-    }};
 }
 
 mod blob;

--- a/gix-diff/tests/diff/rewrites/mod.rs
+++ b/gix-diff/tests/diff/rewrites/mod.rs
@@ -39,7 +39,7 @@ impl gix_diff::rewrites::tracker::Change for Change {
     }
 }
 
-const NULL_ID: LazyLock<gix_hash::ObjectId> = LazyLock::new(|| crate::fixture_hash_kind().null());
+static NULL_ID: LazyLock<gix_hash::ObjectId> = LazyLock::new(|| crate::fixture_hash_kind().null());
 
 impl Change {
     fn modification() -> Self {

--- a/gix-diff/tests/diff/rewrites/mod.rs
+++ b/gix-diff/tests/diff/rewrites/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use gix_diff::{
     rewrites::tracker::ChangeKind,
     tree::visit::{ChangeId, Relation},
@@ -37,12 +39,12 @@ impl gix_diff::rewrites::tracker::Change for Change {
     }
 }
 
-const NULL_ID: gix_hash::ObjectId = gix_hash::Kind::Sha1.null();
+const NULL_ID: LazyLock<gix_hash::ObjectId> = LazyLock::new(|| crate::fixture_hash_kind().null());
 
 impl Change {
     fn modification() -> Self {
         Change {
-            id: NULL_ID,
+            id: *NULL_ID,
             kind: ChangeKind::Modification,
             mode: EntryKind::Blob.into(),
             relation: None,
@@ -50,7 +52,7 @@ impl Change {
     }
     fn deletion() -> Self {
         Change {
-            id: NULL_ID,
+            id: *NULL_ID,
             kind: ChangeKind::Deletion,
             mode: EntryKind::Blob.into(),
             relation: None,
@@ -58,7 +60,7 @@ impl Change {
     }
     fn addition() -> Self {
         Change {
-            id: NULL_ID,
+            id: *NULL_ID,
             kind: ChangeKind::Addition,
             mode: EntryKind::Blob.into(),
             relation: None,
@@ -67,7 +69,7 @@ impl Change {
 
     fn addition_in_tree(id: ChangeId) -> Self {
         Change {
-            id: NULL_ID,
+            id: *NULL_ID,
             kind: ChangeKind::Addition,
             mode: EntryKind::Blob.into(),
             relation: Some(Relation::ChildOfParent(id)),
@@ -76,7 +78,7 @@ impl Change {
 
     fn deletion_in_tree(id: ChangeId) -> Self {
         Change {
-            id: NULL_ID,
+            id: *NULL_ID,
             kind: ChangeKind::Deletion,
             mode: EntryKind::Blob.into(),
             relation: Some(Relation::ChildOfParent(id)),
@@ -85,7 +87,7 @@ impl Change {
 
     fn tree_addition(id: ChangeId) -> Self {
         Change {
-            id: NULL_ID,
+            id: *NULL_ID,
             kind: ChangeKind::Addition,
             mode: EntryKind::Tree.into(),
             relation: Some(Relation::Parent(id)),
@@ -94,7 +96,7 @@ impl Change {
 
     fn tree_deletion(id: ChangeId) -> Self {
         Change {
-            id: NULL_ID,
+            id: *NULL_ID,
             kind: ChangeKind::Deletion,
             mode: EntryKind::Tree.into(),
             relation: Some(Relation::Parent(id)),

--- a/gix-diff/tests/diff/rewrites/tracker.rs
+++ b/gix-diff/tests/diff/rewrites/tracker.rs
@@ -342,7 +342,7 @@ fn copy_by_id_search_in_all_sources() -> crate::Result {
                 );
             }
             _ => todo!(),
-        };
+        }
     }
     Ok(())
 }
@@ -660,7 +660,7 @@ fn rename_by_50_percent_similarity() -> crate::Result {
             );
         }
         _ => todo!(),
-    };
+    }
 
     Ok(())
 }

--- a/gix-diff/tests/diff/rewrites/tracker.rs
+++ b/gix-diff/tests/diff/rewrites/tracker.rs
@@ -225,124 +225,63 @@ fn copy_by_id_search_in_all_sources() -> crate::Result {
 
         let content_id = hex_to_id(
             "2e65efe2a145dda7ee51d1741299f848e5bf752e",
-            "f8625e43f9e04f24291f77cdbe4c71b3c2a3b0003f60419b3ed06a058d766c8b",
+            "eb337bcee2061c5313c9a1392116b6c76039e9e30d71467ae359b36277e17dc7",
         );
 
-        match crate::fixture_hash_kind() {
-            gix_hash::Kind::Sha1 => {
-                let mut calls = 0;
-                let out = util::assert_emit_with_objects_and_sources(
-                    &mut track,
-                    |dst, src| {
-                        let source_a = Source {
-                            entry_mode: EntryKind::Blob.into(),
-                            id: content_id,
-                            kind: SourceKind::Copy,
-                            location: "a-src".into(),
-                            change: &Change {
-                                id: content_id,
-                                ..Change::modification()
-                            },
-                            diff: None,
-                        };
-                        match calls {
-                            0 => {
-                                assert_eq!(src.unwrap(), source_a);
-                                assert_eq!(
-                                    dst.location, "a-cpy-1",
-                                    "it just finds the first possible match in order, ignoring other candidates"
-                                );
-                            }
-                            1 => {
-                                assert_eq!(src.unwrap(), source_a, "copy-sources can be used multiple times");
-                                assert_eq!(dst.location, "a-cpy-2");
-                            }
-                            2 => {
-                                assert!(src.is_none());
-                                assert_eq!(dst.location, "d");
-                            }
-                            _ => panic!("too many emissions"),
-                        }
-                        calls += 1;
-                        std::ops::ControlFlow::Continue(())
+        let mut calls = 0;
+        let out = util::assert_emit_with_objects_and_sources(
+            &mut track,
+            |dst, src| {
+                let source_a = Source {
+                    entry_mode: EntryKind::Blob.into(),
+                    id: content_id,
+                    kind: SourceKind::Copy,
+                    location: "a-src".into(),
+                    change: &Change {
+                        id: content_id,
+                        ..Change::modification()
                     },
-                    odb,
-                    [(
-                        {
-                            let mut c = Change::modification();
-                            c.id = content_id;
-                            c
-                        },
-                        "a-src",
-                    )],
-                );
-                assert_eq!(
-                    out,
-                    rewrites::Outcome {
-                        options: rewrites,
-                        ..Default::default()
-                    },
-                    "no similarity check was performed, it was all matched by id"
-                );
-            }
-            gix_hash::Kind::Sha256 => {
-                let mut calls = 0;
-                let out = util::assert_emit_with_objects_and_sources(
-                    &mut track,
-                    |dst, src| {
-                        let source_a = Source {
-                            entry_mode: EntryKind::Blob.into(),
-                            id: content_id,
-                            kind: SourceKind::Copy,
-                            location: "a-src".into(),
-                            change: &Change {
-                                id: content_id,
-                                ..Change::modification()
-                            },
-                            diff: None,
-                        };
-                        match calls {
-                            0 => {
-                                assert!(src.is_none());
-                                assert_eq!(dst.location, "a-cpy-1");
-                            }
-                            1 => {
-                                assert!(src.is_none());
-                                assert_eq!(dst.location, "a-cpy-2");
-                            }
-                            2 => {
-                                assert_eq!(src.unwrap(), source_a);
-                                assert_eq!(
-                                    dst.location, "a-cpy-1",
-                                    "it just finds the first possible match in order, ignoring other candidates"
-                                );
-                            }
-                            _ => panic!("too many emissions"),
-                        }
-                        calls += 1;
-                        std::ops::ControlFlow::Continue(())
-                    },
-                    odb,
-                    [(
-                        {
-                            let mut c = Change::modification();
-                            c.id = content_id;
-                            c
-                        },
-                        "a-src",
-                    )],
-                );
-                assert_eq!(
-                    out,
-                    rewrites::Outcome {
-                        options: rewrites,
-                        ..Default::default()
-                    },
-                    "no similarity check was performed, it was all matched by id"
-                );
-            }
-            _ => todo!(),
-        }
+                    diff: None,
+                };
+                match calls {
+                    0 => {
+                        assert_eq!(src.unwrap(), source_a);
+                        assert_eq!(
+                            dst.location, "a-cpy-1",
+                            "it just finds the first possible match in order, ignoring other candidates"
+                        );
+                    }
+                    1 => {
+                        assert_eq!(src.unwrap(), source_a, "copy-sources can be used multiple times");
+                        assert_eq!(dst.location, "a-cpy-2");
+                    }
+                    2 => {
+                        assert!(src.is_none());
+                        assert_eq!(dst.location, "d");
+                    }
+                    _ => panic!("too many emissions"),
+                }
+                calls += 1;
+                std::ops::ControlFlow::Continue(())
+            },
+            odb,
+            [(
+                {
+                    let mut c = Change::modification();
+                    c.id = content_id;
+                    c
+                },
+                "a-src",
+            )],
+        );
+        assert_eq!(
+            out,
+            rewrites::Outcome {
+                options: rewrites,
+                ..Default::default()
+            },
+            "no similarity check was performed, it was all matched by id"
+        );
     }
     Ok(())
 }

--- a/gix-diff/tests/diff/rewrites/tracker.rs
+++ b/gix-diff/tests/diff/rewrites/tracker.rs
@@ -487,119 +487,69 @@ fn rename_by_50_percent_similarity() -> crate::Result {
         ],
     )?;
 
-    match crate::fixture_hash_kind() {
-        gix_hash::Kind::Sha1 => {
-            let mut calls = 0;
-            let out = util::assert_emit_with_objects(
-                &mut track,
-                |dst, src| {
-                    match calls {
-                        0 => {
-                            let id = hex_to_id(
-                                "66a52ee7a1d803dc57859c3e95ac9dcdc87c0164",
-                                "fdf2fd32de1d33ee5744979b40b07e0930a12c59dfbc5b3b6d34b807f944ba6e",
-                            );
-                            assert_eq!(
-                                src.unwrap(),
-                                Source {
-                                    entry_mode: EntryKind::Blob.into(),
-                                    id,
-                                    kind: SourceKind::Rename,
-                                    location: "a".into(),
-                                    change: &Change {
-                                        id,
-                                        ..Change::deletion()
-                                    },
-                                    diff: Some(DiffLineStats {
-                                        removals: 1,
-                                        insertions: 1,
-                                        before: 2,
-                                        after: 2,
-                                        similarity: 0.53846157
-                                    })
-                                }
-                            );
-                            assert_eq!(dst.location, "b");
+    let mut calls = 0;
+    let out = util::assert_emit_with_objects(
+        &mut track,
+        |dst, src| {
+            match calls {
+                0 => {
+                    let id = hex_to_id(
+                        "66a52ee7a1d803dc57859c3e95ac9dcdc87c0164",
+                        "fdf2fd32de1d33ee5744979b40b07e0930a12c59dfbc5b3b6d34b807f944ba6e",
+                    );
+                    assert_eq!(
+                        src.unwrap(),
+                        Source {
+                            entry_mode: EntryKind::Blob.into(),
+                            id,
+                            kind: SourceKind::Rename,
+                            location: "a".into(),
+                            change: &Change {
+                                id,
+                                ..Change::deletion()
+                            },
+                            diff: Some(DiffLineStats {
+                                removals: 1,
+                                insertions: 1,
+                                before: 2,
+                                after: 2,
+                                similarity: 0.53846157
+                            })
                         }
-                        1 => {
-                            assert!(src.is_none(), "pair already found");
-                            assert_eq!(dst.location, "c");
-                        }
-                        _ => panic!("too many elements emitted"),
-                    }
-                    calls += 1;
-                    std::ops::ControlFlow::Continue(())
-                },
-                odb,
-            );
-            assert_eq!(
-                out,
-                rewrites::Outcome {
-                    options: rewrites,
-                    num_similarity_checks: 1,
-                    ..Default::default()
-                },
-                "the first attempt already yields the one pair, so it doesn't participate anymore\
-         - we don't have best candidates yet, thus only one check"
-            );
-        }
-        gix_hash::Kind::Sha256 => {
-            let mut calls = 0;
-            let out = util::assert_emit_with_objects(
-                &mut track,
-                |dst, src| {
-                    match calls {
-                        0 => {
-                            let id = hex_to_id(
-                                "66a52ee7a1d803dc57859c3e95ac9dcdc87c0164",
-                                "fdf2fd32de1d33ee5744979b40b07e0930a12c59dfbc5b3b6d34b807f944ba6e",
-                            );
-                            assert_eq!(
-                                src.unwrap(),
-                                Source {
-                                    entry_mode: EntryKind::Blob.into(),
-                                    id,
-                                    kind: SourceKind::Rename,
-                                    location: "a".into(),
-                                    change: &Change {
-                                        id,
-                                        ..Change::deletion()
-                                    },
-                                    diff: Some(DiffLineStats {
-                                        removals: 1,
-                                        insertions: 1,
-                                        before: 2,
-                                        after: 2,
-                                        similarity: 0.53846157
-                                    })
-                                }
-                            );
-                            assert_eq!(dst.location, "b");
-                        }
-                        1 => {
-                            assert!(src.is_none(), "pair already found");
-                            assert_eq!(dst.location, "c");
-                        }
-                        _ => panic!("too many elements emitted"),
-                    }
-                    calls += 1;
-                    std::ops::ControlFlow::Continue(())
-                },
-                odb,
-            );
-            assert_eq!(
-                out,
-                rewrites::Outcome {
-                    options: rewrites,
-                    num_similarity_checks: 2,
-                    ..Default::default()
-                },
-                "the first attempt already yields the one pair, so it doesn't participate anymore\
-         - we don't have best candidates yet, thus only one check"
-            );
-        }
+                    );
+                    assert_eq!(dst.location, "b");
+                }
+                1 => {
+                    assert!(src.is_none(), "pair already found");
+                    assert_eq!(dst.location, "c");
+                }
+                _ => panic!("too many elements emitted"),
+            }
+            calls += 1;
+            std::ops::ControlFlow::Continue(())
+        },
+        odb,
+    );
+
+    // The rename tracker currently sorts by hash, hence the outcome is hash-dependent.
+    let expected = match crate::fixture_hash_kind() {
+        gix_hash::Kind::Sha1 => rewrites::Outcome {
+            options: rewrites,
+            num_similarity_checks: 1,
+            ..Default::default()
+        },
+        gix_hash::Kind::Sha256 => rewrites::Outcome {
+            options: rewrites,
+            num_similarity_checks: 2,
+            ..Default::default()
+        },
         _ => todo!(),
-    }
+    };
+    assert_eq!(
+        out, expected,
+        "the first attempt already yields the one pair, so it doesn't participate anymore\
+ - we don't have best candidates yet, thus only one check"
+    );
 
     Ok(())
 }
@@ -678,9 +628,10 @@ fn directory_renames_by_id_can_fail_gracefully() -> crate::Result {
         ],
     )?;
 
+    // The rename tracker currently sorts by hash, hence the outcome is hash-dependent.
+    let mut calls = 0;
     match crate::fixture_hash_kind() {
         gix_hash::Kind::Sha1 => {
-            let mut calls = 0;
             let out = util::assert_emit_with_objects(
                 &mut track,
                 |dst, src| {
@@ -719,10 +670,8 @@ fn directory_renames_by_id_can_fail_gracefully() -> crate::Result {
                     ..Default::default()
                 }
             );
-            assert_eq!(calls, 5, "Should not have too few calls");
         }
         gix_hash::Kind::Sha256 => {
-            let mut calls = 0;
             let out = util::assert_emit_with_objects(
                 &mut track,
                 |dst, src| {
@@ -765,6 +714,7 @@ fn directory_renames_by_id_can_fail_gracefully() -> crate::Result {
         }
         _ => todo!(),
     }
+    assert_eq!(calls, 5, "Should not have too few calls");
     Ok(())
 }
 
@@ -831,9 +781,9 @@ fn simple_directory_rename_by_id() -> crate::Result {
         ],
     );
 
+    let mut calls = 0;
     match crate::fixture_hash_kind() {
         gix_hash::Kind::Sha1 => {
-            let mut calls = 0;
             let out = util::assert_emit(&mut track, |dst, src| {
                 match calls {
                     0 => {
@@ -877,10 +827,8 @@ fn simple_directory_rename_by_id() -> crate::Result {
                     ..Default::default()
                 }
             );
-            assert_eq!(calls, 8, "Should not have too few calls");
         }
         gix_hash::Kind::Sha256 => {
-            let mut calls = 0;
             let out = util::assert_emit(&mut track, |dst, src| {
                 match calls {
                     0 => {
@@ -924,11 +872,10 @@ fn simple_directory_rename_by_id() -> crate::Result {
                     ..Default::default()
                 }
             );
-            assert_eq!(calls, 8, "Should not have too few calls");
         }
         _ => todo!(),
     }
-
+    assert_eq!(calls, 8, "Should not have too few calls");
     Ok(())
 }
 

--- a/gix-diff/tests/diff/rewrites/tracker.rs
+++ b/gix-diff/tests/diff/rewrites/tracker.rs
@@ -151,7 +151,10 @@ fn copy_by_id() -> crate::Result {
         let out = util::assert_emit_with_objects(
             &mut track,
             |dst, src| {
-                let id = hex_to_id("2e65efe2a145dda7ee51d1741299f848e5bf752e");
+                let id = hex_to_id(
+                    "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+                    "eb337bcee2061c5313c9a1392116b6c76039e9e30d71467ae359b36277e17dc7",
+                );
                 let source_a = Source {
                     entry_mode: EntryKind::Blob.into(),
                     id,
@@ -220,61 +223,126 @@ fn copy_by_id_search_in_all_sources() -> crate::Result {
             ],
         )?;
 
-        let mut calls = 0;
-        let content_id = hex_to_id("2e65efe2a145dda7ee51d1741299f848e5bf752e");
-        let out = util::assert_emit_with_objects_and_sources(
-            &mut track,
-            |dst, src| {
-                let source_a = Source {
-                    entry_mode: EntryKind::Blob.into(),
-                    id: content_id,
-                    kind: SourceKind::Copy,
-                    location: "a-src".into(),
-                    change: &Change {
-                        id: content_id,
-                        ..Change::modification()
+        let content_id = hex_to_id(
+            "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+            "f8625e43f9e04f24291f77cdbe4c71b3c2a3b0003f60419b3ed06a058d766c8b",
+        );
+
+        match crate::fixture_hash_kind() {
+            gix_hash::Kind::Sha1 => {
+                let mut calls = 0;
+                let out = util::assert_emit_with_objects_and_sources(
+                    &mut track,
+                    |dst, src| {
+                        let source_a = Source {
+                            entry_mode: EntryKind::Blob.into(),
+                            id: content_id,
+                            kind: SourceKind::Copy,
+                            location: "a-src".into(),
+                            change: &Change {
+                                id: content_id,
+                                ..Change::modification()
+                            },
+                            diff: None,
+                        };
+                        match calls {
+                            0 => {
+                                assert_eq!(src.unwrap(), source_a);
+                                assert_eq!(
+                                    dst.location, "a-cpy-1",
+                                    "it just finds the first possible match in order, ignoring other candidates"
+                                );
+                            }
+                            1 => {
+                                assert_eq!(src.unwrap(), source_a, "copy-sources can be used multiple times");
+                                assert_eq!(dst.location, "a-cpy-2");
+                            }
+                            2 => {
+                                assert!(src.is_none());
+                                assert_eq!(dst.location, "d");
+                            }
+                            _ => panic!("too many emissions"),
+                        }
+                        calls += 1;
+                        std::ops::ControlFlow::Continue(())
                     },
-                    diff: None,
-                };
-                match calls {
-                    0 => {
-                        assert_eq!(src.unwrap(), source_a);
-                        assert_eq!(
-                            dst.location, "a-cpy-1",
-                            "it just finds the first possible match in order, ignoring other candidates"
-                        );
-                    }
-                    1 => {
-                        assert_eq!(src.unwrap(), source_a, "copy-sources can be used multiple times");
-                        assert_eq!(dst.location, "a-cpy-2");
-                    }
-                    2 => {
-                        assert!(src.is_none());
-                        assert_eq!(dst.location, "d");
-                    }
-                    _ => panic!("too many emissions"),
-                }
-                calls += 1;
-                std::ops::ControlFlow::Continue(())
-            },
-            odb,
-            [(
-                {
-                    let mut c = Change::modification();
-                    c.id = content_id;
-                    c
-                },
-                "a-src",
-            )],
-        );
-        assert_eq!(
-            out,
-            rewrites::Outcome {
-                options: rewrites,
-                ..Default::default()
-            },
-            "no similarity check was performed, it was all matched by id"
-        );
+                    odb,
+                    [(
+                        {
+                            let mut c = Change::modification();
+                            c.id = content_id;
+                            c
+                        },
+                        "a-src",
+                    )],
+                );
+                assert_eq!(
+                    out,
+                    rewrites::Outcome {
+                        options: rewrites,
+                        ..Default::default()
+                    },
+                    "no similarity check was performed, it was all matched by id"
+                );
+            }
+            gix_hash::Kind::Sha256 => {
+                let mut calls = 0;
+                let out = util::assert_emit_with_objects_and_sources(
+                    &mut track,
+                    |dst, src| {
+                        let source_a = Source {
+                            entry_mode: EntryKind::Blob.into(),
+                            id: content_id,
+                            kind: SourceKind::Copy,
+                            location: "a-src".into(),
+                            change: &Change {
+                                id: content_id,
+                                ..Change::modification()
+                            },
+                            diff: None,
+                        };
+                        match calls {
+                            0 => {
+                                assert!(src.is_none());
+                                assert_eq!(dst.location, "a-cpy-1");
+                            }
+                            1 => {
+                                assert!(src.is_none());
+                                assert_eq!(dst.location, "a-cpy-2");
+                            }
+                            2 => {
+                                assert_eq!(src.unwrap(), source_a);
+                                assert_eq!(
+                                    dst.location, "a-cpy-1",
+                                    "it just finds the first possible match in order, ignoring other candidates"
+                                );
+                            }
+                            _ => panic!("too many emissions"),
+                        }
+                        calls += 1;
+                        std::ops::ControlFlow::Continue(())
+                    },
+                    odb,
+                    [(
+                        {
+                            let mut c = Change::modification();
+                            c.id = content_id;
+                            c
+                        },
+                        "a-src",
+                    )],
+                );
+                assert_eq!(
+                    out,
+                    rewrites::Outcome {
+                        options: rewrites,
+                        ..Default::default()
+                    },
+                    "no similarity check was performed, it was all matched by id"
+                );
+            }
+            _ => todo!(),
+        };
     }
     Ok(())
 }
@@ -305,7 +373,10 @@ fn copy_by_50_percent_similarity() -> crate::Result {
     let out = util::assert_emit_with_objects(
         &mut track,
         |dst, src| {
-            let id = hex_to_id("78981922613b2afb6025042ff6bd878ac1994e85");
+            let id = hex_to_id(
+                "78981922613b2afb6025042ff6bd878ac1994e85",
+                "f8625e43f9e04f24291f77cdbe4c71b3c2a3b0003f60419b3ed06a058d766c8b",
+            );
             let source_a = Source {
                 entry_mode: EntryKind::Blob.into(),
                 id,
@@ -477,56 +548,120 @@ fn rename_by_50_percent_similarity() -> crate::Result {
         ],
     )?;
 
-    let mut calls = 0;
-    let out = util::assert_emit_with_objects(
-        &mut track,
-        |dst, src| {
-            match calls {
-                0 => {
-                    let id = hex_to_id("66a52ee7a1d803dc57859c3e95ac9dcdc87c0164");
-                    assert_eq!(
-                        src.unwrap(),
-                        Source {
-                            entry_mode: EntryKind::Blob.into(),
-                            id,
-                            kind: SourceKind::Rename,
-                            location: "a".into(),
-                            change: &Change {
-                                id,
-                                ..Change::deletion()
-                            },
-                            diff: Some(DiffLineStats {
-                                removals: 1,
-                                insertions: 1,
-                                before: 2,
-                                after: 2,
-                                similarity: 0.53846157
-                            })
+    match crate::fixture_hash_kind() {
+        gix_hash::Kind::Sha1 => {
+            let mut calls = 0;
+            let out = util::assert_emit_with_objects(
+                &mut track,
+                |dst, src| {
+                    match calls {
+                        0 => {
+                            let id = hex_to_id(
+                                "66a52ee7a1d803dc57859c3e95ac9dcdc87c0164",
+                                "fdf2fd32de1d33ee5744979b40b07e0930a12c59dfbc5b3b6d34b807f944ba6e",
+                            );
+                            assert_eq!(
+                                src.unwrap(),
+                                Source {
+                                    entry_mode: EntryKind::Blob.into(),
+                                    id,
+                                    kind: SourceKind::Rename,
+                                    location: "a".into(),
+                                    change: &Change {
+                                        id,
+                                        ..Change::deletion()
+                                    },
+                                    diff: Some(DiffLineStats {
+                                        removals: 1,
+                                        insertions: 1,
+                                        before: 2,
+                                        after: 2,
+                                        similarity: 0.53846157
+                                    })
+                                }
+                            );
+                            assert_eq!(dst.location, "b");
                         }
-                    );
-                    assert_eq!(dst.location, "b");
-                }
-                1 => {
-                    assert!(src.is_none(), "pair already found");
-                    assert_eq!(dst.location, "c");
-                }
-                _ => panic!("too many elements emitted"),
-            }
-            calls += 1;
-            std::ops::ControlFlow::Continue(())
-        },
-        odb,
-    );
-    assert_eq!(
-        out,
-        rewrites::Outcome {
-            options: rewrites,
-            num_similarity_checks: 1,
-            ..Default::default()
-        },
-        "the first attempt already yields the one pair, so it doesn't participate anymore\
+                        1 => {
+                            assert!(src.is_none(), "pair already found");
+                            assert_eq!(dst.location, "c");
+                        }
+                        _ => panic!("too many elements emitted"),
+                    }
+                    calls += 1;
+                    std::ops::ControlFlow::Continue(())
+                },
+                odb,
+            );
+            assert_eq!(
+                out,
+                rewrites::Outcome {
+                    options: rewrites,
+                    num_similarity_checks: 1,
+                    ..Default::default()
+                },
+                "the first attempt already yields the one pair, so it doesn't participate anymore\
          - we don't have best candidates yet, thus only one check"
-    );
+            );
+        }
+        gix_hash::Kind::Sha256 => {
+            let mut calls = 0;
+            let out = util::assert_emit_with_objects(
+                &mut track,
+                |dst, src| {
+                    match calls {
+                        0 => {
+                            let id = hex_to_id(
+                                "66a52ee7a1d803dc57859c3e95ac9dcdc87c0164",
+                                "fdf2fd32de1d33ee5744979b40b07e0930a12c59dfbc5b3b6d34b807f944ba6e",
+                            );
+                            assert_eq!(
+                                src.unwrap(),
+                                Source {
+                                    entry_mode: EntryKind::Blob.into(),
+                                    id,
+                                    kind: SourceKind::Rename,
+                                    location: "a".into(),
+                                    change: &Change {
+                                        id,
+                                        ..Change::deletion()
+                                    },
+                                    diff: Some(DiffLineStats {
+                                        removals: 1,
+                                        insertions: 1,
+                                        before: 2,
+                                        after: 2,
+                                        similarity: 0.53846157
+                                    })
+                                }
+                            );
+                            assert_eq!(dst.location, "b");
+                        }
+                        1 => {
+                            assert!(src.is_none(), "pair already found");
+                            assert_eq!(dst.location, "c");
+                        }
+                        _ => panic!("too many elements emitted"),
+                    }
+                    calls += 1;
+                    std::ops::ControlFlow::Continue(())
+                },
+                odb,
+            );
+            assert_eq!(
+                out,
+                rewrites::Outcome {
+                    options: rewrites,
+                    num_similarity_checks: 2,
+                    ..Default::default()
+                },
+                "the first attempt already yields the one pair, so it doesn't participate anymore\
+         - we don't have best candidates yet, thus only one check"
+            );
+        }
+        _ => todo!(),
+    };
+
     Ok(())
 }
 
@@ -559,7 +694,10 @@ fn directory_renames_by_id_can_fail_gracefully() -> crate::Result {
     };
     let mut track = util::new_tracker(rename_by_similarity);
     let tree_dst_id = 1;
-    let tree_id = hex_to_id("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    let tree_id = hex_to_id(
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
     assert!(track
         .try_push_change(
             Change {
@@ -573,7 +711,10 @@ fn directory_renames_by_id_can_fail_gracefully() -> crate::Result {
         .is_none());
 
     let tree_src_id = 3;
-    let tree_id = hex_to_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    let tree_id = hex_to_id(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
     assert!(track
         .try_push_change(
             Change {
@@ -598,46 +739,93 @@ fn directory_renames_by_id_can_fail_gracefully() -> crate::Result {
         ],
     )?;
 
-    let mut calls = 0;
-    let out = util::assert_emit_with_objects(
-        &mut track,
-        |dst, src| {
-            match calls {
-                0..=2 => {
-                    let src = src.unwrap();
-                    let (expected_src, expected_dst) =
-                        &[("d/a", "d-renamed/a"), ("d/c", "d-renamed/subdir/c"), ("a", "b")][calls];
-                    assert_eq!(src.location, expected_src);
-                    assert_eq!(dst.location, expected_dst);
+    match crate::fixture_hash_kind() {
+        gix_hash::Kind::Sha1 => {
+            let mut calls = 0;
+            let out = util::assert_emit_with_objects(
+                &mut track,
+                |dst, src| {
+                    match calls {
+                        0..=2 => {
+                            let src = src.unwrap();
+                            let (expected_src, expected_dst) =
+                                &[("d/a", "d-renamed/a"), ("d/c", "d-renamed/subdir/c"), ("a", "b")][calls];
+                            assert_eq!(src.location, expected_src);
+                            assert_eq!(dst.location, expected_dst);
+                        }
+                        3 => {
+                            assert_eq!(src.unwrap().location, "d");
+                            assert_eq!(
+                                dst.location, "d-renamed",
+                                "it can now track modified and renamed directories"
+                            );
+                        }
+                        4 => {
+                            assert_eq!(src, None);
+                            assert_eq!(dst.change.kind, ChangeKind::Deletion);
+                            assert_eq!(dst.location, "d/subdir/d");
+                        }
+                        _ => unreachable!("Should have expected emission call {calls}"),
+                    }
+                    calls += 1;
+                    std::ops::ControlFlow::Continue(())
+                },
+                &odb,
+            );
+            assert_eq!(
+                out,
+                rewrites::Outcome {
+                    options: rename_by_similarity,
+                    num_similarity_checks: 1,
+                    ..Default::default()
                 }
-                3 => {
-                    assert_eq!(src.unwrap().location, "d");
-                    assert_eq!(
-                        dst.location, "d-renamed",
-                        "it can now track modified and renamed directories"
-                    );
-                }
-                4 => {
-                    assert_eq!(src, None);
-                    assert_eq!(dst.change.kind, ChangeKind::Deletion);
-                    assert_eq!(dst.location, "d/subdir/d");
-                }
-                _ => unreachable!("Should have expected emission call {calls}"),
-            }
-            calls += 1;
-            std::ops::ControlFlow::Continue(())
-        },
-        &odb,
-    );
-    assert_eq!(
-        out,
-        rewrites::Outcome {
-            options: rename_by_similarity,
-            num_similarity_checks: 1,
-            ..Default::default()
+            );
+            assert_eq!(calls, 5, "Should not have too few calls");
         }
-    );
-    assert_eq!(calls, 5, "Should not have too few calls");
+        gix_hash::Kind::Sha256 => {
+            let mut calls = 0;
+            let out = util::assert_emit_with_objects(
+                &mut track,
+                |dst, src| {
+                    match calls {
+                        0..=2 => {
+                            let src = src.unwrap();
+                            let (expected_src, expected_dst) =
+                                &[("d/c", "d-renamed/subdir/c"), ("d/a", "d-renamed/a"), ("a", "b")][calls];
+                            assert_eq!(src.location, expected_src);
+                            assert_eq!(dst.location, expected_dst);
+                        }
+                        3 => {
+                            assert_eq!(src.unwrap().location, "d");
+                            assert_eq!(
+                                dst.location, "d-renamed",
+                                "it can now track modified and renamed directories"
+                            );
+                        }
+                        4 => {
+                            assert_eq!(src, None);
+                            assert_eq!(dst.change.kind, ChangeKind::Deletion);
+                            assert_eq!(dst.location, "d/subdir/d");
+                        }
+                        _ => unreachable!("Should have expected emission call {calls}"),
+                    }
+                    calls += 1;
+                    std::ops::ControlFlow::Continue(())
+                },
+                &odb,
+            );
+            assert_eq!(
+                out,
+                rewrites::Outcome {
+                    options: rename_by_similarity,
+                    num_similarity_checks: 2,
+                    ..Default::default()
+                }
+            );
+            assert_eq!(calls, 5, "Should not have too few calls");
+        }
+        _ => todo!(),
+    }
     Ok(())
 }
 
@@ -658,7 +846,10 @@ fn simple_directory_rename_by_id() -> crate::Result {
     assert!(track
         .try_push_change(Change::tree_deletion(tree_src_id), "d".into())
         .is_none());
-    let tree_id = hex_to_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    let tree_id = hex_to_id(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
     assert!(
         track
             .try_push_change(
@@ -700,51 +891,105 @@ fn simple_directory_rename_by_id() -> crate::Result {
             (Change::addition(), "b", "firt\nsecond\n"),
         ],
     );
-    let mut calls = 0;
-    let out = util::assert_emit(&mut track, |dst, src| {
-        match calls {
-            0 => {
-                let src = src.unwrap();
-                assert_eq!(src.location, "d");
-                assert_eq!(src.entry_mode.kind(), EntryKind::Tree);
-                assert_eq!(src.change.relation, Some(Relation::Parent(3)));
-                assert_eq!(dst.location, "d-renamed", "it found the renamed directory");
-                assert_eq!(dst.change.relation, Some(Relation::Parent(1)));
-                assert_eq!(dst.change.mode.kind(), EntryKind::Tree);
-            }
-            1..=5 => {
-                let src = src.unwrap();
-                let (expected_src, expected_dst) = &[
-                    ("d/a", "d-renamed/a"),
-                    ("d/c", "d-renamed/c"),
-                    ("d/b", "d-renamed/b"),
-                    ("d/subdir", "d-renamed/subdir"),
-                    ("d/subdir/d", "d-renamed/subdir/d"),
-                ][calls - 1];
-                assert_eq!(src.location, expected_src);
-                assert_eq!(dst.location, expected_dst);
-            }
-            6 => {
-                assert_eq!(src, None);
-                assert_eq!(dst.location, "a");
-            }
-            7 => {
-                assert_eq!(src, None);
-                assert_eq!(dst.location, "b");
-            }
-            _ => unreachable!("Should have expected emission call {calls}"),
+
+    match crate::fixture_hash_kind() {
+        gix_hash::Kind::Sha1 => {
+            let mut calls = 0;
+            let out = util::assert_emit(&mut track, |dst, src| {
+                match calls {
+                    0 => {
+                        let src = src.unwrap();
+                        assert_eq!(src.location, "d");
+                        assert_eq!(src.entry_mode.kind(), EntryKind::Tree);
+                        assert_eq!(src.change.relation, Some(Relation::Parent(3)));
+                        assert_eq!(dst.location, "d-renamed", "it found the renamed directory");
+                        assert_eq!(dst.change.relation, Some(Relation::Parent(1)));
+                        assert_eq!(dst.change.mode.kind(), EntryKind::Tree);
+                    }
+                    1..=5 => {
+                        let src = src.unwrap();
+                        let (expected_src, expected_dst) = &[
+                            ("d/a", "d-renamed/a"),
+                            ("d/c", "d-renamed/c"),
+                            ("d/b", "d-renamed/b"),
+                            ("d/subdir", "d-renamed/subdir"),
+                            ("d/subdir/d", "d-renamed/subdir/d"),
+                        ][calls - 1];
+                        assert_eq!(src.location, expected_src);
+                        assert_eq!(dst.location, expected_dst);
+                    }
+                    6 => {
+                        assert_eq!(src, None);
+                        assert_eq!(dst.location, "a");
+                    }
+                    7 => {
+                        assert_eq!(src, None);
+                        assert_eq!(dst.location, "b");
+                    }
+                    _ => unreachable!("Should have expected emission call {calls}"),
+                }
+                calls += 1;
+                std::ops::ControlFlow::Continue(())
+            });
+            assert_eq!(
+                out,
+                rewrites::Outcome {
+                    options: renames_by_identity,
+                    ..Default::default()
+                }
+            );
+            assert_eq!(calls, 8, "Should not have too few calls");
         }
-        calls += 1;
-        std::ops::ControlFlow::Continue(())
-    });
-    assert_eq!(
-        out,
-        rewrites::Outcome {
-            options: renames_by_identity,
-            ..Default::default()
+        gix_hash::Kind::Sha256 => {
+            let mut calls = 0;
+            let out = util::assert_emit(&mut track, |dst, src| {
+                match calls {
+                    0 => {
+                        let src = src.unwrap();
+                        assert_eq!(src.location, "d");
+                        assert_eq!(src.entry_mode.kind(), EntryKind::Tree);
+                        assert_eq!(src.change.relation, Some(Relation::Parent(3)));
+                        assert_eq!(dst.location, "d-renamed", "it found the renamed directory");
+                        assert_eq!(dst.change.relation, Some(Relation::Parent(1)));
+                        assert_eq!(dst.change.mode.kind(), EntryKind::Tree);
+                    }
+                    1..=5 => {
+                        let src = src.unwrap();
+                        let (expected_src, expected_dst) = &[
+                            ("d/subdir/d", "d-renamed/subdir/d"),
+                            ("d/b", "d-renamed/b"),
+                            ("d/subdir", "d-renamed/subdir"),
+                            ("d/c", "d-renamed/c"),
+                            ("d/a", "d-renamed/a"),
+                        ][calls - 1];
+                        assert_eq!(src.location, expected_src);
+                        assert_eq!(dst.location, expected_dst);
+                    }
+                    6 => {
+                        assert_eq!(src, None);
+                        assert_eq!(dst.location, "a");
+                    }
+                    7 => {
+                        assert_eq!(src, None);
+                        assert_eq!(dst.location, "b");
+                    }
+                    _ => unreachable!("Should have expected emission call {calls}"),
+                }
+                calls += 1;
+                std::ops::ControlFlow::Continue(())
+            });
+            assert_eq!(
+                out,
+                rewrites::Outcome {
+                    options: renames_by_identity,
+                    ..Default::default()
+                }
+            );
+            assert_eq!(calls, 8, "Should not have too few calls");
         }
-    );
-    assert_eq!(calls, 8, "Should not have too few calls");
+        _ => todo!(),
+    }
+
     Ok(())
 }
 

--- a/gix-diff/tests/diff/rewrites/tracker.rs
+++ b/gix-diff/tests/diff/rewrites/tracker.rs
@@ -50,7 +50,7 @@ fn rename_by_id() -> crate::Result {
                 src.unwrap(),
                 Source {
                     entry_mode: EntryKind::Blob.into(),
-                    id: NULL_ID,
+                    id: *NULL_ID,
                     kind: SourceKind::Rename,
                     location: "b".into(),
                     change: &Change::deletion(),
@@ -535,7 +535,7 @@ fn directories_without_relation_are_ignored() -> crate::Result {
     let mut track = util::new_tracker(Default::default());
     for mode in [EntryKind::Tree, EntryKind::Commit] {
         let tree_without_relation = Change {
-            id: NULL_ID,
+            id: *NULL_ID,
             kind: ChangeKind::Deletion,
             mode: mode.into(),
             relation: None,

--- a/gix-diff/tests/diff/tree.rs
+++ b/gix-diff/tests/diff/tree.rs
@@ -159,34 +159,37 @@ mod changes {
         fn many_different_states() -> crate::Result {
             let db = db(None)?;
             let all_commits = all_commits(&db);
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["f added"])?,
                 vec![Addition {
                     entry_mode: EntryKind::Blob.into(),
-                    oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                    oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                     path: "f".into(),
                     relation: None
                 }],
                 ":000000 100644 0000000000000000000000000000000000000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 A      f"
             );
 
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["f modified"])?,
                 vec![Modification {
                     previous_entry_mode: EntryKind::Blob.into(),
-                    previous_oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                    previous_oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                     entry_mode: EntryKind::Blob.into(),
-                    oid: hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242"),
+                    oid: hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242", "6ca8d4e3bc5df874055e542d18505b5a5efa0fb7d65776efedc13781073ed0f1"),
                     path: "f".into()
                 }],
                 ":100644 100644 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 28ce6a8b26aa170e1de65536fe8abe1832bd3242 M      f"
             );
 
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["f deleted"])?,
                 vec![Deletion {
                     entry_mode: EntryKind::Blob.into(),
-                    oid: hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242"),
+                    oid: hex_to_id(
+                        "28ce6a8b26aa170e1de65536fe8abe1832bd3242",
+                        "6ca8d4e3bc5df874055e542d18505b5a5efa0fb7d65776efedc13781073ed0f1"
+                    ),
                     path: "f".into(),
                     relation: None
                 }],
@@ -194,24 +197,24 @@ mod changes {
             "
             );
 
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["f mode modified to dir f/"])?,
                 vec![
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242"),
+                        oid: hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242", "6ca8d4e3bc5df874055e542d18505b5a5efa0fb7d65776efedc13781073ed0f1"),
                         path: "f".into(),
                         relation: None
                     },
                     Addition {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("10f2f4b82222d2b5c31985130979a91fd87410f7"),
+                        oid: hex_to_id("10f2f4b82222d2b5c31985130979a91fd87410f7", "9e220e584599b9cff376b638fa71675280f4582a87138b6be425258dbb85f94c"),
                         path: "f".into(),
                         relation: Some(Relation::Parent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242"),
+                        oid: hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242", "6ca8d4e3bc5df874055e542d18505b5a5efa0fb7d65776efedc13781073ed0f1"),
                         path: "f/f".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     }
@@ -220,18 +223,18 @@ mod changes {
                    :000000 100644 0000000000000000000000000000000000000000 28ce6a8b26aa170e1de65536fe8abe1832bd3242 A      f/f"
             );
 
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["a renamed to b"])?,
                 vec![
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "a".into(),
                         relation: None
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "b".into(),
                         relation: None
                     }
@@ -242,43 +245,49 @@ mod changes {
 
             );
 
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["f/f modified"])?,
                 vec![
                     Modification {
                         previous_entry_mode: EntryKind::Tree.into(),
-                        previous_oid: hex_to_id("10f2f4b82222d2b5c31985130979a91fd87410f7"),
+                        previous_oid: hex_to_id("10f2f4b82222d2b5c31985130979a91fd87410f7", "9e220e584599b9cff376b638fa71675280f4582a87138b6be425258dbb85f94c"),
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("ebbe0b3000afdfd1aed15000094b59a2800328eb"),
+                        oid: hex_to_id("ebbe0b3000afdfd1aed15000094b59a2800328eb", "ca3ee6fe1455fc077ae53f0fe7af54153feb35d52a892b1377e9c0b6828428d4"),
                         path: "f".into()
                     },
                     Modification {
                         previous_entry_mode: EntryKind::Blob.into(),
-                        previous_oid: hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242"),
+                        previous_oid: hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242", "6ca8d4e3bc5df874055e542d18505b5a5efa0fb7d65776efedc13781073ed0f1"),
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("13c2aca72ab576cb5f22dc8e7f8ba8ddab553a8a"),
+                        oid: hex_to_id("13c2aca72ab576cb5f22dc8e7f8ba8ddab553a8a", "ab879bd65609705434bab6bc157306769fd1053c6d86d82c89e76df9bee62809"),
                         path: "f/f".into()
                     },
                 ],
                 ":100644 100644 28ce6a8b26aa170e1de65536fe8abe1832bd3242 13c2aca72ab576cb5f22dc8e7f8ba8ddab553a8a M	f/f"
             );
 
-            let tree_with_link_id = hex_to_id("7e26dba59b6336f87d1d4ae3505a2da302b91c76");
-            let link_entry_oid = hex_to_id("2e65efe2a145dda7ee51d1741299f848e5bf752e");
+            let tree_with_link_id = hex_to_id(
+                "7e26dba59b6336f87d1d4ae3505a2da302b91c76",
+                "825cbacedb89cffe4fd6532846f376ab9cb8bc9e5cb399620d3592b714c2e95f",
+            );
+            let link_entry_oid = hex_to_id(
+                "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+                "eb337bcee2061c5313c9a1392116b6c76039e9e30d71467ae359b36277e17dc7",
+            );
             let link_entry_mode = EntryKind::Link;
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["f/f mode changed to link"])?,
                 vec![
                     Modification {
                         previous_entry_mode: EntryKind::Tree.into(),
-                        previous_oid: hex_to_id("849bd76db90b65ebbd2e6d3970ca70c96ee5592c"),
+                        previous_oid: hex_to_id("849bd76db90b65ebbd2e6d3970ca70c96ee5592c", "003781d2cca9a680f5ccfe0963614bb813dea1654968713b48a6a27490c3771e"),
                         entry_mode: EntryKind::Tree.into(),
                         oid: tree_with_link_id,
                         path: "f".into()
                     },
                     Modification {
                         previous_entry_mode: EntryKind::Blob.into(),
-                        previous_oid: hex_to_id("13c2aca72ab576cb5f22dc8e7f8ba8ddab553a8a"),
+                        previous_oid: hex_to_id("13c2aca72ab576cb5f22dc8e7f8ba8ddab553a8a", "ab879bd65609705434bab6bc157306769fd1053c6d86d82c89e76df9bee62809"),
                         entry_mode: link_entry_mode.into(),
                         oid: link_entry_oid,
                         path: "f/f".into()
@@ -287,12 +296,12 @@ mod changes {
                 ":100644 120000 13c2aca72ab576cb5f22dc8e7f8ba8ddab553a8a 2e65efe2a145dda7ee51d1741299f848e5bf752e T	f/f"
             );
 
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["f/ changed into file f"])?,
                 vec![
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "f".into(),
                         relation: None
                     },
@@ -304,13 +313,13 @@ mod changes {
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "f/a".into(),
                         relation: Some(Relation::ChildOfParent(1))
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "f/b".into(),
                         relation: Some(Relation::ChildOfParent(1))
                     },
@@ -326,42 +335,51 @@ mod changes {
                  :100644 000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0000000000000000000000000000000000000000 D	f/b
                  :120000 000000 2e65efe2a145dda7ee51d1741299f848e5bf752e 0000000000000000000000000000000000000000 D	f/f"
             );
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["delete d/"])?,
                 vec![
                     Deletion {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("3d5a503f4062d198b443db5065ca727f8354e7df"),
+                        oid: hex_to_id("3d5a503f4062d198b443db5065ca727f8354e7df", "1f5422fc234c61cf503a86521bcafcb86cc48653c5d80d4e93a6cc677e345b40"),
                         path: "d".into(),
                         relation: Some(Relation::Parent(1))
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "d/f".into(),
                         relation: Some(Relation::ChildOfParent(1))
                     },
                 ],
                 ":100644 000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0000000000000000000000000000000000000000 D	d/f"
             );
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["add /c /d /e"])?,
                 vec![
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "c".into(),
                         relation: None,
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "d".into(),
                         relation: None,
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "e".into(),
                         relation: None,
                     },
@@ -370,42 +388,51 @@ mod changes {
                  :000000 100644 0000000000000000000000000000000000000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 A	d
                  :000000 100644 0000000000000000000000000000000000000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 A	e"
             );
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["add g/a"])?,
                 vec![
                     Addition {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("496d6428b9cf92981dc9495211e6e1120fb6f2ba"),
+                        oid: hex_to_id("496d6428b9cf92981dc9495211e6e1120fb6f2ba", "5f6f307bcc469c02acba4f7da42d8d4defdda8209777fe732956f1e2fa0db3ff"),
                         path: "g".into(),
                         relation: Some(Relation::Parent(1))
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "g/a".into(),
                         relation: Some(Relation::ChildOfParent(1))
                     },
                 ],
                 ":000000 100644 0000000000000000000000000000000000000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 A	g/a"
             );
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["remove /c /d /e"])?,
                 vec![
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "c".into(),
                         relation: None
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "d".into(),
                         relation: None
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "e".into(),
                         relation: None
                     },
@@ -414,18 +441,18 @@ mod changes {
                  :100644 000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0000000000000000000000000000000000000000 D	d
                  :100644 000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0000000000000000000000000000000000000000 D	e"
             );
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["rm /f, add /ff"])?,
                 vec![
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "f".into(),
                         relation: None
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "ff".into(),
                         relation: None
                     },
@@ -433,25 +460,25 @@ mod changes {
                 ":100644 000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0000000000000000000000000000000000000000 D	f
                   :000000 100644 0000000000000000000000000000000000000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 A	ff"
             );
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["rm g/a, add g/aa"])?,
                 vec![
                     Modification {
                         previous_entry_mode: EntryKind::Tree.into(),
-                        previous_oid: hex_to_id("496d6428b9cf92981dc9495211e6e1120fb6f2ba"),
+                        previous_oid: hex_to_id("496d6428b9cf92981dc9495211e6e1120fb6f2ba", "5f6f307bcc469c02acba4f7da42d8d4defdda8209777fe732956f1e2fa0db3ff"),
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("6e5931346904b020301f74f581142826eacc4678"),
+                        oid: hex_to_id("6e5931346904b020301f74f581142826eacc4678", "c56aa83b78552302a7ab7c6377d8a54573a3845e10242df3eae849394ab91b53"),
                         path: "g".into()
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "g/a".into(),
                         relation: None
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "g/aa".into(),
                         relation: None
                     },
@@ -459,18 +486,18 @@ mod changes {
                 ":100644 000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0000000000000000000000000000000000000000 D	g/a
                  :000000 100644 0000000000000000000000000000000000000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 A	g/aa"
             );
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["rm /ff, add /f"])?,
                 vec![
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "f".into(),
                         relation: None,
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "ff".into(),
                         relation: None,
                     },
@@ -478,25 +505,25 @@ mod changes {
                 ":100644 000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0000000000000000000000000000000000000000 D	f
                   :000000 100644 0000000000000000000000000000000000000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 A	ff"
             );
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["rm g/aa, add g/a"])?,
                 vec![
                     Modification {
                         previous_entry_mode: EntryKind::Tree.into(),
-                        previous_oid: hex_to_id("6e5931346904b020301f74f581142826eacc4678"),
+                        previous_oid: hex_to_id("6e5931346904b020301f74f581142826eacc4678", "c56aa83b78552302a7ab7c6377d8a54573a3845e10242df3eae849394ab91b53"),
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("496d6428b9cf92981dc9495211e6e1120fb6f2ba"),
+                        oid: hex_to_id("496d6428b9cf92981dc9495211e6e1120fb6f2ba", "5f6f307bcc469c02acba4f7da42d8d4defdda8209777fe732956f1e2fa0db3ff"),
                         path: "g".into()
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "g/a".into(),
                         relation: None,
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "g/aa".into(),
                         relation: None,
                     },
@@ -512,39 +539,39 @@ mod changes {
             let db = db(["a"].iter().copied())?;
             let all_commits = all_commits(&db);
 
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["f added"])?,
                 vec![
                     Addition {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("3d5a503f4062d198b443db5065ca727f8354e7df"),
+                        oid: hex_to_id("3d5a503f4062d198b443db5065ca727f8354e7df", "1f5422fc234c61cf503a86521bcafcb86cc48653c5d80d4e93a6cc677e345b40"),
                         path: "a".into(),
                         relation: Some(Relation::Parent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         path: "a/f".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     }
                 ],
                 ":000000 100644 0000000000000000000000000000000000000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 A      a/f"
             );
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["f modified"])?,
                 vec![
                     Modification {
                         previous_entry_mode: EntryKind::Tree.into(),
-                        previous_oid: hex_to_id("3d5a503f4062d198b443db5065ca727f8354e7df"),
+                        previous_oid: hex_to_id("3d5a503f4062d198b443db5065ca727f8354e7df", "1f5422fc234c61cf503a86521bcafcb86cc48653c5d80d4e93a6cc677e345b40"),
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("10f2f4b82222d2b5c31985130979a91fd87410f7"),
+                        oid: hex_to_id("10f2f4b82222d2b5c31985130979a91fd87410f7", "9e220e584599b9cff376b638fa71675280f4582a87138b6be425258dbb85f94c"),
                         path: "a".into()
                     },
                     Modification {
                         previous_entry_mode: EntryKind::Blob.into(),
-                        previous_oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        previous_oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"),
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242"),
+                        oid: hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242", "6ca8d4e3bc5df874055e542d18505b5a5efa0fb7d65776efedc13781073ed0f1"),
                         path: "a/f".into()
                     }
                 ],
@@ -567,47 +594,65 @@ mod changes {
 
             let last_commit = all_commits["rm g/aa, add g/a"];
             let first_commit = all_commits["f added"];
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_commits(&db, first_commit.to_owned(), &last_commit, None)?,
                 vec![
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "".into(),
                         relation: None
                     },
                     Addition {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("496d6428b9cf92981dc9495211e6e1120fb6f2ba"),
+                        oid: hex_to_id(
+                            "496d6428b9cf92981dc9495211e6e1120fb6f2ba",
+                            "5f6f307bcc469c02acba4f7da42d8d4defdda8209777fe732956f1e2fa0db3ff"
+                        ),
                         path: "".into(),
                         relation: Some(Relation::Parent(1))
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "".into(),
                         relation: Some(Relation::ChildOfParent(1))
                     }
                 ]
             );
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_commits(&db, last_commit.to_owned(), &first_commit, Location::FileName.into())?,
                 vec![
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "b".into(),
                         relation: None
                     },
                     Deletion {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("496d6428b9cf92981dc9495211e6e1120fb6f2ba"),
+                        oid: hex_to_id(
+                            "496d6428b9cf92981dc9495211e6e1120fb6f2ba",
+                            "5f6f307bcc469c02acba4f7da42d8d4defdda8209777fe732956f1e2fa0db3ff"
+                        ),
                         path: "g".into(),
                         relation: Some(Relation::Parent(1))
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "a".into(),
                         relation: Some(Relation::ChildOfParent(1))
                     }
@@ -621,54 +666,78 @@ mod changes {
             let db = db(["a"].iter().copied())?;
             let all_commits = all_commits(&db);
 
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_commits(&db, None::<ObjectId>, &all_commits["add g/a"], Some(Location::Path))?,
                 vec![
                     Addition {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("0df4d0ed769eacd0a231e7512fca25d3cabdeca4"),
+                        oid: hex_to_id(
+                            "0df4d0ed769eacd0a231e7512fca25d3cabdeca4",
+                            "dac24a12e6d43c6ad271e7ea4f021093dac44f15f99317b2e0d54753b4f09099"
+                        ),
                         path: "a".into(),
                         relation: Some(Relation::Parent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "a/b".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "a/c".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "a/d".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "a/e".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "a/f".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("496d6428b9cf92981dc9495211e6e1120fb6f2ba"),
+                        oid: hex_to_id(
+                            "496d6428b9cf92981dc9495211e6e1120fb6f2ba",
+                            "5f6f307bcc469c02acba4f7da42d8d4defdda8209777fe732956f1e2fa0db3ff"
+                        ),
                         path: "a/g".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "a/g/a".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     }
@@ -682,66 +751,96 @@ mod changes {
             let db = db(None)?;
             let all_commits = all_commits(&db);
 
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["rename git-sec to gix-sec"])?,
                 vec![
                     Deletion {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("d8c30fb72173778ed57fac5813c5e37038a8746c"),
+                        oid: hex_to_id(
+                            "d8c30fb72173778ed57fac5813c5e37038a8746c",
+                            "52a70042eff6fbeed1d6c8c0ed2f9cc775a19cc51b395429c4210bc5091520ad"
+                        ),
                         path: "git-sec".into(),
                         relation: Some(Relation::Parent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("d8c30fb72173778ed57fac5813c5e37038a8746c"),
+                        oid: hex_to_id(
+                            "d8c30fb72173778ed57fac5813c5e37038a8746c",
+                            "52a70042eff6fbeed1d6c8c0ed2f9cc775a19cc51b395429c4210bc5091520ad"
+                        ),
                         path: "gix-sec".into(),
                         relation: Some(Relation::Parent(2)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "git-sec/2".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "git-sec/7".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("fd7938a0c18f993c89eda3f40a6d06fa6785833c"),
+                        oid: hex_to_id(
+                            "fd7938a0c18f993c89eda3f40a6d06fa6785833c",
+                            "5b2e08d098c63c2f31c8937c810f77ff005c48833701e0854f690188f1887aae"
+                        ),
                         path: "git-sec/subdir".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "gix-sec/2".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "gix-sec/7".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     },
                     Addition {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("fd7938a0c18f993c89eda3f40a6d06fa6785833c"),
+                        oid: hex_to_id(
+                            "fd7938a0c18f993c89eda3f40a6d06fa6785833c",
+                            "5b2e08d098c63c2f31c8937c810f77ff005c48833701e0854f690188f1887aae"
+                        ),
                         path: "gix-sec/subdir".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "git-sec/subdir/6".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "gix-sec/subdir/6".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     }
@@ -755,66 +854,96 @@ mod changes {
             let db = db(None)?;
             let all_commits = all_commits(&db);
 
-            assert_hash_agnostic_eq!(
+            pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["rename gix-sec to git-sec"])?,
                 vec![
                     Addition {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("d8c30fb72173778ed57fac5813c5e37038a8746c"),
+                        oid: hex_to_id(
+                            "d8c30fb72173778ed57fac5813c5e37038a8746c",
+                            "52a70042eff6fbeed1d6c8c0ed2f9cc775a19cc51b395429c4210bc5091520ad"
+                        ),
                         path: "git-sec".into(),
                         relation: Some(Relation::Parent(1)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("d8c30fb72173778ed57fac5813c5e37038a8746c"),
+                        oid: hex_to_id(
+                            "d8c30fb72173778ed57fac5813c5e37038a8746c",
+                            "52a70042eff6fbeed1d6c8c0ed2f9cc775a19cc51b395429c4210bc5091520ad"
+                        ),
                         path: "gix-sec".into(),
                         relation: Some(Relation::Parent(2)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "git-sec/2".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "git-sec/7".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("fd7938a0c18f993c89eda3f40a6d06fa6785833c"),
+                        oid: hex_to_id(
+                            "fd7938a0c18f993c89eda3f40a6d06fa6785833c",
+                            "5b2e08d098c63c2f31c8937c810f77ff005c48833701e0854f690188f1887aae"
+                        ),
                         path: "git-sec/subdir".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "gix-sec/2".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "gix-sec/7".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Tree.into(),
-                        oid: hex_to_id("fd7938a0c18f993c89eda3f40a6d06fa6785833c"),
+                        oid: hex_to_id(
+                            "fd7938a0c18f993c89eda3f40a6d06fa6785833c",
+                            "5b2e08d098c63c2f31c8937c810f77ff005c48833701e0854f690188f1887aae"
+                        ),
                         path: "gix-sec/subdir".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "git-sec/subdir/6".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"),
+                        oid: hex_to_id(
+                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                        ),
                         path: "gix-sec/subdir/6".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     }

--- a/gix-diff/tests/diff/tree.rs
+++ b/gix-diff/tests/diff/tree.rs
@@ -353,33 +353,28 @@ mod changes {
                 ],
                 ":100644 000000 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0000000000000000000000000000000000000000 D	d/f"
             );
+            let empty_blob_id = hex_to_id(
+                "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813",
+            );
             pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["add /c /d /e"])?,
                 vec![
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "c".into(),
                         relation: None,
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "d".into(),
                         relation: None,
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "e".into(),
                         relation: None,
                     },
@@ -411,28 +406,19 @@ mod changes {
                 vec![
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "c".into(),
                         relation: None
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "d".into(),
                         relation: None
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "e".into(),
                         relation: None
                     },
@@ -594,15 +580,16 @@ mod changes {
 
             let last_commit = all_commits["rm g/aa, add g/a"];
             let first_commit = all_commits["f added"];
+            let empty_blob_id = hex_to_id(
+                "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813",
+            );
             pretty_assertions::assert_eq!(
                 diff_commits(&db, first_commit.to_owned(), &last_commit, None)?,
                 vec![
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "".into(),
                         relation: None
                     },
@@ -617,10 +604,7 @@ mod changes {
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "".into(),
                         relation: Some(Relation::ChildOfParent(1))
                     }
@@ -631,10 +615,7 @@ mod changes {
                 vec![
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "b".into(),
                         relation: None
                     },
@@ -649,10 +630,7 @@ mod changes {
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "a".into(),
                         relation: Some(Relation::ChildOfParent(1))
                     }
@@ -665,6 +643,10 @@ mod changes {
         fn maximal_difference_nested() -> crate::Result {
             let db = db(["a"].iter().copied())?;
             let all_commits = all_commits(&db);
+            let empty_blob_id = hex_to_id(
+                "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813",
+            );
 
             pretty_assertions::assert_eq!(
                 diff_commits(&db, None::<ObjectId>, &all_commits["add g/a"], Some(Location::Path))?,
@@ -680,46 +662,31 @@ mod changes {
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "a/b".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "a/c".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "a/d".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "a/e".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "a/f".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
@@ -734,10 +701,7 @@ mod changes {
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "a/g/a".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     }
@@ -750,6 +714,10 @@ mod changes {
         fn directory_rename() -> crate::Result {
             let db = db(None)?;
             let all_commits = all_commits(&db);
+            let empty_blob_id = hex_to_id(
+                "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813",
+            );
 
             pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["rename git-sec to gix-sec"])?,
@@ -774,19 +742,13 @@ mod changes {
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "git-sec/2".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "git-sec/7".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
@@ -801,19 +763,13 @@ mod changes {
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "gix-sec/2".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "gix-sec/7".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     },
@@ -828,19 +784,13 @@ mod changes {
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "git-sec/subdir/6".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "gix-sec/subdir/6".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     }
@@ -853,6 +803,10 @@ mod changes {
         fn reverse_directory_rename() -> crate::Result {
             let db = db(None)?;
             let all_commits = all_commits(&db);
+            let empty_blob_id = hex_to_id(
+                "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813",
+            );
 
             pretty_assertions::assert_eq!(
                 diff_with_previous_commit_from(&db, &all_commits["rename gix-sec to git-sec"])?,
@@ -877,19 +831,13 @@ mod changes {
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "git-sec/2".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "git-sec/7".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
@@ -904,19 +852,13 @@ mod changes {
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "gix-sec/2".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "gix-sec/7".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     },
@@ -931,19 +873,13 @@ mod changes {
                     },
                     Addition {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "git-sec/subdir/6".into(),
                         relation: Some(Relation::ChildOfParent(1)),
                     },
                     Deletion {
                         entry_mode: EntryKind::Blob.into(),
-                        oid: hex_to_id(
-                            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
-                        ),
+                        oid: empty_blob_id,
                         path: "gix-sec/subdir/6".into(),
                         relation: Some(Relation::ChildOfParent(2)),
                     }

--- a/gix-imara-diff/Cargo.toml
+++ b/gix-imara-diff/Cargo.toml
@@ -32,9 +32,6 @@ gix-object = { version = "^0.58.0", path = "../gix-object", features = ["sha1"] 
 cov-mark = "2.1.0"
 expect-test = "1.4.0"
 
-[profile.release]
-debug = true
-
 # [[bench]]
 # name = "git_repo"
 # harness = false

--- a/justfile
+++ b/justfile
@@ -224,6 +224,7 @@ unit-tests:
     cargo nextest run -p gix-odb-tests --features gix-features-parallel --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-pack --all-features --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-pack --all-features --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-diff-tests --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-diff-tests --no-fail-fast
     cargo nextest run -p gix-pack-tests --features all-features --no-fail-fast
     cargo nextest run -p gix-pack-tests --features gix-features-parallel --no-fail-fast

--- a/justfile
+++ b/justfile
@@ -201,6 +201,8 @@ unit-tests:
     cargo nextest run -p gix-archive --no-default-features --features tar --no-fail-fast
     cargo nextest run -p gix-archive --no-default-features --features tar_gz --no-fail-fast
     cargo nextest run -p gix-archive --no-default-features --features zip --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-diff --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-diff --no-fail-fast
     cargo nextest run -p gix-status-tests --features gix-features-parallel --no-fail-fast
     cargo nextest run -p gix-worktree-state-tests --features gix-features-parallel --no-fail-fast
     cargo nextest run -p gix-worktree-tests --features gix-features-parallel --no-fail-fast


### PR DESCRIPTION
This is a follow-up to #2497 which made tests in `gix-diff-tests` run with `GIX_TEST_FIXTURE_HASH=sha256`.

This PR adds:
- Remove `profile.release` section in `gix-imara-diff`
  This fixes the following warning:

  ```
  warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
  package:   .../gix-imara-diff/Cargo.toml
  workspace: .../Cargo.toml
  ```

  There’s also a commented out `[[bench]]` section in `gix-imara-diff/Cargo.toml` that could be removed as well.
- Run `gix-diff-tests` with `GIX_TEST_FIXTURE_HASH=sha1` as well (before, they were only run with `GIX_TEST_FIXTURE_HASH=sha256`)
- Use `GIX_TEST_FIXTURE_HASH` for `gix-diff` as well (as opposed to `gix-diff-tests` which is a separate crate)

This is part of #281