### PR TITLE
Use `GIX_TEST_FIXTURE_HASH` for `gix-worktree-stream`

### DIFF
--- a/etc/plan/sha256-support.md
+++ b/etc/plan/sha256-support.md
@@ -2,6 +2,7 @@
 
 Source issue: [GitoxideLabs/gitoxide#281](https://github.com/GitoxideLabs/gitoxide/issues/281)  
 Imported on: 2026-04-22  
+Last reconciled: 2026-04-30
 Working assumption: checkboxes in this file reflect current checkout, not only historical issue state.
 
 ## Mission
@@ -20,9 +21,11 @@ Make object-hash kind first-class across config, protocol, storage, tests, and c
 - [ ] Remove hash-type specific methods from `gix-hash` and lean on `gix_hash::Kind`-parametric usage.
   Evidence: `gix-hash` still contains `new_sha1`, `new_sha256`, `from_20_bytes`, `from_32_bytes`, `null_sha1`, `null_sha256`.
 - [ ] Remove len-20 assumptions from all relevant code paths.
-  Evidence: big progress exists, but 73 `Kind::Sha1.null()` call sites still remain, plus a few explicit 20-byte comments and helpers.
+  Evidence: big progress exists, but 69 non-plan/non-changelog `Kind::Sha1.null()` call sites still remain, plus a few explicit 20-byte comments and helpers.
 - [ ] Provide visible CLI path for choosing object hash kind.
   Evidence: current tree has 0 `--object-hash` matches.
+- [ ] Propagate `sha256` feature support through crates that participate in object traversal, object parsing, and object-id storage.
+  Evidence: only `gix-hash`, `gix-ref`, `gix-worktree-stream`, and top-level `gix` define a `sha256` feature today; `gix-traverse` only exposes `sha1`, while `justfile` compile-guards it for missing hash selection and only checks `--features sha1`.
 - [x] Remove default `sha1` feature from `gix-hash` and deal with fallout.
   Evidence: `gix-hash` has `default = []`, docs.rs explicitly enables `sha1`, root `gitoxide` chooses SHA1 via features, and `justfile` contains 31 compile-guard checks for missing hash selection.
 - [x] Remove SHA1 mention from `gix-features` feature toggles.
@@ -45,11 +48,13 @@ Make object-hash kind first-class across config, protocol, storage, tests, and c
 
 ## Current Snapshot
 
-Workspace signals on 2026-04-22:
+Workspace signals on 2026-04-30:
 
 - `gix-hash` default hash feature: removed
 - compile-guard checks for missing hash selection in `justfile`: 31
-- `Kind::Sha1.null()` occurrences: 73
+- crates with explicit `sha256 = ...` feature declarations: 4 (`gix-hash`, `gix-ref`, `gix-worktree-stream`, `gix`)
+- `gix-traverse` hash feature declarations: `sha1` only
+- `Kind::Sha1.null()` occurrences outside this plan and changelogs: 69
 - `object-format=sha1` fixture occurrences: 10
 - clone path `unimplemented!()` for hash mismatch: 1
 - `--object-hash` CLI flag matches: 0
@@ -57,16 +62,21 @@ Workspace signals on 2026-04-22:
 Dual-hash test hooks already exist in `justfile` for at least:
 
 - `gix-filter`
+- `gix-diff`
 - `gix-commitgraph`
 - `gix-object`
+- `gix-ref-tests`
 - `gix-pack`
+- `gix-diff-tests`
+- `gix-blame`
 - `gix-refspec`
+- `gix-worktree-stream`
 - `gix-hash`
 
 ## Confirmed Done
 
 - [x] `gix-commitgraph`
-  Evidence: issue marked it complete, crate depends on `gix-hash` with `sha1` and `sha256`, and `justfile` runs it with `GIX_TEST_FIXTURE_HASH=sha1` and `sha256`.
+  Evidence: issue marked it complete, dev-dependencies enable `gix-hash` with `sha1` and `sha256`, and `justfile` runs it with `GIX_TEST_FIXTURE_HASH=sha1` and `sha256`.
 
 ## Remaining Hotspots
 
@@ -78,6 +88,12 @@ Dual-hash test hooks already exist in `justfile` for at least:
   repository object hash still falls back to SHA1 when config does not say otherwise.
 - `gix/src/clone/fetch/mod.rs`
   clone still aborts on remote hash mismatch instead of configuring repo state.
+- `gix-traverse/Cargo.toml`
+  only defines a `sha1` feature and docs.rs/dev-dependencies use `sha1`; there is no `sha256` feature despite traversal code carrying `ObjectId` and `object_hash` state.
+- `gix/Cargo.toml`
+  top-level `sha256` currently forwards only to `gix-hash/sha256`, unlike `sha1`, which fans out to the stack including `gix-traverse/sha1`.
+- `gix-worktree-stream/Cargo.toml`
+  has a `sha256` feature, but it forwards only `gix-hash/sha256`; its `sha1` feature forwards into `gix-filter`, `gix-object`, and `gix-traverse`.
 
 ## Execution Order
 
@@ -85,6 +101,8 @@ Dual-hash test hooks already exist in `justfile` for at least:
 
 - [ ] `gix-hash`
   Remove remaining SHA1/SHA256-shaped helper APIs where `Kind`-based forms can replace them.
+- [ ] feature propagation
+  Add and forward `sha256` features where crates already have hash-sensitive APIs or compile guards, starting with `gix-traverse`, then the dependent stack that needs to run under SHA256.
 - [ ] `gitoxide` CLI surface
   Decide whether to restore a flag like `--object-hash` or bless config-only selection and document it clearly.
 - [ ] `gix-refspec`
@@ -100,6 +118,8 @@ Dual-hash test hooks already exist in `justfile` for at least:
   Expand refs and reflog read/write coverage to both hash lengths.
 - [ ] `gix-index`
   Extend checksum and extension tests to SHA256-sized object ids.
+- [ ] `gix-traverse`
+  Add `sha256` feature support and traversal tests that parse SHA256 commit parents and tree ids instead of relying on SHA1-shaped fixtures.
 
 ### Batch 3: protocol and transport
 
@@ -123,6 +143,8 @@ Dual-hash test hooks already exist in `justfile` for at least:
   Remove SHA1-only sentinel assumptions where caller hash kind should drive impossible ids.
 - [ ] `gix-blame`
   Same sentinel cleanup where SHA1 null ids are only placeholders.
+- [ ] `gix-traverse`
+  Replace remaining SHA1 defaults in traversal state with caller/repository hash kind where traversal starts from generic object ids.
 - [ ] broad repo sweep
   Review remaining `Kind::Sha1.null()` occurrences one by one and separate acceptable sentinels from real SHA1 assumptions.
 
@@ -136,6 +158,7 @@ Dual-hash test hooks already exist in `justfile` for at least:
 ## Immediate Next Moves
 
 - [ ] Decide whether `--object-hash` is still required as CLI UX, or whether config plus API is enough.
+- [ ] Add `sha256` feature support to `gix-traverse` and forward it from dependent crates.
 - [ ] Make `extensions.objectFormat=sha256` parse successfully.
 - [ ] Make fetch negotiation accept `object-format=sha256`.
 - [ ] Remove clone-time `unimplemented!()` for remote hash mismatch.

--- a/gitoxide-core/src/hours/mod.rs
+++ b/gitoxide-core/src/hours/mod.rs
@@ -83,9 +83,9 @@ fn parse_trailer_identity(trailer: gix::objs::commit::message::body::TrailerRef<
 /// Return `(commit_author, [commit_author, co_authors...])`. Use the `commit_author` for easy access to the commit author itself.
 fn commit_author_identities(
     commit_data: &[u8],
-    hash_kind: gix::hash::Kind,
+    object_hash: gix::hash::Kind,
 ) -> Result<(gix::actor::SignatureRef<'_>, SmallVec<[ParsedIdentity<'_>; 2]>), gix::objs::decode::Error> {
-    let commit = gix::objs::CommitRef::from_bytes(commit_data, hash_kind)?;
+    let commit = gix::objs::CommitRef::from_bytes(commit_data, object_hash)?;
     let author = commit.author()?.trim();
     let mut authors = smallvec![ParsedIdentity::Borrowed(gix::actor::IdentityRef::from(author))];
     authors.extend(commit.co_authored_by_trailers().filter_map(parse_trailer_identity));

--- a/gitoxide-core/src/index/checkout.rs
+++ b/gitoxide-core/src/index/checkout.rs
@@ -192,7 +192,7 @@ where
             // …but write nothing
             Ok(Some(gix::objs::Data {
                 kind,
-                hash_kind: id.kind(),
+                object_hash: id.kind(),
                 data: buf,
             }))
         } else {
@@ -209,7 +209,7 @@ impl gix::objs::Find for Empty {
         buffer.clear();
         Ok(Some(gix::objs::Data {
             kind: gix::object::Kind::Blob,
-            hash_kind: id.kind(),
+            object_hash: id.kind(),
             data: buffer,
         }))
     }

--- a/gitoxide-core/src/query/engine/update.rs
+++ b/gitoxide-core/src/query/engine/update.rs
@@ -395,7 +395,7 @@ pub fn update(
                 self.progress.inc();
                 if self.known_commits.binary_search(&id.to_owned()).is_err() {
                     let res = {
-                        let mut parents = gix::objs::CommitRefIter::from_bytes(obj.data, obj.hash_kind).parent_ids();
+                        let mut parents = gix::objs::CommitRefIter::from_bytes(obj.data, obj.object_hash).parent_ids();
                         let res = parents.next().map(|first_parent| (Some(first_parent), id.to_owned()));
                         match parents.next() {
                             Some(_) => None,

--- a/gitoxide-core/src/repository/archive.rs
+++ b/gitoxide-core/src/repository/archive.rs
@@ -34,7 +34,7 @@ pub fn stream(
                 .ok_or_else(|| anyhow!("Adding files requires a worktree directory that contains them"))?,
         )?;
         for path in add_paths {
-            stream.add_entry_from_path(&root, &gix::path::realpath(&path)?)?;
+            stream.add_entry_from_path(&root, &gix::path::realpath(&path)?, repo.object_hash())?;
         }
     }
     for (path, content) in files {

--- a/gix-archive/tests/archive.rs
+++ b/gix-archive/tests/archive.rs
@@ -240,11 +240,12 @@ mod from_tree {
                     .map(|_| ())
             },
         );
+        let hash_kind = gix_testtools::hash_kind_from_env().unwrap_or_default();
         stream
-            .add_entry_from_path(&dir, &dir.join("extra-file"))?
-            .add_entry_from_path(&dir, &dir.join("extra-exe"))?
-            .add_entry_from_path(&dir, &dir.join("extra-dir-empty"))?
-            .add_entry_from_path(&dir, &dir.join("extra-dir").join("symlink-to-extra"))?;
+            .add_entry_from_path(&dir, &dir.join("extra-file"), hash_kind)?
+            .add_entry_from_path(&dir, &dir.join("extra-exe"), hash_kind)?
+            .add_entry_from_path(&dir, &dir.join("extra-dir-empty"), hash_kind)?
+            .add_entry_from_path(&dir, &dir.join("extra-dir").join("symlink-to-extra"), hash_kind)?;
 
         let mut buf = Vec::new();
         if format == Format::InternalTransientNonPersistable {

--- a/gix-archive/tests/archive.rs
+++ b/gix-archive/tests/archive.rs
@@ -240,7 +240,7 @@ mod from_tree {
                     .map(|_| ())
             },
         );
-        let object_hash = gix_testtools::hash_kind_from_env().unwrap_or_default();
+        let object_hash = gix_testtools::object_hash();
         stream
             .add_entry_from_path(&dir, &dir.join("extra-file"), object_hash)?
             .add_entry_from_path(&dir, &dir.join("extra-exe"), object_hash)?

--- a/gix-archive/tests/archive.rs
+++ b/gix-archive/tests/archive.rs
@@ -240,12 +240,12 @@ mod from_tree {
                     .map(|_| ())
             },
         );
-        let hash_kind = gix_testtools::hash_kind_from_env().unwrap_or_default();
+        let object_hash = gix_testtools::hash_kind_from_env().unwrap_or_default();
         stream
-            .add_entry_from_path(&dir, &dir.join("extra-file"), hash_kind)?
-            .add_entry_from_path(&dir, &dir.join("extra-exe"), hash_kind)?
-            .add_entry_from_path(&dir, &dir.join("extra-dir-empty"), hash_kind)?
-            .add_entry_from_path(&dir, &dir.join("extra-dir").join("symlink-to-extra"), hash_kind)?;
+            .add_entry_from_path(&dir, &dir.join("extra-file"), object_hash)?
+            .add_entry_from_path(&dir, &dir.join("extra-exe"), object_hash)?
+            .add_entry_from_path(&dir, &dir.join("extra-dir-empty"), object_hash)?
+            .add_entry_from_path(&dir, &dir.join("extra-dir").join("symlink-to-extra"), object_hash)?;
 
         let mut buf = Vec::new();
         if format == Format::InternalTransientNonPersistable {

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -5,7 +5,7 @@ use gix_hash::ObjectId;
 use gix_object::bstr;
 
 fn fixture_hash_kind() -> gix_hash::Kind {
-    gix_testtools::hash_kind_from_env().unwrap_or_default()
+    gix_testtools::object_hash()
 }
 
 struct Baseline<'a> {

--- a/gix-diff/src/tree/function.rs
+++ b/gix-diff/src/tree/function.rs
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn compare_select_samples() {
-        let null = gix_testtools::hash_kind_from_env().unwrap_or_default().null();
+        let null = gix_testtools::object_hash().null();
         let actual = compare(
             &EntryRef {
                 mode: EntryKind::Blob.into(),

--- a/gix-diff/tests/diff/main.rs
+++ b/gix-diff/tests/diff/main.rs
@@ -2,7 +2,7 @@ use gix_testtools::Result;
 use std::collections::HashMap;
 
 fn hex_to_id(hex_sha1: &str, hex_sha256: &str) -> gix_hash::ObjectId {
-    match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+    match gix_testtools::object_hash() {
         gix_hash::Kind::Sha1 => gix_hash::ObjectId::from_hex(hex_sha1.as_bytes()).expect("40 bytes hex"),
         gix_hash::Kind::Sha256 => gix_hash::ObjectId::from_hex(hex_sha256.as_bytes()).expect("64 bytes hex"),
         _ => unimplemented!(),
@@ -10,7 +10,7 @@ fn hex_to_id(hex_sha1: &str, hex_sha256: &str) -> gix_hash::ObjectId {
 }
 
 fn fixture_hash_kind() -> gix_hash::Kind {
-    gix_testtools::hash_kind_from_env().unwrap_or_default()
+    gix_testtools::object_hash()
 }
 
 fn open_odb(objects_dir: impl Into<std::path::PathBuf>) -> std::io::Result<gix_odb::Handle> {

--- a/gix-diff/tests/diff/main.rs
+++ b/gix-diff/tests/diff/main.rs
@@ -162,7 +162,7 @@ mod util {
                     buffer.extend_from_slice(data);
                     Ok(Some(gix_object::Data {
                         kind: gix_object::Kind::Blob,
-                        hash_kind: id.kind(),
+                        object_hash: id.kind(),
                         data: buffer.as_slice(),
                     }))
                 }

--- a/gix-diff/tests/diff/tree_with_rewrites.rs
+++ b/gix-diff/tests/diff/tree_with_rewrites.rs
@@ -107,8 +107,8 @@ fn empty_to_new_tree_without_rename_tracking() -> crate::Result {
     {
         let (lhs, rhs, mut cache, odb) = repo_with_trees(None, "c1 - initial")?;
         let err = gix_diff::tree_with_rewrites(
-            TreeRefIter::from_bytes(&lhs, gix_testtools::hash_kind_from_env().unwrap_or_default()),
-            TreeRefIter::from_bytes(&rhs, gix_testtools::hash_kind_from_env().unwrap_or_default()),
+            TreeRefIter::from_bytes(&lhs, gix_testtools::object_hash()),
+            TreeRefIter::from_bytes(&rhs, gix_testtools::object_hash()),
             &mut cache,
             &mut Default::default(),
             &odb,
@@ -1960,7 +1960,7 @@ mod util {
     }
 
     pub fn fixture_hash_kind() -> gix_hash::Kind {
-        gix_testtools::hash_kind_from_env().unwrap_or_default()
+        gix_testtools::object_hash()
     }
 
     pub fn repo_with_trees(

--- a/gix-filter/tests/filter/ident.rs
+++ b/gix-filter/tests/filter/ident.rs
@@ -78,11 +78,7 @@ mod apply {
             "$ID$ case sensitive matching",
             "$Id: expanded is ignored$",
         ] {
-            let changed = ident::apply(
-                input_no_match.as_bytes(),
-                gix_testtools::hash_kind_from_env().unwrap_or_default(),
-                &mut buf,
-            )?;
+            let changed = ident::apply(input_no_match.as_bytes(), gix_testtools::object_hash(), &mut buf)?;
             assert!(!changed, "no substitution happens, nothing to do");
             assert_eq!(buf.len(), 0);
         }
@@ -93,14 +89,10 @@ mod apply {
     fn simple() -> crate::Result {
         let mut buf = Vec::new();
         assert!(
-            ident::apply(
-                B("$Id$"),
-                gix_testtools::hash_kind_from_env().unwrap_or_default(),
-                &mut buf
-            )?,
+            ident::apply(B("$Id$"), gix_testtools::object_hash(), &mut buf)?,
             "a change happens"
         );
-        let expected_hash = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+        let expected_hash = match gix_testtools::object_hash() {
             gix_hash::Kind::Sha1 => "b3f5ebfb5843bc43ceecff6d4f26bb37c615beb1",
             gix_hash::Kind::Sha256 => "63cdf77e7872965e2af1bee42e925f9b4bd6a3ab9f5ef6c06c4312f7d90d8021",
             _ => unimplemented!(),
@@ -109,10 +101,10 @@ mod apply {
 
         assert!(ident::apply(
             B("$Id$ $Id$ foo"),
-            gix_testtools::hash_kind_from_env().unwrap_or_default(),
+            gix_testtools::object_hash(),
             &mut buf
         )?);
-        let expected_hash = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+        let expected_hash = match gix_testtools::object_hash() {
             gix_hash::Kind::Sha1 => "e230cff7a9624f59eaa28bfb97602c3a03651a49",
             gix_hash::Kind::Sha256 => "64a29d2cfd88cf6cfd786cdd88e99112bef2f7d8596a8701f6955784624604ca",
             _ => unimplemented!(),
@@ -132,11 +124,7 @@ mod apply {
             "$Id$",
             "$Id$ and one more $Id$ and done",
         ] {
-            let changed = ident::apply(
-                B(input),
-                gix_testtools::hash_kind_from_env().unwrap_or_default(),
-                &mut buf,
-            )?;
+            let changed = ident::apply(B(input), gix_testtools::object_hash(), &mut buf)?;
             assert!(changed, "the input was rewritten");
             assert!(ident::undo(&buf.clone(), &mut buf)?, "undo does something as well");
             assert_eq!(buf.as_bstr(), input, "the filter can be undone perfectly");

--- a/gix-filter/tests/filter/pipeline/convert_to_git.rs
+++ b/gix-filter/tests/filter/pipeline/convert_to_git.rs
@@ -48,7 +48,7 @@ fn all_stages_mean_streaming_is_impossible() -> gix_testtools::Result {
         )
     })?;
 
-    let source_hash = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+    let source_hash = match gix_testtools::object_hash() {
         gix_hash::Kind::Sha1 => "2188d1cdee2b93a80084b61af431a49d21bc7cc0",
         gix_hash::Kind::Sha256 => "66b8b3bf4f18bcb5f74e09b24ac62e10934e9453a1de9793edb9390dc2ab1d6b",
         _ => unimplemented!(),
@@ -83,7 +83,7 @@ fn only_driver_means_streaming_is_possible() -> gix_testtools::Result {
         )
     })?;
 
-    let source_hash = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+    let source_hash = match gix_testtools::object_hash() {
         gix_hash::Kind::Sha1 => "2188d1cdee2b93a80084b61af431a49d21bc7cc0",
         gix_hash::Kind::Sha256 => "66b8b3bf4f18bcb5f74e09b24ac62e10934e9453a1de9793edb9390dc2ab1d6b",
         _ => unimplemented!(),
@@ -118,7 +118,7 @@ fn no_filter_means_reader_is_returned_unchanged() -> gix_testtools::Result {
         (vec![], Vec::new(), CrlfRoundTripCheck::Fail, Default::default())
     })?;
 
-    let source_hash = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+    let source_hash = match gix_testtools::object_hash() {
         gix_hash::Kind::Sha1 => "2188d1cdee2b93a80084b61af431a49d21bc7cc0",
         gix_hash::Kind::Sha256 => "66b8b3bf4f18bcb5f74e09b24ac62e10934e9453a1de9793edb9390dc2ab1d6b",
         _ => unimplemented!(),

--- a/gix-filter/tests/filter/pipeline/convert_to_worktree.rs
+++ b/gix-filter/tests/filter/pipeline/convert_to_worktree.rs
@@ -35,7 +35,7 @@ fn all_stages() -> gix_testtools::Result {
     assert!(out.as_read().is_some(), "process filter is last");
     let mut buf = Vec::new();
     out.read_to_end(&mut buf)?;
-    let expected_hash = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+    let expected_hash = match gix_testtools::object_hash() {
         gix_hash::Kind::Sha1 => "2188d1cdee2b93a80084b61af431a49d21bc7cc0",
         gix_hash::Kind::Sha256 => "66b8b3bf4f18bcb5f74e09b24ac62e10934e9453a1de9793edb9390dc2ab1d6b",
         _ => unimplemented!(),
@@ -71,7 +71,7 @@ fn all_stages_no_filter() -> gix_testtools::Result {
         "there is no filter process, so no chance for getting a stream"
     );
     let buf = out.as_bytes().expect("no filter process");
-    let expected_hash = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+    let expected_hash = match gix_testtools::object_hash() {
         gix_hash::Kind::Sha1 => "a77d7acbc809ac8df987a769221c83137ba1b9f9",
         gix_hash::Kind::Sha256 => "5ac811252c70ca9761feaa6fe00a74fbf558378ff4fc2853e43b097b153bd7eb",
         _ => unimplemented!(),

--- a/gix-filter/tests/filter/pipeline/mod.rs
+++ b/gix-filter/tests/filter/pipeline/mod.rs
@@ -65,7 +65,7 @@ fn pipeline(
             eol_config,
             encodings_with_roundtrip_check,
             crlf_roundtrip_check,
-            object_hash: gix_testtools::hash_kind_from_env().unwrap_or_default(),
+            object_hash: gix_testtools::object_hash(),
         },
     );
     Ok((cache, pipe))

--- a/gix-index/src/extension/end_of_index_entry/write.rs
+++ b/gix-index/src/extension/end_of_index_entry/write.rs
@@ -1,6 +1,6 @@
 use crate::extension::{end_of_index_entry::SIGNATURE, Signature};
 
-/// Write this extension to out and generate a hash of `hash_kind` over all `prior_extensions` which are specified as `(signature, size)`
+/// Write this extension to out and generate a hash of `object_hash` over all `prior_extensions` which are specified as `(signature, size)`
 /// pair. `one_past_entries` is the offset to the first byte past the entries, which is also the first byte of the signature of the
 /// first extension in `prior_extensions`. Note that `prior_extensions` must have been written prior to this one, as the name suggests,
 /// allowing this extension to be the last one in the index file.
@@ -8,17 +8,17 @@ use crate::extension::{end_of_index_entry::SIGNATURE, Signature};
 /// Even if there are no `prior_extensions`, this extension will be written unconditionally.
 pub fn write_to(
     mut out: impl std::io::Write,
-    hash_kind: gix_hash::Kind,
+    object_hash: gix_hash::Kind,
     offset_to_extensions: u32,
     prior_extensions: impl IntoIterator<Item = (Signature, u32)>,
 ) -> Result<(), gix_hash::io::Error> {
     out.write_all(&SIGNATURE)?;
-    let extension_size: u32 = 4 + hash_kind.len_in_bytes() as u32;
+    let extension_size: u32 = 4 + object_hash.len_in_bytes() as u32;
     out.write_all(&extension_size.to_be_bytes())?;
 
     out.write_all(&offset_to_extensions.to_be_bytes())?;
 
-    let mut hasher = gix_hash::hasher(hash_kind);
+    let mut hasher = gix_hash::hasher(object_hash);
     for (signature, size) in prior_extensions {
         hasher.update(&signature);
         hasher.update(&size.to_be_bytes());

--- a/gix-merge/tests/merge/blob/mod.rs
+++ b/gix-merge/tests/merge/blob/mod.rs
@@ -33,7 +33,7 @@ mod util {
                     buffer.extend_from_slice(data);
                     Ok(Some(gix_object::Data {
                         kind: gix_object::Kind::Blob,
-                        hash_kind: id.kind(),
+                        object_hash: id.kind(),
                         data: buffer.as_slice(),
                     }))
                 }

--- a/gix-object/benches/decode_objects.rs
+++ b/gix-object/benches/decode_objects.rs
@@ -30,7 +30,7 @@ fn parse_tag(c: &mut Criterion) {
 }
 
 fn parse_tree(c: &mut Criterion) {
-    let hash_kind = gix_testtools::hash_kind_from_env().unwrap_or_default();
+    let hash_kind = gix_testtools::object_hash();
     c.bench_function("TreeRef()", |b| {
         b.iter(|| black_box(gix_object::TreeRef::from_bytes(TREE, hash_kind)).unwrap());
     });

--- a/gix-object/benches/edit_tree.rs
+++ b/gix-object/benches/edit_tree.rs
@@ -173,7 +173,7 @@ impl gix_object::Find for StorageOdb {
                 tree.write_to(buffer).expect("valid trees can always be serialized");
                 Ok(Some(gix_object::Data {
                     kind: gix_object::Kind::Tree,
-                    hash_kind: id.kind(),
+                    object_hash: id.kind(),
                     data: &*buffer,
                 }))
             }

--- a/gix-object/src/commit/decode.rs
+++ b/gix-object/src/commit/decode.rs
@@ -37,13 +37,13 @@ pub fn message<'a>(i: &mut &'a [u8]) -> ParseResult<&'a BStr> {
 /// This parser is not transactional as a whole: if a later required field or
 /// the final message parse fails, `i` may already have been advanced past
 /// earlier successfully parsed fields.
-pub fn commit<'a>(i: &mut &'a [u8], hash_kind: gix_hash::Kind) -> ParseResult<CommitRef<'a>> {
-    let tree = parse::header_field(i, b"tree", |value| parse::hex_hash(value, hash_kind))?;
+pub fn commit<'a>(i: &mut &'a [u8], objeect_hash: gix_hash::Kind) -> ParseResult<CommitRef<'a>> {
+    let tree = parse::header_field(i, b"tree", |value| parse::hex_hash(value, objeect_hash))?;
 
     let mut parents = SmallVec::new();
     loop {
         let before = *i;
-        match parse::header_field(i, b"parent", |value| parse::hex_hash(value, hash_kind)) {
+        match parse::header_field(i, b"parent", |value| parse::hex_hash(value, objeect_hash)) {
             Ok(parent) => parents.push(parent),
             Err(_) => {
                 *i = before;

--- a/gix-object/src/commit/decode.rs
+++ b/gix-object/src/commit/decode.rs
@@ -37,13 +37,13 @@ pub fn message<'a>(i: &mut &'a [u8]) -> ParseResult<&'a BStr> {
 /// This parser is not transactional as a whole: if a later required field or
 /// the final message parse fails, `i` may already have been advanced past
 /// earlier successfully parsed fields.
-pub fn commit<'a>(i: &mut &'a [u8], objeect_hash: gix_hash::Kind) -> ParseResult<CommitRef<'a>> {
-    let tree = parse::header_field(i, b"tree", |value| parse::hex_hash(value, objeect_hash))?;
+pub fn commit<'a>(i: &mut &'a [u8], object_hash: gix_hash::Kind) -> ParseResult<CommitRef<'a>> {
+    let tree = parse::header_field(i, b"tree", |value| parse::hex_hash(value, object_hash))?;
 
     let mut parents = SmallVec::new();
     loop {
         let before = *i;
-        match parse::header_field(i, b"parent", |value| parse::hex_hash(value, objeect_hash)) {
+        match parse::header_field(i, b"parent", |value| parse::hex_hash(value, object_hash)) {
             Ok(parent) => parents.push(parent),
             Err(_) => {
                 *i = before;

--- a/gix-object/src/commit/mod.rs
+++ b/gix-object/src/commit/mod.rs
@@ -62,11 +62,11 @@ mod write;
 
 /// Lifecycle
 impl<'a> CommitRef<'a> {
-    /// Deserialize a commit from the given `data` bytes while avoiding most allocations, using `hash_kind` to know
+    /// Deserialize a commit from the given `data` bytes while avoiding most allocations, using `object_hash` to know
     /// what kind of hash to expect for validation.
-    pub fn from_bytes(mut data: &'a [u8], hash_kind: gix_hash::Kind) -> Result<CommitRef<'a>, crate::decode::Error> {
+    pub fn from_bytes(mut data: &'a [u8], object_hash: gix_hash::Kind) -> Result<CommitRef<'a>, crate::decode::Error> {
         let input = &mut data;
-        match decode::commit(input, hash_kind) {
+        match decode::commit(input, object_hash) {
             Ok(tag) => Ok(tag),
             Err(err) => Err(err),
         }

--- a/gix-object/src/commit/ref_iter.rs
+++ b/gix-object/src/commit/ref_iter.rs
@@ -30,7 +30,7 @@ pub(crate) enum State {
 
 /// Lifecycle
 impl<'a> CommitRefIter<'a> {
-    /// Create a commit iterator from the given `data`, using `hash_kind` to know
+    /// Create a commit iterator from the given `data`, using `object_hash` to know
     /// what kind of hash to expect for validation.
     pub fn from_bytes(data: &'a [u8], hash_kind: gix_hash::Kind) -> CommitRefIter<'a> {
         CommitRefIter {
@@ -44,7 +44,7 @@ impl<'a> CommitRefIter<'a> {
 /// Access
 impl<'a> CommitRefIter<'a> {
     /// Parse `data` as commit and return its PGP signature, along with *all non-signature* data as [`SignedData`], or `None`
-    /// if the commit isn't signed. All hashes in `data` are parsed as `hash_kind`.
+    /// if the commit isn't signed. All hashes in `data` are parsed as `object_hash`.
     ///
     /// This allows the caller to validate the signature by passing the signed data along with the signature back to the program
     /// that created it.

--- a/gix-object/src/data.rs
+++ b/gix-object/src/data.rs
@@ -3,7 +3,7 @@
 use crate::{BlobRef, CommitRef, CommitRefIter, Data, Kind, ObjectRef, TagRef, TagRefIter, TreeRef, TreeRefIter};
 
 impl<'a> Data<'a> {
-    /// Constructs a new data object from `data`, `kind` and `hash_kind`.
+    /// Constructs a new data object from `data`, `kind` and `object_hash`.
     pub fn new(data: &'a [u8], kind: Kind, hash_kind: gix_hash::Kind) -> Data<'a> {
         Data { kind, hash_kind, data }
     }

--- a/gix-object/src/data.rs
+++ b/gix-object/src/data.rs
@@ -5,7 +5,11 @@ use crate::{BlobRef, CommitRef, CommitRefIter, Data, Kind, ObjectRef, TagRef, Ta
 impl<'a> Data<'a> {
     /// Constructs a new data object from `data`, `kind` and `object_hash`.
     pub fn new(data: &'a [u8], kind: Kind, hash_kind: gix_hash::Kind) -> Data<'a> {
-        Data { kind, hash_kind, data }
+        Data {
+            kind,
+            object_hash: hash_kind,
+            data,
+        }
     }
     /// Decodes the data in the backing slice into a [`ObjectRef`], allowing to access all of its data
     /// conveniently. The cost of parsing an object is negligible.
@@ -14,10 +18,10 @@ impl<'a> Data<'a> {
     /// using [`crate::ObjectRef::into_owned()`].
     pub fn decode(&self) -> Result<ObjectRef<'a>, crate::decode::Error> {
         Ok(match self.kind {
-            Kind::Tree => ObjectRef::Tree(TreeRef::from_bytes(self.data, self.hash_kind)?),
+            Kind::Tree => ObjectRef::Tree(TreeRef::from_bytes(self.data, self.object_hash)?),
             Kind::Blob => ObjectRef::Blob(BlobRef { data: self.data }),
-            Kind::Commit => ObjectRef::Commit(CommitRef::from_bytes(self.data, self.hash_kind)?),
-            Kind::Tag => ObjectRef::Tag(TagRef::from_bytes(self.data, self.hash_kind)?),
+            Kind::Commit => ObjectRef::Commit(CommitRef::from_bytes(self.data, self.object_hash)?),
+            Kind::Tag => ObjectRef::Tag(TagRef::from_bytes(self.data, self.object_hash)?),
         })
     }
 
@@ -25,7 +29,7 @@ impl<'a> Data<'a> {
     /// `None` if this is not a tree object.
     pub fn try_into_tree_iter(self) -> Option<TreeRefIter<'a>> {
         match self.kind {
-            Kind::Tree => Some(TreeRefIter::from_bytes(self.data, self.hash_kind)),
+            Kind::Tree => Some(TreeRefIter::from_bytes(self.data, self.object_hash)),
             _ => None,
         }
     }
@@ -34,7 +38,7 @@ impl<'a> Data<'a> {
     /// `None` if this is not a commit object.
     pub fn try_into_commit_iter(self) -> Option<CommitRefIter<'a>> {
         match self.kind {
-            Kind::Commit => Some(CommitRefIter::from_bytes(self.data, self.hash_kind)),
+            Kind::Commit => Some(CommitRefIter::from_bytes(self.data, self.object_hash)),
             _ => None,
         }
     }
@@ -43,7 +47,7 @@ impl<'a> Data<'a> {
     /// `None` if this is not a tag object.
     pub fn try_into_tag_iter(self) -> Option<TagRefIter<'a>> {
         match self.kind {
-            Kind::Tag => Some(TagRefIter::from_bytes(self.data, self.hash_kind)),
+            Kind::Tag => Some(TagRefIter::from_bytes(self.data, self.object_hash)),
             _ => None,
         }
     }

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -376,7 +376,7 @@ fn object_hasher(hash_kind: gix_hash::Kind, object_kind: Kind, object_size: u64)
     hasher
 }
 
-/// A function to compute a hash of kind `hash_kind` for an object of `object_kind` and its `data`.
+/// A function to compute a hash of kind `object_hash` for an object of `object_kind` and its `data`.
 #[doc(alias = "hash_object", alias = "git2")]
 pub fn compute_hash(
     hash_kind: gix_hash::Kind,
@@ -388,7 +388,7 @@ pub fn compute_hash(
     hasher.try_finalize()
 }
 
-/// A function to compute a hash of kind `hash_kind` for an object of `object_kind` and its data read from `stream`
+/// A function to compute a hash of kind `object_hash` for an object of `object_kind` and its data read from `stream`
 /// which has to yield exactly `stream_len` bytes.
 /// Use `progress` to learn about progress in bytes processed and `should_interrupt` to be able to abort the operation
 /// if set to `true`.

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -294,7 +294,7 @@ pub struct Data<'a> {
     /// kind of object
     pub kind: Kind,
     /// The hash kind to use for parsing this data.
-    pub hash_kind: gix_hash::Kind,
+    pub object_hash: gix_hash::Kind,
     /// decoded, decompressed data, owned by a backing store.
     pub data: &'a [u8],
 }

--- a/gix-object/src/object/mod.rs
+++ b/gix-object/src/object/mod.rs
@@ -190,7 +190,7 @@ pub enum LooseDecodeError {
 }
 
 impl<'a> ObjectRef<'a> {
-    /// Deserialize an object from a loose serialisation given `data`, parsing with the provided `hash_kind`.
+    /// Deserialize an object from a loose serialisation given `data`, parsing with the provided `object_hash`.
     pub fn from_loose(data: &'a [u8], hash_kind: gix_hash::Kind) -> Result<ObjectRef<'a>, LooseDecodeError> {
         let (kind, size, offset) = loose_header(data)?;
 
@@ -203,7 +203,7 @@ impl<'a> ObjectRef<'a> {
         Ok(Self::from_bytes(body, kind, hash_kind)?)
     }
 
-    /// Deserialize an object of `kind` from the given `data`, using `hash_kind`.
+    /// Deserialize an object of `kind` from the given `data`, using `object_hash`.
     pub fn from_bytes(
         data: &'a [u8],
         kind: Kind,

--- a/gix-object/src/parse.rs
+++ b/gix-object/src/parse.rs
@@ -109,10 +109,10 @@ pub(crate) fn any_header_field<'a>(i: &mut &'a [u8]) -> ParseResult<(&'a [u8], &
     }
 }
 
-/// Parse a complete hexadecimal object id of the given `hash_kind`.
+/// Parse a complete hexadecimal object id of the given `object_hash`.
 ///
 /// Typical input is a 40-byte SHA-1 hex id or a 64-byte SHA-256 hex id,
-/// depending on `hash_kind`. The entire input slice must be ASCII hex and
+/// depending on `object_hash`. The entire input slice must be ASCII hex and
 /// match the expected object hash length.
 pub fn hex_hash(i: &[u8], hash_kind: gix_hash::Kind) -> ParseResult<&BStr> {
     if i.len() != hash_kind.len_in_hex() || !i.iter().all(u8::is_ascii_hexdigit) {

--- a/gix-object/src/tag/decode.rs
+++ b/gix-object/src/tag/decode.rs
@@ -38,7 +38,7 @@ pub fn git_tag<'a>(i: &mut &'a [u8], hash_kind: gix_hash::Kind) -> ParseResult<T
 /// Parse the `object <hex>\n` header and return the object id as bytes.
 ///
 /// Typical input is `object 0123456789012345678901234567890123456789\n`.
-/// The hash must match `hash_kind`. Uppercase ASCII hex is also valid.
+/// The hash must match `object_hash`. Uppercase ASCII hex is also valid.
 /// On success, `i` is advanced past the entire header line.
 pub(crate) fn target<'a>(i: &mut &'a [u8], hash_kind: gix_hash::Kind) -> ParseResult<&'a BStr> {
     parse::header_field(i, b"object", |value| parse::hex_hash(value, hash_kind))

--- a/gix-object/src/tag/ref_iter.rs
+++ b/gix-object/src/tag/ref_iter.rs
@@ -14,7 +14,7 @@ pub(crate) enum State {
 }
 
 impl<'a> TagRefIter<'a> {
-    /// Create a tag iterator from `data`, parsing hashes as `hash_kind`.
+    /// Create a tag iterator from `data`, parsing hashes as `object_hash`.
     pub fn from_bytes(data: &'a [u8], hash_kind: gix_hash::Kind) -> TagRefIter<'a> {
         TagRefIter {
             data,

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -38,7 +38,7 @@ where
         return ControlFlow::Break(None);
     };
 
-    let Some(entry) = TreeRefIter::from_bytes(tree.data, tree.hash_kind)
+    let Some(entry) = TreeRefIter::from_bytes(tree.data, tree.object_hash)
         .filter_map(Result::ok)
         .find(|entry| component.eq(entry.filename))
     else {

--- a/gix-object/src/tree/ref_iter.rs
+++ b/gix-object/src/tree/ref_iter.rs
@@ -53,7 +53,7 @@ where
 }
 
 impl<'a> TreeRefIter<'a> {
-    /// Instantiate an iterator from the given tree `data` and `hash_kind`.
+    /// Instantiate an iterator from the given tree `data` and `object_hash`.
     pub fn from_bytes(data: &'a [u8], hash_kind: gix_hash::Kind) -> TreeRefIter<'a> {
         TreeRefIter { data, hash_kind }
     }
@@ -121,7 +121,7 @@ impl<'a> TreeRefIter<'a> {
 }
 
 impl<'a> TreeRef<'a> {
-    /// Deserialize a Tree from `data`, assuming `hash_kind` to determine how the object ids are encoded in this particular tree.
+    /// Deserialize a Tree from `data`, assuming `object_hash` to determine how the object ids are encoded in this particular tree.
     pub fn from_bytes(data: &'a [u8], hash_kind: gix_hash::Kind) -> Result<TreeRef<'a>, crate::decode::Error> {
         decode::tree(data, hash_kind.len_in_bytes())
     }

--- a/gix-object/tests/object/encode.rs
+++ b/gix-object/tests/object/encode.rs
@@ -6,8 +6,8 @@ enum Error {
     TryFromError,
 }
 
-/// Needed for roundtripping object types that take a `hash_kind` parameter.
-/// This is the same as `round_trip`, but for types that have `from_bytes()` with `hash_kind`.
+/// Needed for roundtripping object types that take a `object_hash` parameter.
+/// This is the same as `round_trip`, but for types that have `from_bytes()` with `object_hash`.
 macro_rules! round_trip_with_hash_kind {
     ($owned:ty, $borrowed:ty, $( $files:literal ), +) => {
         #[test]
@@ -186,7 +186,7 @@ mod blob {
             let w = &mut output;
             w.write_all(&item.loose_header())?;
             item.write_to(w)?;
-            let parsed = ObjectRef::from_loose(&output, gix_testtools::hash_kind_from_env().unwrap_or_default())?;
+            let parsed = ObjectRef::from_loose(&output, gix_testtools::object_hash())?;
             let item2 = BlobRef::try_from(parsed).or(Err(super::Error::TryFromError))?;
             assert_eq!(
                 item2,
@@ -202,7 +202,7 @@ mod blob {
         let w = &mut output;
         w.write_all(&item.loose_header())?;
         item.write_to(w)?;
-        let parsed = ObjectRef::from_loose(&output, gix_testtools::hash_kind_from_env().unwrap_or_default())?;
+        let parsed = ObjectRef::from_loose(&output, gix_testtools::object_hash())?;
         let parsed_borrowed = BlobRef::try_from(parsed).or(Err(super::Error::TryFromError))?;
         let item2: Blob = parsed_borrowed.into();
         assert_eq!(

--- a/gix-object/tests/object/main.rs
+++ b/gix-object/tests/object/main.rs
@@ -73,7 +73,7 @@ pub fn fixture(path: &str) -> PathBuf {
 }
 
 pub fn fixture_hash_kind() -> gix_hash::Kind {
-    gix_testtools::hash_kind_from_env().unwrap_or_default()
+    gix_testtools::object_hash()
 }
 
 fn fixture_bytes(path: &str) -> Vec<u8> {

--- a/gix-object/tests/object/object_ref.rs
+++ b/gix-object/tests/object/object_ref.rs
@@ -4,12 +4,9 @@ mod from_loose {
     #[test]
     fn shorter_than_advertised() {
         assert_eq!(
-            ObjectRef::from_loose(
-                b"tree 1000\x00",
-                gix_testtools::hash_kind_from_env().unwrap_or_default(),
-            )
-            .unwrap_err()
-            .to_string(),
+            ObjectRef::from_loose(b"tree 1000\x00", gix_testtools::object_hash(),)
+                .unwrap_err()
+                .to_string(),
             "object data was shorter than its size declared in the header"
         );
     }

--- a/gix-object/tests/object/tree/editor.rs
+++ b/gix-object/tests/object/tree/editor.rs
@@ -874,7 +874,7 @@ mod utils {
                     tree.write_to(buffer).expect("valid trees can always be serialized");
                     Ok(Some(gix_object::Data {
                         kind: gix_object::Kind::Tree,
-                        hash_kind: id.kind(),
+                        object_hash: id.kind(),
                         data: &*buffer,
                     }))
                 }

--- a/gix-object/tests/object/tree/entries.rs
+++ b/gix-object/tests/object/tree/entries.rs
@@ -5,7 +5,7 @@ fn sort_order_is_correct() -> crate::Result {
     let root = gix_testtools::scripted_fixture_read_only("make_trees.sh")?;
     let input = std::fs::read(root.join("tree.baseline"))?;
 
-    let mut tree = TreeRef::from_bytes(&input, gix_testtools::hash_kind_from_env().unwrap_or_default())?;
+    let mut tree = TreeRef::from_bytes(&input, gix_testtools::object_hash())?;
     let expected = tree.entries.clone();
 
     tree.entries.sort();

--- a/gix-object/tests/object/tree/from_bytes.rs
+++ b/gix-object/tests/object/tree/from_bytes.rs
@@ -4,7 +4,7 @@ use crate::{fixture_oid, tree_fixture};
 
 #[test]
 fn empty() -> crate::Result {
-    let tree_ref = TreeRef::from_bytes(&[], gix_testtools::hash_kind_from_env().unwrap_or_default())?;
+    let tree_ref = TreeRef::from_bytes(&[], gix_testtools::object_hash())?;
     assert_eq!(
         tree_ref,
         TreeRef { entries: vec![] },
@@ -79,7 +79,7 @@ fn invalid() {
 #[test]
 fn fuzzed() {
     assert!(
-        gix_object::TreeRef::from_bytes(b"2", gix_testtools::hash_kind_from_env().unwrap_or_default()).is_err(),
+        gix_object::TreeRef::from_bytes(b"2", gix_testtools::object_hash()).is_err(),
         "fail, but don't crash"
     );
 }

--- a/gix-object/tests/object/tree/iter.rs
+++ b/gix-object/tests/object/tree/iter.rs
@@ -10,7 +10,7 @@ use crate::{fixture_hash_kind, fixture_oid, tree_fixture};
 #[test]
 fn empty() {
     assert_eq!(
-        TreeRefIter::from_bytes(&[], gix_testtools::hash_kind_from_env().unwrap_or_default()).count(),
+        TreeRefIter::from_bytes(&[], gix_testtools::object_hash()).count(),
         0,
         "empty trees are definitely ok"
     );

--- a/gix-odb/src/memory.rs
+++ b/gix-odb/src/memory.rs
@@ -152,7 +152,7 @@ where
                 buffer.extend_from_slice(data);
                 return Ok(Some(Data {
                     kind: *kind,
-                    hash_kind: id.kind(),
+                    object_hash: id.kind(),
                     data: &*buffer,
                 }));
             }

--- a/gix-odb/src/store_impls/dynamic/find.rs
+++ b/gix-odb/src/store_impls/dynamic/find.rs
@@ -164,7 +164,7 @@ where
                             Ok(r) => Ok((
                                 gix_object::Data {
                                     kind: r.kind,
-                                    hash_kind: pack.object_hash(),
+                                    object_hash: pack.object_hash(),
                                     data: buffer.as_slice(),
                                 },
                                 Some(gix_pack::data::entry::Location {
@@ -266,7 +266,7 @@ where
                                     (
                                         gix_object::Data {
                                             kind: r.kind,
-                                            hash_kind: pack.object_hash(),
+                                            object_hash: pack.object_hash(),
                                             data: buffer.as_slice(),
                                         },
                                         Some(gix_pack::data::entry::Location {

--- a/gix-odb/src/store_impls/dynamic/handle.rs
+++ b/gix-odb/src/store_impls/dynamic/handle.rs
@@ -349,7 +349,7 @@ impl TryFrom<&super::Store> for super::Store {
             &mut s.replacements(),
             crate::store::init::Options {
                 slots: crate::store::init::Slots::Given(s.files.len().try_into().expect("BUG: too many slots")),
-                object_hash: Default::default(),
+                object_hash: s.object_hash,
                 use_multi_pack_index: false,
                 alloc_limit_bytes: s.alloc_limit_bytes,
                 current_dir: s.current_dir.clone().into(),

--- a/gix-odb/src/store_impls/loose/find.rs
+++ b/gix-odb/src/store_impls/loose/find.rs
@@ -214,7 +214,7 @@ impl Store {
         }
         Ok(Some(gix_object::Data {
             kind,
-            hash_kind: id.kind(),
+            object_hash: id.kind(),
             data: out,
         }))
     }

--- a/gix-pack/src/bundle/find.rs
+++ b/gix-pack/src/bundle/find.rs
@@ -58,7 +58,7 @@ impl crate::Bundle {
                     gix_object::Data {
                         kind: r.kind,
                         data: out.as_slice(),
-                        hash_kind: self.pack.object_hash(),
+                        object_hash: self.pack.object_hash(),
                     },
                     crate::data::entry::Location {
                         pack_id: self.pack.id,

--- a/gix-pack/src/data/output/count/objects/mod.rs
+++ b/gix-pack/src/data/output/count/objects/mod.rs
@@ -175,7 +175,7 @@ mod expand {
                         match obj.kind {
                             Tree | Blob => break,
                             Tag => {
-                                id = TagRefIter::from_bytes(obj.data, obj.hash_kind)
+                                id = TagRefIter::from_bytes(obj.data, obj.object_hash)
                                     .target_id()
                                     .expect("every tag has a target");
                                 let tmp = db.find(&id, buf1)?;
@@ -188,7 +188,7 @@ mod expand {
                             }
                             Commit => {
                                 let current_tree_iter = {
-                                    let mut commit_iter = CommitRefIter::from_bytes(obj.data, obj.hash_kind);
+                                    let mut commit_iter = CommitRefIter::from_bytes(obj.data, obj.object_hash);
                                     let tree_id = commit_iter.tree_id().expect("every commit has a tree");
                                     parent_commit_ids.clear();
                                     for token in commit_iter {
@@ -204,7 +204,7 @@ mod expand {
                                     push_obj_count_unique(
                                         &mut out, seen_objs, &tree_id, location, objects, stats, true,
                                     );
-                                    gix_object::TreeRefIter::from_bytes(obj.data, obj.hash_kind)
+                                    gix_object::TreeRefIter::from_bytes(obj.data, obj.object_hash)
                                 };
 
                                 let objects_ref = if parent_commit_ids.is_empty() {
@@ -229,7 +229,7 @@ mod expand {
                                             );
                                             CommitRefIter::from_bytes(
                                                 parent_commit_obj.data,
-                                                parent_commit_obj.hash_kind,
+                                                parent_commit_obj.object_hash,
                                             )
                                             .tree_id()
                                             .expect("every commit has a tree")
@@ -247,7 +247,7 @@ mod expand {
                                             );
                                             gix_object::TreeRefIter::from_bytes(
                                                 parent_tree_obj.data,
-                                                parent_tree_obj.hash_kind,
+                                                parent_tree_obj.object_hash,
                                             )
                                         };
 
@@ -285,7 +285,7 @@ mod expand {
                                 {
                                     let objects = ExpandedCountingObjects::new(db, out, objects);
                                     gix_traverse::tree::breadthfirst(
-                                        gix_object::TreeRefIter::from_bytes(obj.0.data, obj.0.hash_kind),
+                                        gix_object::TreeRefIter::from_bytes(obj.0.data, obj.0.object_hash),
                                         &mut tree_traversal_state,
                                         &objects,
                                         &mut traverse_delegate,
@@ -299,7 +299,7 @@ mod expand {
                                 break;
                             }
                             Commit => {
-                                id = CommitRefIter::from_bytes(obj.0.data, obj.0.hash_kind)
+                                id = CommitRefIter::from_bytes(obj.0.data, obj.0.object_hash)
                                     .tree_id()
                                     .expect("every commit has a tree");
                                 stats.expanded_objects += 1;
@@ -308,7 +308,7 @@ mod expand {
                             }
                             Blob => break,
                             Tag => {
-                                id = TagRefIter::from_bytes(obj.0.data, obj.0.hash_kind)
+                                id = TagRefIter::from_bytes(obj.0.data, obj.0.object_hash)
                                     .target_id()
                                     .expect("every tag has a target");
                                 stats.expanded_objects += 1;

--- a/gix-pack/tests/pack/data/input.rs
+++ b/gix-pack/tests/pack/data/input.rs
@@ -32,7 +32,7 @@ mod lookup_ref_delta_objects {
     fn entry(header: Header, data: &'static [u8]) -> input::Entry {
         let obj = gix_object::Data {
             kind: header.as_kind().unwrap_or(gix_object::Kind::Blob),
-            hash_kind: gix_testtools::hash_kind_from_env().unwrap_or_default(),
+            hash_kind: gix_testtools::object_hash(),
             data,
         };
         let mut entry = input::Entry::from_data_obj(&obj, 0).expect("valid object");

--- a/gix-pack/tests/pack/data/input.rs
+++ b/gix-pack/tests/pack/data/input.rs
@@ -32,7 +32,7 @@ mod lookup_ref_delta_objects {
     fn entry(header: Header, data: &'static [u8]) -> input::Entry {
         let obj = gix_object::Data {
             kind: header.as_kind().unwrap_or(gix_object::Kind::Blob),
-            hash_kind: gix_testtools::object_hash(),
+            object_hash: gix_testtools::object_hash(),
             data,
         };
         let mut entry = input::Entry::from_data_obj(&obj, 0).expect("valid object");
@@ -86,7 +86,7 @@ mod lookup_ref_delta_objects {
                 buf.copy_from_slice(data);
                 Ok(Some(gix_object::Data {
                     kind: gix_object::Kind::Blob,
-                    hash_kind: id.kind(),
+                    object_hash: id.kind(),
                     data: buf.as_slice(),
                 }))
             } else {

--- a/gix-ref/src/parse.rs
+++ b/gix-ref/src/parse.rs
@@ -6,9 +6,9 @@ fn is_hex_digit(b: u8) -> bool {
     b.is_ascii_hexdigit()
 }
 
-/// Copy from `gix-object`, validating the hash against `hash_kind`.
-pub fn hex_hash<'a>(i: &mut &'a [u8], hash_kind: gix_hash::Kind) -> ParseResult<&'a BStr> {
-    let len = hash_kind.len_in_hex();
+/// Copy from `gix-object`, validating the hash against `object_hash`.
+pub fn hex_hash<'a>(i: &mut &'a [u8], object_hash: gix_hash::Kind) -> ParseResult<&'a BStr> {
+    let len = object_hash.len_in_hex();
     let Some(hex) = i.get(..len) else {
         return Err(());
     };

--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -44,11 +44,11 @@ impl TryFrom<MaybeUnsafeState> for Target {
 
 impl Reference {
     /// Create a new reference named `name` from the loose reference file contents in `path_contents`,
-    /// parsing object ids as `hash_kind`.
-    pub fn try_from_path(name: FullName, path_contents: &[u8], hash_kind: gix_hash::Kind) -> Result<Self, Error> {
+    /// parsing object ids as `object_hash`.
+    pub fn try_from_path(name: FullName, path_contents: &[u8], object_hash: gix_hash::Kind) -> Result<Self, Error> {
         Ok(Reference {
             name,
-            target: parse(path_contents, hash_kind)
+            target: parse(path_contents, object_hash)
                 .map_err(|_| Error::Parse {
                     content: path_contents.into(),
                 })?
@@ -68,7 +68,7 @@ impl Reference {
 /// [`MaybeUnsafeState::Id`].
 ///
 /// If neither reference form can be parsed, an error is returned.
-fn parse(mut i: &[u8], hash_kind: gix_hash::Kind) -> Result<MaybeUnsafeState, ()> {
+fn parse(mut i: &[u8], object_hash: gix_hash::Kind) -> Result<MaybeUnsafeState, ()> {
     if let Some(rest) = i.strip_prefix(b"ref: ") {
         i = rest;
         while i.first() == Some(&b' ') {
@@ -78,7 +78,7 @@ fn parse(mut i: &[u8], hash_kind: gix_hash::Kind) -> Result<MaybeUnsafeState, ()
         let path = i[..path_end].into();
         Ok(MaybeUnsafeState::UnvalidatedPath(path))
     } else {
-        let hex = hex_hash(&mut i, hash_kind)?;
+        let hex = hex_hash(&mut i, object_hash)?;
         if i.first().is_some_and(u8::is_ascii_hexdigit) {
             return Err(());
         }

--- a/gix-ref/src/store/file/overlay_iter.rs
+++ b/gix-ref/src/store/file/overlay_iter.rs
@@ -21,7 +21,7 @@ use crate::{
 pub struct LooseThenPacked<'p, 's> {
     git_dir: &'s Path,
     common_dir: Option<&'s Path>,
-    hash_kind: gix_hash::Kind,
+    object_hash: gix_hash::Kind,
     namespace: Option<&'s Namespace>,
     iter_packed: Option<Peekable<packed::Iter<'p>>>,
     iter_git_dir: Peekable<SortedLoosePaths>,
@@ -98,7 +98,7 @@ impl<'p> LooseThenPacked<'p, '_> {
                 source: err,
                 path: refpath.to_owned(),
             })?;
-        loose::Reference::try_from_path(name, buf, self.hash_kind)
+        loose::Reference::try_from_path(name, buf, self.object_hash)
             .map_err(|err| {
                 let relative_path = refpath
                     .strip_prefix(git_dir)
@@ -433,7 +433,7 @@ impl file::Store {
         Ok(LooseThenPacked {
             git_dir: self.git_dir(),
             common_dir: self.common_dir(),
-            hash_kind: self.object_hash,
+            object_hash: self.object_hash,
             iter_packed: match packed {
                 Some(packed) => Some(
                     match git_dir_info.prefix() {

--- a/gix-ref/src/store/file/raw_ext.rs
+++ b/gix-ref/src/store/file/raw_ext.rs
@@ -160,13 +160,16 @@ impl ReferenceExt for Reference {
                 let mut oid = self.follow_to_object_packed(store, packed)?;
                 let mut buf = Vec::new();
                 let peeled_id = loop {
-                    let gix_object::Data { kind, data, hash_kind } =
-                        objects
-                            .try_find(&oid, &mut buf)?
-                            .ok_or_else(|| peel::to_id::Error::NotFound {
-                                oid,
-                                name: self.name.0.clone(),
-                            })?;
+                    let gix_object::Data {
+                        kind,
+                        data,
+                        object_hash: hash_kind,
+                    } = objects
+                        .try_find(&oid, &mut buf)?
+                        .ok_or_else(|| peel::to_id::Error::NotFound {
+                            oid,
+                            name: self.name.0.clone(),
+                        })?;
                     match kind {
                         gix_object::Kind::Tag => {
                             oid = gix_object::TagRefIter::from_bytes(data, hash_kind)

--- a/gix-ref/src/store/packed/buffer.rs
+++ b/gix-ref/src/store/packed/buffer.rs
@@ -26,7 +26,7 @@ pub mod open {
         fn open_with_backing(
             backing: packed::Backing,
             path: PathBuf,
-            hash_kind: gix_hash::Kind,
+            object_hash: gix_hash::Kind,
         ) -> Result<Self, Error> {
             let (backing, offset) = {
                 let (offset, sorted) = {
@@ -43,7 +43,7 @@ pub mod open {
                 if !sorted {
                     // this implementation is likely slower than what git does, but it's less code, too.
                     let mut entries =
-                        packed::Iter::new(&backing.as_ref()[offset..], hash_kind)?.collect::<Result<Vec<_>, _>>()?;
+                        packed::Iter::new(&backing.as_ref()[offset..], object_hash)?.collect::<Result<Vec<_>, _>>()?;
                     entries.sort_by_key(|e| e.name.as_bstr());
                     let mut serialized = Vec::<u8>::new();
                     for entry in entries {
@@ -66,11 +66,11 @@ pub mod open {
                 offset,
                 data: backing,
                 path,
-                hash_kind,
+                object_hash,
             })
         }
 
-        /// Open the file at `path`, parsing object ids as `hash_kind`, and map it into memory if the file size is larger
+        /// Open the file at `path`, parsing object ids as `object_hash`, and map it into memory if the file size is larger
         /// than `use_memory_map_if_larger_than_bytes`.
         ///
         /// In order to allow fast lookups and optimizations, the contents of the packed refs must be sorted.
@@ -78,7 +78,7 @@ pub mod open {
         pub fn open(
             path: PathBuf,
             use_memory_map_if_larger_than_bytes: u64,
-            hash_kind: gix_hash::Kind,
+            object_hash: gix_hash::Kind,
         ) -> Result<Self, Error> {
             let backing = if std::fs::metadata(&path)?.len() <= use_memory_map_if_larger_than_bytes {
                 packed::Backing::InMemory(std::fs::read(&path)?)
@@ -91,17 +91,17 @@ pub mod open {
                     },
                 )
             };
-            Self::open_with_backing(backing, path, hash_kind)
+            Self::open_with_backing(backing, path, object_hash)
         }
 
         /// Open a buffer from `bytes`, which is the content of a typical `packed-refs` file, parsing object ids as
-        /// `hash_kind`.
+        /// `object_hash`.
         ///
         /// In order to allow fast lookups and optimizations, the contents of the packed refs must be sorted.
         /// If that's not the case, they will be sorted on the fly.
-        pub fn from_bytes(bytes: &[u8], hash_kind: gix_hash::Kind) -> Result<Self, Error> {
+        pub fn from_bytes(bytes: &[u8], object_hash: gix_hash::Kind) -> Result<Self, Error> {
             let backing = packed::Backing::InMemory(bytes.into());
-            Self::open_with_backing(backing, PathBuf::from("<memory>"), hash_kind)
+            Self::open_with_backing(backing, PathBuf::from("<memory>"), object_hash)
         }
     }
 

--- a/gix-ref/src/store/packed/decode.rs
+++ b/gix-ref/src/store/packed/decode.rs
@@ -72,12 +72,12 @@ pub fn header(input: &mut &[u8]) -> Result<Header, ()> {
 /// The reference line has the form `<hex-object-id> <ref-name>` followed by a
 /// line ending. If the following line starts with `^`, it is parsed as the
 /// peeled object id for the returned [`packed::Reference`].
-/// Object ids are parsed according to `hash_kind`.
+/// Object ids are parsed according to `object_hash`.
 ///
 /// On success, `input` is advanced past the reference line and, if present, the
 /// peeled object line.
-pub fn reference<'a>(input: &mut &'a [u8], hash_kind: gix_hash::Kind) -> Result<packed::Reference<'a>, ()> {
-    let target = parse::hex_hash(input, hash_kind)?;
+pub fn reference<'a>(input: &mut &'a [u8], object_hash: gix_hash::Kind) -> Result<packed::Reference<'a>, ()> {
+    let target = parse::hex_hash(input, object_hash)?;
     let Some(rest) = input.strip_prefix(b" ") else {
         return Err(());
     };
@@ -86,7 +86,7 @@ pub fn reference<'a>(input: &mut &'a [u8], hash_kind: gix_hash::Kind) -> Result<
 
     let object = if let Some(rest) = input.strip_prefix(b"^") {
         *input = rest;
-        let object = parse::hex_hash(input, hash_kind)?;
+        let object = parse::hex_hash(input, object_hash)?;
         parse::newline(input)?;
         Some(object)
     } else {

--- a/gix-ref/src/store/packed/find.rs
+++ b/gix-ref/src/store/packed/find.rs
@@ -41,7 +41,7 @@ impl packed::Buffer {
             Ok(line_start) => {
                 let mut input = &self.as_ref()[line_start..];
                 Ok(Some(
-                    packed::decode::reference(&mut input, self.hash_kind).map_err(|_| Error::Parse)?,
+                    packed::decode::reference(&mut input, self.object_hash).map_err(|_| Error::Parse)?,
                 ))
             }
             Err((parse_failure, _)) => {
@@ -90,7 +90,7 @@ impl packed::Buffer {
         a.binary_search_by_key(&full_name.as_ref(), |b: &u8| {
             let ofs = std::ptr::from_ref::<u8>(b) as usize - a.as_ptr() as usize;
             let mut line = &a[search_start_of_record(ofs)..];
-            packed::decode::reference(&mut line, self.hash_kind)
+            packed::decode::reference(&mut line, self.object_hash)
                 .map(|r| r.name.as_bstr().as_bytes())
                 .inspect_err(|_err| {
                     encountered_parse_failure = true;

--- a/gix-ref/src/store/packed/iter.rs
+++ b/gix-ref/src/store/packed/iter.rs
@@ -10,13 +10,17 @@ impl packed::Buffer {
     ///
     /// There is no namespace support in packed iterators. It can be emulated using `iter_prefixed(…)`.
     pub fn iter(&self) -> Result<packed::Iter<'_>, packed::iter::Error> {
-        packed::Iter::new(self.as_ref(), self.hash_kind)
+        packed::Iter::new(self.as_ref(), self.object_hash)
     }
 
     /// Return an iterator yielding only references matching the given prefix, ordered by reference name.
     pub fn iter_prefixed(&self, prefix: BString) -> Result<packed::Iter<'_>, packed::iter::Error> {
         let first_record_with_prefix = self.binary_search_by(prefix.as_bstr()).unwrap_or_else(|(_, pos)| pos);
-        packed::Iter::new_with_prefix(&self.as_ref()[first_record_with_prefix..], self.hash_kind, Some(prefix))
+        packed::Iter::new_with_prefix(
+            &self.as_ref()[first_record_with_prefix..],
+            self.object_hash,
+            Some(prefix),
+        )
     }
 }
 
@@ -29,7 +33,7 @@ impl<'a> Iterator for packed::Iter<'a> {
         }
 
         let start = self.cursor;
-        match decode::reference(&mut self.cursor, self.hash_kind) {
+        match decode::reference(&mut self.cursor, self.object_hash) {
             Ok(reference) => {
                 self.current_line += 1;
                 if let Some(ref prefix) = self.prefix {
@@ -64,23 +68,23 @@ impl<'a> Iterator for packed::Iter<'a> {
 
 impl<'a> packed::Iter<'a> {
     /// Return a new iterator after successfully parsing the possibly existing first line of the given `packed` refs buffer,
-    /// parsing object ids as `hash_kind`.
-    pub fn new(packed: &'a [u8], hash_kind: gix_hash::Kind) -> Result<Self, Error> {
-        Self::new_with_prefix(packed, hash_kind, None)
+    /// parsing object ids as `object_hash`.
+    pub fn new(packed: &'a [u8], object_hash: gix_hash::Kind) -> Result<Self, Error> {
+        Self::new_with_prefix(packed, object_hash, None)
     }
 
     /// Returns an iterator whose references will only match `prefix`.
     ///
-    /// It assumes that the underlying `packed` buffer is indeed sorted and parses object ids as `hash_kind`.
+    /// It assumes that the underlying `packed` buffer is indeed sorted and parses object ids as `object_hash`.
     pub(in crate::store_impl::packed) fn new_with_prefix(
         packed: &'a [u8],
-        hash_kind: gix_hash::Kind,
+        object_hash: gix_hash::Kind,
         prefix: Option<BString>,
     ) -> Result<Self, Error> {
         if packed.is_empty() {
             Ok(packed::Iter {
                 cursor: packed,
-                hash_kind,
+                object_hash,
                 prefix,
                 current_line: 1,
             })
@@ -92,14 +96,14 @@ impl<'a> packed::Iter<'a> {
             let refs = input;
             Ok(packed::Iter {
                 cursor: refs,
-                hash_kind,
+                object_hash,
                 prefix,
                 current_line: 2,
             })
         } else {
             Ok(packed::Iter {
                 cursor: packed,
-                hash_kind,
+                object_hash,
                 prefix,
                 current_line: 1,
             })

--- a/gix-ref/src/store/packed/mod.rs
+++ b/gix-ref/src/store/packed/mod.rs
@@ -21,7 +21,7 @@ enum Backing {
 pub struct Buffer {
     data: Backing,
     /// The hash kind to expect when parsing packed references.
-    hash_kind: gix_hash::Kind,
+    object_hash: gix_hash::Kind,
     /// The offset to the first record, how many bytes to skip past the header
     offset: usize,
     /// The path from which we were loaded
@@ -78,7 +78,7 @@ pub struct Iter<'a> {
     /// The position at which to parse the next reference
     cursor: &'a [u8],
     /// The hash kind to expect when parsing packed references.
-    hash_kind: gix_hash::Kind,
+    object_hash: gix_hash::Kind,
     /// The next line, starting at 1
     current_line: usize,
     /// If set, references returned will match the prefix, the first failed match will stop all iteration.

--- a/gix-ref/src/store/packed/transaction.rs
+++ b/gix-ref/src/store/packed/transaction.rs
@@ -112,7 +112,7 @@ impl packed::Transaction {
                         Some(gix_object::Data {
                             kind: gix_object::Kind::Tag,
                             data,
-                            hash_kind,
+                            object_hash: hash_kind,
                         }) => {
                             next_id = gix_object::TagRefIter::from_bytes(data, hash_kind)
                                 .target_id()

--- a/gix-ref/tests/refs/file/mod.rs
+++ b/gix-ref/tests/refs/file/mod.rs
@@ -60,7 +60,7 @@ impl gix_object::Find for EmptyCommit {
     ) -> Result<Option<gix_object::Data<'a>>, gix_object::find::Error> {
         Ok(Some(gix_object::Data {
             kind: gix_object::Kind::Commit,
-            hash_kind: id.kind(),
+            object_hash: id.kind(),
             data: &[],
         }))
     }

--- a/gix-ref/tests/refs/main.rs
+++ b/gix-ref/tests/refs/main.rs
@@ -15,7 +15,7 @@ pub fn sha1_hex_to_id(hex: &str) -> ObjectId {
 }
 
 pub fn fixture_hash_kind() -> gix_hash::Kind {
-    gix_testtools::hash_kind_from_env().unwrap_or_default()
+    gix_testtools::object_hash()
 }
 
 fn translate_sha1_to_fixture_sha256(hex: &str) -> String {

--- a/gix-refspec/tests/refspec/match_group.rs
+++ b/gix-refspec/tests/refspec/match_group.rs
@@ -2,12 +2,12 @@ mod single {
     use crate::matching::baseline;
 
     fn test_hashes() -> (String, String) {
-        let annotated_tag = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+        let annotated_tag = match gix_testtools::object_hash() {
             gix_hash::Kind::Sha1 => "78b1c1be9421b33a49a7a8176d93eeeafa112da1",
             gix_hash::Kind::Sha256 => "b071221ea854da2958fba3a37527ca5cf32c4ebcd71ab0b68b6b8f10f04e93ad",
             _ => unimplemented!(),
         };
-        let initial_commit = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+        let initial_commit = match gix_testtools::object_hash() {
             gix_hash::Kind::Sha1 => "9d2fab1a0ba3585d0bc50922bfdd04ebb59361df",
             gix_hash::Kind::Sha256 => "ac050883b75422e0d03bfee760c591b292cbc10cee8ad934480ea5fb2ebc44fe",
             _ => unimplemented!(),

--- a/gix-revwalk/src/graph/commit.rs
+++ b/gix-revwalk/src/graph/commit.rs
@@ -8,7 +8,7 @@ impl<'graph, 'cache> LazyCommit<'graph, 'cache> {
     /// Return an iterator over the parents of this commit.
     pub fn iter_parents(&self) -> Parents<'graph, 'cache> {
         let backing = match &self.backing {
-            Either::Left(buf) => Either::Left(gix_object::CommitRefIter::from_bytes(buf, self.hash_kind)),
+            Either::Left(buf) => Either::Left(gix_object::CommitRefIter::from_bytes(buf, self.object_hash)),
             Either::Right((cache, pos)) => Either::Right((*cache, cache.commit_at(*pos).iter_parents())),
         };
         Parents { backing }
@@ -20,7 +20,7 @@ impl<'graph, 'cache> LazyCommit<'graph, 'cache> {
     /// Note that this can only fail if the commit is backed by the object database *and* parsing fails.
     pub fn committer_timestamp(&self) -> Result<SecondsSinceUnixEpoch, gix_object::decode::Error> {
         Ok(match &self.backing {
-            Either::Left(buf) => gix_object::CommitRefIter::from_bytes(buf, self.hash_kind)
+            Either::Left(buf) => gix_object::CommitRefIter::from_bytes(buf, self.object_hash)
                 .committer()?
                 .seconds(),
             Either::Right((cache, pos)) => cache.commit_at(*pos).committer_timestamp() as SecondsSinceUnixEpoch, // a cast as we cannot represent the error and trying seems overkill
@@ -42,7 +42,7 @@ impl<'graph, 'cache> LazyCommit<'graph, 'cache> {
         Ok(match &self.backing {
             Either::Left(buf) => (
                 None,
-                gix_object::CommitRefIter::from_bytes(buf, self.hash_kind)
+                gix_object::CommitRefIter::from_bytes(buf, self.object_hash)
                     .committer()?
                     .seconds(),
             ),
@@ -64,7 +64,7 @@ impl<'graph, 'cache> LazyCommit<'graph, 'cache> {
         Ok(match &self.backing {
             Either::Left(buf) => {
                 use gix_object::commit::ref_iter::Token;
-                let iter = gix_object::CommitRefIter::from_bytes(buf, self.hash_kind);
+                let iter = gix_object::CommitRefIter::from_bytes(buf, self.object_hash);
                 let mut parents = SmallVec::default();
                 let mut timestamp = None;
                 for token in iter {

--- a/gix-revwalk/src/graph/mod.rs
+++ b/gix-revwalk/src/graph/mod.rs
@@ -381,7 +381,7 @@ fn try_lookup<'graph, 'cache>(
             .map_err(gix_object::find::existing_iter::Error::Find)?
         {
             Some(data) => data.kind.is_commit().then_some(LazyCommit {
-                object_hash: data.hash_kind,
+                object_hash: data.object_hash,
                 backing: Either::Left(buf),
             }),
             None => None,

--- a/gix-revwalk/src/graph/mod.rs
+++ b/gix-revwalk/src/graph/mod.rs
@@ -369,7 +369,7 @@ fn try_lookup<'graph, 'cache>(
     if let Some(cache) = cache {
         if let Some(pos) = cache.lookup(id) {
             return Ok(Some(LazyCommit {
-                hash_kind: id.kind(),
+                object_hash: id.kind(),
                 backing: Either::Right((cache, pos)),
             }));
         }
@@ -381,7 +381,7 @@ fn try_lookup<'graph, 'cache>(
             .map_err(gix_object::find::existing_iter::Error::Find)?
         {
             Some(data) => data.kind.is_commit().then_some(LazyCommit {
-                hash_kind: data.hash_kind,
+                object_hash: data.hash_kind,
                 backing: Either::Left(buf),
             }),
             None => None,
@@ -441,7 +441,7 @@ where
 ///
 /// The owned version of this type is called [`Commit`] and can be obtained by calling [`LazyCommit::to_owned()`].
 pub struct LazyCommit<'graph, 'cache> {
-    hash_kind: gix_hash::Kind,
+    object_hash: gix_hash::Kind,
     backing: Either<&'graph [u8], (&'cache gix_commitgraph::Graph, gix_commitgraph::Position)>,
 }
 

--- a/gix-worktree-stream/Cargo.toml
+++ b/gix-worktree-stream/Cargo.toml
@@ -35,7 +35,7 @@ parking_lot = "0.12.4"
 
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }
-gix-hash = { version = "^0.23.0", path = "../gix-hash", features = ["sha1", "sha256"] }
+gix-hash = { path = "../gix-hash", features = ["sha1", "sha256"] }
 gix-odb = { path = "../gix-odb" }
 gix-worktree = { path = "../gix-worktree", default-features = false, features = ["attributes"] }
 

--- a/gix-worktree-stream/Cargo.toml
+++ b/gix-worktree-stream/Cargo.toml
@@ -17,6 +17,8 @@ doctest = false
 [features]
 ## Enable support for the SHA-1 hash by forwarding the feature to dependencies.
 sha1 = ["gix-filter/sha1", "gix-hash/sha1", "gix-object/sha1", "gix-traverse/sha1"]
+## Enable support for the SHA-256 hash by forwarding the feature to dependencies.
+sha256 = ["gix-hash/sha256"]
 
 [dependencies]
 gix-features = { version = "^0.48.0", path = "../gix-features", features = ["progress", "io-pipe"] }
@@ -33,6 +35,7 @@ parking_lot = "0.12.4"
 
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }
+gix-hash = { version = "^0.23.0", path = "../gix-hash", features = ["sha1", "sha256"] }
 gix-odb = { path = "../gix-odb" }
 gix-worktree = { path = "../gix-worktree", default-features = false, features = ["attributes"] }
 

--- a/gix-worktree-stream/src/lib.rs
+++ b/gix-worktree-stream/src/lib.rs
@@ -125,11 +125,16 @@ impl Stream {
     ///
     /// Note that the created entries will always have a null SHA1, and that we access this path
     /// to determine its type, and will access it again when it is requested.
-    pub fn add_entry_from_path(&mut self, root: &Path, path: &Path) -> std::io::Result<&mut Self> {
+    pub fn add_entry_from_path(
+        &mut self,
+        root: &Path,
+        path: &Path,
+        hash_kind: gix_hash::Kind,
+    ) -> std::io::Result<&mut Self> {
         let rela_path = path.strip_prefix(root).map_err(std::io::Error::other)?;
         let meta = path.symlink_metadata()?;
         let relative_path = gix_path::to_unix_separators_on_windows(gix_path::into_bstr(rela_path)).into_owned();
-        let id = gix_hash::ObjectId::null(gix_hash::Kind::Sha1);
+        let id = hash_kind.null();
 
         let entry = if meta.is_symlink() {
             let content = std::fs::read_link(path)?;

--- a/gix-worktree-stream/src/lib.rs
+++ b/gix-worktree-stream/src/lib.rs
@@ -123,18 +123,18 @@ impl Stream {
 
     /// Add the item at `path` as entry to this stream, which is expected to be under `root`.
     ///
-    /// Note that the created entries will always have a null SHA1, and that we access this path
+    /// Note that the created entries will always have a null hash, and that we access this path
     /// to determine its type, and will access it again when it is requested.
     pub fn add_entry_from_path(
         &mut self,
         root: &Path,
         path: &Path,
-        hash_kind: gix_hash::Kind,
+        object_hash: gix_hash::Kind,
     ) -> std::io::Result<&mut Self> {
         let rela_path = path.strip_prefix(root).map_err(std::io::Error::other)?;
         let meta = path.symlink_metadata()?;
         let relative_path = gix_path::to_unix_separators_on_windows(gix_path::into_bstr(rela_path)).into_owned();
-        let id = hash_kind.null();
+        let id = object_hash.null();
 
         let entry = if meta.is_symlink() {
             let content = std::fs::read_link(path)?;

--- a/gix-worktree-stream/src/protocol.rs
+++ b/gix-worktree-stream/src/protocol.rs
@@ -91,6 +91,8 @@ pub(crate) fn write_stream(
 fn byte_to_hash(b: u8) -> gix_hash::Kind {
     match b {
         0 => gix_hash::Kind::Sha1,
+        #[cfg(feature = "sha256")]
+        1 => gix_hash::Kind::Sha256,
         _ => unreachable!("BUG: we control the protocol"),
     }
 }
@@ -111,6 +113,8 @@ fn byte_to_mode(b: u8) -> gix_object::tree::EntryMode {
 fn hash_to_byte(h: gix_hash::Kind) -> u8 {
     match h {
         gix_hash::Kind::Sha1 => 0,
+        #[cfg(feature = "sha256")]
+        gix_hash::Kind::Sha256 => 1,
         _ => unreachable!("BUG: not implemented for hash kind {h}"),
     }
 }

--- a/gix-worktree-stream/tests/stream.rs
+++ b/gix-worktree-stream/tests/stream.rs
@@ -1,6 +1,10 @@
 /// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
-fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
-    gix_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+fn hex_to_id(hex_sha1: &str, hex_sha256: &str) -> gix_hash::ObjectId {
+    match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+        gix_hash::Kind::Sha1 => gix_hash::ObjectId::from_hex(hex_sha1.as_bytes()).expect("40 bytes hex"),
+        gix_hash::Kind::Sha256 => gix_hash::ObjectId::from_hex(hex_sha256.as_bytes()).expect("64 bytes hex"),
+        _ => unimplemented!(),
+    }
 }
 
 mod from_tree {
@@ -35,7 +39,7 @@ mod from_tree {
     #[test]
     fn can_receive_err_if_root_is_not_found() {
         let mut stream = gix_worktree_stream::from_tree(
-            gix_hash::Kind::Sha1.null(),
+            gix_testtools::hash_kind_from_env().unwrap_or_default().null(),
             FailObjectRetrieval,
             mutating_pipeline(false),
             |_, _, _| -> Result<_, Infallible> { unreachable!("must not be called") },
@@ -58,11 +62,6 @@ mod from_tree {
         Ok(())
     }
 
-    #[cfg(target_pointer_width = "64")]
-    const EXPECTED_BUFFER_LENGTH: usize = 320302;
-    #[cfg(target_pointer_width = "32")]
-    const EXPECTED_BUFFER_LENGTH: usize = 320198;
-
     #[test]
     fn will_provide_all_information_and_respect_export_ignore() -> gix_testtools::Result {
         let (dir, head_tree, odb, mut cache) = basic()?;
@@ -77,12 +76,13 @@ mod from_tree {
                     .map(|_| ())
             },
         );
+        let hash_kind = gix_testtools::hash_kind_from_env().unwrap_or_default();
         stream
-            .add_entry_from_path(&dir, &dir.join("extra-file"))?
-            .add_entry_from_path(&dir, &dir.join("extra-bigfile"))?
-            .add_entry_from_path(&dir, &dir.join("extra-exe"))?
-            .add_entry_from_path(&dir, &dir.join("extra-dir-empty"))?
-            .add_entry_from_path(&dir, &dir.join("extra-dir").join("symlink-to-extra"))?;
+            .add_entry_from_path(&dir, &dir.join("extra-file"), hash_kind)?
+            .add_entry_from_path(&dir, &dir.join("extra-bigfile"), hash_kind)?
+            .add_entry_from_path(&dir, &dir.join("extra-exe"), hash_kind)?
+            .add_entry_from_path(&dir, &dir.join("extra-dir-empty"), hash_kind)?
+            .add_entry_from_path(&dir, &dir.join("extra-dir").join("symlink-to-extra"), hash_kind)?;
 
         let tee_read = TeeToMemory {
             read: stream.into_read(),
@@ -121,53 +121,69 @@ mod from_tree {
                 (
                     ".gitattributes".into(),
                     EntryKind::Blob,
-                    hex_to_id("45c160c35c17ad264b96431cceb9793160396e99")
+                    hex_to_id(
+                        "45c160c35c17ad264b96431cceb9793160396e99",
+                        "e34ae8e2c517230c6c613202a955b5f2095567830de5c3bb7081d72f1af393dd"
+                    )
                 ),
                 (
                     "a".into(),
                     EntryKind::Blob,
-                    hex_to_id("45b983be36b73c0788dc9cbcb76cbb80fc7bb057")
+                    hex_to_id(
+                        "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
+                        "96c18f0297e38d01f4b2dacddea4259aea6b2961eb0822bd2c0c3f6029030045"
+                    )
                 ),
                 (
                     "bigfile".into(),
                     EntryKind::Blob,
-                    hex_to_id("4995fde49ed64e043977e22539f66a0d372dd129")
+                    hex_to_id(
+                        "4995fde49ed64e043977e22539f66a0d372dd129",
+                        "527a170c0c29520af58bf61a383c4e99a7a7c63c0475cbb630cf98d38d6c0dce"
+                    )
                 ),
                 (
                     "symlink-to-a".into(),
                     EntryKind::Link,
-                    hex_to_id("2e65efe2a145dda7ee51d1741299f848e5bf752e")
+                    hex_to_id(
+                        "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+                        "eb337bcee2061c5313c9a1392116b6c76039e9e30d71467ae359b36277e17dc7"
+                    )
                 ),
                 (
                     "dir/.gitattributes".into(),
                     EntryKind::Blob,
-                    hex_to_id("81b9a375276405703e05be6cecf0fc1c8b8eed64")
+                    hex_to_id(
+                        "81b9a375276405703e05be6cecf0fc1c8b8eed64",
+                        "4b74474eca46ad7e1807afe8855e7a511d132b314d3d0f481bb55a331b249fb7"
+                    )
                 ),
                 (
                     "dir/b".into(),
                     EntryKind::Blob,
-                    hex_to_id("ab4a98190cf776b43cb0fe57cef231fb93fd07e6")
+                    hex_to_id(
+                        "ab4a98190cf776b43cb0fe57cef231fb93fd07e6",
+                        "cf84f9ae227fa5c481dacd97f6d6506de727dabd30377c6907f623ef1192637a"
+                    )
                 ),
                 (
                     "dir/subdir/exe".into(),
                     EntryKind::BlobExecutable,
-                    hex_to_id("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")
+                    hex_to_id(
+                        "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                        "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813"
+                    )
                 ),
                 (
                     "dir/subdir/streamed".into(),
                     EntryKind::Blob,
-                    hex_to_id("08991f58f4de5d85b61c0f87f3ac053c79d0e739")
+                    hex_to_id(
+                        "08991f58f4de5d85b61c0f87f3ac053c79d0e739",
+                        "8c13ad7df9686daf00357f34700922485802cb0be33e684ec5171f7d0d8a84fd"
+                    )
                 ),
-                (
-                    "extra-file".into(),
-                    EntryKind::Blob,
-                    hex_to_id("0000000000000000000000000000000000000000")
-                ),
-                (
-                    "extra-bigfile".into(),
-                    EntryKind::Blob,
-                    hex_to_id("0000000000000000000000000000000000000000")
-                ),
+                ("extra-file".into(), EntryKind::Blob, hash_kind.null()),
+                ("extra-bigfile".into(), EntryKind::Blob, hash_kind.null()),
                 (
                     "extra-exe".into(),
                     if cfg!(windows) {
@@ -175,23 +191,29 @@ mod from_tree {
                     } else {
                         EntryKind::BlobExecutable
                     },
-                    hex_to_id("0000000000000000000000000000000000000000")
+                    hash_kind.null()
                 ),
-                (
-                    "extra-dir-empty".into(),
-                    EntryKind::Tree,
-                    hex_to_id("0000000000000000000000000000000000000000")
-                ),
-                (
-                    "extra-dir/symlink-to-extra".into(),
-                    EntryKind::Link,
-                    hex_to_id("0000000000000000000000000000000000000000")
-                )
+                ("extra-dir-empty".into(), EntryKind::Tree, hash_kind.null()),
+                ("extra-dir/symlink-to-extra".into(), EntryKind::Link, hash_kind.null())
             ]
         );
+
+        #[cfg(target_pointer_width = "64")]
+        let expected_buffer_length: usize = match gix_testtools::hash_kind_from_env() {
+            Some(gix_hash::Kind::Sha1) => 320302,
+            Some(gix_hash::Kind::Sha256) => 320458,
+            _ => unimplemented!(),
+        };
+        #[cfg(target_pointer_width = "32")]
+        let expected_buffer_length: usize = match gix_testtools::hash_kind_from_env() {
+            Some(gix_hash::Kind::Sha1) => 320198,
+            Some(gix_hash::Kind::Sha256) => todo!("let the test fail on CI and add the value here"),
+            _ => unimplemented!(),
+        };
+
         assert_eq!(
             copy.lock().len(),
-            EXPECTED_BUFFER_LENGTH,
+            expected_buffer_length,
             "keep track of file size changes of the streaming format"
         );
 
@@ -237,7 +259,14 @@ mod from_tree {
             let hex = std::fs::read(dir.join("head.hex"))?;
             gix_hash::ObjectId::from_hex(hex.trim())?
         };
-        let odb = gix_odb::at(dir.join(".git").join("objects"))?;
+        let odb = gix_odb::at_opts(
+            dir.join(".git").join("objects"),
+            Vec::new(),
+            gix_odb::store::init::Options {
+                object_hash: gix_testtools::hash_kind_from_env().unwrap_or_default(),
+                ..Default::default()
+            },
+        )?;
 
         let mut collection = Default::default();
         let mut buf = Default::default();

--- a/gix-worktree-stream/tests/stream.rs
+++ b/gix-worktree-stream/tests/stream.rs
@@ -76,13 +76,13 @@ mod from_tree {
                     .map(|_| ())
             },
         );
-        let hash_kind = gix_testtools::hash_kind_from_env().unwrap_or_default();
+        let object_hash = gix_testtools::hash_kind_from_env().unwrap_or_default();
         stream
-            .add_entry_from_path(&dir, &dir.join("extra-file"), hash_kind)?
-            .add_entry_from_path(&dir, &dir.join("extra-bigfile"), hash_kind)?
-            .add_entry_from_path(&dir, &dir.join("extra-exe"), hash_kind)?
-            .add_entry_from_path(&dir, &dir.join("extra-dir-empty"), hash_kind)?
-            .add_entry_from_path(&dir, &dir.join("extra-dir").join("symlink-to-extra"), hash_kind)?;
+            .add_entry_from_path(&dir, &dir.join("extra-file"), object_hash)?
+            .add_entry_from_path(&dir, &dir.join("extra-bigfile"), object_hash)?
+            .add_entry_from_path(&dir, &dir.join("extra-exe"), object_hash)?
+            .add_entry_from_path(&dir, &dir.join("extra-dir-empty"), object_hash)?
+            .add_entry_from_path(&dir, &dir.join("extra-dir").join("symlink-to-extra"), object_hash)?;
 
         let tee_read = TeeToMemory {
             read: stream.into_read(),
@@ -182,8 +182,8 @@ mod from_tree {
                         "8c13ad7df9686daf00357f34700922485802cb0be33e684ec5171f7d0d8a84fd"
                     )
                 ),
-                ("extra-file".into(), EntryKind::Blob, hash_kind.null()),
-                ("extra-bigfile".into(), EntryKind::Blob, hash_kind.null()),
+                ("extra-file".into(), EntryKind::Blob, object_hash.null()),
+                ("extra-bigfile".into(), EntryKind::Blob, object_hash.null()),
                 (
                     "extra-exe".into(),
                     if cfg!(windows) {
@@ -191,10 +191,10 @@ mod from_tree {
                     } else {
                         EntryKind::BlobExecutable
                     },
-                    hash_kind.null()
+                    object_hash.null()
                 ),
-                ("extra-dir-empty".into(), EntryKind::Tree, hash_kind.null()),
-                ("extra-dir/symlink-to-extra".into(), EntryKind::Link, hash_kind.null())
+                ("extra-dir-empty".into(), EntryKind::Tree, object_hash.null()),
+                ("extra-dir/symlink-to-extra".into(), EntryKind::Link, object_hash.null())
             ]
         );
 

--- a/gix-worktree-stream/tests/stream.rs
+++ b/gix-worktree-stream/tests/stream.rs
@@ -1,6 +1,6 @@
 /// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
 fn hex_to_id(hex_sha1: &str, hex_sha256: &str) -> gix_hash::ObjectId {
-    match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+    match gix_testtools::object_hash() {
         gix_hash::Kind::Sha1 => gix_hash::ObjectId::from_hex(hex_sha1.as_bytes()).expect("40 bytes hex"),
         gix_hash::Kind::Sha256 => gix_hash::ObjectId::from_hex(hex_sha256.as_bytes()).expect("64 bytes hex"),
         _ => unimplemented!(),
@@ -39,7 +39,7 @@ mod from_tree {
     #[test]
     fn can_receive_err_if_root_is_not_found() {
         let mut stream = gix_worktree_stream::from_tree(
-            gix_testtools::hash_kind_from_env().unwrap_or_default().null(),
+            gix_testtools::object_hash().null(),
             FailObjectRetrieval,
             mutating_pipeline(false),
             |_, _, _| -> Result<_, Infallible> { unreachable!("must not be called") },
@@ -76,7 +76,7 @@ mod from_tree {
                     .map(|_| ())
             },
         );
-        let object_hash = gix_testtools::hash_kind_from_env().unwrap_or_default();
+        let object_hash = gix_testtools::object_hash();
         stream
             .add_entry_from_path(&dir, &dir.join("extra-file"), object_hash)?
             .add_entry_from_path(&dir, &dir.join("extra-bigfile"), object_hash)?
@@ -199,13 +199,13 @@ mod from_tree {
         );
 
         #[cfg(target_pointer_width = "64")]
-        let expected_buffer_length: usize = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+        let expected_buffer_length: usize = match gix_testtools::object_hash() {
             gix_hash::Kind::Sha1 => 320302,
             gix_hash::Kind::Sha256 => 320458,
             _ => unimplemented!(),
         };
         #[cfg(target_pointer_width = "32")]
-        let expected_buffer_length: usize = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+        let expected_buffer_length: usize = match gix_testtools::object_hash() {
             gix_hash::Kind::Sha1 => 320198,
             gix_hash::Kind::Sha256 => todo!("let the test fail on CI and add the value here"),
             _ => unimplemented!(),
@@ -263,7 +263,7 @@ mod from_tree {
             dir.join(".git").join("objects"),
             Vec::new(),
             gix_odb::store::init::Options {
-                object_hash: gix_testtools::hash_kind_from_env().unwrap_or_default(),
+                object_hash: gix_testtools::object_hash(),
                 ..Default::default()
             },
         )?;

--- a/gix-worktree-stream/tests/stream.rs
+++ b/gix-worktree-stream/tests/stream.rs
@@ -199,15 +199,15 @@ mod from_tree {
         );
 
         #[cfg(target_pointer_width = "64")]
-        let expected_buffer_length: usize = match gix_testtools::hash_kind_from_env() {
-            Some(gix_hash::Kind::Sha1) => 320302,
-            Some(gix_hash::Kind::Sha256) => 320458,
+        let expected_buffer_length: usize = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+            gix_hash::Kind::Sha1 => 320302,
+            gix_hash::Kind::Sha256 => 320458,
             _ => unimplemented!(),
         };
         #[cfg(target_pointer_width = "32")]
-        let expected_buffer_length: usize = match gix_testtools::hash_kind_from_env() {
-            Some(gix_hash::Kind::Sha1) => 320198,
-            Some(gix_hash::Kind::Sha256) => todo!("let the test fail on CI and add the value here"),
+        let expected_buffer_length: usize = match gix_testtools::hash_kind_from_env().unwrap_or_default() {
+            gix_hash::Kind::Sha1 => 320198,
+            gix_hash::Kind::Sha256 => todo!("let the test fail on CI and add the value here"),
             _ => unimplemented!(),
         };
 

--- a/gix/src/repository/impls.rs
+++ b/gix/src/repository/impls.rs
@@ -151,7 +151,7 @@ impl gix_object::Find for crate::Repository {
             buffer.clear();
             return Ok(Some(gix_object::Data {
                 kind: gix_object::Kind::Tree,
-                hash_kind: self.object_hash(),
+                object_hash: self.object_hash(),
                 data: &[],
             }));
         }

--- a/justfile
+++ b/justfile
@@ -246,7 +246,7 @@ unit-tests:
     env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-refspec --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-refspec --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-worktree-stream --no-fail-fast
-    env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-worktree-stream --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-worktree-stream --features sha256 --no-fail-fast
     cargo nextest run -p gix --no-default-features --no-fail-fast
     cargo nextest run -p gix --no-default-features --features basic,comfort,max-performance-safe --no-fail-fast
     cargo nextest run -p gix --no-default-features --features basic,extras,comfort,need-more-recent-msrv --no-fail-fast

--- a/justfile
+++ b/justfile
@@ -245,6 +245,8 @@ unit-tests:
     env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-blame --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-refspec --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-refspec --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-worktree-stream --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-worktree-stream --no-fail-fast
     cargo nextest run -p gix --no-default-features --no-fail-fast
     cargo nextest run -p gix --no-default-features --features basic,comfort,max-performance-safe --no-fail-fast
     cargo nextest run -p gix --no-default-features --features basic,extras,comfort,need-more-recent-msrv --no-fail-fast

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -1067,11 +1067,7 @@ fn force_and_dir(
             let dir = fixture_path_inner(
                 Path::new("generated-do-not-edit")
                     .join(archive_name)
-                    .join(
-                        hash_kind
-                            .unwrap_or_else(|| hash_kind_from_env().unwrap_or_default())
-                            .to_string(),
-                    )
+                    .join(hash_kind.unwrap_or_else(self::object_hash).to_string())
                     .join(format!("{}-{}", script_identity, family_name())),
                 root,
             );
@@ -1166,7 +1162,7 @@ where
         gix_tempfile::signal::handler::Mode::DeleteTempfilesOnTerminationAndRestoreDefaultBehaviour,
     );
 
-    let hash_kind = hash_kind_from_env().unwrap_or_default();
+    let object_hash = object_hash();
 
     let script_location = script_name.as_ref();
     let script_path = fixture_path_inner(script_location, root);
@@ -1176,10 +1172,10 @@ where
     let post_version = post_process.as_ref().map(|(v, _)| *v);
     let script_identity = {
         let mut map = SCRIPT_IDENTITY.lock();
-        let init = if hash_kind == gix_hash::Kind::Sha1 {
+        let init = if object_hash == gix_hash::Kind::Sha1 {
             script_path.clone()
         } else {
-            script_path.clone().join(hash_kind.to_string())
+            script_path.clone().join(object_hash.to_string())
         };
         let key = args.iter().fold(init, |p, a| p.join(a));
         // Include post_version in the key if present
@@ -1224,10 +1220,10 @@ where
                 }
                 ArgsInHash::No => "".into(),
             };
-            let potential_hash_suffix = if hash_kind == gix_hash::Kind::Sha1 {
+            let potential_hash_suffix = if object_hash == gix_hash::Kind::Sha1 {
                 "".into()
             } else {
-                format!("_{hash_kind}")
+                format!("_{object_hash}")
             };
             Path::new(ARCHIVE_DIR_NAME).join(format!(
                 "{}{suffix}{potential_hash_suffix}.{}",
@@ -1241,7 +1237,7 @@ where
         destination_dir,
         root,
         script_basename,
-        Some(hash_kind),
+        Some(object_hash),
         &script_identity,
     );
     let _marker = marker_if_needed(destination_dir, script_basename)?;
@@ -1262,14 +1258,14 @@ where
         |fixture_state| {
             if let FixtureState::Uninitialized(dir) = fixture_state {
                 let mut cmd = std::process::Command::new(&script_absolute_path);
-                let output = match configure_command(&mut cmd, hash_kind, &args, dir).output() {
+                let output = match configure_command(&mut cmd, object_hash, &args, dir).output() {
                     Ok(out) => out,
                     Err(err)
                         if err.kind() == std::io::ErrorKind::PermissionDenied
                             || err.raw_os_error() == Some(193) /* windows */ =>
                     {
                         cmd = std::process::Command::new(bash_program());
-                        configure_command(cmd.arg(&script_absolute_path), hash_kind, &args, dir).output()?
+                        configure_command(cmd.arg(&script_absolute_path), object_hash, &args, dir).output()?
                     }
                     Err(err) => return Err(err.into()),
                 };
@@ -1301,7 +1297,7 @@ where
 /// # Panics
 ///
 /// If the value set in `GIX_TEST_FIXTURE_HASH` is not valid.
-pub fn hash_kind_from_env() -> Option<gix_hash::Kind> {
+pub fn object_hash_from_env() -> Option<gix_hash::Kind> {
     static FIXTURE_HASH: LazyLock<Option<gix_hash::Kind>> = LazyLock::new(|| {
         env::var_os("GIX_TEST_FIXTURE_HASH").and_then(|value| value.into_string().ok()).map(|object_kind| {
         gix_hash::Kind::from_str(&object_kind).unwrap_or_else(|_| {
@@ -1313,6 +1309,11 @@ pub fn hash_kind_from_env() -> Option<gix_hash::Kind> {
     })
     });
     *FIXTURE_HASH
+}
+
+/// Like [`object_hash_from_env()`], but returns the default hash if `GIX_TEST_FIXTURE_HASH` is not set.
+pub fn object_hash() -> gix_hash::Kind {
+    object_hash_from_env().unwrap_or_default()
 }
 
 #[cfg(windows)]

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -1059,7 +1059,7 @@ fn force_and_dir(
     destination_dir: Option<&Path>,
     root: DirectoryRoot,
     archive_name: impl AsRef<Path>,
-    hash_kind: Option<gix_hash::Kind>,
+    object_hash: Option<gix_hash::Kind>,
     script_identity: &dyn std::fmt::Display,
 ) -> (bool, PathBuf) {
     destination_dir.map_or_else(
@@ -1067,7 +1067,7 @@ fn force_and_dir(
             let dir = fixture_path_inner(
                 Path::new("generated-do-not-edit")
                     .join(archive_name)
-                    .join(hash_kind.unwrap_or_else(self::object_hash).to_string())
+                    .join(object_hash.unwrap_or_else(self::object_hash).to_string())
                     .join(format!("{}-{}", script_identity, family_name())),
                 root,
             );
@@ -1323,7 +1323,7 @@ const NULL_DEVICE: &str = "/dev/null";
 
 fn configure_command<'a, I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
     cmd: &'a mut std::process::Command,
-    hash_kind: gix_hash::Kind,
+    object_hash: gix_hash::Kind,
     args: I,
     script_result_directory: &Path,
 ) -> &'a mut std::process::Command {
@@ -1363,7 +1363,7 @@ fn configure_command<'a, I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
         .env("GIT_CONFIG_VALUE_2", "main")
         .env("GIT_CONFIG_KEY_3", "protocol.file.allow")
         .env("GIT_CONFIG_VALUE_3", "always")
-        .env("GIT_DEFAULT_HASH", hash_kind.to_string())
+        .env("GIT_DEFAULT_HASH", object_hash.to_string())
 }
 
 /// Get the path attempted as a `bash` interpreter, for fixture scripts having no `#!` we can use.


### PR DESCRIPTION
CI failed with the following error message:

```text
error: failed to select a version for the requirement `gix-hash = "^0.23.0"`
candidate versions found which didn't match: 0.24.0
location searched: /home/runner/work/gitoxide/gitoxide/gix-hash
required by package `gix-worktree-stream v0.31.0 (/home/runner/work/gitoxide/gitoxide/gix-worktree-stream)`
```

This is odd as, in this PR, `gix-worktree-stream` is only at version `0.30.0`.

## Open questions

- Are the additions to `byte_to_hash` and `hash_to_byte` correct?
- In `TryFrom<&super::Store> for super::Store`, do we want to replace `use_multi_pack_index: false` by `use_multi_pack_index: s.use_multi_pack_index`?

This is part of #281
