### PR TITLE
fix: shallow clone with tag ref_name now uses correct refspec

### DIFF
--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -114,34 +114,50 @@ impl PrepareFetch {
             && self.fetch_options.extra_refspecs.is_empty();
 
         let target_ref = if use_single_branch_for_shallow {
-            // Determine target branch from user-specified ref_name or default branch
-            if let Some(ref_name) = &self.ref_name {
-                Some(Category::LocalBranch.to_full_name(ref_name.as_ref().as_bstr())?)
-            } else {
-                // For shallow clones without a specified ref, we need to determine the ref to clone.
-                // Just fetch HEAD for that.
-                let prev_tags = std::mem::replace(&mut remote.fetch_tags, remote::fetch::Tags::None);
-                let mut connection = remote.connect(remote::Direction::Fetch).await?;
-                if let Some(f) = self.configure_connection.as_mut() {
-                    f(&mut connection).map_err(Error::RemoteConnection)?;
-                }
-                let refmap = connection
-                    .ref_map_by_ref(
-                        &mut progress,
-                        remote::ref_map::Options {
-                            extra_refspecs: vec![gix_refspec::parse(
-                                "HEAD".into(),
-                                gix_refspec::parse::Operation::Fetch,
-                            )
-                            .expect("valid")
-                            .to_owned()],
-                            ..Default::default()
-                        },
-                    )
-                    .await?;
+            // For shallow clones, we need to determine the actual remote ref to build a
+            // single-branch refspec. Connect to the remote to discover refs.
+            let prev_tags = std::mem::replace(&mut remote.fetch_tags, remote::fetch::Tags::None);
+            let mut connection = remote.connect(remote::Direction::Fetch).await?;
+            if let Some(f) = self.configure_connection.as_mut() {
+                f(&mut connection).map_err(Error::RemoteConnection)?;
+            }
 
+            let extra_refspec = if let Some(ref_name) = &self.ref_name {
+                // Use the user-specified ref_name as the refspec to discover what it resolves to.
+                gix_refspec::parse(ref_name.as_ref().as_bstr(), gix_refspec::parse::Operation::Fetch)
+                    .expect("partial names are valid refspecs")
+                    .to_owned()
+            } else {
+                gix_refspec::parse("HEAD".into(), gix_refspec::parse::Operation::Fetch)
+                    .expect("valid")
+                    .to_owned()
+            };
+
+            let refmap = connection
+                .ref_map_by_ref(
+                    &mut progress,
+                    remote::ref_map::Options {
+                        extra_refspecs: vec![extra_refspec],
+                        ..Default::default()
+                    },
+                )
+                .await?;
+
+            let target = if let Some(ref_name) = &self.ref_name {
+                // Find the ref matching ref_name in the remote refs
+                let found = util::find_custom_refname(&refmap, ref_name)?;
+                found
+                    .1
+                    .map(|name| {
+                        gix_ref::FullName::try_from(name).map_err(|err| Error::InvalidHeadRef {
+                            head_ref_name: name.to_owned(),
+                            source: err,
+                        })
+                    })
+                    .transpose()?
+            } else {
                 // Find HEAD in the remote refs (works for both Protocol V1 and V2)
-                let target = refmap
+                refmap
                     .remote_refs
                     .iter()
                     .find_map(|r| match r {
@@ -158,17 +174,20 @@ impl PrepareFetch {
                             .into(),
                         _ => None,
                     })
-                    .transpose()?;
+                    .transpose()?
+            };
 
-                let target = target.ok_or_else(|| Error::RefNameMissing {
-                    wanted: "HEAD".try_into().expect("valid partial name"),
-                })?;
+            let target = target.ok_or_else(|| Error::RefNameMissing {
+                wanted: self
+                    .ref_name
+                    .clone()
+                    .unwrap_or_else(|| "HEAD".try_into().expect("valid partial name")),
+            })?;
 
-                drop(connection);
-                remote.fetch_tags = prev_tags;
+            drop(connection);
+            remote.fetch_tags = prev_tags;
 
-                Some(target)
-            }
+            Some(target)
         } else {
             None
         };
@@ -177,13 +196,20 @@ impl PrepareFetch {
         // which requires a single ref to match Git unless it's overridden.
         if remote.fetch_specs.is_empty() {
             if let Some(target_ref) = &target_ref {
-                // Single-branch refspec for shallow clones
-                let short_name = target_ref.shorten();
+                // Single-branch refspec for shallow clones.
+                // For tags, git maps them as +refs/tags/X:refs/tags/X.
+                // For branches, git maps them as +refs/heads/X:refs/remotes/origin/X.
+                let refspec = match target_ref.category() {
+                    Some(Category::Tag) => {
+                        format!("+{target_ref}:{target_ref}")
+                    }
+                    _ => {
+                        let short_name = target_ref.shorten();
+                        format!("+{target_ref}:refs/remotes/{remote_name}/{short_name}")
+                    }
+                };
                 remote = remote
-                    .with_refspecs(
-                        Some(format!("+{target_ref}:refs/remotes/{remote_name}/{short_name}").as_str()),
-                        remote::Direction::Fetch,
-                    )
+                    .with_refspecs(Some(refspec.as_str()), remote::Direction::Fetch)
                     .expect("valid refspec");
             } else {
                 // Wildcard refspec for non-shallow clones or when target couldn't be determined

--- a/gix/tests/gix/clone.rs
+++ b/gix/tests/gix/clone.rs
@@ -120,6 +120,35 @@ mod blocking_io {
     }
 
     #[test]
+    fn shallow_clone_with_tag_ref_name_uses_tag_refspec() -> crate::Result {
+        let tmp = gix_testtools::tempfile::TempDir::new()?;
+        let (repo, _out) = gix::prepare_clone_bare(remote::repo("base").path(), tmp.path())?
+            .with_shallow(Shallow::DepthAtRemote(1.try_into()?))
+            .with_ref_name(Some("b-tag"))?
+            .fetch_only(gix::progress::Discard, &std::sync::atomic::AtomicBool::default())?;
+
+        assert!(repo.is_shallow(), "repository should be shallow");
+
+        // Verify that the refspec maps as a tag (same src and dst), not as a branch
+        let remote = repo.find_remote("origin")?;
+        let refspecs: Vec<_> = remote
+            .refspecs(Direction::Fetch)
+            .iter()
+            .map(|spec| spec.to_ref().to_bstring())
+            .collect();
+
+        assert_eq!(refspecs.len(), 1, "shallow clone should have only one fetch refspec");
+
+        let refspec_str = refspecs[0].to_str().expect("valid utf8");
+        assert_eq!(
+            refspec_str, "+refs/tags/b-tag:refs/tags/b-tag",
+            "shallow clone with tag ref_name should use tag-style refspec: {refspec_str}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn from_shallow_prohibited_with_option() -> crate::Result {
         let tmp = gix_testtools::tempfile::TempDir::new()?;
         let err = gix::clone::PrepareFetch::new(


### PR DESCRIPTION
## Summary

Fixes a bug where shallow clones with a tag-based fail with:

\\\
None of the refspec(s) +refs/heads/v1.30.0:refs/remotes/origin/v1.30.0, ... matched any of the 23 refs on the remote
\\\

Fix for issue: https://github.com/GitoxideLabs/gitoxide/issues/2554
### Root Cause

The shallow clone path unconditionally assumed ref_name was a branch via Category::LocalBranch.to_full_name(), generating refs/heads/* even when the remote only had refs/tags/*.

### Fix

The shallow clone path now always connects to the remote to discover the actual ref type before constructing the refspec:

### Testing

- Added shallow_clone_with_tag_ref_name_uses_tag_refspec test
- All 15 existing clone::blocking_io tests pass
- Both blocking-network-client and sync-network-client feature builds compile cleanly

### Related Issues

- Extends the fix from #2229 (which addressed #2227) to handle tag refs correctly
- Related to #2311 (wrong branch in shallow clone refspec, now closed)