### PR TITLE
fix: fetching and cloning with refspecs that are tags (in shallow clones)

### DIFF
--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -134,9 +134,6 @@ impl PrepareFetch {
                     )
                     .await?;
                 let (_target, full_ref_name) = util::find_custom_refname(&refmap, ref_name)?;
-                let full_ref_name = full_ref_name.ok_or_else(|| Error::RefNameMissing {
-                    wanted: ref_name.clone(),
-                })?;
                 Some(full_ref_name.try_into()?)
             } else {
                 // For shallow clones without a specified ref, we need to determine the ref to clone.

--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -116,6 +116,7 @@ impl PrepareFetch {
         let target_ref = if use_single_branch_for_shallow {
             // Determine target branch from user-specified ref_name or default branch
             if let Some(ref_name) = &self.ref_name {
+                let prev_tags = std::mem::replace(&mut remote.fetch_tags, remote::fetch::Tags::None);
                 let mut connection = remote.connect(remote::Direction::Fetch).await?;
                 if let Some(f) = self.configure_connection.as_mut() {
                     f(&mut connection).map_err(Error::RemoteConnection)?;
@@ -134,6 +135,8 @@ impl PrepareFetch {
                     )
                     .await?;
                 let (_target, full_ref_name) = util::find_custom_refname(&refmap, ref_name)?;
+                drop(connection);
+                remote.fetch_tags = prev_tags;
                 Some(full_ref_name.try_into()?)
             } else {
                 // For shallow clones without a specified ref, we need to determine the ref to clone.

--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -116,7 +116,28 @@ impl PrepareFetch {
         let target_ref = if use_single_branch_for_shallow {
             // Determine target branch from user-specified ref_name or default branch
             if let Some(ref_name) = &self.ref_name {
-                Some(Category::LocalBranch.to_full_name(ref_name.as_ref().as_bstr())?)
+                let mut connection = remote.connect(remote::Direction::Fetch).await?;
+                if let Some(f) = self.configure_connection.as_mut() {
+                    f(&mut connection).map_err(Error::RemoteConnection)?;
+                }
+                let refmap = connection
+                    .ref_map_by_ref(
+                        &mut progress,
+                        remote::ref_map::Options {
+                            extra_refspecs: vec![
+                                gix_refspec::parse(ref_name.as_ref().as_bstr(), gix_refspec::parse::Operation::Fetch)
+                                    .expect("partial names are valid refspecs")
+                                    .to_owned(),
+                            ],
+                            ..Default::default()
+                        },
+                    )
+                    .await?;
+                let (_target, full_ref_name) = util::find_custom_refname(&refmap, ref_name)?;
+                let full_ref_name = full_ref_name.ok_or_else(|| Error::RefNameMissing {
+                    wanted: ref_name.clone(),
+                })?;
+                Some(full_ref_name.try_into()?)
             } else {
                 // For shallow clones without a specified ref, we need to determine the ref to clone.
                 // Just fetch HEAD for that.
@@ -177,10 +198,15 @@ impl PrepareFetch {
         if remote.fetch_specs.is_empty() {
             if let Some(target_ref) = &target_ref {
                 // Single-branch refspec for shallow clones
-                let short_name = target_ref.shorten();
+                let destination = match target_ref.category_and_short_name() {
+                    Some((Category::LocalBranch, short_name)) => {
+                        format!("refs/remotes/{remote_name}/{short_name}")
+                    }
+                    _ => target_ref.to_string(),
+                };
                 remote = remote
                     .with_refspecs(
-                        Some(format!("+{target_ref}:refs/remotes/{remote_name}/{short_name}").as_str()),
+                        Some(format!("+{target_ref}:{destination}").as_str()),
                         remote::Direction::Fetch,
                     )
                     .expect("valid refspec");

--- a/gix/src/clone/fetch/util.rs
+++ b/gix/src/clone/fetch/util.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, io::Write};
 
 use gix_ref::{
-    FullNameRef, PartialName,
+    Category, FullNameRef, PartialName,
     transaction::{LogChange, RefLog},
 };
 
@@ -73,7 +73,10 @@ pub fn update_head(
         transaction::{PreviousValue, RefEdit},
     };
     let head_info = match ref_name {
-        Some(ref_name) => Some(find_custom_refname(ref_map, ref_name)?),
+        Some(ref_name) => {
+            let (target, full_ref_name) = find_custom_refname(ref_map, ref_name)?;
+            Some((Some(target), Some(full_ref_name)))
+        }
         None => ref_map.remote_refs.iter().find_map(|r| {
             Some(match r {
                 gix_protocol::handshake::Ref::Symbolic {
@@ -186,12 +189,11 @@ pub fn update_head(
 pub(super) fn find_custom_refname<'a>(
     ref_map: &'a crate::remote::fetch::RefMap,
     ref_name: &PartialName,
-) -> Result<(Option<&'a gix_hash::oid>, Option<&'a BStr>), Error> {
+) -> Result<(&'a gix_hash::oid, &'a BStr), Error> {
     let group = gix_refspec::MatchGroup::from_fetch_specs(Some(
         gix_refspec::parse(ref_name.as_ref().as_bstr(), gix_refspec::parse::Operation::Fetch)
             .expect("partial names are valid refs"),
     ));
-    // TODO: to fix ambiguity, implement priority system
     let filtered_items: Vec<_> = ref_map
         .mappings
         .iter()
@@ -206,6 +208,25 @@ pub(super) fn find_custom_refname<'a>(
             object: None,
         })
         .collect();
+
+    let requested_name = ref_name.as_ref().as_bstr();
+    let find_item = |name: &BStr| filtered_items.iter().find(|item| item.full_ref_name == name).copied();
+    // Preserve gix's documented full-ref support, then match git clone --branch by trying heads before tags.
+    if let Some(item) = find_item(requested_name) {
+        return Ok((item.target, item.full_ref_name));
+    }
+    if !requested_name.starts_with(b"refs/") {
+        let branch_name = Category::LocalBranch.to_full_name(requested_name)?;
+        if let Some(item) = find_item(branch_name.as_bstr()) {
+            return Ok((item.target, item.full_ref_name));
+        }
+
+        let tag_name = Category::Tag.to_full_name(requested_name)?;
+        if let Some(item) = find_item(tag_name.as_bstr()) {
+            return Ok((item.target, item.full_ref_name));
+        }
+    }
+
     let res = group.match_lhs(filtered_items.iter().copied());
     match res.mappings.len() {
         0 => Err(Error::RefNameMissing {
@@ -215,7 +236,7 @@ pub(super) fn find_custom_refname<'a>(
             let item = filtered_items[res.mappings[0]
                 .item_index
                 .expect("we map by name only and have no object-id in refspec")];
-            Ok((Some(item.target), Some(item.full_ref_name)))
+            Ok((item.target, item.full_ref_name))
         }
         _ => Err(Error::RefNameAmbiguous {
             wanted: ref_name.clone(),

--- a/gix/tests/gix/clone.rs
+++ b/gix/tests/gix/clone.rs
@@ -11,6 +11,7 @@ mod blocking_io {
     use gix::{
         bstr::BString,
         config::tree::{Clone, Core, Init, Key},
+        refs::transaction::PreviousValue,
         remote::{
             Direction,
             fetch::{Shallow, refmap::SpecIndex},
@@ -117,6 +118,62 @@ mod blocking_io {
         assert_eq!(
             refspec_str, "+refs/heads/main:refs/remotes/origin/main",
             "shallow clone refspec should not use wildcard and should be the main branch: {refspec_str}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn shallow_clone_with_ambiguous_branch_and_tag_name_prefers_branch() -> crate::Result {
+        let fixture = gix_testtools::scripted_fixture_writable("make_remote_repos.sh")?;
+        let remote_repo = gix::open_opts(fixture.path().join("base"), restricted())?;
+        let branch_name = "b";
+        remote_repo.tag_reference(
+            branch_name,
+            remote_repo.find_reference("refs/heads/main")?.id(),
+            PreviousValue::MustNotExist,
+        )?;
+
+        let destination = gix_testtools::tempfile::TempDir::new()?;
+        let mut prepare = gix::clone::PrepareFetch::new(
+            remote_repo.path(),
+            destination.path(),
+            gix::create::Kind::WithWorktree,
+            Default::default(),
+            restricted(),
+        )?
+        .with_ref_name(Some(branch_name))?
+        .with_shallow(Shallow::DepthAtRemote(1.try_into()?));
+
+        let (mut checkout, _out) = prepare.fetch_then_checkout(gix::progress::Discard, &AtomicBool::default())?;
+        let (repo, _) = checkout.main_worktree(gix::progress::Discard, &AtomicBool::default())?;
+
+        let checked_out_ref = repo.head_ref()?.expect("head points to ref");
+        assert_eq!(
+            checked_out_ref.name().as_bstr(),
+            "refs/heads/b",
+            "branches win over same-named tags, matching git clone --branch"
+        );
+        assert_eq!(
+            checked_out_ref
+                .remote_ref_name(gix::remote::Direction::Fetch)
+                .transpose()?
+                .unwrap()
+                .as_bstr(),
+            "refs/heads/b",
+            "branch merge configuration records the chosen branch"
+        );
+
+        let remote = repo.find_remote("origin")?;
+        let refspecs: Vec<_> = remote
+            .refspecs(Direction::Fetch)
+            .iter()
+            .map(|spec| spec.to_ref().to_bstring().to_str().expect("valid utf8").to_owned())
+            .collect();
+        assert_eq!(
+            refspecs,
+            vec!["+refs/heads/b:refs/remotes/origin/b"],
+            "the shallow clone follows only the chosen branch"
         );
 
         Ok(())

--- a/gix/tests/gix/clone.rs
+++ b/gix/tests/gix/clone.rs
@@ -821,38 +821,60 @@ mod blocking_io {
         let tmp = gix_testtools::tempfile::TempDir::new()?;
         let remote_repo = remote::repo("base");
         let ref_to_checkout = "annotated-detached-tag";
-        let mut prepare = gix::clone::PrepareFetch::new(
-            remote_repo.path(),
-            tmp.path(),
-            gix::create::Kind::WithWorktree,
-            Default::default(),
-            restricted(),
-        )?
-        .with_ref_name(Some(ref_to_checkout))?;
-        let (mut checkout, _out) = prepare.fetch_then_checkout(gix::progress::Discard, &AtomicBool::default())?;
+        for shallow in [false, true] {
+            let destination = tmp.path().join(if shallow { "shallow" } else { "full" });
+            let mut prepare = gix::clone::PrepareFetch::new(
+                remote_repo.path(),
+                destination,
+                gix::create::Kind::WithWorktree,
+                Default::default(),
+                restricted(),
+            )?;
+            if shallow {
+                prepare = prepare.with_shallow(Shallow::DepthAtRemote(1.try_into()?));
+            }
+            let mut prepare = prepare.with_ref_name(Some(ref_to_checkout))?;
+            let (mut checkout, _out) = prepare.fetch_then_checkout(gix::progress::Discard, &AtomicBool::default())?;
 
-        let (repo, _) = checkout.main_worktree(gix::progress::Discard, &AtomicBool::default())?;
+            let (repo, _) = checkout.main_worktree(gix::progress::Discard, &AtomicBool::default())?;
 
-        assert_eq!(
-            repo.references()?.all()?.count() - 1,
-            remote_repo.references()?.all()?.count(),
-            "all references have been cloned, + remote HEAD (not listed in remote_repo)"
-        );
-        let checked_out_ref = repo.head_ref()?.expect("head points to ref");
-        let remote_ref_name = format!("refs/tags/{ref_to_checkout}");
-        assert_eq!(
-            checked_out_ref.name().as_bstr(),
-            remote_ref_name,
-            "it also works with tags"
-        );
+            assert_eq!(repo.is_shallow(), shallow);
+            let remote_ref_name = format!("refs/tags/{ref_to_checkout}");
+            if shallow {
+                let remote = repo.find_remote("origin")?;
+                let refspecs: Vec<_> = remote
+                    .refspecs(Direction::Fetch)
+                    .iter()
+                    .map(|spec| spec.to_ref().to_bstring().to_str().expect("valid utf8").to_owned())
+                    .collect();
+                assert_eq!(
+                    refspecs,
+                    vec![format!("+{remote_ref_name}:{remote_ref_name}")],
+                    "shallow clones of tags use a tag refspec"
+                );
+            } else {
+                assert_eq!(
+                    repo.references()?.all()?.count() - 1,
+                    remote_repo.references()?.all()?.count(),
+                    "all references have been cloned, + remote HEAD (not listed in remote_repo)"
+                );
+            }
 
-        assert_eq!(
-            checked_out_ref
-                .remote_ref_name(gix::remote::Direction::Fetch)
-                .transpose()?,
-            None,
-            "there is no merge configuration for tags"
-        );
+            let checked_out_ref = repo.head_ref()?.expect("head points to ref");
+            assert_eq!(
+                checked_out_ref.name().as_bstr(),
+                remote_ref_name,
+                "it also works with tags"
+            );
+
+            assert_eq!(
+                checked_out_ref
+                    .remote_ref_name(gix::remote::Direction::Fetch)
+                    .transpose()?,
+                None,
+                "there is no merge configuration for tags"
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Fixes #2554.

### Tasks

* [x] refackiew

----

## Summary

Fix shallow clones with an explicit tag ref by resolving the requested ref name against the remote before constructing the shallow single-ref refspec.

This addresses #2554, where `PrepareFetch::with_shallow(...).with_ref_name(Some("tag"))` incorrectly treated the requested name as a local branch and generated a refspec like:

```text
+refs/heads/<tag>:refs/remotes/origin/<tag>
```

That refspec does not match tag-only refs and now fails once fetch refspec validation rejects unmatched required mappings.

## Research

I checked baseline Git behavior using the local Git checkout at:

```text
/Users/byron/dev/github.com/git/git
```

For a non-shallow clone with `--branch <tag>`, Git keeps the normal wildcard fetch refspec:

```text
+refs/heads/*:refs/remotes/origin/*
```

For a shallow clone with `--depth 1 --branch <tag>`, Git writes a tag-to-tag refspec instead:

```text
+refs/tags/<tag>:refs/tags/<tag>
```

The fix follows that behavior: shallow tag clones fetch the selected tag into `refs/tags/*`, while shallow branch clones continue to fetch into `refs/remotes/<remote>/*`.

## Changes

- Resolve `with_ref_name()` against the remote refs when using the shallow single-ref clone optimization.
- Use the resolved full ref name when constructing the shallow refspec.
- Preserve branch behavior by mapping `refs/heads/<name>` to `refs/remotes/<remote>/<name>`.
- Map non-branch refs, including tags, to themselves.
- Extend the annotated tag clone test to cover both non-shallow and shallow clones in one test.
- Assert that the shallow tag clone stores a tag refspec of the form:

```text
+refs/tags/<tag>:refs/tags/<tag>
```
