### PR TITLE
Use `GIX_TEST_FIXTURE_HASH` for `gix-status-tests`

### DIFF
--- a/gix-status/tests/Cargo.toml
+++ b/gix-status/tests/Cargo.toml
@@ -28,7 +28,7 @@ gix-filter = { path = "../../gix-filter" }
 gix-path = { path = "../../gix-path" }
 gix-dir = { path = "../../gix-dir" }
 gix-odb = { path = "../../gix-odb" }
-gix-hash = { path = "../../gix-hash" }
+gix-hash = { path = "../../gix-hash", features = ["sha1", "sha256"] }
 gix-object = { path = "../../gix-object" }
 gix-features = { path = "../../gix-features", features = ["parallel"] }
 gix-pathspec = { path = "../../gix-pathspec" }

--- a/gix-status/tests/fixtures/generated-archives/.gitignore
+++ b/gix-status/tests/fixtures/generated-archives/.gitignore
@@ -5,20 +5,20 @@
 
 # Uses `ln -sf` to create a symlink (`dir/sub-dir/symlink`).
 status_unchanged.tar
+status_unchanged_sha256.tar
 # Same as above; also relies on a `chmod -x` toggle.
 status_changed.tar
+status_changed_sha256.tar
 # Composed entirely of symlinks (including a symlink-to-base-dir).
 symlink_stack.tar
+symlink_stack_sha256.tar
 # Uses `mkfifo`; FIFOs cannot be represented in archives extracted on Windows.
 status_nonfile.tar
+status_nonfile_sha256.tar
 # Uses `ln -sf` plus installation-wide `core.autocrlf` line-ending normalization
 # on checkout.
 status_unchanged_filter.tar
+status_unchanged_filter_sha256.tar
 # Uses `chmod 000` on a tracked file; the unreadable mode is not portable.
 unreadable_untracked.tar
-status_unchanged_sha256.tar
-status_changed_sha256.tar
-symlink_stack_sha256.tar
-status_nonfile_sha256.tar
-status_unchanged_filter_sha256.tar
 unreadable_untracked_sha256.tar

--- a/gix-status/tests/fixtures/generated-archives/.gitignore
+++ b/gix-status/tests/fixtures/generated-archives/.gitignore
@@ -16,3 +16,9 @@ status_nonfile.tar
 status_unchanged_filter.tar
 # Uses `chmod 000` on a tracked file; the unreadable mode is not portable.
 unreadable_untracked.tar
+status_unchanged_sha256.tar
+status_changed_sha256.tar
+symlink_stack_sha256.tar
+status_nonfile_sha256.tar
+status_unchanged_filter_sha256.tar
+unreadable_untracked_sha256.tar

--- a/gix-status/tests/status/index_as_worktree.rs
+++ b/gix-status/tests/status/index_as_worktree.rs
@@ -160,8 +160,8 @@ fn fixture_filtered_detailed(
 
     let worktree = fixture_path(name).join(subdir);
     let git_dir = worktree.join(".git");
-    let mut index =
-        gix_index::File::at(git_dir.join("index"), gix_hash::Kind::Sha1, false, Default::default()).unwrap();
+    let object_hash = gix_testtools::object_hash();
+    let mut index = gix_index::File::at(git_dir.join("index"), object_hash, false, Default::default()).unwrap();
     prepare_index(&mut index);
     let mut recorder = Recorder::default();
     let search = gix_pathspec::Search::from_specs(to_pathspecs(pathspecs), None, std::path::Path::new(""))
@@ -194,7 +194,17 @@ fn fixture_filtered_detailed(
         ..Options::default()
     };
     let outcome = if use_odb {
-        let odb = gix_odb::at(git_dir.join("objects")).unwrap().into_arc().unwrap();
+        let odb = gix_odb::at_opts(
+            git_dir.join("objects"),
+            Vec::new(),
+            gix_odb::store::init::Options {
+                object_hash,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .into_arc()
+        .unwrap();
         index_as_worktree(
             &index,
             &worktree,
@@ -1006,8 +1016,8 @@ fn racy_git() {
     let worktree = dir.path();
     let git_dir = worktree.join(".git");
     let fs = gix_fs::Capabilities::probe(&git_dir);
-    let mut index =
-        gix_index::File::at(git_dir.join("index"), gix_hash::Kind::Sha1, false, Default::default()).unwrap();
+    let object_hash = gix_testtools::object_hash();
+    let mut index = gix_index::File::at(git_dir.join("index"), object_hash, false, Default::default()).unwrap();
 
     #[derive(Clone)]
     struct CountCalls(Arc<AtomicUsize>, FastEq);

--- a/gix-status/tests/status/index_as_worktree.rs
+++ b/gix-status/tests/status/index_as_worktree.rs
@@ -17,7 +17,7 @@ use gix_status::{
     },
 };
 
-use crate::{fixture_path, hex_to_id};
+use crate::{fixture_path, hex_to_id, odb_at};
 use gix_index::entry::{Flags, Mode};
 use gix_status::index_as_worktree::ConflictIndexEntry;
 use pretty_assertions::assert_eq;
@@ -194,17 +194,7 @@ fn fixture_filtered_detailed(
         ..Options::default()
     };
     let outcome = if use_odb {
-        let odb = gix_odb::at_opts(
-            git_dir.join("objects"),
-            Vec::new(),
-            gix_odb::store::init::Options {
-                object_hash,
-                ..Default::default()
-            },
-        )
-        .unwrap()
-        .into_arc()
-        .unwrap();
+        let odb = odb_at(&git_dir, object_hash);
         index_as_worktree(
             &index,
             &worktree,

--- a/gix-status/tests/status/index_as_worktree_with_renames.rs
+++ b/gix-status/tests/status/index_as_worktree_with_renames.rs
@@ -91,6 +91,9 @@ fn changed_and_untracked_and_renamed() {
         Some(Default::default()),
         Fixture::ReadOnly,
     );
+    // The amount of checks currently depends on hashes as they are sorted,
+    // and with changes in order come changes in checks. This shold go away
+    // with proper, non-hash dependent heuristics.
     let num_similarity_checks = match gix_testtools::object_hash() {
         gix_hash::Kind::Sha1 => 11,
         gix_hash::Kind::Sha256 => 10,
@@ -350,17 +353,7 @@ fn fixture_filtered_detailed(
     };
 
     let mut recorder = Recorder::default();
-    let objects = gix_odb::at_opts(
-        git_dir.join("objects"),
-        Vec::new(),
-        gix_odb::store::init::Options {
-            object_hash,
-            ..Default::default()
-        },
-    )
-    .unwrap()
-    .into_arc()
-    .unwrap();
+    let objects = crate::odb_at(&git_dir, object_hash);
     let outcome = index_as_worktree_with_renames(
         &index,
         &worktree,

--- a/gix-status/tests/status/index_as_worktree_with_renames.rs
+++ b/gix-status/tests/status/index_as_worktree_with_renames.rs
@@ -91,11 +91,16 @@ fn changed_and_untracked_and_renamed() {
         Some(Default::default()),
         Fixture::ReadOnly,
     );
+    let num_similarity_checks = match gix_testtools::object_hash() {
+        gix_hash::Kind::Sha1 => 11,
+        gix_hash::Kind::Sha256 => 10,
+        _ => unimplemented!(),
+    };
     assert_eq!(
         out.rewrites,
         Some(gix_diff::rewrites::Outcome {
             options: rewrites,
-            num_similarity_checks: 11,
+            num_similarity_checks,
             num_similarity_checks_skipped_for_rename_tracking_due_to_limit: 0,
             num_similarity_checks_skipped_for_copy_tracking_due_to_limit: 0,
         })
@@ -283,7 +288,8 @@ fn fixture_filtered_detailed(
         }
     };
     let git_dir = worktree.join(".git");
-    let index = gix_index::File::at(git_dir.join("index"), gix_hash::Kind::Sha1, false, Default::default()).unwrap();
+    let object_hash = gix_testtools::object_hash();
+    let index = gix_index::File::at(git_dir.join("index"), object_hash, false, Default::default()).unwrap();
     let search = gix_pathspec::Search::from_specs(
         crate::index_as_worktree::to_pathspecs(pathspecs),
         None,
@@ -332,7 +338,7 @@ fn fixture_filtered_detailed(
         },
     };
     let options = Options {
-        object_hash: gix_hash::Kind::Sha1,
+        object_hash,
         tracked_file_modifications: gix_status::index_as_worktree::Options {
             fs: capabilities,
             stat: crate::index_as_worktree::TEST_OPTIONS,
@@ -344,7 +350,17 @@ fn fixture_filtered_detailed(
     };
 
     let mut recorder = Recorder::default();
-    let objects = gix_odb::at(git_dir.join("objects")).unwrap().into_arc().unwrap();
+    let objects = gix_odb::at_opts(
+        git_dir.join("objects"),
+        Vec::new(),
+        gix_odb::store::init::Options {
+            object_hash,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .into_arc()
+    .unwrap();
     let outcome = index_as_worktree_with_renames(
         &index,
         &worktree,

--- a/gix-status/tests/status/mod.rs
+++ b/gix-status/tests/status/mod.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+
+use gix_hash::ObjectId;
 use gix_testtools::Creation;
 pub use gix_testtools::Result;
 
@@ -20,6 +23,86 @@ pub fn fixture_path_rw_slow(name: &str) -> gix_testtools::tempfile::TempDir {
     .expect("script works")
 }
 
+pub static SHA1_TO_SHA256_HASHES: std::sync::LazyLock<HashMap<&str, &str>> = std::sync::LazyLock::new(|| {
+    [
+        (
+            "3189cd3cb0af8586c39a838aa3e54fd72a872a41",
+            "735ec3eb1e74b0815da6d8aeca80ffbffdca25a2b624cc54d5d34caca9bc4dec",
+        ),
+        (
+            "e376f96e6a7f1c9335ca16c3f62e172166146bda",
+            "0fd8abe17be34797b2c5f7d31996b753f71ca457f863100da6c72383e4e7ab2d",
+        ),
+        (
+            "ba2906d0666cf726c7eaadd2cd3db615dedfdf3a",
+            "e493de051d847062f56a4d6d8535aba26effa5ee920b13f5e2ba87aad8b62ba7",
+        ),
+        (
+            "dde77be9fbfb155ff0473e7fe31781d56d50e5d3",
+            "02f895333cb699f3c2093987859e4a8192d9f36577d0324ded4693006660f372",
+        ),
+        (
+            "9daeafb9864cf43055ae93beb0afd6c7d144bfa4",
+            "999f24152159e51756a944d32257bf22080ff8608fff87ca9a4a823764e13dbe",
+        ),
+        (
+            "df967b96a579e45a18b8251732d16804b2e56a55",
+            "abed979e3cd3667c5a295c2641f8319f950860c65cc168eebd1571c51bb4f6fc",
+        ),
+        (
+            "d244dd0bf67758236f793fd7749a1c814fbfeac4",
+            "a9c387002cad1a6d1df14f93a758a8ddead88d8b4490ec2255a26ed361bdd3c9",
+        ),
+        (
+            "e14959721a622239cc8de786a4b8cfcefea8304c",
+            "eba7bfbfb4c69d21e48a6c5b424f3d2028565d4652585fdec7ae4a69be204f21",
+        ),
+        (
+            "e019be006cf33489e2d0177a3837a2384eddebc5",
+            "8e57afe4b9ab5713ce94fb5f1aa4ee7e2922b2b9ec5ee51a661b6af0bf8312cf",
+        ),
+        (
+            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+            "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813",
+        ),
+        (
+            "c7747099cf9e073babc68f52cdfb4d280ba5689f",
+            "4be0e5ba4a5a905c1ebfdc2459c2cdda407c4d25dcf169ad5cc401f6aa5abccd",
+        ),
+        (
+            "0835e4f9714005ed591f68d306eea0d6d2ae8fd7",
+            "2f46b964cf615d9cdcc0da6c78c0ace2e8839486f8bd72a19dde75063c355634",
+        ),
+        (
+            "b1b716105590454bfc4c0247f193a04088f39c7f",
+            "e23d150d7b09ce3cabcc858d8d866a8c3dbd11a8f8eb956a915c3cc76e3297ce",
+        ),
+        (
+            "e45c9c2666d44e0327c1f9c239a74c508336053e",
+            "e18941661c834f08aa0a19e626484916937df12c0e08d5f015b3b53d0284aa02",
+        ),
+        (
+            "7d5ae6def200acda76d2ccf7c93170a9d88d6cb1",
+            "8dd94999e55b5d13a576adc83d56c9bfb3ea0f98d7dbee30f78937664b6a7422",
+        ),
+        (
+            "aac4af54d6427ef10af2b51a524e7272c4f37c02",
+            "5b10c51fc44a8adf5650810cef8c5509f24bb66e627bbef9a35941652af94172",
+        ),
+    ]
+    .into()
+});
+
 fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
-    gix_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+    match gix_testtools::object_hash_from_env().unwrap_or_default() {
+        gix_hash::Kind::Sha1 => ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex"),
+        gix_hash::Kind::Sha256 => ObjectId::from_hex(
+            SHA1_TO_SHA256_HASHES
+                .get(hex)
+                .expect("40 bytes hash to be present in mapping")
+                .as_bytes(),
+        )
+        .expect("64 bytes hex"),
+        _ => unimplemented!(),
+    }
 }

--- a/gix-status/tests/status/mod.rs
+++ b/gix-status/tests/status/mod.rs
@@ -23,6 +23,20 @@ pub fn fixture_path_rw_slow(name: &str) -> gix_testtools::tempfile::TempDir {
     .expect("script works")
 }
 
+fn odb_at(git_dir: &std::path::Path, object_hash: gix_hash::Kind) -> gix_odb::HandleArc {
+    gix_odb::at_opts(
+        git_dir.join("objects"),
+        Vec::new(),
+        gix_odb::store::init::Options {
+            object_hash,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .into_arc()
+    .unwrap()
+}
+
 pub static SHA1_TO_SHA256_HASHES: std::sync::LazyLock<HashMap<&str, &str>> = std::sync::LazyLock::new(|| {
     [
         (

--- a/justfile
+++ b/justfile
@@ -203,7 +203,8 @@ unit-tests:
     cargo nextest run -p gix-archive --no-default-features --features zip --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-diff --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-diff --no-fail-fast
-    cargo nextest run -p gix-status-tests --features gix-features-parallel --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-status-tests --features gix-features-parallel --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-status-tests --features gix-features-parallel --no-fail-fast
     cargo nextest run -p gix-worktree-state-tests --features gix-features-parallel --no-fail-fast
     cargo nextest run -p gix-worktree-tests --features gix-features-parallel --no-fail-fast
     cargo nextest run -p gix-error --no-fail-fast --test auto-chain-error --features auto-chain-error


### PR DESCRIPTION
This PR makes `gix-status-tests` run with `GIX_TEST_FIXTURE_HASH=sha256`. For mapping SHA-1 to SHA-256 hashes, it uses the same pattern as #2573. Also, there’s some similar duplication surrounding the uses of `gix_odb::at_opts(…)`. Apart from that, not a lot of code had to be changed.

This is part of #281.