### PR TITLE
Improve comment in object/commit.rs

### DIFF
--- a/gix/src/object/commit.rs
+++ b/gix/src/object/commit.rs
@@ -101,7 +101,7 @@ impl<'repo> Commit<'repo> {
 
     /// Decode the commit and obtain the time at which the commit was created.
     ///
-    /// For the time at which it was authored, refer to `.decode()?.author()?.time()`.
+    /// For the time at which it was authored, refer to `.author()?.time()`.
     pub fn time(&self) -> Result<gix_date::Time, Error> {
         Ok(self.committer()?.time()?)
     }


### PR DESCRIPTION
cc @Byron 

`Commit` now has an `author` method as well:

```rust
    /// Return the commits author, with surrounding whitespace trimmed.
    pub fn author(&self) -> Result<gix_actor::SignatureRef<'_>, gix_object::decode::Error> {
        gix_object::CommitRefIter::from_bytes(&self.data, self.id.kind())
            .author()
            .map(|s| s.trim())
    }
```

Seems we don't need to `decode` first? Or else the API looks unintuitive to understand.