### PR TITLE
gix: cache packed-refs in a HashMap during fetch update_refs

### DIFF
--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -530,23 +530,26 @@ impl LookupFastPath {
 /// `None` return causes the caller to fall back to the unmodified slow path,
 /// so the optimization is purely additive.
 fn build_lookup_fast_path(repo: &Repository) -> Option<LookupFastPath> {
+    // `cached_packed_buffer()` returns raw, namespace-prefixed names from
+    // `packed-refs`, while lookups here use namespace-stripped local names.
+    // Defer to the slow path, which applies the namespace correctly.
+    if repo.refs.namespace.is_some() {
+        return None;
+    }
     let buf = repo.refs.cached_packed_buffer().ok().flatten()?;
-    let iter = buf.iter().ok()?;
-    let packed: HashMap<BString, gix_ref::Reference> = iter
-        .filter_map(Result::ok)
-        .map(|r| {
-            let name = r.name.as_bstr().to_owned();
-            let r: gix_ref::Reference = r.into();
-            (name, r)
-        })
-        .collect();
-    let loose_shadows: HashSet<BString> = repo
-        .refs
-        .loose_iter()
-        .ok()?
-        .filter_map(Result::ok)
-        .map(|r| r.name.as_bstr().to_owned())
-        .collect();
+    let mut packed = HashMap::new();
+    for r in buf.iter().ok()? {
+        // Bail to the slow path on parse errors so corruption surfaces via
+        // `repo.try_find_reference()` instead of being silently dropped.
+        let r = r.ok()?;
+        let name = r.name.as_bstr().to_owned();
+        packed.insert(name, r.into());
+    }
+    let mut loose_shadows = HashSet::new();
+    for r in repo.refs.loose_iter().ok()? {
+        let r = r.ok()?;
+        loose_shadows.insert(r.name.as_bstr().to_owned());
+    }
     Some(LookupFastPath { packed, loose_shadows })
 }
 

--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -547,10 +547,7 @@ fn build_lookup_fast_path(repo: &Repository) -> Option<LookupFastPath> {
         .filter_map(Result::ok)
         .map(|r| r.name.as_bstr().to_owned())
         .collect();
-    Some(LookupFastPath {
-        packed,
-        loose_shadows,
-    })
+    Some(LookupFastPath { packed, loose_shadows })
 }
 
 #[cfg(test)]

--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -1,7 +1,13 @@
 #![allow(clippy::result_large_err)]
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    path::PathBuf,
+};
 
-use gix_object::Exists;
+use gix_object::{
+    Exists,
+    bstr::{BString, ByteSlice},
+};
 use gix_ref::{
     Target, TargetRef,
     transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
@@ -77,6 +83,15 @@ pub(crate) fn update(
     let mut edit_indices_to_validate = Vec::new();
 
     let mut checked_out_branches = worktree_branches(repo)?;
+    // For wide-refs fetches (e.g. mirror clones with 100k+ branches in
+    // `packed-refs`) the per-mapping `repo.try_find_reference()` call below
+    // dominates wall time: each call does one filesystem stat for a loose
+    // ref plus a binary search over `packed-refs`. The fast path here is
+    // purely additive — if either snapshot fails to build, fall through to
+    // the original lookup with unchanged semantics. Loose refs shadow
+    // packed entries, so the HashMap is only consulted when no loose ref
+    // exists for that name.
+    let lookup_fast_path = build_lookup_fast_path(repo);
     let implicit_tag_refspec = fetch_tags
         .to_refspec()
         .filter(|_| matches!(fetch_tags, crate::remote::fetch::Tags::Included));
@@ -113,7 +128,12 @@ pub(crate) fn update(
         }
         let (mode, edit_index, type_change) = match local {
             Some(name) => {
-                let (mode, reflog_message, name, previous_value) = match repo.try_find_reference(name)? {
+                let existing = match lookup_fast_path.as_ref().map(|fp| fp.lookup(name.as_bstr())) {
+                    Some(LookupOutcome::Hit(r)) => Some(crate::Reference::from_ref(r, repo)),
+                    Some(LookupOutcome::NotFound) => None,
+                    Some(LookupOutcome::TakeSlowPath) | None => repo.try_find_reference(name)?,
+                };
+                let (mode, reflog_message, name, previous_value) = match existing {
                     Some(existing) => {
                         if let Some(wt_dirs) = checked_out_branches.get_mut(existing.name()) {
                             wt_dirs.sort();
@@ -469,6 +489,68 @@ fn worktree_branches(repo: &Repository) -> Result<BTreeMap<gix_ref::FullName, Ve
         insert_head(repo.head().ok(), &mut map)?;
     }
     Ok(map)
+}
+
+/// A precomputed snapshot of packed-refs plus the set of loose ref names that
+/// shadow them, used to answer `repo.try_find_reference()`-style queries for
+/// the bulk of the `update()` loop without touching the filesystem or doing a
+/// binary search per call.
+struct LookupFastPath {
+    /// Packed-refs keyed by ref name (e.g. `refs/remotes/origin/foo`).
+    packed: HashMap<BString, gix_ref::Reference>,
+    /// Names of loose refs which shadow entries in `packed` and must take the
+    /// slow path so existing precedence is preserved.
+    loose_shadows: HashSet<BString>,
+}
+
+/// Result of a fast-path lookup. `TakeSlowPath` is distinct from `NotFound`:
+/// the former means "we can't answer from the snapshot alone, defer to
+/// `repo.try_find_reference()`" (e.g. a loose ref shadows this name), while
+/// the latter means "we are certain no ref exists with this name".
+enum LookupOutcome {
+    Hit(gix_ref::Reference),
+    NotFound,
+    TakeSlowPath,
+}
+
+impl LookupFastPath {
+    fn lookup(&self, name: &gix_object::bstr::BStr) -> LookupOutcome {
+        if self.loose_shadows.contains(name) {
+            return LookupOutcome::TakeSlowPath;
+        }
+        match self.packed.get(name) {
+            Some(r) => LookupOutcome::Hit(r.clone()),
+            None => LookupOutcome::NotFound,
+        }
+    }
+}
+
+/// Build [`LookupFastPath`] for the repo, returning `None` if either of the
+/// inputs (packed-refs snapshot, loose refs enumeration) is unavailable. A
+/// `None` return causes the caller to fall back to the unmodified slow path,
+/// so the optimization is purely additive.
+fn build_lookup_fast_path(repo: &Repository) -> Option<LookupFastPath> {
+    let buf = repo.refs.cached_packed_buffer().ok().flatten()?;
+    let iter = buf.iter().ok()?;
+    let packed: HashMap<BString, gix_ref::Reference> = iter
+        .filter_map(Result::ok)
+        .map(|r| {
+            let name = r.name.as_bstr().to_owned();
+            let r: gix_ref::Reference = r.into();
+            (name, r)
+        })
+        .collect();
+    let loose_shadows: HashSet<BString> = repo
+        .refs
+        .loose_iter()
+        .ok()?
+        .filter_map(Result::ok)
+        .map(|r| r.name.as_bstr().to_owned())
+        .collect();
+    Some(LookupFastPath {
+        packed,
+        loose_shadows,
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`fetch::refs::update()` calls `repo.try_find_reference(name)` once per advertised mapping. Each call does a filesystem stat for a loose ref followed by a binary search over `packed-refs` — and on wide-refs mirrors (e.g. AUR's 154k branches) that loop dominates wall time.

This PR snapshots `packed-refs` into a `HashMap<BString, gix_ref::Reference>` once and enumerates loose ref names into a `HashSet` once at the start of `update()`. Per-mapping lookups consult the HashMap when the name has no loose shadow, falling back to `repo.try_find_reference()` only when a loose ref exists (preserving the loose-shadows-packed precedence) or when the snapshot couldn't be built.

The optimization is **purely additive**: any failure to build the snapshots makes `build_lookup_fast_path` return `None` and the loop falls back to the unchanged slow path.

## Measured impact

`gitaur -Sy` against the AUR mirror (154k packed refs, ~200 loose refs, warm cache, no incoming updates):

| variant | wall | user CPU |
|---|---|---|
| unpatched main | 11.0 s | 8.1 s |
| this PR alone | 8.0 s | 5.8 s |
| this PR + #2604 (gix-ref binary-search skip-validation) | **5.0 s** | **3.3 s** |

The two changes target different fetch phases:
- This PR drops the *post-pack ref-update* loop from 154k binary searches to 154k hash lookups.
- #2604 drops the per-comparison validation in `packed::Buffer::binary_search_by`, which speeds up the *negotiation have-set build* phase (still does many binary searches via `Negotiate::mark_complete`).

Together they bring gitaur's incremental fetch on the AUR mirror to roughly the same wall time as `git fetch`, down from ~2.2× slower previously.

## Trade-offs / scope

- One extra full iteration over `packed-refs` per `update()` call (cost amortized across all mappings). For small repos with few refs the overhead is in the microseconds — not benchmarked specifically, but the HashMap insertions are O(n) where n is the packed-refs entry count, and a `gitoxide` smoke run on a small repo showed no regression.
- Loose-ref snapshot uses `repo.refs.loose_iter()` and bails to the slow path on iteration error. For repos where most refs are loose this is essentially the same work as today; for mirror-style repos with packed-heavy state it's the right shape.
- The optimization could plausibly live deeper, inside `packed::Buffer` itself (e.g. a lazy index of name→offset), to also accelerate non-fetch callers of `try_find_full_name`. That's a larger change touching a cached data structure — happy to discuss whether you'd prefer the optimization in that form instead, but this localized version was easier to scope, measure, and review independently.

## Test coverage

`cargo test -p gix-ref` passes (161/161). `cargo test -p gix --features blocking-network-client --test gix remote::fetch::blocking_and_async_io` passes the 7 tests that pass on main (3 tests fail with the same hash-mismatch on main without this PR — pre-existing, fixture-dependent).

## AI disclosure

Per `CONTRIBUTING.md`, this change was drafted with the help of Claude Opus 4.7 (see the `Co-authored-by:` trailer on the commit). Investigation, profiling, and review were done by me.