### PR TITLE
gix-url: accept `impl Into<&BStr>` in `parse`

### DIFF
--- a/gix-url/fuzz/fuzz_targets/parse.rs
+++ b/gix-url/fuzz/fuzz_targets/parse.rs
@@ -1,11 +1,12 @@
 #![no_main]
 use anyhow::Result;
+use bstr::ByteSlice;
 use libfuzzer_sys::fuzz_target;
 use std::hint::black_box;
 use std::path::Path;
 
 fn fuzz(data: &[u8]) -> Result<()> {
-    let url = gix_url::parse(data.into())?;
+    let url = gix_url::parse(data.as_bstr())?;
     _ = black_box(url.user());
     _ = black_box(url.password());
     _ = black_box(url.password());
@@ -20,7 +21,7 @@ fn fuzz(data: &[u8]) -> Result<()> {
     _ = black_box(url.canonicalized(Path::new("/cwd")));
     _ = black_box(url.to_bstring());
 
-    _ = black_box(gix_url::expand_path::parse(data.into()));
+    _ = black_box(gix_url::expand_path::parse(data.as_bstr()));
     Ok(())
 }
 

--- a/gix-url/fuzz/fuzz_targets/parse.rs
+++ b/gix-url/fuzz/fuzz_targets/parse.rs
@@ -1,12 +1,11 @@
 #![no_main]
 use anyhow::Result;
-use bstr::ByteSlice;
 use libfuzzer_sys::fuzz_target;
 use std::hint::black_box;
 use std::path::Path;
 
 fn fuzz(data: &[u8]) -> Result<()> {
-    let url = gix_url::parse(data.as_bstr())?;
+    let url = gix_url::parse(data)?;
     _ = black_box(url.user());
     _ = black_box(url.password());
     _ = black_box(url.password());
@@ -21,7 +20,7 @@ fn fuzz(data: &[u8]) -> Result<()> {
     _ = black_box(url.canonicalized(Path::new("/cwd")));
     _ = black_box(url.to_bstring());
 
-    _ = black_box(gix_url::expand_path::parse(data.as_bstr()));
+    _ = black_box(gix_url::expand_path::parse(data.into()));
     Ok(())
 }
 

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -184,19 +184,17 @@ impl Url {
         path: BString,
         serialize_alternative_form: bool,
     ) -> Result<Self, parse::Error> {
-        parse(
-            Url {
-                scheme,
-                user,
-                password,
-                host,
-                port,
-                path,
-                serialize_alternative_form,
-            }
-            .to_bstring()
-            .as_bstr(),
-        )
+        let serialized = Url {
+            scheme,
+            user,
+            password,
+            host,
+            port,
+            path,
+            serialize_alternative_form,
+        }
+        .to_bstring();
+        parse(BStr::new(&serialized))
     }
 }
 

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -3,7 +3,7 @@
 //! ## Examples
 //!
 //! ```
-//! let mut url = gix_url::parse("ssh://git@example.com/gitoxide".into()).unwrap();
+//! let mut url = gix_url::parse("ssh://git@example.com/gitoxide").unwrap();
 //! assert_eq!(url.user(), Some("git"));
 //! assert_eq!(url.host(), Some("example.com"));
 //! assert_eq!(url.to_bstring(), "ssh://git@example.com/gitoxide");
@@ -12,7 +12,7 @@
 //! assert_eq!(url.user_argument_safe(), Some("byron"));
 //! assert_eq!(url.to_bstring(), "ssh://byron@example.com/gitoxide");
 //!
-//! let suspicious = gix_url::parse("ssh://-Fconfig@host/repo".into()).unwrap();
+//! let suspicious = gix_url::parse("ssh://-Fconfig@host/repo").unwrap();
 //! assert_eq!(suspicious.user_argument_safe(), None, "The user isn't returned as it looks like an argument");
 //! ```
 //! ## Feature Flags
@@ -47,8 +47,9 @@ mod simple_url;
 ///
 /// We cannot and should never have to deal with UTF-16 encoded windows strings, so bytes input is acceptable.
 /// For file-paths, we don't expect UTF8 encoding either.
-pub fn parse(input: &BStr) -> Result<Url, parse::Error> {
+pub fn parse<'a>(input: impl Into<&'a BStr>) -> Result<Url, parse::Error> {
     use parse::InputScheme;
+    let input = input.into();
     match parse::find_scheme(input) {
         InputScheme::Local => parse::local(input),
         InputScheme::Url { protocol_end } if input[..protocol_end].eq_ignore_ascii_case(b"file") => {
@@ -194,7 +195,7 @@ impl Url {
                 serialize_alternative_form,
             }
             .to_bstring()
-            .as_ref(),
+            .as_bstr(),
         )
     }
 }


### PR DESCRIPTION
Per #2468, `gix_url::parse` now takes `impl Into<&'a BStr>` instead of `&BStr`. A `&bstring` borrow now suffices at the call site; existing `&BStr` callers keep compiling via the reflexive `From<&BStr> for &BStr` impl in `bstr`. String literals also work directly through `From<&str> for &BStr`.

The signature widens to a borrowed `Into` (`Into<&'a BStr>`) rather than the owned `Into<BString>` shape the issue mentions, because callers in this codebase already hold borrowed bstrs and the borrowed form avoids an allocation. The `bstr` re-export question raised in the same issue is out of scope here; happy to follow up.

One internal `.as_ref()` had to become `.as_bstr()` because `BString` exposes several `AsRef` impls and the call was ambiguous after the signature change. Doc-test examples were left passing literals directly.

## Validation

- `cargo test -p gix-url`
- `cargo check --workspace`
- `cargo doc -p gix-url` (doc-test examples)

## Disclosure

This PR was drafted with Claude Code (Anthropic). I reviewed and verified the diff before submission.

Closes #2468