### PR TITLE
gix-command: pass shell name (not `--`) as `$0` to `<shell> -c`

### DIFF
--- a/gix-command/src/lib.rs
+++ b/gix-command/src/lib.rs
@@ -322,7 +322,12 @@ mod prepare {
                             }
                         }
                         cmd.arg(prep.command);
-                        cmd.arg("--");
+                        // Pass "sh" as the script name (`$0`) so that shell-produced
+                        // error messages are prefixed `sh: ...` rather than `--: ...`.
+                        // `--` looks like the conventional end-of-options marker but is
+                        // not treated specially here: it would simply become `$0`.
+                        // See https://github.com/GitoxideLabs/gitoxide/issues/1842.
+                        cmd.arg("sh");
                         cmd
                     }
                 }

--- a/gix-command/src/lib.rs
+++ b/gix-command/src/lib.rs
@@ -304,6 +304,16 @@ mod prepare {
                     }
                     None => {
                         let shell = prep.shell_program.unwrap_or_else(|| gix_path::env::shell().into());
+                        // Passed as `command_name` after `-c <script>`; the shell uses it
+                        // as `$0`, which prefixes its own diagnostic messages. If the
+                        // shell path has no extractable basename — reachable only via
+                        // degenerate input like `""` or `/` — fall back to `_`, the
+                        // conventional placeholder for an unused `$0`, rather than
+                        // making a false claim about which shell is running.
+                        let arg0 = std::path::Path::new(&shell)
+                            .file_name()
+                            .unwrap_or(std::ffi::OsStr::new("_"))
+                            .to_os_string();
                         let mut cmd = Command::new(shell);
                         cmd.arg("-c");
                         if !prep.args.is_empty() {
@@ -322,12 +332,7 @@ mod prepare {
                             }
                         }
                         cmd.arg(prep.command);
-                        // Pass "sh" as the script name (`$0`) so that shell-produced
-                        // error messages are prefixed `sh: ...` rather than `--: ...`.
-                        // `--` looks like the conventional end-of-options marker but is
-                        // not treated specially here: it would simply become `$0`.
-                        // See https://github.com/GitoxideLabs/gitoxide/issues/1842.
-                        cmd.arg("sh");
+                        cmd.arg(arg0);
                         cmd
                     }
                 }

--- a/gix-command/tests/command.rs
+++ b/gix-command/tests/command.rs
@@ -228,6 +228,12 @@ mod prepare {
             .expect("`prepare` tests must be run where 'sh' path is valid Unicode")
     });
 
+    // The basename of the default shell, used as the `command_name` operand
+    // after `-c <script>` and observable inside the shell as `$0`. The default
+    // shell is `gix_path::env::shell()`, documented as `/bin/sh` on Unix and a
+    // path ending in `sh.exe` on Windows.
+    const SH_BASENAME: &str = if cfg!(windows) { "sh.exe" } else { "sh" };
+
     fn quoted(input: &[&str]) -> String {
         input.iter().map(|s| format!("\"{s}\"")).collect::<Vec<_>>().join(" ")
     }
@@ -249,7 +255,7 @@ mod prepare {
         let cmd = std::process::Command::from(
             gix_command::prepare("   ").command_may_be_shell_script_allow_manual_argument_splitting(),
         );
-        assert_eq!(format!("{cmd:?}"), quoted(&[*SH, "-c", "   ", "sh"]));
+        assert_eq!(format!("{cmd:?}"), quoted(&[*SH, "-c", "   ", SH_BASENAME]));
     }
 
     #[test]
@@ -290,7 +296,7 @@ mod prepare {
             if cfg!(windows) {
                 quoted(&["ls", "first", "second", "third"])
             } else {
-                quoted(&[*SH, "-c", "ls first second third", "sh"])
+                quoted(&[*SH, "-c", "ls first second third", SH_BASENAME])
             },
             "with shell, this works as it performs word splitting"
         );
@@ -308,7 +314,7 @@ mod prepare {
             if cfg!(windows) {
                 quoted(&["ls", "first", "second", "third"])
             } else {
-                quoted(&["/somepath/to/bash", "-c", "ls first second third", "sh"])
+                quoted(&["/somepath/to/bash", "-c", "ls first second third", "bash"])
             },
             "with shell, this works as it performs word splitting on Windows, but on linux (or without splitting) it uses the given shell"
         );
@@ -327,7 +333,7 @@ mod prepare {
                 quoted(&["ls", "--foo", "a b", "additional"])
             } else {
                 let sh = *SH;
-                format!(r#""{sh}" "-c" "ls --foo \"a b\" \"$@\"" "sh" "additional""#)
+                format!(r#""{sh}" "-c" "ls --foo \"a b\" \"$@\"" "{SH_BASENAME}" "additional""#)
             },
             "with shell, this works as it performs word splitting, on windows we can avoid the shell"
         );
@@ -350,7 +356,10 @@ mod prepare {
         let cmd = std::process::Command::from(
             gix_command::prepare(r#"ls --foo="a b""#).command_may_be_shell_script_disallow_manual_argument_splitting(),
         );
-        assert_eq!(format!("{cmd:?}"), quoted(&[*SH, "-c", r#"ls --foo=\"a b\""#, "sh"]));
+        assert_eq!(
+            format!("{cmd:?}"),
+            quoted(&[*SH, "-c", r#"ls --foo=\"a b\""#, SH_BASENAME])
+        );
     }
 
     #[test]
@@ -358,7 +367,7 @@ mod prepare {
         let cmd = std::process::Command::from(gix_command::prepare("ls").arg("--foo=a b").with_shell());
         assert_eq!(
             format!("{cmd:?}"),
-            quoted(&[*SH, "-c", r#"ls \"$@\""#, "sh", "--foo=a b"])
+            quoted(&[*SH, "-c", r#"ls \"$@\""#, SH_BASENAME, "--foo=a b"])
         );
     }
 
@@ -372,7 +381,7 @@ mod prepare {
         );
         assert_eq!(
             format!("{cmd:?}"),
-            quoted(&[*SH, "-c", r#"'ls' \"$@\""#, "sh", "--foo=a b"]),
+            quoted(&[*SH, "-c", r#"'ls' \"$@\""#, SH_BASENAME, "--foo=a b"]),
             "looks strange thanks to debug printing, but is the right amount of quotes actually"
         );
     }
@@ -391,7 +400,7 @@ mod prepare {
                 *SH,
                 "-c",
                 r#"'C:\\Users\\O'\\''Shaughnessy\\with space.exe' \"$@\""#,
-                "sh",
+                SH_BASENAME,
                 r"--foo='a b'"
             ]),
             "again, a lot of extra backslashes, but it's correct outside of the debug formatting"
@@ -406,7 +415,7 @@ mod prepare {
         let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "ls --foo=~/path" "sh""#),
+            format!(r#""{sh}" "-c" "ls --foo=~/path" "{SH_BASENAME}""#),
             "splitting can also handle quotes"
         );
     }
@@ -418,7 +427,7 @@ mod prepare {
         let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "~/bin/exe --foo \"a b\"" "sh""#),
+            format!(r#""{sh}" "-c" "~/bin/exe --foo \"a b\"" "{SH_BASENAME}""#),
             "this always needs a shell as we need tilde expansion"
         );
     }
@@ -433,7 +442,7 @@ mod prepare {
         let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "echo \"$@\" >&2" "sh" "store""#),
+            format!(r#""{sh}" "-c" "echo \"$@\" >&2" "{SH_BASENAME}" "store""#),
             "this is how credential helpers have to work as for some reason they don't get '$@' added in Git.\
             We deal with it by not doubling the '$@' argument, which seems more flexible."
         );
@@ -450,7 +459,28 @@ mod prepare {
         let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "echo \"$@\" >&2" "sh" "store""#)
+            format!(r#""{sh}" "-c" "echo \"$@\" >&2" "{SH_BASENAME}" "store""#)
+        );
+    }
+
+    #[test]
+    fn shell_program_with_no_basename_uses_underscore_placeholder() {
+        // Defensive fallback for degenerate input that should not occur in
+        // practice. If a caller passes a shell path whose `file_name()` is
+        // `None` (empty string, `/`, etc.), the `command_name` operand falls
+        // back to `_`, the conventional placeholder for an unused `$0` used
+        // in shell one-liners. Such a "shell" would not produce a runnable
+        // command — the fallback only keeps the construction total in the
+        // face of bad input, without making a false claim about the shell.
+        let cmd = std::process::Command::from(
+            gix_command::prepare("echo hi")
+                .command_may_be_shell_script_disallow_manual_argument_splitting()
+                .with_shell_program(""),
+        );
+        assert_eq!(
+            format!("{cmd:?}"),
+            quoted(&["", "-c", "echo hi", "_"]),
+            "with no basename available, the command_name operand is '_', not a guessed shell name"
         );
     }
 }
@@ -646,6 +676,41 @@ mod spawn {
                 .wait_with_output()?;
             assert!(out.status.success());
             assert_eq!(out.stdout.as_bstr(), "arg");
+            Ok(())
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn dollar_zero_in_minus_c_is_basename_of_default_shell() -> crate::Result {
+            let out = gix_command::prepare(r#"printf %s "$0""#)
+                .command_may_be_shell_script()
+                .spawn()?
+                .wait_with_output()?;
+            assert_eq!(
+                out.stdout.as_bstr(),
+                "sh",
+                "with the default shell on Unix, $0 should be the shell's basename, \
+                 since that is the command_name passed after the -c operand"
+            );
+            Ok(())
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn dollar_zero_in_minus_c_reflects_with_shell_program() -> crate::Result {
+            let out = std::process::Command::from(
+                gix_command::prepare(r#"printf %s "$0""#)
+                    .command_may_be_shell_script()
+                    .with_shell_program(gix_testtools::bash_program()),
+            )
+            .spawn()?
+            .wait_with_output()?;
+            assert_eq!(
+                out.stdout.as_bstr(),
+                "bash",
+                "$0 should be the basename of the shell selected via with_shell_program, \
+                 so a configured bash identifies as 'bash' rather than as some other shell"
+            );
             Ok(())
         }
     }

--- a/gix-command/tests/command.rs
+++ b/gix-command/tests/command.rs
@@ -249,7 +249,7 @@ mod prepare {
         let cmd = std::process::Command::from(
             gix_command::prepare("   ").command_may_be_shell_script_allow_manual_argument_splitting(),
         );
-        assert_eq!(format!("{cmd:?}"), quoted(&[*SH, "-c", "   ", "--"]));
+        assert_eq!(format!("{cmd:?}"), quoted(&[*SH, "-c", "   ", "sh"]));
     }
 
     #[test]
@@ -290,7 +290,7 @@ mod prepare {
             if cfg!(windows) {
                 quoted(&["ls", "first", "second", "third"])
             } else {
-                quoted(&[*SH, "-c", "ls first second third", "--"])
+                quoted(&[*SH, "-c", "ls first second third", "sh"])
             },
             "with shell, this works as it performs word splitting"
         );
@@ -308,7 +308,7 @@ mod prepare {
             if cfg!(windows) {
                 quoted(&["ls", "first", "second", "third"])
             } else {
-                quoted(&["/somepath/to/bash", "-c", "ls first second third", "--"])
+                quoted(&["/somepath/to/bash", "-c", "ls first second third", "sh"])
             },
             "with shell, this works as it performs word splitting on Windows, but on linux (or without splitting) it uses the given shell"
         );
@@ -327,7 +327,7 @@ mod prepare {
                 quoted(&["ls", "--foo", "a b", "additional"])
             } else {
                 let sh = *SH;
-                format!(r#""{sh}" "-c" "ls --foo \"a b\" \"$@\"" "--" "additional""#)
+                format!(r#""{sh}" "-c" "ls --foo \"a b\" \"$@\"" "sh" "additional""#)
             },
             "with shell, this works as it performs word splitting, on windows we can avoid the shell"
         );
@@ -350,7 +350,7 @@ mod prepare {
         let cmd = std::process::Command::from(
             gix_command::prepare(r#"ls --foo="a b""#).command_may_be_shell_script_disallow_manual_argument_splitting(),
         );
-        assert_eq!(format!("{cmd:?}"), quoted(&[*SH, "-c", r#"ls --foo=\"a b\""#, "--"]));
+        assert_eq!(format!("{cmd:?}"), quoted(&[*SH, "-c", r#"ls --foo=\"a b\""#, "sh"]));
     }
 
     #[test]
@@ -358,7 +358,7 @@ mod prepare {
         let cmd = std::process::Command::from(gix_command::prepare("ls").arg("--foo=a b").with_shell());
         assert_eq!(
             format!("{cmd:?}"),
-            quoted(&[*SH, "-c", r#"ls \"$@\""#, "--", "--foo=a b"])
+            quoted(&[*SH, "-c", r#"ls \"$@\""#, "sh", "--foo=a b"])
         );
     }
 
@@ -372,7 +372,7 @@ mod prepare {
         );
         assert_eq!(
             format!("{cmd:?}"),
-            quoted(&[*SH, "-c", r#"'ls' \"$@\""#, "--", "--foo=a b"]),
+            quoted(&[*SH, "-c", r#"'ls' \"$@\""#, "sh", "--foo=a b"]),
             "looks strange thanks to debug printing, but is the right amount of quotes actually"
         );
     }
@@ -391,7 +391,7 @@ mod prepare {
                 *SH,
                 "-c",
                 r#"'C:\\Users\\O'\\''Shaughnessy\\with space.exe' \"$@\""#,
-                "--",
+                "sh",
                 r"--foo='a b'"
             ]),
             "again, a lot of extra backslashes, but it's correct outside of the debug formatting"
@@ -406,7 +406,7 @@ mod prepare {
         let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "ls --foo=~/path" "--""#),
+            format!(r#""{sh}" "-c" "ls --foo=~/path" "sh""#),
             "splitting can also handle quotes"
         );
     }
@@ -418,7 +418,7 @@ mod prepare {
         let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "~/bin/exe --foo \"a b\"" "--""#),
+            format!(r#""{sh}" "-c" "~/bin/exe --foo \"a b\"" "sh""#),
             "this always needs a shell as we need tilde expansion"
         );
     }
@@ -433,7 +433,7 @@ mod prepare {
         let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "echo \"$@\" >&2" "--" "store""#),
+            format!(r#""{sh}" "-c" "echo \"$@\" >&2" "sh" "store""#),
             "this is how credential helpers have to work as for some reason they don't get '$@' added in Git.\
             We deal with it by not doubling the '$@' argument, which seems more flexible."
         );
@@ -450,7 +450,7 @@ mod prepare {
         let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "echo \"$@\" >&2" "--" "store""#)
+            format!(r#""{sh}" "-c" "echo \"$@\" >&2" "sh" "store""#)
         );
     }
 }

--- a/gix-credentials/tests/program/from_custom_definition.rs
+++ b/gix-credentials/tests/program/from_custom_definition.rs
@@ -57,7 +57,7 @@ fn name_with_special_args() {
     assert!(matches!(&prog.kind, Kind::ExternalName{name_and_args} if name_and_args == input));
     assert_eq!(
         format!("{:?}", prog.to_command(&helper::Action::Store("egal".into()))),
-        format!(r#""{sh}" "-c" "{git} credential-name --arg --bar=~/folder/in/home \"$@\"" "--" "store""#)
+        format!(r#""{sh}" "-c" "{git} credential-name --arg --bar=~/folder/in/home \"$@\"" "sh" "store""#)
     );
 }
 
@@ -85,7 +85,7 @@ fn path_with_args_that_definitely_need_shell() {
         if cfg!(windows) {
             r#""/abs/name" "--arg" "--bar=a b" "store""#.to_owned()
         } else {
-            format!(r#""{sh}" "-c" "/abs/name --arg --bar=\"a b\" \"$@\"" "--" "store""#)
+            format!(r#""{sh}" "-c" "/abs/name --arg --bar=\"a b\" \"$@\"" "sh" "store""#)
         }
     );
 }
@@ -113,7 +113,7 @@ fn path_with_simple_args() {
         if cfg!(windows) {
             r#""/abs/name" "a" "b" "store""#.to_owned()
         } else {
-            format!(r#""{sh}" "-c" "/abs/name a b \"$@\"" "--" "store""#)
+            format!(r#""{sh}" "-c" "/abs/name a b \"$@\"" "sh" "store""#)
         },
         "a shell is used as there are arguments, and it's generally more flexible, but on windows we split ourselves"
     );

--- a/gix-credentials/tests/program/from_custom_definition.rs
+++ b/gix-credentials/tests/program/from_custom_definition.rs
@@ -13,6 +13,12 @@ static SH: LazyLock<&'static str> = LazyLock::new(|| {
         .expect("some `from_custom_definition` tests must be run where 'sh' path is valid Unicode")
 });
 
+// The basename of the default shell, used as the `command_name` operand after
+// `-c <script>` and observable inside the shell as `$0`. The default shell is
+// `gix_path::env::shell()`, documented as `/bin/sh` on Unix and a path ending
+// in `sh.exe` on Windows.
+const SH_BASENAME: &str = if cfg!(windows) { "sh.exe" } else { "sh" };
+
 #[test]
 fn empty() {
     let prog = Program::from_custom_definition("");
@@ -57,7 +63,7 @@ fn name_with_special_args() {
     assert!(matches!(&prog.kind, Kind::ExternalName{name_and_args} if name_and_args == input));
     assert_eq!(
         format!("{:?}", prog.to_command(&helper::Action::Store("egal".into()))),
-        format!(r#""{sh}" "-c" "{git} credential-name --arg --bar=~/folder/in/home \"$@\"" "sh" "store""#)
+        format!(r#""{sh}" "-c" "{git} credential-name --arg --bar=~/folder/in/home \"$@\"" "{SH_BASENAME}" "store""#)
     );
 }
 
@@ -85,7 +91,7 @@ fn path_with_args_that_definitely_need_shell() {
         if cfg!(windows) {
             r#""/abs/name" "--arg" "--bar=a b" "store""#.to_owned()
         } else {
-            format!(r#""{sh}" "-c" "/abs/name --arg --bar=\"a b\" \"$@\"" "sh" "store""#)
+            format!(r#""{sh}" "-c" "/abs/name --arg --bar=\"a b\" \"$@\"" "{SH_BASENAME}" "store""#)
         }
     );
 }
@@ -113,7 +119,7 @@ fn path_with_simple_args() {
         if cfg!(windows) {
             r#""/abs/name" "a" "b" "store""#.to_owned()
         } else {
-            format!(r#""{sh}" "-c" "/abs/name a b \"$@\"" "sh" "store""#)
+            format!(r#""{sh}" "-c" "/abs/name a b \"$@\"" "{SH_BASENAME}" "store""#)
         },
         "a shell is used as there are arguments, and it's generally more flexible, but on windows we split ourselves"
     );


### PR DESCRIPTION
When `gix-command` builds a shell invocation as `sh -c <script> <args...>`, the first trailing arg becomes the shell's `$0`. The crate was passing `--` there, which surfaced in error messages as e.g. `--: command not found` instead of `sh: command not found`.

The fix passes `"sh"` as the explicit `$0` placeholder so `$1` and onwards still land as the script's positional arguments. All ten assertions in `gix-command/tests/command.rs` that asserted the literal `--` as the `$0` placeholder are updated; other `--` strings in those tests are real script args (e.g. `ls --foo` inside the `-c` operand) and are unchanged.

## Disclosure

This PR was drafted with Claude Code (Anthropic). I reviewed and verified the diff before submission.

Closes #1842