### PR TITLE
doc: Document executable-bit behavior during checkout

### DIFF
--- a/gix-worktree-state/src/checkout/mod.rs
+++ b/gix-worktree-state/src/checkout/mod.rs
@@ -55,6 +55,10 @@ pub struct Options {
     /// even if they appear to be changed. When creating directories that clash with existing worktree entries,
     /// these will try to delete the existing entry.
     /// This is similar in behaviour as `git checkout --force`.
+    ///
+    /// Note that when `destination_is_initially_empty` is `false`, existing files may still have their
+    /// executable bit updated to match the index. This option prevents overwriting file contents, but
+    /// does not necessarily prevent metadata updates.
     pub overwrite_existing: bool,
     /// If true, default false, try to checkout as much as possible and don't abort on first error which isn't
     /// due to a conflict.


### PR DESCRIPTION
## Reported issue

`checkout::Options::overwrite_existing` currently documents that existing worktree entries won't be overwritten unless the option is enabled. However, it doesn't mention that in a non-exclusive checkout, pre-existing files may still have their executable bit updated to match the index even when `overwrite_existing` is `false`.

This can be surprising because callers may interpret `overwrite_existing = false` as preventing all changes to existing files, while the current behavior only prevents overwriting file contents.

Closes #1787.

## Summary

- Clarified the documentation for `checkout::Options::overwrite_existing`.
- Documented that when `destination_is_initially_empty` is `false`, existing files may still receive executable-bit updates even if `overwrite_existing` is `false`.
- Left the checkout behavior unchanged.

## Validation

- `cargo fmt`

I also tried to run `cargo check -p gix-worktree-state`, but it failed while compiling `gix-hash` without hash features, which appears unrelated to this documentation-only change.