### PR TITLE
fix: use main repo when listing worktrees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,6 +1445,7 @@ dependencies = [
  "tracing",
  "tracing-forest 0.2.0",
  "tracing-subscriber",
+ "unicode-width",
 ]
 
 [[package]]

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -61,6 +61,7 @@ anyhow = "1.0.102"
 thiserror = "2.0.18"
 bytesize = "2.3.1"
 tempfile = "3.26.0"
+unicode-width = "0.2.2"
 
 # for async-client
 async-trait = { version = "0.1.51", optional = true }

--- a/gitoxide-core/src/repository/worktree.rs
+++ b/gitoxide-core/src/repository/worktree.rs
@@ -2,28 +2,150 @@ use anyhow::bail;
 
 use crate::OutputFormat;
 
+const HEAD_LENGTH: usize = 9;
+const ZERO_HEAD: &str = "000000000";
+
+/// list: List all worktrees associated with the main repository.
+///
+/// This function collects information about the main worktree and any linked
+/// worktrees, then writes them to the provided output stream in a human-readable
+/// format.
+///
+/// # Parameters
+///
+/// - `repo`: The Git repository from which the worktrees are retrieved.
+/// - `out`: The output stream where the worktree list is written.
+/// - `format`: The output format to use. Currently, only `OutputFormat::Human`
+///   is supported.
+///
+/// # Returns
+///
+/// Returns `Ok(())` if the worktrees are successfully listed.
 pub fn list(repo: gix::Repository, out: &mut dyn std::io::Write, format: OutputFormat) -> anyhow::Result<()> {
     if format != OutputFormat::Human {
         bail!("JSON output isn't implemented yet");
     }
+    let main_repo = repo.main_repo()?;
+    let mut worktrees = Vec::new();
 
-    if let Some(worktree) = repo.worktree() {
-        writeln!(
-            out,
-            "{base} [{branch}]",
-            base = gix::path::realpath(worktree.base())?.display(),
-            branch = repo
-                .head_name()?
-                .map_or("<detached>".into(), |name| name.shorten().to_owned()),
-        )?;
+    if let Some(worktree) = main_repo.worktree() {
+        worktrees.push(create_worktree_info(&main_repo, gix::path::realpath(worktree.base())?)?);
     }
-    for proxy in repo.worktrees()? {
-        writeln!(
-            out,
-            "{base} [{name}]",
-            base = proxy.base()?.display(),
-            name = proxy.id()
-        )?;
+
+    for proxy in main_repo.worktrees()? {
+        let base = gix::path::realpath(proxy.base()?)?;
+
+        match proxy.into_repo() {
+            Ok(worktree_repo) => {
+                worktrees.push(create_worktree_info(&worktree_repo, base)?);
+            }
+            Err(_) => {
+                worktrees.push(create_inaccessible_worktree_info(base));
+            }
+        }
     }
+
+    let path_width = worktrees.iter().map(|worktree| worktree.base.len()).max().unwrap_or(0);
+
+    for worktree in worktrees {
+        worktree.write(out, path_width)?;
+    }
+
     Ok(())
+}
+
+/// WorktreeInfo
+///
+/// Stores display worktree information
+struct WorktreeInfo {
+    base: String,
+    head: String,
+    branch: String,
+}
+
+impl WorktreeInfo {
+    /// write: Writes the worktree information to the given output stream.
+    ///
+    /// The output contains the worktree path, the shortened HEAD commit hash,
+    /// and the current branch name.
+    ///
+    /// # Parameters
+    ///
+    /// - `out`: The output stream where the worktree information is written.
+    /// - `path_width`: The width used to align the worktree paths.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the information is successfully written.
+    fn write(&self, out: &mut dyn std::io::Write, path_width: usize) -> std::io::Result<()> {
+        writeln!(
+            out,
+            "{:<path_width$} {} [{}]",
+            self.base,
+            self.head,
+            self.branch,
+            path_width = path_width,
+        )
+    }
+}
+
+/// create_worktree_info: Creates display information for an accessible worktree.
+///
+/// This function reads the worktree HEAD and branch name from the given
+/// repository. If the HEAD commit cannot be read, a zero hash is used instead.
+/// If the repository is in a detached HEAD state, the branch name is displayed
+/// as `<detached>`.
+///
+/// # Parameters
+///
+/// - `repo`: The repository associated with the worktree.
+/// - `base`: The resolved base path of the worktree.
+///
+/// # Returns
+///
+/// Returns a `WorktreeInfo` value containing:
+/// - the worktree base path,
+/// - the shortened HEAD commit hash,
+/// - the current branch name or `<detached>`.
+fn create_worktree_info(repo: &gix::Repository, base: std::path::PathBuf) -> anyhow::Result<WorktreeInfo> {
+    let head = repo.head_id().map_or_else(
+        |_| ZERO_HEAD.to_string(),
+        |id| id.to_hex_with_len(HEAD_LENGTH).to_string(),
+    );
+
+    let branch = repo.head_name()?.map_or_else(
+        || "<detached>".to_string(),
+        |name| name.shorten().to_owned().to_string(),
+    );
+
+    Ok(WorktreeInfo {
+        base: base.display().to_string(),
+        head,
+        branch,
+    })
+}
+
+/// create_inaccessible_worktree_info: Creates display information for
+/// an inaccessible worktree.
+///
+/// This function is used when a linked worktree exists but its repository
+/// cannot be opened. In that case, the HEAD is displayed as a zero hash and
+/// the branch is displayed as `<unknown>`.
+///
+/// # Parameters
+///
+/// - `base`: The resolved base path of the inaccessible worktree.
+///
+/// # Returns
+///
+/// Returns a `WorktreeInfo` value containing:
+/// - the worktree base path,
+/// - a zero hash as the HEAD value,
+/// - `<unknown>` as the branch name.
+fn create_inaccessible_worktree_info(base: std::path::PathBuf) -> WorktreeInfo {
+    WorktreeInfo {
+        base: base.display().to_string(),
+        head: ZERO_HEAD.to_string(),
+        branch: "<unknown>".to_string(),
+    }
 }

--- a/gitoxide-core/src/repository/worktree.rs
+++ b/gitoxide-core/src/repository/worktree.rs
@@ -1,26 +1,9 @@
 use anyhow::bail;
+use gix::prelude::ObjectIdExt;
+use unicode_width::UnicodeWidthStr;
 
 use crate::OutputFormat;
 
-const HEAD_LENGTH: usize = 9;
-const ZERO_HEAD: &str = "000000000";
-
-/// list: List all worktrees associated with the main repository.
-///
-/// This function collects information about the main worktree and any linked
-/// worktrees, then writes them to the provided output stream in a human-readable
-/// format.
-///
-/// # Parameters
-///
-/// - `repo`: The Git repository from which the worktrees are retrieved.
-/// - `out`: The output stream where the worktree list is written.
-/// - `format`: The output format to use. Currently, only `OutputFormat::Human`
-///   is supported.
-///
-/// # Returns
-///
-/// Returns `Ok(())` if the worktrees are successfully listed.
 pub fn list(repo: gix::Repository, out: &mut dyn std::io::Write, format: OutputFormat) -> anyhow::Result<()> {
     if format != OutputFormat::Human {
         bail!("JSON output isn't implemented yet");
@@ -40,12 +23,16 @@ pub fn list(repo: gix::Repository, out: &mut dyn std::io::Write, format: OutputF
                 worktrees.push(create_worktree_info(&worktree_repo, base)?);
             }
             Err(_) => {
-                worktrees.push(create_inaccessible_worktree_info(base));
+                worktrees.push(create_inaccessible_worktree_info(&repo, base));
             }
         }
     }
 
-    let path_width = worktrees.iter().map(|worktree| worktree.base.len()).max().unwrap_or(0);
+    let path_width = worktrees
+        .iter()
+        .map(|worktree| UnicodeWidthStr::width(worktree.base.as_str()))
+        .max()
+        .unwrap_or(0);
 
     for worktree in worktrees {
         worktree.write(out, path_width)?;
@@ -54,9 +41,6 @@ pub fn list(repo: gix::Repository, out: &mut dyn std::io::Write, format: OutputF
     Ok(())
 }
 
-/// WorktreeInfo
-///
-/// Stores display worktree information
 struct WorktreeInfo {
     base: String,
     head: String,
@@ -64,54 +48,26 @@ struct WorktreeInfo {
 }
 
 impl WorktreeInfo {
-    /// write: Writes the worktree information to the given output stream.
-    ///
-    /// The output contains the worktree path, the shortened HEAD commit hash,
-    /// and the current branch name.
-    ///
-    /// # Parameters
-    ///
-    /// - `out`: The output stream where the worktree information is written.
-    /// - `path_width`: The width used to align the worktree paths.
-    ///
-    /// # Returns
-    ///
-    /// Returns `Ok(())` if the information is successfully written.
     fn write(&self, out: &mut dyn std::io::Write, path_width: usize) -> std::io::Result<()> {
         writeln!(
             out,
-            "{:<path_width$} {} [{}]",
+            "{}{} {} [{}]",
             self.base,
+            " ".repeat(path_width.saturating_sub(UnicodeWidthStr::width(self.base.as_str()))),
             self.head,
             self.branch,
-            path_width = path_width,
         )
     }
 }
 
-/// create_worktree_info: Creates display information for an accessible worktree.
-///
-/// This function reads the worktree HEAD and branch name from the given
-/// repository. If the HEAD commit cannot be read, a zero hash is used instead.
-/// If the repository is in a detached HEAD state, the branch name is displayed
-/// as `<detached>`.
-///
-/// # Parameters
-///
-/// - `repo`: The repository associated with the worktree.
-/// - `base`: The resolved base path of the worktree.
-///
-/// # Returns
-///
-/// Returns a `WorktreeInfo` value containing:
-/// - the worktree base path,
-/// - the shortened HEAD commit hash,
-/// - the current branch name or `<detached>`.
 fn create_worktree_info(repo: &gix::Repository, base: std::path::PathBuf) -> anyhow::Result<WorktreeInfo> {
-    let head = repo.head_id().map_or_else(
-        |_| ZERO_HEAD.to_string(),
-        |id| id.to_hex_with_len(HEAD_LENGTH).to_string(),
-    );
+    let head = repo
+        .head_id()
+        .map_or_else(
+            |_| repo.object_hash().null().attach(repo).shorten_or_id(),
+            |id| id.shorten_or_id(),
+        )
+        .to_string();
 
     let branch = repo.head_name()?.map_or_else(
         || "<detached>".to_string(),
@@ -125,27 +81,10 @@ fn create_worktree_info(repo: &gix::Repository, base: std::path::PathBuf) -> any
     })
 }
 
-/// create_inaccessible_worktree_info: Creates display information for
-/// an inaccessible worktree.
-///
-/// This function is used when a linked worktree exists but its repository
-/// cannot be opened. In that case, the HEAD is displayed as a zero hash and
-/// the branch is displayed as `<unknown>`.
-///
-/// # Parameters
-///
-/// - `base`: The resolved base path of the inaccessible worktree.
-///
-/// # Returns
-///
-/// Returns a `WorktreeInfo` value containing:
-/// - the worktree base path,
-/// - a zero hash as the HEAD value,
-/// - `<unknown>` as the branch name.
-fn create_inaccessible_worktree_info(base: std::path::PathBuf) -> WorktreeInfo {
+fn create_inaccessible_worktree_info(repo: &gix::Repository, base: std::path::PathBuf) -> WorktreeInfo {
     WorktreeInfo {
         base: base.display().to_string(),
-        head: ZERO_HEAD.to_string(),
+        head: repo.object_hash().null().attach(repo).shorten_or_id().to_string(),
         branch: "<unknown>".to_string(),
     }
 }


### PR DESCRIPTION
## Reported issue

`gix worktree list` displayed different kinds of information in the final column depending on the row.

When run from a linked worktree, the command used the current worktree as the first row, and then listed linked worktrees from the repository metadata. This could cause the current linked worktree to appear twice while the main worktree was omitted.

This also made the output differ from `git worktree list`, where the main worktree is listed first and the final column consistently shows the checked-out branch, or detached HEAD state.

Closes #1649.

## Summary

- Use the main repository as the starting point when listing worktrees.
- Open each linked worktree as its own repository before reading its HEAD information.
- Show the checked-out branch for linked worktrees instead of the worktree ID.
- Align the path column based on the longest worktree path, matching `git worktree list` more closely.

## Git reference

`git worktree list` lists the main worktree first, followed by linked worktrees. Its final column describes the checked-out branch or detached HEAD state for each worktree, rather than the internal worktree ID.

## Validation

- `cargo fmt`
- `cargo check -p gitoxide-core`
- `cargo check -p gitoxide`
- `cargo test -p gitoxide -- worktree`
- Manually compared `gix worktree list` with `git worktree list` from:
  - the main worktree
  - a linked worktree
  - a detached linked worktree
  - linked worktrees with short and long paths