### PR TITLE
Don't skip `fuzzed_timeout` on `windows-11-arm`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
         include:
           - test-args: ""
           - os: windows-11-arm
-            test-args: "--skip fuzzed-timeout --skip performance --skip speed"
+            test-args: "--skip fuzzed_timeout --skip performance --skip speed"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
         include:
           - test-args: ""
           - os: windows-11-arm
-            test-args: "--skip fuzzed_timeout --skip performance --skip speed"
+            test-args: "--skip performance --skip speed"
 
     runs-on: ${{ matrix.os }}
 
@@ -336,7 +336,7 @@ jobs:
         include:
           - test-args: ""
           - os: windows-11-arm
-            test-args: "--skip fuzzed_timeout --skip performance --skip speed"
+            test-args: "--skip performance --skip speed"
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Skipping `fuzzed-timeout` on `windows-11-arm` did not save significant time--even once I fixed a bug introduced in https://github.com/GitoxideLabs/gitoxide/commit/87a533e69d190ebc586ca906fa276e713afd63e9 (https://github.com/GitoxideLabs/gitoxide/pull/2115) when skipping them initially, where it wasn't actually skipped properly.

The first commit here fixes the skip, so if we ever bring back the skip, we won't have the bug. The second commit removes the skip. The other two skips do save considerable time and are preserved. See commit messages for further details.

The code changes (to the workflow file) and commit messages (though not this PR description) were generated with Claude Code. The commit messages were carefully reviewed and iterated on, and I will also recheck both the diff and the commit messages one more time before merging this.