### PR TITLE
Address relative worktree review comments

### DIFF
--- a/gix-discover/src/path.rs
+++ b/gix-discover/src/path.rs
@@ -96,20 +96,32 @@ pub fn repository_kind(git_dir: &Path) -> Option<RepositoryKind> {
     }
 }
 
-/// Reads a plain path from a file that contains it as its only content, with trailing newlines trimmed.
+/// Reads a plain path from a file that contains it as its only content, with trailing whitespace trimmed.
+///
+/// Empty or whitespace-only path files are invalid.
 pub fn from_plain_file(path: &std::path::Path) -> Option<std::io::Result<PathBuf>> {
     read_plain_file_content(path).map(|res| res.map(gix_path::from_bstring))
 }
 
 /// Reads a plain path from a file like [`from_plain_file()`], resolving relative paths against
 /// the file's containing directory as needed.
+///
+/// The `path` argument is expected to name the path file itself, which is always supposed to be
+/// a file path.
 pub fn from_plain_file_relative_to_file(path: &std::path::Path) -> Option<std::io::Result<PathBuf>> {
     read_plain_file_content(path).map(|res| {
-        res.map(|buf| {
+        res.and_then(|buf| {
             let plain_path = gix_path::from_bstring(buf);
-            match (plain_path.is_relative(), path.parent()) {
-                (true, Some(parent)) => parent.join(plain_path),
-                _ => plain_path,
+            if !plain_path.is_relative() {
+                return Ok(plain_path);
+            }
+            match path.parent() {
+                Some(parent) => Ok(parent.join(plain_path)),
+                _ => Err(std::io::Error::other(format!(
+                    "'{path}' has no parent, but '{plain_path}' is relative. It's impossible",
+                    path = path.display(),
+                    plain_path = plain_path.display()
+                ))),
             }
         })
     })


### PR DESCRIPTION
## Tasks

- [x] refackiew

----
Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Follow up on unresolved review comments from https://github.com/GitoxideLabs/gitoxide/pull/2599#pullrequestreview-4363158082 after PR #2599 was merged.

## Changes

- Update `gix_discover::path::from_plain_file()` docs to say it trims trailing whitespace and rejects empty or whitespace-only files.
- Document `from_plain_file_relative_to_file()` path-file semantics for single-component relative paths, matching `Path::parent()` behavior.
- Make both relative-worktree fixture scripts independent of global Git identity configuration by setting a fixture commit identity.
- Regenerate the archived fixtures for those script changes.

## Validation

- `cargo fmt --all --check`
- `cargo test -p gix-discover --test discover path::from_plain_file`
- `cargo test -p gix-discover --test discover worktree_with_relative_linking_files`
- `cargo test -p gix --test gix linked_worktree_proxy_base`
- `git diff --check`
- `codex review --commit 9e8094ea1f64ddb3de2441b55d1e6e7ba60f5f49`