### PR TITLE
Document installation via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ on your needs, for _Linux_, _MacOS_ and _Windows_.
 
 [releases]: https://github.com/GitoxideLabs/gitoxide/releases
 
+### Install with Homebrew
+
+For macOS and Linux, `gitoxide` can be installed from [Homebrew](https://brew.sh):
+
+```sh
+brew install gitoxide
+```
+
 ### Download from Arch Linux repository
 
 For Arch Linux you can download `gitoxide` from `community` repository:


### PR DESCRIPTION
Closes #759

As described in https://github.com/GitoxideLabs/gitoxide/issues/759#issuecomment-4566472618, Homebrew has provided `gitoxide`, we just hadn't mentioned it in any documentation. This fixes that, mentioning it in the section of the readme that mentions other downstream distributions.

The diff and commit message here are generated with Claude Code. I reviewed them carefully before opening this PR, including verifying the specific claims. (The text of this PR description is not LLM-generated.)