### PR TITLE
fix: cap aggregate delta data allocation in gix-pack

### DIFF
--- a/gix-pack/src/data/file/decode/entry.rs
+++ b/gix-pack/src/data/file/decode/entry.rs
@@ -253,6 +253,12 @@ where
             total_delta_data_size = total_delta_data_size
                 .checked_add(cursor.decompressed_size)
                 .ok_or(Error::OutOfMemory)?;
+            if self
+                .alloc_limit_bytes
+                .is_some_and(|limit| total_delta_data_size > limit as u64)
+            {
+                return Err(Error::OutOfMemory);
+            }
             let decompressed_size = self.decoded_object_size(cursor.decompressed_size)?;
             chain.push(Delta {
                 data: Range {


### PR DESCRIPTION
## Tasks

- [x] refackiew

----
Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

This fixes a `gix-pack` `data_file` fuzz out-of-memory failure caused by a malformed delta chain whose individual delta sizes stayed under the configured fuzz allocation cap while the aggregate delta payload buffer grew to multi-gigabyte scale.

The fix rejects aggregate delta payload sizes once they exceed `File::with_alloc_limit_bytes()`, matching the existing protection for individual decoded object sizes. The minimized ClusterFuzz testcase was added to `gix-pack/fuzz/artifacts/data_file/` as an artefact.

## Reported issue

```text
$issue-full-auto a gix-pack out-of-memory fuzz failure. The reproducer is clusterfuzz-testcase-minimized-gix-pack-data_file-5840107382046720 . Reproduce the issue, add the reproducer as `artefact`, then it should already run as part of the test-suite. Here is more details.

Last Tested Stacktrace on revision 5aadd6ed92c97ac364a743d23da0151960b50e3b (76 lines)
[Environment] ASAN_OPTIONS=exitcode=77
Command: /mnt/scratch0/clusterfuzz/resources/platform/linux/unshare -c -n /mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_gitoxide_9a561c2a19701ceb3cded247e9ae8f349711bbca/revisions/gix-pack-data_file -rss_limit_mb=2560 -timeout=60 -runs=100 /mnt/scratch0/clusterfuzz/bot/inputs/fuzzer-testcases/oom-d051373ab5fc82eb3898a8645a2434b1920cd790
ERROR: libFuzzer: out-of-memory (malloc(3634099439))
#17 <gix_pack::data::File<&[u8]>>::resolve_deltas gitoxide/gix-pack/src/data/file/decode/entry.rs:314:17
#18 <gix_pack::data::File<&[u8]>>::decode_entry gitoxide/gix-pack/src/data/file/decode/entry.rs:215:55
#19 data_file::fuzz gitoxide/gix-pack/fuzz/fuzz_targets/data_file.rs:41:28
SUMMARY: libFuzzer: out-of-memory
```

## Validation

- `env -u http_proxy -u https_proxy -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY cargo +nightly fuzz run --fuzz-dir gix-pack/fuzz data_file gix-pack/fuzz/artifacts/data_file/clusterfuzz-testcase-minimized-gix-pack-data_file-5840107382046720 -- -runs=1`
- `cargo test -p gix-pack fuzzed`

## Notes

I left the integration test behavior unchanged after follow-up instruction; the new artefact is available to the fuzz target and the existing artifact smoke test.
