### PR TITLE
fix: write new remote sections to the local config file (#1951)

### DIFF
--- a/gix/src/remote/save.rs
+++ b/gix/src/remote/save.rs
@@ -73,8 +73,13 @@ impl Remote<'_> {
                 config.remove_section_by_id(id);
             }
         }
+        // Only reuse an existing section that belongs to the file we are writing to. Otherwise a
+        // section provided by another source (e.g. global config like `remote.<name>.prune`) would
+        // be mutated in place, mixing foreign metadata with our values and getting lost when the
+        // caller writes back only the local sections. In that case, create a fresh local section.
+        let target_meta = config.meta().clone();
         let mut section = config
-            .section_mut_or_create_new("remote", Some(name.as_ref()))
+            .section_mut_or_create_new_filter("remote", Some(name.as_ref()), |meta| *meta == target_meta)
             .expect("section name is validated and 'remote' is acceptable");
         if let Some(url) = self.url.as_ref() {
             section.push(as_key("url"), Some(url.to_bstring().as_ref()));

--- a/gix/src/remote/save.rs
+++ b/gix/src/remote/save.rs
@@ -77,6 +77,7 @@ impl Remote<'_> {
         // section provided by another source (e.g. global config like `remote.<name>.prune`) would
         // be mutated in place, mixing foreign metadata with our values and getting lost when the
         // caller writes back only the local sections. In that case, create a fresh local section.
+        // We assume that `config.meta()` is truly the 'identity' of the configuration file.
         let target_meta = config.meta().clone();
         let mut section = config
             .section_mut_or_create_new_filter("remote", Some(name.as_ref()), |meta| *meta == target_meta)

--- a/gix/tests/gix/remote/save.rs
+++ b/gix/tests/gix/remote/save.rs
@@ -118,6 +118,38 @@ mod save_as_to {
         );
         Ok(())
     }
+
+    #[test]
+    fn new_remote_in_presence_of_global_section_writes_to_local_file() -> crate::Result {
+        use gix::bstr::ByteSlice;
+        // A repo with no remotes, opened so that `remote.origin` exists only as a non-local (`Api`)
+        // override, mirroring global configuration like `remote.origin.prune = true` (issue #1951).
+        let repo = gix::ThreadSafeRepository::open_opts(
+            gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?,
+            gix::open::Options::isolated().config_overrides(["remote.origin.prune=true"]),
+        )?
+        .to_thread_local();
+
+        let mut config = repo.config_snapshot().plumbing().clone();
+        let local_meta = config.meta().clone();
+
+        repo.remote_at("https://example.com/")?
+            .save_as_to("origin", &mut config)?;
+
+        let url_is_in_local_section = config
+            .sections_by_name("remote")
+            .into_iter()
+            .flatten()
+            .filter(|s| s.header().subsection_name() == Some(b"origin".as_bstr()))
+            .any(|s| *s.meta() == local_meta && s.value("url").is_some());
+
+        assert!(
+            url_is_in_local_section,
+            "the new remote's url must be written to a section owned by the local config file, \
+             not merged into the global/override section"
+        );
+        Ok(())
+    }
 }
 
 fn uniformize(input: String) -> String {

--- a/gix/tests/gix/remote/save.rs
+++ b/gix/tests/gix/remote/save.rs
@@ -124,11 +124,10 @@ mod save_as_to {
         use gix::bstr::ByteSlice;
         // A repo with no remotes, opened so that `remote.origin` exists only as a non-local (`Api`)
         // override, mirroring global configuration like `remote.origin.prune = true` (issue #1951).
-        let repo = gix::ThreadSafeRepository::open_opts(
+        let repo = gix::open_opts(
             gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?,
             gix::open::Options::isolated().config_overrides(["remote.origin.prune=true"]),
-        )?
-        .to_thread_local();
+        )?;
 
         let mut config = repo.config_snapshot().plumbing().clone();
         let local_meta = config.meta().clone();


### PR DESCRIPTION
Fixes #1951.

### Problem

When a `remote.<name>` section exists only from non-local configuration — e.g. a global `remote.origin.prune = true` — `Remote::save_to` wrote the new `url`/`fetch` into that foreign section instead of a local one. The metadata then mixes sources, and a caller that writes back only local sections (`write_to_filter(|s| s.meta() == config.meta())`, as jj does) loses the new remote.

### Fix

Select the write-target section filtered to the file's own metadata, creating a fresh local section when only a foreign one exists — the approach suggested by the maintainer in the issue. It's a single call changed in `gix/src/remote/save.rs`, reusing the existing `section_mut_or_create_new_filter` API.

### Tests

Added `new_remote_in_presence_of_global_section_writes_to_local_file` in `gix/tests/gix/remote/save.rs`: opens a repo with `remote.origin.prune` provided only as an override and asserts the saved `url` lands in a section owned by the local file. It fails before the change and passes after.

Verified locally against `main`:

```
cargo fmt -p gix --check
cargo clippy -p gix --all-targets -- -D warnings
cargo test -p gix --test gix remote:: clone::
```

All pass (remote 39, clone 5, plus the new test); the existing save tests are unchanged.

### Files changed

- `gix/src/remote/save.rs`
- `gix/tests/gix/remote/save.rs`

---
*Disclosure: developed with AI assistance, reviewed and tested by me.*
