### PR TITLE
fix: only expand attribute macros when they are set

### DIFF
--- a/gix-attributes/src/search/outcome.rs
+++ b/gix-attributes/src/search/outcome.rs
@@ -188,6 +188,10 @@ impl Outcome {
             }
             // Let's be explicit - this is only non-empty for macros.
             let is_macro = !slot.macro_attributes.is_empty();
+            // Like git, macros only apply their expansion when *set* - assigning any
+            // other state suppresses it (`attr.c`: `macroexpand_one()` expands only
+            // `if (item->macro && item->value == ATTR__TRUE)`).
+            let expand_macro = is_macro && matches!(assignment.state, crate::State::Set);
 
             slot.r#match = Some(Match {
                 pattern: self.patterns.insert(pattern),
@@ -208,7 +212,7 @@ impl Outcome {
                 return true;
             }
 
-            if is_macro {
+            if expand_macro {
                 // TODO(borrowchk): one fine day we should be able to re-borrow `slot` without having to redo the array access.
                 let slot = &self.matches_by_id[id.0];
                 self.attrs_stack.extend(

--- a/gix-attributes/tests/fixtures/make_attributes_baseline.sh
+++ b/gix-attributes/tests/fixtures/make_attributes_baseline.sh
@@ -97,6 +97,23 @@ function baseline() {
   baseline global
 )
 
+mkdir macro-states
+(cd macro-states
+  git init
+  : > user.attributes
+  cat <<'EOF' > .gitattributes
+[attr]mymacro attr-a attr-b=val -attr-c
+*.set mymacro
+*.unset -mymacro
+*.unspecified !mymacro
+*.value mymacro=other
+EOF
+  baseline file.set
+  baseline file.unset
+  baseline file.unspecified
+  baseline file.value
+)
+
 mkdir lookup-order
 (cd lookup-order
 

--- a/gix-attributes/tests/search/mod.rs
+++ b/gix-attributes/tests/search/mod.rs
@@ -129,6 +129,38 @@ fn assert_references(out: &Outcome) {
 }
 
 #[test]
+fn macros_are_only_expanded_when_set() -> crate::Result {
+    let (mut group, mut collection, base, input) = baseline::user_attributes("macro-states")?;
+
+    let mut buf = Vec::new();
+    group.add_patterns_file(
+        base.join(".gitattributes"),
+        false,
+        None,
+        &mut buf,
+        &mut collection,
+        true, /* allow macros */
+    )?;
+
+    let mut actual = Outcome::default();
+    actual.initialize(&collection);
+    for (rela_path, expected) in (baseline::Expectations { lines: input.lines() }) {
+        actual.reset();
+        group.pattern_matching_relative_path(rela_path, Case::Sensitive, None, &mut actual);
+        assert_references(&actual);
+        let actual: Vec<_> = actual
+            .iter()
+            .filter_map(|m| (!m.assignment.state.is_unspecified()).then_some(m.assignment))
+            .collect();
+        assert_eq!(
+            actual, expected,
+            "{rela_path}: only set macros apply their expansion, like git"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn all_attributes_are_listed_in_declaration_order() -> crate::Result {
     let (mut group, mut collection, base, input) = baseline::user_attributes("lookup-order")?;
 


### PR DESCRIPTION
Fixes #2639.

### What

`Outcome::fill_attributes()` expanded a macro's sub-assignments whenever a pattern referencing the macro matched, regardless of the assignment's state. Git expands a macro only when the matching rule *sets* it — `attr.c`'s `macroexpand_one()` acts only `if (item->macro && item->value == ATTR__TRUE)` — so `-macro`, `!macro`, and `macro=value` must not apply the expansion.

The fix gates the expansion on `State::Set` while still recording the macro's own match (git also reports e.g. `mymacro: unset` for a `-mymacro` rule; only the expansion is suppressed).

### Tests

A new `macro-states` repository in `make_attributes_baseline.sh` records `git check-attr -a` output for one path per assignment state (`macro`, `-macro`, `!macro`, `macro=value`), and a new `macros_are_only_expanded_when_set` test asserts parity, following the existing baseline-test pattern. Before the fix it fails with the full expansion showing up for the three non-set states; the existing `lookup-order` macro-cycle/recursion tests still pass since those macros are matched as set.

Ran `cargo test -p gix-attributes`, `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix-attributes --test attributes`, `cargo test -p gix-worktree`, `cargo clippy -p gix-attributes --all-targets`, and `cargo fmt --check`.

### AI disclosure

This change was researched, written, and tested by an AI agent (Claude Fable 5, via Claude Code) directed and reviewed by @NilsIrl; the commit is authored accordingly. The underlying issue (#2639) includes the standalone reproduction and the `attr.c` comparison.