### PR TITLE
Limit postprocess heuristics fuzz input size

### DIFF
--- a/gix-imara-diff/fuzz/fuzz_targets/postprocess_heuristics.rs
+++ b/gix-imara-diff/fuzz/fuzz_targets/postprocess_heuristics.rs
@@ -12,6 +12,10 @@ struct Input<'a> {
     ident_level: u8,
 }
 
+/// It's possible to cause slow-enough inputs (due to post-processing) on `max-time=60s runs=100` fuzzer runs
+/// if the input is very large. However, this seems unrealistics, and they aren't exponential either.
+const MAX_INPUT_BYTES: usize = 128 * 1024;
+
 /// Tests postprocessing with different heuristics:
 /// - No heuristic
 /// - Line heuristic (default indent-based)
@@ -24,6 +28,10 @@ fn do_fuzz(
         ident_level,
     }: Input<'_>,
 ) {
+    if before.len().saturating_add(after.len()) > MAX_INPUT_BYTES {
+        return;
+    }
+
     let input = InternedInput::new(before, after);
 
     // Test with different algorithms
@@ -46,10 +54,7 @@ fn do_fuzz(
         diff3.postprocess_with_heuristic(
             &input,
             IndentHeuristic::new(|token| {
-                IndentLevel::for_ascii_line(
-                    input.interner[token].as_bytes().iter().copied(),
-                    ident_level,
-                )
+                IndentLevel::for_ascii_line(input.interner[token].as_bytes().iter().copied(), ident_level)
             }),
         );
         let _ = diff3.count_additions();

--- a/gix-imara-diff/fuzz/fuzz_targets/postprocess_heuristics.rs
+++ b/gix-imara-diff/fuzz/fuzz_targets/postprocess_heuristics.rs
@@ -12,8 +12,8 @@ struct Input<'a> {
     ident_level: u8,
 }
 
-/// It's possible to cause slow-enough inputs (due to post-processing) on `max-time=60s runs=100` fuzzer runs
-/// if the input is very large. However, this seems unrealistics, and they aren't exponential either.
+/// It's possible to cause slow-enough inputs (due to Myers, usually) on `max-time=60s runs=100` fuzzer runs
+/// if the input is very large and repetitive.
 const MAX_INPUT_BYTES: usize = 128 * 1024;
 
 /// Tests postprocessing with different heuristics:


### PR DESCRIPTION
## Tasks

- [x] refackiew

----
Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Limit the `gix-imara-diff` `postprocess_heuristics` fuzz target to inputs whose parsed `before` and `after` strings are at most 128 KiB in total. The guard is fuzz-target-local and contained in `fuzz_targets/postprocess_heuristics.rs`, so the public diff API still handles large inputs normally.

## Reported issue

Plain-text report from the session:

```text
There is a fuzzer timeout in the gix-imara-diff post-process heuristics. The reproducer is pretty hefty clusterfuzz-testcase-minimized-gix-imara-diff-postprocess_heuristics-4774375640072192, and it's 'too slow' measured in 100 runs over 60 seconds.

It seems best to fix it by limitting the input size, after all the input document that causes this is huge measured in what people typically diff, with the timing being not slow on the individual run.

Take a quick look at possible performance improvements, the algorithm seems to be very recursive as well.

Original Stacktrace on revision eac50e1207e2549b23302c9faf595a420b9919fc:
- libFuzzer timeout after 61 seconds while running the minimized postprocess_heuristics testcase 100 times.
- The stack is in Myers diff computation before post-processing, with repeated gix_imara_diff::myers::Myers::run frames at gix-imara-diff/src/myers.rs:94.
- The call path reaches the fuzz target through Diff::compute -> postprocess_heuristics::do_fuzz.
```

## Notes

Local measurements:

- Before the guard, the reproducer took about 13.8 seconds for a single release-mode fuzzer run locally.
- After the guard, the reported 100-run fuzzer command completed the reproducer in 25 ms.

## Validation

- `cargo +nightly fuzz run --fuzz-dir gix-imara-diff/fuzz postprocess_heuristics ../clusterfuzz-testcase-minimized-gix-imara-diff-postprocess_heuristics-4774375640072192 -- -runs=100`
- `cargo test --manifest-path gix-imara-diff/fuzz/Cargo.toml`
- `cargo test -p gix-imara-diff`
- `codex review --commit e8170f92363380c16e9f028564709dfad1720a0b`
