### PR TITLE
fix: handle loose ref path-prefix collisions

### DIFF
--- a/gix-ref/src/store/file/find.rs
+++ b/gix-ref/src/store/file/find.rs
@@ -291,7 +291,7 @@ impl file::Store {
             )));
         }
 
-        let ref_path = base.join(relative_path);
+        let ref_path = base.join(&relative_path);
         match std::fs::File::open(&ref_path) {
             Ok(mut file) => {
                 let mut buf = Vec::with_capacity(128);
@@ -300,12 +300,43 @@ impl file::Store {
                 }
                 Ok(buf.into())
             }
-            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                #[cfg(windows)]
+                if path_has_file_prefix(base.as_ref(), relative_path.as_ref()) {
+                    return Err(io::Error::new(io::ErrorKind::NotADirectory, err));
+                }
+                Ok(None)
+            }
             #[cfg(windows)]
-            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => Ok(None),
+            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+                if path_has_file_prefix(base.as_ref(), relative_path.as_ref()) {
+                    Err(io::Error::new(io::ErrorKind::NotADirectory, err))
+                } else {
+                    Ok(None)
+                }
+            }
             Err(err) => Err(err),
         }
     }
+}
+
+#[cfg(windows)]
+fn path_has_file_prefix(base: &Path, relative_path: &Path) -> bool {
+    let mut path = base.to_owned();
+    let mut components = relative_path.components().peekable();
+    while let Some(component) = components.next() {
+        if components.peek().is_none() {
+            break;
+        }
+        path.push(component.as_os_str());
+        match std::fs::metadata(&path) {
+            Ok(metadata) if metadata.is_file() => return true,
+            Ok(_) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return false,
+            Err(_) => {}
+        }
+    }
+    false
 }
 
 ///

--- a/gix-ref/src/store/file/find.rs
+++ b/gix-ref/src/store/file/find.rs
@@ -164,10 +164,16 @@ impl file::Store {
         let full_name = precomposed_partial_name
             .unwrap_or(partial_name)
             .construct_full_name_ref(inbetween, path_buf, consider_pseudo_ref);
-        let content_buf = self.ref_contents(full_name).map_err(|err| Error::ReadFileContents {
-            source: err,
-            path: self.reference_path(full_name),
-        })?;
+        let content_buf = match self.ref_contents(full_name) {
+            Ok(content_buf) => content_buf,
+            Err(err) if err.kind() == io::ErrorKind::NotADirectory => return Ok(None),
+            Err(err) => {
+                return Err(Error::ReadFileContents {
+                    source: err,
+                    path: self.reference_path(full_name),
+                });
+            }
+        };
 
         match content_buf {
             None => {

--- a/gix-ref/tests/refs/file/store/find.rs
+++ b/gix-ref/tests/refs/file/store/find.rs
@@ -194,4 +194,33 @@ mod loose {
         }
         Ok(())
     }
+
+    #[test]
+    fn prefix_file_collision_is_not_found() -> crate::Result {
+        let (_tmp, store) = crate::file::store_writable("make_ref_repository.sh")?;
+
+        assert!(
+            store.try_find("refs/heads/A/new")?.is_none(),
+            "a ref whose path prefix is an existing loose ref does not exist"
+        );
+        assert!(
+            store.try_find_loose("refs/heads/A/new")?.is_none(),
+            "a loose ref whose path prefix is an existing ref does not exist"
+        );
+
+        std::fs::write(
+            store.git_dir().join("packed-refs"),
+            format!(
+                "# pack-refs with: peeled fully-peeled sorted\n{} refs/heads/A/new\n",
+                hex_to_id("134385f6d781b7e97062102c6a483440bfda2a03")
+            ),
+        )?;
+        store.force_refresh_packed_buffer()?;
+        assert!(
+            store.try_find("refs/heads/A/new")?.is_none(),
+            "a ref whose path prefix is an existing loose ref does not exist, even if a packed ref matches"
+        );
+
+        Ok(())
+    }
 }

--- a/gix-ref/tests/refs/file/transaction/prepare_and_commit/delete.rs
+++ b/gix-ref/tests/refs/file/transaction/prepare_and_commit/delete.rs
@@ -249,18 +249,12 @@ fn rename_a_to_a_slash_b_in_one_transaction() -> crate::Result {
         .unwrap_err();
 
     match err {
-        #[cfg(unix)]
         Error::Io(err) => {
             assert_eq!(
                 err.kind(),
                 std::io::ErrorKind::NotADirectory,
-                "For now this isn't supported in the same transaction."
+                "For now this isn't supported in the same transaction, and path-prefix collisions are reported early."
             );
-        }
-        #[cfg(windows)]
-        Error::LockAcquire { .. } => {
-            // It's bad that the error differs on Windows, but then again, doing this kind of pseudo-db on a filesystem
-            // probably is never going to be great, so let's wait for ref-tables.
         }
         err => unreachable!("unexpected error variant: {err:?}"),
     }

--- a/gix/tests/gix/repository/reference.rs
+++ b/gix/tests/gix/repository/reference.rs
@@ -76,6 +76,22 @@ mod set_namespace {
     }
 }
 
+#[test]
+fn try_find_reference_with_existing_ref_as_path_prefix_returns_none() -> crate::Result {
+    let (repo, _tmp) = crate::repo_rw("make_references_repo.sh")?;
+    std::fs::create_dir_all(repo.git_dir().join("refs/heads"))?;
+    std::fs::write(
+        repo.git_dir().join("refs/heads/A"),
+        repo.head_id()?.to_hex().to_string(),
+    )?;
+
+    assert!(
+        repo.try_find_reference("refs/heads/A/new")?.is_none(),
+        "a ref whose path prefix is an existing ref does not exist"
+    );
+    Ok(())
+}
+
 mod iter_references {
     use crate::util::hex_to_id;
 


### PR DESCRIPTION
## Tasks

- [x] Reproduce the loose-reference path-prefix collision.
- [x] Ensure `repo.try_find_reference()` returns `Ok(None)` for that case.
- [x] Handle the Windows `ref_contents()` normalization case without falling through to packed refs.
- [x] Address CI fallout from the transaction regression test.
- [x] Address review feedback about prefix-helper metadata checks.

----
Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

$issue-full-auto Look at the fix in https://github.com/gitbutlerapp/gitbutler/pull/14153 and reproduce the underlying issue in `gix` or `gix-ref` (or both). Then make sure that `repo.try_find_reference()` returns `Ok(None)` in that moment.

## Context

GitButler PR: https://github.com/gitbutlerapp/gitbutler/pull/14153

The issue is a loose reference path-prefix collision: `refs/heads/A` exists as a file, and lookup asks for `refs/heads/A/new`.

Git baseline: `/Users/byron/dev/github.com/git/git` at `7760f83b59`; `refs/refs-internal.h` documents `ENOTDIR` as “ref prefix is not a directory”.

## Changes

- Treat `NotADirectory` as absence for the current loose ref lookup candidate in `gix-ref` find.
- Make `ref_contents()` preserve Windows path-prefix collisions as `NotADirectory` instead of normalizing them to ordinary absence.
- Avoid packed-ref fallback when an existing loose ref file is a path prefix of the requested ref, including cases where Windows reports the collision as `NotFound` or `PermissionDenied`.
- Add `gix-ref` and `gix` regression tests, including packed-overlay coverage for the collision behavior.
- Update the transaction rename/delete regression to expect the earlier `NotADirectory` error now surfaced on Windows too.
- Address review feedback by making the Windows prefix helper use explicit metadata checks and stop early when an intermediate prefix is missing.

## Validation

- `cargo fmt --check`
- `cargo check -p gix-ref --target aarch64-pc-windows-msvc --features sha1`
- `cargo test -p gix-ref --test refs file::transaction::prepare_and_commit::delete::rename_a_to_a_slash_b_in_one_transaction -- --exact`
- `cargo test -p gix-ref --test refs file::store::find::loose::prefix_file_collision_is_not_found -- --exact`
- `cargo test -p gix --test gix try_find_reference_with_existing_ref_as_path_prefix_returns_none`

Head validated locally: `27c0ba6b4f6ab96300cf5f67764a6f1ac65b6047`