### PR TITLE
fix: avoid GIT_DIR environment discovery panic

### DIFF
--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -153,6 +153,7 @@ impl ThreadSafeRepository {
 
         let git_dir_trust = gix_sec::Trust::from_path_ownership(&git_dir)?;
         let mut options = trust_map.into_value_by_level(git_dir_trust);
+        options.git_dir_trust = git_dir_trust.into();
         options.current_dir = Some(cwd);
         ThreadSafeRepository::open_from_paths(git_dir, worktree_dir, options)
     }

--- a/gix/tests/gix/repository/open.rs
+++ b/gix/tests/gix/repository/open.rs
@@ -11,6 +11,32 @@ fn open_permissions_is_isolated() {
 }
 
 #[test]
+#[serial_test::serial]
+fn discover_with_git_dir_environment_override_sets_trust() -> crate::Result {
+    let tmp = gix_testtools::tempfile::TempDir::new()?;
+    let initialized = gix::init(tmp.path())?;
+    let _env = gix_testtools::Env::new()
+        .unset("GIT_WORK_TREE")
+        .set("GIT_DIR", initialized.git_dir().to_string_lossy().into_owned());
+
+    let repo = gix::ThreadSafeRepository::discover_with_environment_overrides_opts(
+        tmp.path(),
+        Default::default(),
+        gix_sec::trust::Mapping {
+            full: crate::restricted(),
+            reduced: crate::restricted(),
+        },
+    )?;
+
+    assert_eq!(
+        repo.git_dir(),
+        initialized.git_dir(),
+        "the git-dir from the environment opens without panicking on missing trust"
+    );
+    Ok(())
+}
+
+#[test]
 fn on_root_with_decomposed_unicode() -> crate::Result {
     let tmp = gix_testtools::tempfile::TempDir::new()?;
 


### PR DESCRIPTION
## Tasks

- [x] refackiew

----
Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Avoid a panic when repository discovery uses a `GIT_DIR` environment override by preserving the trust value already derived for the effective git directory before calling `open_from_paths()`.

## Reported issue

I ran into a panic while using this. You can reproduce by running

```bash
cd $(mktemp -d)
git init
GIT_DIR=.git hx newfile.txt
```

or

```bash
VISUAL=hx git --git-dir=.git commit --allow-empty
```

This panics at https://github.com/GitoxideLabs/gitoxide/blob/eac50e1207e2549b23302c9faf595a420b9919fc/gix/src/open/repository.rs#L184 with the following backtrace:

```text
thread 'main' panicked at ~/.local/share/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gix-0.84.0/src/open/repository.rs:184:52:
trust must be determined by now
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::option::expect_failed
   3: gix::open::repository::<impl gix::types::ThreadSafeRepository>::open_from_paths
   4: gix::discover::<impl gix::types::ThreadSafeRepository>::discover_with_environment_overrides_opts
   5: helix_vcs::git::open_repo
   6: helix_vcs::git::get_diff_base
   7: helix_vcs::DiffProviderRegistry::get_diff_base
   8: helix_view::editor::Editor::open
   9: helix_term::application::Application::new
  10: hx::main_impl::{{closure}}
  11: tokio::runtime::park::CachedParkThread::block_on
  12: tokio::runtime::context::runtime::enter_runtime
  13: tokio::runtime::runtime::Runtime::block_on
  14: hx::main
```

For context, I use the `--git-dir` option for tracking my dotfiles in a bare git repo.

## Change

`open_with_environment_overrides()` already computes ownership trust for the effective git directory and chooses the mapped options from that trust level. This change stores the computed trust in `Options` before opening, matching `discover_opts()` and preventing the internal `expect()` from being reached with unset trust.

## Git baseline

`git --git-dir=<repo/.git> --work-tree=<repo> status --short` exits successfully.

## Validation

- `cargo test -p gix --test gix repository::open::discover_with_git_dir_environment_override_sets_trust`
- `cargo test -p gix --test gix repository::open`
- `codex review --commit b3e83763562408cb99c8d860ea823607195119b8`
