### PR TITLE
allow assuming trust during upward discovery

### DIFF
--- a/gix-discover/src/upwards/mod.rs
+++ b/gix-discover/src/upwards/mod.rs
@@ -1,5 +1,5 @@
 mod types;
-pub use types::{Error, Options};
+pub use types::{Error, Options, TrustPolicy};
 
 mod util;
 
@@ -8,7 +8,7 @@ pub(crate) mod function {
 
     use gix_sec::Trust;
 
-    use super::{Error, Options};
+    use super::{Error, Options, TrustPolicy};
     #[cfg(unix)]
     use crate::upwards::util::device_id;
     use crate::{
@@ -27,14 +27,14 @@ pub(crate) mod function {
     pub fn discover_opts(
         directory: &Path,
         Options {
-            required_trust,
+            trust,
             ceiling_dirs,
             match_ceiling_dir_or_error,
             cross_fs,
             current_dir,
             dot_git_only,
         }: Options<'_>,
-    ) -> Result<(crate::repository::Path, Trust), Error> {
+    ) -> Result<(crate::repository::Path, gix_sec::Trust), Error> {
         // Normalize the path so that `Path::parent()` _actually_ gives
         // us the parent directory. (`Path::parent` just strips off the last
         // path component, which means it will not do what you expect when
@@ -67,9 +67,15 @@ pub(crate) mod function {
                 .or_else(|_| dir.as_ref().strip_prefix(cwd.as_ref()))
                 .is_ok();
 
-        let filter_by_trust = |x: &Path| -> Result<Option<Trust>, Error> {
-            let trust = Trust::from_path_ownership(x).map_err(|err| Error::CheckTrust { path: x.into(), err })?;
-            Ok((trust >= required_trust).then_some(trust))
+        let filter_by_trust = |x: &Path| -> Result<Result<Trust, Trust>, Error> {
+            match trust {
+                TrustPolicy::Required(required) => {
+                    let trust =
+                        Trust::from_path_ownership(x).map_err(|err| Error::CheckTrust { path: x.into(), err })?;
+                    Ok(if trust >= required { Ok(trust) } else { Err(required) })
+                }
+                TrustPolicy::Assume(trust) => Ok(Ok(trust)),
+            }
         };
 
         let max_height = if !ceiling_dirs.is_empty() {
@@ -134,7 +140,7 @@ pub(crate) mod function {
                     None => is_git(&cursor),
                 } {
                     match filter_by_trust(&cursor)? {
-                        Some(trust) => {
+                        Ok(trust) => {
                             // TODO: test this more, it definitely doesn't always find the shortest path to a directory
                             let path = if dir_made_absolute {
                                 shorten_path_with_cwd(cursor, cwd.as_ref())
@@ -150,11 +156,11 @@ pub(crate) mod function {
                                 trust,
                             ));
                         }
-                        None => {
+                        Err(required) => {
                             break 'outer Err(Error::NoTrustedGitRepository {
                                 path: dir.into_owned(),
                                 candidate: cursor,
-                                required: required_trust,
+                                required,
                             });
                         }
                     }
@@ -198,7 +204,7 @@ pub(crate) mod function {
     /// the trust level derived from Path ownership.
     ///
     /// Fail if no valid-looking git repository could be found.
-    pub fn discover(directory: &Path) -> Result<(crate::repository::Path, Trust), Error> {
+    pub fn discover(directory: &Path) -> Result<(crate::repository::Path, gix_sec::Trust), Error> {
         discover_opts(directory, Default::default())
     }
 }

--- a/gix-discover/src/upwards/types.rs
+++ b/gix-discover/src/upwards/types.rs
@@ -32,14 +32,30 @@ pub enum Error {
     },
 }
 
+/// How to obtain the trust level for a discovered repository.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum TrustPolicy {
+    /// Determine trust from repository ownership and require it to be at least the given level.
+    Required(gix_sec::Trust),
+    /// Trust computation is skipped and the given trust level is assumed.
+    Assume(gix_sec::Trust),
+}
+
+impl Default for TrustPolicy {
+    fn default() -> Self {
+        TrustPolicy::Required(gix_sec::Trust::Reduced)
+    }
+}
+
 /// Options to help guide the [discovery][crate::upwards()] of repositories, along with their options
 /// when instantiated.
 pub struct Options<'a> {
-    /// When discovering a repository, assure it has at least this trust level or ignore it otherwise.
+    /// When discovering a repository, determine how trust should be obtained.
     ///
-    /// This defaults to [`Reduced`][gix_sec::Trust::Reduced] as our default settings are geared towards avoiding abuse.
-    /// Set it to `Full` to only see repositories that [are owned by the current user][gix_sec::Trust::from_path_ownership()].
-    pub required_trust: gix_sec::Trust,
+    /// This defaults to [`Required(Reduced)`][TrustPolicy::Required] as our default settings are geared towards avoiding abuse.
+    /// Set it to `Required(Full)` to only see repositories that [are owned by the current user][gix_sec::Trust::from_path_ownership()],
+    /// or [`TrustPolicy::Assume`] to skip trust computation and return the given trust level.
+    pub trust: TrustPolicy,
     /// When discovering a repository, ignore any repositories that are located in these directories or any of their parents.
     ///
     /// Note that we ignore ceiling directories if the search directory is directly on top of one, which by default is an error
@@ -73,7 +89,7 @@ pub struct Options<'a> {
 impl Default for Options<'_> {
     fn default() -> Self {
         Options {
-            required_trust: gix_sec::Trust::Reduced,
+            trust: TrustPolicy::default(),
             ceiling_dirs: vec![],
             match_ceiling_dir_or_error: true,
             cross_fs: false,

--- a/gix-discover/tests/discover/upwards/mod.rs
+++ b/gix-discover/tests/discover/upwards/mod.rs
@@ -13,6 +13,34 @@ fn expected_trust() -> gix_sec::Trust {
 mod ceiling_dirs;
 
 #[test]
+fn can_override_computed_trust() -> crate::Result {
+    let dir = repo_path()?.join("some/very/deeply/nested/subdir");
+    let overridden_trust = match expected_trust() {
+        gix_sec::Trust::Full => gix_sec::Trust::Reduced,
+        gix_sec::Trust::Reduced => gix_sec::Trust::Full,
+    };
+
+    let (path, trust) = gix_discover::upwards_opts(
+        &dir,
+        gix_discover::upwards::Options {
+            trust: gix_discover::upwards::TrustPolicy::Assume(overridden_trust),
+            ..Default::default()
+        },
+    )?;
+
+    assert_eq!(
+        path.kind(),
+        Kind::WorkTree { linked_git_dir: None },
+        "discovery still finds the worktree"
+    );
+    assert_eq!(
+        trust, overridden_trust,
+        "the caller-provided trust is returned instead of the computed ownership trust"
+    );
+    Ok(())
+}
+
+#[test]
 fn from_bare_git_dir() -> crate::Result {
     let dir = repo_path()?.join("bare.git");
     let (path, trust) = gix_discover::upwards(&dir)?;

--- a/gix/src/discover.rs
+++ b/gix/src/discover.rs
@@ -27,10 +27,9 @@ impl ThreadSafeRepository {
     /// for instantiations.
     ///
     /// Note that [trust overrides](crate::open::Options::with()) in the `trust_map` are not effective here and we will
-    /// always override it with the determined trust value. This is a precaution as the API user is unable to actually know
-    /// if the directory that is discovered can indeed be trusted (or else they'd have to implement the discovery themselves
-    /// and be sure that no attacker ever gets access to a directory structure. The cost of this is a permission check, which
-    /// seems acceptable).
+    /// always override it with the determined trust value as per [gix_discover::upwards::Options::trust].
+    /// This value, however, can be set to [assume a given trust level](gix_discover::upwards::TrustPolicy::Assume) to let
+    /// callers control the trust level without re-determining it.
     pub fn discover_opts(
         directory: impl AsRef<Path>,
         options: upwards::Options<'_>,


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

```text
In gix-discover/src/upwards/types.rs:38-42, change the field to become an enum that can also represent a given trust. If so, no trust computation will be done and the given trust is assumed. This is useful if users should be able to override the trust level, even during discovery. Related to https://github.com/helix-editor/helix/pull/15857#issuecomment-4726705250 .
```

## Summary

- Changed `gix_discover::upwards::Options::required_trust` to the new `gix_discover::upwards::Trust` enum.
- Kept the default behavior as `Trust::Required(gix_sec::Trust::Reduced)`.
- Added `Trust::Assume(level)` so discovery skips `Trust::from_path_ownership()` and returns the caller-provided trust level.
- Added regression coverage that asks for the opposite of the fixture's computed trust and verifies the assumed trust is returned.

## Validation

- `cargo test -p gix-discover --test discover upwards::can_override_computed_trust`
- `cargo test -p gix-discover`
- `cargo check -p gix-discover -p gix --tests`
- `cargo check --workspace --all-targets --no-default-features --features lean`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p gix-discover --no-deps --features sha1`

## Review

- `codex review --commit 93d6a0b6f5aaf68b458086b1d405b223f4621472` reported that the public field type change should be marked as breaking.
- The patch was rewritten with `change!:` and a commit body documenting the source break.
- `codex review --commit 1ef03b25c6b3b99efe56a0e7648267a952a6e0c4` reported no issues.
