### PR TITLE
feat: add leaf-only tree-editor removal

### DIFF
--- a/gix-object/src/tree/editor.rs
+++ b/gix-object/src/tree/editor.rs
@@ -39,6 +39,8 @@ pub enum Error {
     EmptyPathComponent,
     #[error(transparent)]
     FindExistingObject(#[from] crate::find::existing_object::Error),
+    #[error("Cannot remove '{rela_path}' as leaf entry because it is a tree")]
+    CannotRemoveNonLeaf { rela_path: BString },
 }
 
 /// Lifecycle
@@ -85,15 +87,28 @@ impl Editor<'_> {
 
     /// Remove the entry at `rela_path`, loading all trees on the path accordingly.
     /// It's no error if the entry doesn't exist, or if `rela_path` doesn't lead to an existing entry at all.
-    ///
-    /// Note that trying to remove a path with an empty component is also forbidden.
     pub fn remove<I, C>(&mut self, rela_path: I) -> Result<&mut Self, Error>
     where
         I: IntoIterator<Item = C>,
         C: AsRef<BStr>,
     {
         self.path_buf.borrow_mut().clear();
-        self.upsert_or_remove_at_pathbuf(rela_path, None)
+        self.upsert_or_remove_at_pathbuf(rela_path, EditMode::Remove(RemoveMode::Any))
+    }
+
+    /// Remove a non-tree entry at `rela_path`, loading all trees on the path accordingly.
+    /// It's no error if the entry doesn't exist, or if `rela_path` doesn't lead to an existing entry at all.
+    ///
+    /// Return an error if the entry exists and is a tree, as that would otherwise also remove all entries below it.
+    /// Empty path components are rejected if reached while loading the path. This is useful to not unintentionally
+    /// remove a directory.
+    pub fn remove_leaf<I, C>(&mut self, rela_path: I) -> Result<&mut Self, Error>
+    where
+        I: IntoIterator<Item = C>,
+        C: AsRef<BStr>,
+    {
+        self.path_buf.borrow_mut().clear();
+        self.upsert_or_remove_at_pathbuf(rela_path, EditMode::Remove(RemoveMode::LeafOnly))
     }
 
     /// Obtain the entry at `rela_path` or return `None` if none was found, or the tree wasn't yet written
@@ -130,7 +145,7 @@ impl Editor<'_> {
         C: AsRef<BStr>,
     {
         self.path_buf.borrow_mut().clear();
-        self.upsert_or_remove_at_pathbuf(rela_path, Some((kind, id, UpsertMode::Normal)))
+        self.upsert_or_remove_at_pathbuf(rela_path, EditMode::Upsert(kind, id, UpsertMode::Normal))
     }
 
     fn get_inner<I, C>(&self, rela_path: I) -> Option<&tree::Entry>
@@ -251,11 +266,7 @@ impl Editor<'_> {
         unreachable!("we exit as soon as everything is consumed")
     }
 
-    fn upsert_or_remove_at_pathbuf<I, C>(
-        &mut self,
-        rela_path: I,
-        kind_and_id: Option<(EntryKind, ObjectId, UpsertMode)>,
-    ) -> Result<&mut Self, Error>
+    fn upsert_or_remove_at_pathbuf<I, C>(&mut self, rela_path: I, edit: EditMode) -> Result<&mut Self, Error>
     where
         I: IntoIterator<Item = C>,
         C: AsRef<BStr>,
@@ -263,7 +274,7 @@ impl Editor<'_> {
         let mut path_buf = self.path_buf.borrow_mut();
         let mut cursor = self.trees.get_mut(path_buf.as_bstr()).expect("root is always present");
         let mut rela_path = rela_path.into_iter().peekable();
-        let new_kind_is_tree = kind_and_id.is_some_and(|(kind, _, _)| kind == EntryKind::Tree);
+        let new_kind_is_tree = matches!(edit, EditMode::Upsert(EntryKind::Tree, _, _));
         while let Some(name) = rela_path.next() {
             let name = name.as_ref();
             if name.is_empty() {
@@ -289,9 +300,14 @@ impl Editor<'_> {
                         })
                 }) {
                 Ok(idx) => {
-                    match kind_and_id {
-                        None => {
+                    match edit {
+                        EditMode::Remove(mode) => {
                             if is_last {
+                                if mode == RemoveMode::LeafOnly && cursor.entries[idx].mode.is_tree() {
+                                    return Err(Error::CannotRemoveNonLeaf {
+                                        rela_path: path_with_component(path_buf.as_bstr(), name),
+                                    });
+                                }
                                 cursor.entries.remove(idx);
                                 break;
                             } else {
@@ -303,7 +319,7 @@ impl Editor<'_> {
                                 }
                             }
                         }
-                        Some((kind, id, _mode)) => {
+                        EditMode::Upsert(kind, id, _mode) => {
                             let entry = &mut cursor.entries[idx];
                             if is_last {
                                 // unconditionally overwrite what's there.
@@ -324,9 +340,9 @@ impl Editor<'_> {
                         }
                     }
                 }
-                Err(insertion_idx) => match kind_and_id {
-                    None => break,
-                    Some((kind, id, _mode)) => {
+                Err(insertion_idx) => match edit {
+                    EditMode::Remove(_) => break,
+                    EditMode::Upsert(kind, id, _mode) => {
                         cursor.entries.insert(
                             insertion_idx,
                             tree::Entry {
@@ -342,12 +358,15 @@ impl Editor<'_> {
             if needs_sorting {
                 cursor.entries.sort();
             }
-            if is_last && kind_and_id.is_some_and(|(_, _, mode)| mode == UpsertMode::Normal) {
+            if is_last && matches!(edit, EditMode::Upsert(_, _, UpsertMode::Normal)) {
                 break;
             }
+            let stop_at_unedited_empty_tree = matches!(edit, EditMode::Remove(RemoveMode::LeafOnly))
+                && tree_to_lookup.is_some_and(|id| id.is_empty_tree());
             push_path_component(&mut path_buf, name);
             cursor = match self.trees.entry(path_buf.clone()) {
                 hash_map::Entry::Occupied(e) => e.into_mut(),
+                hash_map::Entry::Vacant(_) if stop_at_unedited_empty_tree => break,
                 hash_map::Entry::Vacant(e) => e.insert(
                     if let Some(tree_id) = tree_to_lookup.filter(|tree_id| !tree_id.is_empty_tree()) {
                         self.find.find_tree(&tree_id, &mut self.tree_buf)?.into()
@@ -381,7 +400,7 @@ mod cursor {
         Tree, tree,
         tree::{
             Editor, EntryKind,
-            editor::{Cursor, UpsertMode, WriteMode},
+            editor::{Cursor, EditMode, RemoveMode, UpsertMode, WriteMode},
         },
     };
 
@@ -409,7 +428,7 @@ mod cursor {
             self.path_buf.borrow_mut().clear();
             self.upsert_or_remove_at_pathbuf(
                 rela_path,
-                Some((EntryKind::Tree, self.object_hash.null(), UpsertMode::AssureTreeOnly)),
+                EditMode::Upsert(EntryKind::Tree, self.object_hash.null(), UpsertMode::AssureTreeOnly),
             )?;
             let prefix = self.path_buf.borrow_mut().clone();
             Ok(Cursor {
@@ -442,7 +461,7 @@ mod cursor {
         {
             self.parent.path_buf.borrow_mut().clone_from(&self.prefix);
             self.parent
-                .upsert_or_remove_at_pathbuf(rela_path, Some((kind, id, UpsertMode::Normal)))?;
+                .upsert_or_remove_at_pathbuf(rela_path, EditMode::Upsert(kind, id, UpsertMode::Normal))?;
             Ok(self)
         }
 
@@ -453,7 +472,20 @@ mod cursor {
             C: AsRef<BStr>,
         {
             self.parent.path_buf.borrow_mut().clone_from(&self.prefix);
-            self.parent.upsert_or_remove_at_pathbuf(rela_path, None)?;
+            self.parent
+                .upsert_or_remove_at_pathbuf(rela_path, EditMode::Remove(RemoveMode::Any))?;
+            Ok(self)
+        }
+
+        /// Like [`Editor::remove_leaf()`], but with the constraint of only editing in this cursor's tree.
+        pub fn remove_leaf<I, C>(&mut self, rela_path: I) -> Result<&mut Self, super::Error>
+        where
+            I: IntoIterator<Item = C>,
+            C: AsRef<BStr>,
+        {
+            self.parent.path_buf.borrow_mut().clone_from(&self.prefix);
+            self.parent
+                .upsert_or_remove_at_pathbuf(rela_path, EditMode::Remove(RemoveMode::LeafOnly))?;
             Ok(self)
         }
 
@@ -470,6 +502,21 @@ enum UpsertMode {
     Normal,
     /// Only make sure there is a tree at the given location (requires kind tree and null-id)
     AssureTreeOnly,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum RemoveMode {
+    /// Remove any entry, including entire subtrees.
+    Any,
+    /// Only remove leaf entries, and reject an existing tree at the target path.
+    LeafOnly,
+}
+
+#[derive(Copy, Clone)]
+enum EditMode {
+    Remove(RemoveMode),
+    /// Insert or replace an entry of `kind` and `id` according to the given mode.
+    Upsert(EntryKind, ObjectId, UpsertMode),
 }
 
 enum WriteMode {
@@ -503,4 +550,15 @@ fn push_path_component(base: &mut BString, component: &[u8]) -> usize {
     }
     base.push_str(component);
     prev_len
+}
+
+fn path_with_component(base: &BStr, component: &BStr) -> BString {
+    if base.is_empty() {
+        component.into()
+    } else {
+        let mut out = base.to_owned();
+        out.push_byte(b'/');
+        out.push_str(component);
+        out
+    }
 }

--- a/gix-object/tests/object/tree/editor.rs
+++ b/gix-object/tests/object/tree/editor.rs
@@ -306,6 +306,86 @@ fn from_empty_removal() -> crate::Result {
 
     Ok(())
 }
+
+#[test]
+fn from_empty_remove_accepts_empty_segments_after_unreachable_paths() -> crate::Result {
+    let (storage, mut write, _num_writes_and_clear) = new_inmemory_writes();
+    let odb = StorageOdb::new(storage.clone());
+    let mut edit = gix_object::tree::Editor::new(Tree::default(), &odb, hash_kind());
+
+    let actual = edit
+        .upsert(Some("file"), EntryKind::Blob, any_blob())?
+        .upsert(["dir", "file"], EntryKind::Blob, any_blob())?
+        .remove(["missing", ""])?
+        .remove(["file", ""])?
+        .remove(["dir", "missing", ""])?
+        .write(&mut write)?;
+
+    insta::assert_snapshot!(
+        crate::normalize_tree_snapshot(&display_tree(actual, &storage)),
+        "empty path components after an unreachable removal target are not reached or validated",
+        @r#"
+        Oid(1)
+        ├── dir
+        │   └── file Oid(2).100644
+        └── file Oid(2).100644
+    "#
+    );
+    Ok(())
+}
+
+#[test]
+fn from_empty_remove_leaf_rejects_tree_entries() -> crate::Result {
+    let (storage, mut write, _num_writes_and_clear) = new_inmemory_writes();
+    let odb = StorageOdb::new(storage.clone());
+    let mut edit = gix_object::tree::Editor::new(Tree::default(), &odb, hash_kind());
+
+    edit.upsert(["A", "one"], EntryKind::Blob, any_blob())?;
+
+    let err = edit.remove_leaf(Some("A")).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Cannot remove 'A' as leaf entry because it is a tree",
+        "leaf-only removal must reject non-leaf entries"
+    );
+
+    edit.remove_leaf(["A", "one"])?;
+    let actual = edit.write(&mut write)?;
+    assert_eq!(actual, empty_tree(), "the leaf itself can still be removed");
+
+    let actual = edit
+        .upsert(Some("empty-dir"), EntryKind::Tree, empty_tree())?
+        .remove_leaf(["empty-dir", "missing"])?
+        .write(&mut write)?;
+    insta::assert_snapshot!(
+        crate::normalize_tree_snapshot(&display_tree(actual, &storage)),
+        "an absent leaf below an empty tree is a no-op and must not prune the tree",
+        @r#"
+        Oid(1)
+        └── empty-dir (empty)
+    "#
+    );
+    edit.remove_leaf(["empty-dir", ""])?;
+    edit.remove_leaf(["empty-dir", "missing", ""])?;
+    edit.remove_leaf(["missing", ""])?;
+    edit.upsert(["non-empty", "file"], EntryKind::Blob, any_blob())?
+        .remove_leaf(["non-empty", "missing", ""])?
+        .remove_leaf(["non-empty", "file", ""])?;
+
+    let actual = edit
+        .set_root(Tree::default())
+        .upsert(Some("empty-dir"), EntryKind::Tree, empty_tree())?
+        .upsert(["empty-dir", "file"], EntryKind::Blob, any_blob())?
+        .remove_leaf(["empty-dir", "file"])?
+        .write(&mut write)?;
+    assert_eq!(
+        actual,
+        empty_tree(),
+        "leaf-only removal still descends into edited subtrees backed by an empty tree"
+    );
+    Ok(())
+}
+
 #[test]
 fn from_existing_remove() -> crate::Result {
     let (storage, mut write, num_writes_and_clear) = new_inmemory_writes();

--- a/gix/src/object/tree/editor.rs
+++ b/gix/src/object/tree/editor.rs
@@ -176,6 +176,12 @@ impl<'repo> Cursor<'_, 'repo> {
         Ok(self)
     }
 
+    /// Like [`Editor::remove_leaf()`](super::Editor::remove_leaf), but with the constraint of only editing in this cursor's tree.
+    pub fn remove_leaf(&mut self, rela_path: impl ToComponents) -> Result<&mut Self, gix_object::tree::editor::Error> {
+        self.inner.remove_leaf(rela_path.to_components())?;
+        Ok(self)
+    }
+
     /// Like [`Editor::write()`](super::Editor::write()), but will write only the subtree of the cursor.
     pub fn write(&mut self) -> Result<Id<'repo>, write::Error> {
         write_cursor(self)
@@ -240,6 +246,15 @@ impl<'repo> super::Editor<'repo> {
     /// It's no error if the entry doesn't exist, or if `rela_path` doesn't lead to an existing entry at all.
     pub fn remove(&mut self, rela_path: impl ToComponents) -> Result<&mut Self, gix_object::tree::editor::Error> {
         self.inner.remove(rela_path.to_components())?;
+        Ok(self)
+    }
+
+    /// Remove a non-tree entry at `rela_path`, loading all trees on the path accordingly.
+    /// It's no error if the entry doesn't exist, or if `rela_path` doesn't lead to an existing entry at all.
+    ///
+    /// Return an error if the entry exists and is a tree, as that would otherwise also remove all entries below it.
+    pub fn remove_leaf(&mut self, rela_path: impl ToComponents) -> Result<&mut Self, gix_object::tree::editor::Error> {
+        self.inner.remove_leaf(rela_path.to_components())?;
         Ok(self)
     }
 

--- a/gix/tests/gix/repository/object.rs
+++ b/gix/tests/gix/repository/object.rs
@@ -165,6 +165,33 @@ mod edit_tree {
     }
 
     #[test]
+    fn remove_leaf_rejects_tree_entries() -> crate::Result {
+        let (repo, _tmp) = crate::repo_rw("make_packed_and_loose.sh")?;
+        let head_tree_id = repo.head_tree_id()?;
+        let this_id = hex_to_id("317e9677c3bcffd006f9fc84bbb0a54ef1676197");
+        let mut editor = repo.edit_tree(head_tree_id)?;
+
+        editor.upsert("A/one", EntryKind::Blob, this_id)?;
+        let err = match editor.remove_leaf("A") {
+            Ok(_) => unreachable!("removing a tree as leaf must fail"),
+            Err(err) => err,
+        };
+        assert_eq!(
+            err.to_string(),
+            "Cannot remove 'A' as leaf entry because it is a tree",
+            "leaf-only removal must reject non-leaf entries"
+        );
+
+        let actual = editor.remove_leaf("A/one")?.write()?;
+        assert_eq!(
+            display_tree_snapshot(actual, &repo),
+            display_tree_snapshot(head_tree_id, &repo),
+            "removing the leaf prunes the now-empty intermediate tree ('A')"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn missing_objects_and_illformed_path_components_trigger_error() -> crate::Result {
         let (repo, _tmp) = crate::repo_rw("make_packed_and_loose.sh")?;
         let tree = repo.head_tree_id()?.object()?.into_tree();


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

Byron asked Codex to take a look at https://github.com/gitbutlerapp/gitbutler/pull/14312/commits and see if this commit-message comment could be resolved by adding such an API:

> In order to prevent issues like this from happening in the future,
> ideally gix would have an API to delete a leaf entry (returning an
> error if the entry to be deleted was a non-leaf - in the example above,
> deleting "A" when "A/one" is present would be an error), but looking at
> its documentation, I don't think such an API exists.

Motivation: https://github.com/gitbutlerapp/gitbutler/pull/14312

## Summary

- Added `remove_leaf()` to `gix_object::tree::Editor` and cursor, preserving existing `remove()` semantics.
- Exposed `remove_leaf()` through the public `gix` tree editor and cursor wrappers.
- Added regression coverage for rejecting tree entries, tolerating absent paths, preserving empty-tree no-ops, and validating malformed trailing path components.

## Validation

- `cargo fmt --all`
- `cargo test -p gix-object --test object from_empty_remove_leaf_rejects_tree_entries`
- `cargo test -p gix-object --test object tree::editor`
- `cargo test -p gix --test gix repository::object::edit_tree`
- `cargo check -p gix-object -p gix --features tree-editor`
- `cargo check -p gix --no-default-features --features tree-editor,sha1`
- `cargo check -p gix-object -p gix --no-default-features --features tree-editor,sha1`
- `git diff --check`
- `codex review --commit 829533b5f52ee35e578984a82e092f566b947292`