### PR TITLE
Cover gix-pack multi-index write under SHA-256

### DIFF
--- a/gix-pack/src/index/verify.rs
+++ b/gix-pack/src/index/verify.rs
@@ -221,7 +221,7 @@ where
             None => self
                 .verify_checksum(
                     &mut progress
-                        .add_child_with_id("Sha1 of index".into(), integrity::ProgressId::ChecksumBytes.into()),
+                        .add_child_with_id("checksum of index".into(), integrity::ProgressId::ChecksumBytes.into()),
                     should_interrupt,
                 )
                 .map_err(index::traverse::Error::IndexVerify)

--- a/gix-pack/tests/pack/multi_index/write.rs
+++ b/gix-pack/tests/pack/multi_index/write.rs
@@ -5,6 +5,8 @@ use gix_testtools::fixture_path;
 
 use crate::hex_to_id;
 
+/// Writes a multi-index from the static SHA-1 pack indices, with pinned SHA-1 expectations.
+/// The SHA-256 counterpart lives in `from_a_hash_parameterized_pack` below.
 #[test]
 fn from_paths() -> crate::Result {
     let dir = gix_testtools::tempfile::TempDir::new()?;
@@ -64,5 +66,63 @@ fn from_paths() -> crate::Result {
     let outcome = file.verify_integrity_fast(&mut progress::Discard, &AtomicBool::new(false))?;
 
     assert_eq!(outcome, file.checksum());
+    Ok(())
+}
+
+/// Like `from_paths`, but sources its input index from the hash-parameterized fixture so the
+/// writer runs under both SHA-1 and SHA-256. The fixture's gc leaves one pack, hence one index.
+#[test]
+fn from_a_hash_parameterized_pack() -> crate::Result {
+    let object_hash = crate::object_hash();
+    let pack_dir = crate::scripted_fixture_read_only("make_pack_gen_repo_multi_index.sh")?.join(".git/objects/pack");
+    let input_indices = std::fs::read_dir(&pack_dir)?
+        .filter_map(|r| {
+            r.ok()
+                .map(|e| e.path())
+                .filter(|p| p.extension().and_then(std::ffi::OsStr::to_str) == Some("idx"))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(input_indices.len(), 1, "the aggressive gc leaves a single pack");
+
+    let dir = gix_testtools::tempfile::TempDir::new()?;
+    let output_path = dir.path().join("multi-pack-index");
+    let mut out = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&output_path)?;
+    let outcome = gix_pack::multi_index::write_from_index_paths(
+        input_indices.clone(),
+        &mut out,
+        &mut progress::Discard,
+        &AtomicBool::new(false),
+        gix_pack::multi_index::write::Options { object_hash },
+    )?;
+
+    let file = gix_pack::multi_index::File::at(output_path, None)?;
+    assert_eq!(
+        file.object_hash(),
+        object_hash,
+        "the writer records the requested object hash"
+    );
+    assert_eq!(file.num_indices(), 1);
+    assert_eq!(file.num_objects(), 868);
+    assert_eq!(file.checksum(), outcome.multi_index_checksum);
+
+    // Place the referenced pack and index next to the multi-index so integrity can resolve them.
+    for index in &input_indices {
+        std::fs::copy(index, dir.path().join(index.file_name().expect("present")))?;
+        let pack = index.with_extension("pack");
+        std::fs::copy(&pack, dir.path().join(pack.file_name().expect("present")))?;
+    }
+
+    assert_eq!(
+        file.verify_integrity(&mut progress::Discard, &AtomicBool::new(false), Default::default())?
+            .actual_index_checksum,
+        outcome.multi_index_checksum
+    );
+    assert_eq!(
+        file.verify_integrity_fast(&mut progress::Discard, &AtomicBool::new(false))?,
+        file.checksum()
+    );
     Ok(())
 }


### PR DESCRIPTION
**What**

After https://github.com/GitoxideLabs/gitoxide/pull/2653 lands (this PR is not dependent on it btw), all object-storage crates run tests under both hashes, but the gix-pack multi-index writer was only fed the static sha1 pack indices, so it had no sha256 coverage. This closes that gap (test-only, plus the one-line label fix).

Also part of #281 

**Testing**
The new test is added as a plain `#[test]`, not feature gated, so the dual-hash gix-pack test runs from the justfile already cover it:
```
GIX_TEST_FIXTURE_HASH=sha1   cargo nextest run -p gix-pack
GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-pack
```

**AI disclosure**

This PR was written with the help of Claude Code, but was **not** vibe-coded. I'm not a fan of vibe-coding. I used AI to better understand the codebase myself (asked it a lot of questions), review both my code and the code generated by AI, used it especially to detect bugs and corner-cases and suggest fixes, however I very carefully reviewed & edited each code/comment lines, the commit messages and so on, until I was satisfied with the result.