### PR TITLE
dev/aratiu/sha256 transport fixtures

### DIFF
--- a/gix-transport/tests/client/blocking_io/http/mod.rs
+++ b/gix-transport/tests/client/blocking_io/http/mod.rs
@@ -720,6 +720,53 @@ fn handshake_and_lsrefs_and_fetch_v2_service_announced() -> crate::Result {
     handshake_and_lsrefs_and_fetch_v2_impl("v2/http-handshake-service-announced.response")
 }
 
+#[test]
+fn handshake_v2_surfaces_sha256_object_format() -> crate::Result {
+    let (_server, mut c) = mock::serve_and_connect(
+        "v2/http-handshake-sha256.response",
+        "path/not/important/due/to/mock",
+        Protocol::V2,
+    )?;
+    let SetServiceResponse {
+        actual_protocol,
+        capabilities,
+        refs,
+    } = c.handshake(Service::UploadPack, &[])?;
+    assert_eq!(actual_protocol, Protocol::V2);
+    assert!(
+        refs.is_none(),
+        "refs are only returned in V1, as V2 favors a separate command (with more options)"
+    );
+    assert_eq!(
+        capabilities
+            .iter()
+            .map(|v| {
+                (
+                    v.name().to_owned(),
+                    v.values().map(|v| v.map(ToOwned::to_owned).collect::<Vec<_>>()),
+                )
+            })
+            .collect::<Vec<_>>(),
+        [
+            ("agent", Some(&["git/github-gdf51a71f0236"][..])),
+            ("ls-refs", None),
+            ("fetch", Some(&["shallow", "filter"][..])),
+            ("server-option", None),
+            ("object-format", Some(&["sha256"][..])),
+        ]
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.as_bytes().into(),
+                v.map(|v| v.iter().map(|v| v.as_bytes().into()).collect::<Vec<_>>()),
+            )
+        })
+        .collect::<Vec<_>>(),
+        "the sha256 object-format advertised over http is surfaced from the V2 handshake"
+    );
+    Ok(())
+}
+
 fn handshake_and_lsrefs_and_fetch_v2_impl(handshake_fixture: &str) -> crate::Result {
     let (server, mut c) = mock::serve_and_connect(handshake_fixture, "path/not/important/due/to/mock", Protocol::V2)?;
     assert!(

--- a/gix-transport/tests/client/blocking_io/http/mod.rs
+++ b/gix-transport/tests/client/blocking_io/http/mod.rs
@@ -740,27 +740,17 @@ fn handshake_v2_surfaces_sha256_object_format() -> crate::Result {
     assert_eq!(
         capabilities
             .iter()
-            .map(|v| {
-                (
-                    v.name().to_owned(),
-                    v.values().map(|v| v.map(ToOwned::to_owned).collect::<Vec<_>>()),
-                )
-            })
+            .map(|v| (v.name().to_owned(), v.value().map(ToOwned::to_owned)))
             .collect::<Vec<_>>(),
         [
-            ("agent", Some(&["git/github-gdf51a71f0236"][..])),
+            ("agent", Some("git/github-gdf51a71f0236")),
             ("ls-refs", None),
-            ("fetch", Some(&["shallow", "filter"][..])),
+            ("fetch", Some("shallow filter")),
             ("server-option", None),
-            ("object-format", Some(&["sha256"][..])),
+            ("object-format", Some("sha256")),
         ]
         .iter()
-        .map(|(k, v)| {
-            (
-                k.as_bytes().into(),
-                v.map(|v| v.iter().map(|v| v.as_bytes().into()).collect::<Vec<_>>()),
-            )
-        })
+        .map(|(k, v)| (k.as_bytes().into(), v.map(|v| v.as_bytes().into())))
         .collect::<Vec<_>>(),
         "the sha256 object-format advertised over http is surfaced from the V2 handshake"
     );

--- a/gix-transport/tests/client/capabilities.rs
+++ b/gix-transport/tests/client/capabilities.rs
@@ -58,6 +58,23 @@ fn from_bytes() -> crate::Result {
     Ok(())
 }
 
+#[test]
+fn from_bytes_with_sha256_object_format() -> crate::Result {
+    let (caps, _delim_pos) = Capabilities::from_bytes(
+        &b"7814e8a05a59c0cf5fb186661d1551c75d1299b5 HEAD\0side-band-64k object-format=sha256 agent=git/2.40.0"[..],
+    )?;
+    let object_format = caps.capability("object-format").expect("cap exists");
+    assert!(
+        object_format.supports("sha256").expect("there is a value"),
+        "sha256 is supported"
+    );
+    assert!(
+        !object_format.supports("sha1").expect("there is a value"),
+        "sha1 is not supported when the server advertises sha256"
+    );
+    Ok(())
+}
+
 #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
 async fn from_lines_with_version_detection_v0() -> crate::Result {
     let mut buf = Vec::<u8>::new();

--- a/gix-transport/tests/client/git.rs
+++ b/gix-transport/tests/client/git.rs
@@ -452,3 +452,52 @@ async fn handshake_v2_and_request_inner() -> crate::Result {
     );
     Ok(())
 }
+
+#[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
+async fn handshake_v2_with_sha256_object_format() -> crate::Result {
+    let mut out = Vec::new();
+    let input = fixture_bytes("v2/handshake-sha256.response");
+    let mut c = Connection::new(
+        input.as_slice(),
+        &mut out,
+        Protocol::V2,
+        "/bar.git",
+        Some(("example.org", None)),
+        git::ConnectMode::Daemon,
+        false,
+    );
+    let res = c.handshake(Service::UploadPack, &[]).await?;
+    assert_eq!(res.actual_protocol, Protocol::V2);
+    assert!(
+        res.refs.is_none(),
+        "V2 needs a separate trip for getting refs (with additional capabilities)"
+    );
+    assert_eq!(
+        res.capabilities
+            .iter()
+            .map(|c| {
+                (
+                    c.name().to_owned(),
+                    c.values().map(|v| v.map(ToOwned::to_owned).collect::<Vec<_>>()),
+                )
+            })
+            .collect::<Vec<_>>(),
+        [
+            ("agent", Some(&["git/2.40.0"][..])),
+            ("ls-refs", None),
+            ("fetch", Some(&["shallow"][..])),
+            ("server-option", None),
+            ("object-format", Some(&["sha256"][..])),
+        ]
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.as_bytes().into(),
+                v.map(|v| v.iter().map(|v| v.as_bytes().into()).collect::<Vec<_>>()),
+            )
+        })
+        .collect::<Vec<_>>(),
+        "the sha256 object-format advertised by the server is surfaced from the V2 handshake"
+    );
+    Ok(())
+}

--- a/gix-transport/tests/client/git.rs
+++ b/gix-transport/tests/client/git.rs
@@ -475,27 +475,17 @@ async fn handshake_v2_with_sha256_object_format() -> crate::Result {
     assert_eq!(
         res.capabilities
             .iter()
-            .map(|c| {
-                (
-                    c.name().to_owned(),
-                    c.values().map(|v| v.map(ToOwned::to_owned).collect::<Vec<_>>()),
-                )
-            })
+            .map(|c| (c.name().to_owned(), c.value().map(ToOwned::to_owned)))
             .collect::<Vec<_>>(),
         [
-            ("agent", Some(&["git/2.40.0"][..])),
+            ("agent", Some("git/2.40.0")),
             ("ls-refs", None),
-            ("fetch", Some(&["shallow"][..])),
+            ("fetch", Some("shallow")),
             ("server-option", None),
-            ("object-format", Some(&["sha256"][..])),
+            ("object-format", Some("sha256")),
         ]
         .iter()
-        .map(|(k, v)| {
-            (
-                k.as_bytes().into(),
-                v.map(|v| v.iter().map(|v| v.as_bytes().into()).collect::<Vec<_>>()),
-            )
-        })
+        .map(|(k, v)| (k.as_bytes().into(), v.map(|v| v.as_bytes().into())))
         .collect::<Vec<_>>(),
         "the sha256 object-format advertised by the server is surfaced from the V2 handshake"
     );

--- a/gix-transport/tests/fixtures/.gitattributes
+++ b/gix-transport/tests/fixtures/.gitattributes
@@ -1,0 +1,3 @@
+# These are byte-exact protocol captures (CRLF headers, pkt-line length
+# prefixes, Content-Length matching the body), never convert line endings.
+* -text

--- a/gix-transport/tests/fixtures/v2/handshake-sha256.response
+++ b/gix-transport/tests/fixtures/v2/handshake-sha256.response
@@ -1,0 +1,7 @@
+000eversion 2
+0015agent=git/2.40.0
+000cls-refs
+0012fetch=shallow
+0012server-option
+0019object-format=sha256
+0000

--- a/gix-transport/tests/fixtures/v2/http-handshake-sha256.response
+++ b/gix-transport/tests/fixtures/v2/http-handshake-sha256.response
@@ -1,0 +1,18 @@
+HTTP/1.1 200 OK
+Server: GitHub Babel 2.0
+Content-Type: application/x-git-upload-pack-advertisement
+Content-Length: 133
+Expires: Fri, 01 Jan 1980 00:00:00 GMT
+Pragma: no-cache
+Cache-Control: no-cache, max-age=0, must-revalidate
+Vary: Accept-Encoding
+X-Frame-Options: DENY
+X-GitHub-Request-Id: 737D:544E:C932CB:113F404:5F3F3EE5
+
+000eversion 2
+0023agent=git/github-gdf51a71f0236
+000cls-refs
+0019fetch=shallow filter
+0012server-option
+0019object-format=sha256
+0000


### PR DESCRIPTION
This is PR https://github.com/GitoxideLabs/gitoxide/pull/2647 with one commit added on top.
No revwrites, but can't push back there.
