### PR TITLE
fix: tolerate NUL suffixes in symbolic ref files

### DIFF
--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -61,8 +61,8 @@ impl Reference {
 ///
 /// A *symbolic* reference starts with `ref: `, may have additional spaces before
 /// the path, and returns [`MaybeUnsafeState::UnvalidatedPath`] with the path
-/// bytes up to the next line ending or the end of input. The path is validated
-/// later when it is converted into a [`Target`].
+/// bytes up to the next NUL byte (just like Git), line ending, or the end of input. The path
+/// is validated later when it is converted into a [`Target`].
 ///
 /// A *direct* reference starts with a hexadecimal object id and returns
 /// [`MaybeUnsafeState::Id`].
@@ -74,7 +74,10 @@ fn parse(mut i: &[u8], object_hash: gix_hash::Kind) -> Result<MaybeUnsafeState, 
         while i.first() == Some(&b' ') {
             i = &i[1..];
         }
-        let path_end = i.iter().position(|b| *b == b'\r' || *b == b'\n').unwrap_or(i.len());
+        let path_end = i
+            .iter()
+            .position(|b| *b == b'\0' || *b == b'\r' || *b == b'\n')
+            .unwrap_or(i.len());
         let path = i[..path_end].into();
         Ok(MaybeUnsafeState::UnvalidatedPath(path))
     } else {

--- a/gix-ref/tests/refs/file/reference.rs
+++ b/gix-ref/tests/refs/file/reference.rs
@@ -299,6 +299,28 @@ mod parse {
         );
 
         #[test]
+        fn symbolic_ignores_nul_suffix_like_git() {
+            use std::convert::TryInto;
+
+            let reference = Reference::try_from_path(
+                "HEAD".try_into().expect("valid static name"),
+                b"ref: refs/heads/main\0hidden-head-metadata",
+                gix_hash::Kind::Sha1,
+            )
+            .expect("Git ignores bytes past the first NUL in symbolic ref files, so this parses as well");
+            assert_eq!(
+                reference.kind(),
+                gix_ref::Kind::Symbolic,
+                "the ref is still symbolic despite ignored trailing metadata"
+            );
+            assert_eq!(
+                reference.target.to_ref().try_name().map(gix_ref::FullNameRef::as_bstr),
+                Some(b"refs/heads/main".as_bstr()),
+                "only the target before the first NUL is used"
+            );
+        }
+
+        #[test]
         fn peeled_sha256() {
             use std::convert::TryInto;
 


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Tolerate NUL suffixes in loose symbolic ref files by parsing the symbolic target only up to the first NUL byte, matching Git's C-string behavior for symbolic referents.

## Reported issue

```text
When refs (like HEAD) contains null bytes, Git will just ignore everything past it, but we currently fail. Instead, we should be as permissive as Git. Current behaviour leads to errors like this:

error: The reference at "HEAD" could not be instantiated: The path "refs/heads/main\0codex-hidden-head-metadata: status-clean-demo" to a symbolic reference within a ref file is invalid: Reference name contains invalid byte: "\0"
```

## Git baseline

Local Git checkout `7760f83b59` shows `parse_loose_ref_contents()` in `refs/files-backend.c` stores symbolic referents through C-string semantics. A command-level check with a `HEAD` file containing `ref: refs/heads/main\0codex-hidden-head-metadata: status-clean-demo` returned `refs/heads/main` from `git symbolic-ref HEAD`.

## Validation

- `cargo test -p gix-ref --test refs file::reference::parse::valid::symbolic_ignores_nul_suffix_like_git -- --exact`
- `cargo test -p gix-ref --test refs file::reference::parse --`
- `cargo clippy -p gix-ref --test refs -- -D warnings`
- `cargo test -p gix-ref --test refs`
- `codex review --commit 2e2c8a7f52f648369c054b6d060f5cde24f51a18`