### PR TITLE
Fix transaction race for file refs, fixes: #2600

### DIFF
--- a/gitoxide-core/src/lib.rs
+++ b/gitoxide-core/src/lib.rs
@@ -78,6 +78,8 @@ pub mod organize;
 pub mod pack;
 #[cfg(feature = "query")]
 pub mod query;
+#[cfg(feature = "blocking-client")]
+pub mod remote;
 pub mod repository;
 
 mod discover;

--- a/gitoxide-core/src/remote.rs
+++ b/gitoxide-core/src/remote.rs
@@ -1,0 +1,183 @@
+use std::{
+    io,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+use crate::{OutputFormat, net};
+use anyhow::bail;
+use gix::protocol::transport::client::blocking_io::connect;
+use gix::{
+    NestedProgress,
+    config::tree::Key,
+    objs::bstr::ByteSlice,
+    protocol::{self, handshake::Ref, transport},
+    refs::{
+        Target,
+        transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
+    },
+};
+
+pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=2;
+
+pub struct Context<W> {
+    pub format: OutputFormat,
+    pub out: W,
+    pub object_hash: gix::hash::Kind,
+    pub write_reflog: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RefsWriteOutcome {
+    pub num_refs: usize,
+    pub elapsed: Duration,
+}
+
+pub fn refs<P, W>(
+    protocol: Option<net::Protocol>,
+    url: &str,
+    refs_directory: Option<PathBuf>,
+    mut progress: P,
+    ctx: Context<W>,
+) -> anyhow::Result<()>
+where
+    W: io::Write,
+    P: NestedProgress + 'static,
+    P::SubProgress: 'static,
+{
+    if ctx.format != OutputFormat::Human {
+        bail!("JSON output isn't supported");
+    }
+
+    let mut transport = net::connect(
+        url,
+        connect::Options {
+            version: protocol.unwrap_or_default().into(),
+            ..Default::default()
+        },
+    )?;
+    let trace_packetlines = std::env::var_os(
+        gix::config::tree::Gitoxide::TRACE_PACKET
+            .environment_override()
+            .expect("set"),
+    )
+    .is_some();
+
+    progress.info(format!("Connecting to {url:?}"));
+    let agent = protocol::agent(gix::env::agent());
+    let mut handshake = protocol::handshake(
+        &mut transport.inner,
+        transport::Service::UploadPack,
+        protocol::credentials::builtin,
+        vec![("agent".into(), Some(agent.clone()))],
+        &mut progress,
+    )?;
+    let fetch_refmap = handshake.prepare_lsrefs_or_extract_refmap(
+        ("agent", Some(agent.into())),
+        false,
+        protocol::fetch::refmap::init::Context {
+            fetch_refspecs: Vec::new(),
+            extra_refspecs: Vec::new(),
+        },
+    )?;
+
+    let refmap = fetch_refmap.fetch_blocking(&mut progress, &mut transport.inner, trace_packetlines)?;
+    let refs = refmap.remote_refs;
+
+    let refs_write = refs_directory
+        .map(|directory| write_refs(&refs, directory, ctx.object_hash, ctx.write_reflog))
+        .transpose()?;
+    print_refs(ctx.out, &refs, refs_write)?;
+
+    Ok(())
+}
+
+fn print_refs(mut out: impl io::Write, refs: &[Ref], refs_write: Option<RefsWriteOutcome>) -> io::Result<()> {
+    crate::repository::remote::refs::print(&mut out, refs)?;
+    if let Some(outcome) = refs_write {
+        writeln!(out)?;
+        writeln!(out, "refs-write: {} refs in {:?}", outcome.num_refs, outcome.elapsed)?;
+    }
+    Ok(())
+}
+
+fn write_refs(
+    refs: &[Ref],
+    directory: PathBuf,
+    object_hash: gix::hash::Kind,
+    write_reflog: bool,
+) -> anyhow::Result<RefsWriteOutcome> {
+    let _span = gix::trace::coarse!("write remote refs", refs = refs.len(), directory = ?directory);
+    std::fs::create_dir_all(&directory)?;
+
+    let start = Instant::now();
+    let precompose_unicode = gix::fs::Capabilities::probe(&directory).precompose_unicode;
+    let store = gix::RefStore::at(
+        directory,
+        gix::refs::store::init::Options {
+            write_reflog: if write_reflog {
+                gix::refs::store::WriteReflog::Always
+            } else {
+                gix::refs::store::WriteReflog::Disable
+            },
+            object_hash,
+            precompose_unicode,
+            prohibit_windows_device_names: cfg!(windows),
+        },
+    );
+    let edits = refs
+        .iter()
+        .map(ref_to_edit)
+        .collect::<Result<Vec<_>, gix::refs::name::Error>>()?;
+
+    store
+        .transaction()
+        .prepare(
+            edits,
+            gix::lock::acquire::Fail::Immediately,
+            gix::lock::acquire::Fail::Immediately,
+        )?
+        .commit(write_reflog.then_some(reflog_committer()))?;
+    let outcome = RefsWriteOutcome {
+        num_refs: refs.len(),
+        elapsed: start.elapsed(),
+    };
+    gix::trace::info!(
+        refs = outcome.num_refs,
+        elapsed_secs = outcome.elapsed.as_secs_f64(),
+        "wrote remote refs"
+    );
+    Ok(outcome)
+}
+
+fn reflog_committer() -> gix::actor::SignatureRef<'static> {
+    gix::actor::SignatureRef {
+        name: b"gitoxide".as_bstr(),
+        email: b"gitoxide@example.com".as_bstr(),
+        time: "0 +0000",
+    }
+}
+
+fn ref_to_edit(ref_: &Ref) -> Result<RefEdit, gix::refs::name::Error> {
+    let (name, target) = match ref_ {
+        Ref::Unborn { full_ref_name, target } => (full_ref_name, Target::Symbolic(target.as_bstr().try_into()?)),
+        Ref::Symbolic {
+            full_ref_name, target, ..
+        } => (full_ref_name, Target::Symbolic(target.as_bstr().try_into()?)),
+        Ref::Peeled { full_ref_name, tag, .. } => (full_ref_name, Target::Object(*tag)),
+        Ref::Direct { full_ref_name, object } => (full_ref_name, Target::Object(*object)),
+    };
+    Ok(RefEdit {
+        change: Change::Update {
+            log: LogChange {
+                mode: RefLog::AndReference,
+                force_create_reflog: false,
+                message: "remote refs".into(),
+            },
+            expected: PreviousValue::Any,
+            new: target,
+        },
+        name: name.as_bstr().try_into()?,
+        deref: false,
+    })
+}

--- a/gix-fs/src/dir/create.rs
+++ b/gix-fs/src/dir/create.rs
@@ -152,7 +152,10 @@ impl<'a> Iterator for Iter<'a> {
                         self.state = State::CurrentlyCreatingDirectories;
                         Some(Ok(dir))
                     }
-                    AlreadyExists => self.permanent_failure(dir, err), // is non-directory
+                    // A component exists but is not a directory. Report that precisely instead
+                    // of the raw `AlreadyExists` so callers (e.g. locking) can tell a path
+                    // collision apart from a directory that already exists.
+                    AlreadyExists => self.permanent_failure(dir, std::io::Error::new(NotADirectory, err)),
                     NotFound => {
                         self.retries.on_create_directory_failure -= 1;
                         if let State::CurrentlyCreatingDirectories = self.state {

--- a/gix-fs/tests/fs/dir/create.rs
+++ b/gix-fs/tests/fs/dir/create.rs
@@ -110,9 +110,9 @@ mod iter {
 
         let mut it = create::Iter::new(&new_dir);
         assert!(
-            matches!(it.next(), Some(Err(Permanent{ dir, err, .. })) if err.kind() == AlreadyExists
+            matches!(it.next(), Some(Err(Permanent{ dir, err, .. })) if err.kind() == NotADirectory
                                                                     && dir == new_dir),
-            "parent dir is not present and we run out of attempts"
+            "a non-directory in the path is reported precisely as NotADirectory"
         );
         assert!(it.next().is_none(), "iterator depleted");
         assert!(new_dir.is_file(), "file is untouched");

--- a/gix-ref/src/store/file/find.rs
+++ b/gix-ref/src/store/file/find.rs
@@ -276,21 +276,29 @@ impl file::Store {
         base.join(relative_path)
     }
 
-    /// Read the file contents with a verified full reference path and return it in the given vector if possible.
-    pub(crate) fn ref_contents(&self, name: &FullNameRef) -> io::Result<Option<Vec<u8>>> {
-        let (base, relative_path) = self.reference_path_with_base(name);
-        if self.prohibit_windows_device_names
-            && relative_path
+    /// If `prohibit_windows_device_names` is set, check that `name` does not
+    /// contain a path component that matches a reserved Windows device name.
+    pub(crate) fn check_windows_device_name(&self, name: &FullNameRef) -> io::Result<()> {
+        if self.prohibit_windows_device_names {
+            let (_, relative_path) = self.reference_path_with_base(name);
+            if relative_path
                 .components()
                 .filter_map(|c| gix_path::try_os_str_into_bstr(c.as_os_str().into()).ok())
                 .any(|c| gix_validate::path::component_is_windows_device(c.as_ref()))
-        {
-            return Err(std::io::Error::other(format!(
-                "Illegal use of reserved Windows device name in \"{}\"",
-                name.as_bstr()
-            )));
+            {
+                return Err(std::io::Error::other(format!(
+                    "Illegal use of reserved Windows device name in \"{}\"",
+                    name.as_bstr()
+                )));
+            }
         }
+        Ok(())
+    }
 
+    /// Read the file contents with a verified full reference path and return it in the given vector if possible.
+    pub(crate) fn ref_contents(&self, name: &FullNameRef) -> io::Result<Option<Vec<u8>>> {
+        self.check_windows_device_name(name)?;
+        let (base, relative_path) = self.reference_path_with_base(name);
         let ref_path = base.join(&relative_path);
         match std::fs::File::open(&ref_path) {
             Ok(mut file) => {

--- a/gix-ref/src/store/file/find.rs
+++ b/gix-ref/src/store/file/find.rs
@@ -279,20 +279,22 @@ impl file::Store {
     /// If `prohibit_windows_device_names` is set, check that `name` does not
     /// contain a path component that matches a reserved Windows device name.
     pub(crate) fn check_windows_device_name(&self, name: &FullNameRef) -> io::Result<()> {
-        if self.prohibit_windows_device_names {
-            let (_, relative_path) = self.reference_path_with_base(name);
-            if relative_path
-                .components()
-                .filter_map(|c| gix_path::try_os_str_into_bstr(c.as_os_str().into()).ok())
-                .any(|c| gix_validate::path::component_is_windows_device(c.as_ref()))
-            {
-                return Err(std::io::Error::other(format!(
-                    "Illegal use of reserved Windows device name in \"{}\"",
-                    name.as_bstr()
-                )));
-            }
+        if !self.prohibit_windows_device_names {
+            return Ok(());
         }
-        Ok(())
+        let (_, relative_path) = self.reference_path_with_base(name);
+        if relative_path
+            .components()
+            .filter_map(|c| gix_path::try_os_str_into_bstr(c.as_os_str().into()).ok())
+            .any(|c| gix_validate::path::component_is_windows_device(c.as_ref()))
+        {
+            Err(std::io::Error::other(format!(
+                "Illegal use of reserved Windows device name in \"{}\"",
+                name.as_bstr()
+            )))
+        } else {
+            Ok(())
+        }
     }
 
     /// Read the file contents with a verified full reference path and return it in the given vector if possible.

--- a/gix-ref/src/store/file/transaction/prepare.rs
+++ b/gix-ref/src/store/file/transaction/prepare.rs
@@ -50,6 +50,7 @@ impl Transaction<'_, '_> {
     /// Map a lock-acquisition failure to our error type, surfacing genuine I/O errors
     /// (such as a path collision reported as `NotADirectory`) as [`Error::Io`] rather than
     /// burying them in [`Error::LockAcquire`], which is reserved for actual contention.
+    // This happens for path collisions where `a` is a ref file, and `a/b` is the lock to be created.
     fn lock_acquire_error(err: gix_lock::acquire::Error, full_name: &str) -> Error {
         match err {
             gix_lock::acquire::Error::Io(err) => Error::Io(err),
@@ -146,8 +147,6 @@ impl Transaction<'_, '_> {
                         )
                     })
                 };
-                // A path collision (`a/b` where `a` is a ref file) makes lock acquisition fail
-                // with `NotADirectory`, surfaced as `Error::Io` by `lock_acquire_error`.
                 let mut lock = (!has_global_lock).then(obtain_lock).transpose()?;
 
                 let existing_ref = Self::read_existing_ref(store, change.update.name.as_ref(), packed)?;

--- a/gix-ref/src/store/file/transaction/prepare.rs
+++ b/gix-ref/src/store/file/transaction/prepare.rs
@@ -12,6 +12,51 @@ use crate::{
 };
 
 impl Transaction<'_, '_> {
+    /// Read the current value of a reference from loose storage, falling back to packed refs.
+    fn read_existing_ref(
+        store: &file::Store,
+        name: &FullNameRef,
+        packed: Option<&packed::Buffer>,
+    ) -> Result<Option<Reference>, Error> {
+        store
+            .ref_contents(name)
+            .map_err(Error::from)
+            .and_then(|maybe_loose| {
+                maybe_loose
+                    .map(|buf| {
+                        loose::Reference::try_from_path(name.to_owned(), &buf, store.object_hash)
+                            .map(Reference::from)
+                            .map_err(Error::from)
+                    })
+                    .transpose()
+            })
+            .or_else(|err| match err {
+                Error::ReferenceDecode(_) => Ok(None),
+                other => Err(other),
+            })
+            .and_then(|maybe_loose| match (maybe_loose, packed) {
+                (None, Some(packed)) => packed
+                    .try_find(name)
+                    .map(|opt| opt.map(Into::into))
+                    .map_err(Error::from),
+                (None, None) => Ok(None),
+                (maybe_loose, _) => Ok(maybe_loose),
+            })
+    }
+
+    /// Map a lock-acquisition failure to our error type, surfacing genuine I/O errors
+    /// (such as a path collision reported as `NotADirectory`) as [`Error::Io`] rather than
+    /// burying them in [`Error::LockAcquire`], which is reserved for actual contention.
+    fn lock_acquire_error(err: gix_lock::acquire::Error, full_name: &str) -> Error {
+        match err {
+            gix_lock::acquire::Error::Io(err) => Error::Io(err),
+            source => Error::LockAcquire {
+                source,
+                full_name: full_name.into(),
+            },
+        }
+    }
+
     fn lock_ref_and_apply_change(
         store: &file::Store,
         lock_fail_mode: gix_lock::acquire::Fail,
@@ -26,30 +71,6 @@ impl Transaction<'_, '_> {
             "locks can only be acquired once and it's all or nothing"
         );
 
-        let existing_ref = store
-            .ref_contents(change.update.name.as_ref())
-            .map_err(Error::from)
-            .and_then(|maybe_loose| {
-                maybe_loose
-                    .map(|buf| {
-                        loose::Reference::try_from_path(change.update.name.clone(), &buf, store.object_hash)
-                            .map(Reference::from)
-                            .map_err(Error::from)
-                    })
-                    .transpose()
-            })
-            .or_else(|err| match err {
-                Error::ReferenceDecode(_) => Ok(None),
-                other => Err(other),
-            })
-            .and_then(|maybe_loose| match (maybe_loose, packed) {
-                (None, Some(packed)) => packed
-                    .try_find(change.update.name.as_ref())
-                    .map(|opt| opt.map(Into::into))
-                    .map_err(Error::from),
-                (None, None) => Ok(None),
-                (maybe_loose, _) => Ok(maybe_loose),
-            })?;
         let lock = match &mut change.update.change {
             Change::Delete { expected, .. } => {
                 let (base, relative_path) = store.reference_path_with_base(change.update.name.as_ref());
@@ -61,12 +82,13 @@ impl Transaction<'_, '_> {
                         lock_fail_mode,
                         Some(base.clone().into_owned()),
                     )
-                    .map_err(|err| Error::LockAcquire {
-                        source: err,
-                        full_name: "borrowcheck won't allow change.name()".into(),
-                    })?
+                    .map_err(|err| Self::lock_acquire_error(err, "borrowcheck won't allow change.name()"))?
                     .into()
                 };
+
+                // Read the ref while holding the lock so the CAS check below
+                // compares against a value that cannot be changed concurrently.
+                let existing_ref = Self::read_existing_ref(store, change.update.name.as_ref(), packed)?;
 
                 match (&expected, &existing_ref) {
                     (PreviousValue::MustNotExist, _) => {
@@ -110,12 +132,20 @@ impl Transaction<'_, '_> {
                         lock_fail_mode,
                         Some(base.clone().into_owned()),
                     )
-                    .map_err(|err| Error::LockAcquire {
-                        source: err,
-                        full_name: "borrowcheck won't allow change.name() and this will be corrected by caller".into(),
+                    .map_err(|err| {
+                        Self::lock_acquire_error(
+                            err,
+                            "borrowcheck won't allow change.name() and this will be corrected by caller",
+                        )
                     })
                 };
+                // A path collision (`a/b` where `a` is a ref file) makes lock acquisition fail
+                // with `NotADirectory`, surfaced as `Error::Io` by `lock_acquire_error`.
                 let mut lock = (!has_global_lock).then(obtain_lock).transpose()?;
+
+                // Read the ref while holding the lock so the CAS check below
+                // compares against a value that cannot be changed concurrently.
+                let existing_ref = Self::read_existing_ref(store, change.update.name.as_ref(), packed)?;
 
                 match (&expected, &existing_ref) {
                     (PreviousValue::Any, _)

--- a/gix-ref/src/store/file/transaction/prepare.rs
+++ b/gix-ref/src/store/file/transaction/prepare.rs
@@ -13,6 +13,9 @@ use crate::{
 
 impl Transaction<'_, '_> {
     /// Read the current value of a reference from loose storage, falling back to packed refs.
+    ///
+    /// Must be called while holding the lock for `name` so the subsequent CAS check
+    /// compares against a value that cannot be changed concurrently.
     fn read_existing_ref(
         store: &file::Store,
         name: &FullNameRef,
@@ -71,6 +74,12 @@ impl Transaction<'_, '_> {
             "locks can only be acquired once and it's all or nothing"
         );
 
+        // Reject Windows reserved device names before acquiring the lock.
+        // The lock file itself (e.g. `CON.lock`) is also a device name,
+        // so acquiring it would fail or open the device instead of
+        // returning the configured validation error.
+        store.check_windows_device_name(change.update.name.as_ref())?;
+
         let lock = match &mut change.update.change {
             Change::Delete { expected, .. } => {
                 let (base, relative_path) = store.reference_path_with_base(change.update.name.as_ref());
@@ -86,8 +95,6 @@ impl Transaction<'_, '_> {
                     .into()
                 };
 
-                // Read the ref while holding the lock so the CAS check below
-                // compares against a value that cannot be changed concurrently.
                 let existing_ref = Self::read_existing_ref(store, change.update.name.as_ref(), packed)?;
 
                 match (&expected, &existing_ref) {
@@ -143,8 +150,6 @@ impl Transaction<'_, '_> {
                 // with `NotADirectory`, surfaced as `Error::Io` by `lock_acquire_error`.
                 let mut lock = (!has_global_lock).then(obtain_lock).transpose()?;
 
-                // Read the ref while holding the lock so the CAS check below
-                // compares against a value that cannot be changed concurrently.
                 let existing_ref = Self::read_existing_ref(store, change.update.name.as_ref(), packed)?;
 
                 match (&expected, &existing_ref) {

--- a/gix-ref/tests/refs/file/transaction/prepare_and_commit/create_or_update/mod.rs
+++ b/gix-ref/tests/refs/file/transaction/prepare_and_commit/create_or_update/mod.rs
@@ -494,6 +494,55 @@ fn windows_device_name_is_illegal_with_enabled_windows_protections() -> crate::R
     Ok(())
 }
 
+/// Regression test for the ordering of validation vs. lock acquisition.
+///
+/// On Windows, the lock path `refs/heads/CON.lock` is itself a reserved device
+/// name, so acquiring it would fail (or accidentally open the device) before
+/// the configured device-name validation could run. We can't observe that on
+/// non-Windows directly, but we can demonstrate the ordering by pre-creating
+/// the would-be lock file: if device-name validation runs first we still get
+/// the validation error; if lock acquisition runs first we'd get
+/// `LockAcquire(PermanentlyLocked)` instead.
+#[cfg(not(windows))]
+#[test]
+fn windows_device_name_check_runs_before_lock_acquisition() -> crate::Result {
+    let (keep, mut store) = empty_store()?;
+    store.prohibit_windows_device_names = true;
+
+    let refs_heads = keep.path().join("refs").join("heads");
+    std::fs::create_dir_all(&refs_heads)?;
+    std::fs::write(refs_heads.join("CON.lock"), b"")?;
+
+    let err = store
+        .transaction()
+        .prepare(
+            Some(RefEdit {
+                change: Change::Update {
+                    log: LogChange {
+                        mode: RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: "ignored".into(),
+                    },
+                    new: Target::Object(hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242")),
+                    expected: PreviousValue::Any,
+                },
+                name: "refs/heads/CON".try_into()?,
+                deref: false,
+            }),
+            Fail::Immediately,
+            Fail::Immediately,
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        err.source().expect("inner").to_string(),
+        "Illegal use of reserved Windows device name in \"refs/heads/CON\"",
+        "device-name validation must short-circuit before lock acquisition; otherwise the \
+         pre-existing lock file would surface as `LockAcquire(PermanentlyLocked)`"
+    );
+    Ok(())
+}
+
 #[test]
 fn symbolic_head_missing_referent_then_update_referent() -> crate::Result {
     for reflog_writemode in &[WriteReflog::Normal, WriteReflog::Disable, WriteReflog::Always] {

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -921,6 +921,36 @@ pub fn main() -> Result<()> {
                     move |_progress, out, _err| core::mailmap::verify(path, format, out),
                 ),
             },
+            #[cfg(feature = "gitoxide-core-blocking-client")]
+            free::Subcommands::Remote(subcommands) => match subcommands {
+                free::remote::Subcommands::Refs {
+                    protocol,
+                    refs_directory,
+                    write_reflog,
+                    url,
+                } => prepare_and_run(
+                    "remote-refs",
+                    trace,
+                    verbose,
+                    progress,
+                    progress_keep_open,
+                    core::remote::PROGRESS_RANGE,
+                    move |progress, out, _err| {
+                        core::remote::refs(
+                            protocol,
+                            &url,
+                            refs_directory,
+                            progress,
+                            core::remote::Context {
+                                format,
+                                out,
+                                object_hash,
+                                write_reflog,
+                            },
+                        )
+                    },
+                ),
+            },
             free::Subcommands::Pack(subcommands) => match subcommands {
                 free::pack::Subcommands::Create {
                     repository,

--- a/src/plumbing/options/free.rs
+++ b/src/plumbing/options/free.rs
@@ -12,6 +12,10 @@ pub enum Subcommands {
     /// Subcommands for interacting with pack files and indices
     #[clap(subcommand)]
     Pack(pack::Subcommands),
+    /// Subcommands for interacting with remote hosts.
+    #[cfg(feature = "gitoxide-core-blocking-client")]
+    #[clap(subcommand)]
+    Remote(remote::Subcommands),
     /// Subcommands for interacting with a worktree index, typically at .git/index
     Index(index::Platform),
     /// Show information about repository discovery and when opening a repository at the current path.
@@ -100,6 +104,37 @@ pub mod index {
             empty_files: bool,
             /// The directory into which to write all index entries.
             directory: PathBuf,
+        },
+    }
+}
+
+///
+#[cfg(feature = "gitoxide-core-blocking-client")]
+pub mod remote {
+    use std::path::PathBuf;
+
+    use gitoxide_core as core;
+
+    #[derive(Debug, clap::Subcommand)]
+    pub enum Subcommands {
+        /// Print all references available on the remote, optionally writing them to a ref store.
+        Refs {
+            /// The protocol version to use. Valid values are 1 and 2.
+            #[clap(long, short = 'p')]
+            protocol: Option<core::net::Protocol>,
+
+            /// The git-dir-like directory into which to write refs with a ref-store transaction.
+            ///
+            /// The directory is created if needed and existing refs may be overwritten.
+            #[clap(long, short = 'd')]
+            refs_directory: Option<PathBuf>,
+
+            /// Write reflog entries while updating refs.
+            #[clap(long, requires = "refs_directory")]
+            write_reflog: bool,
+
+            /// The URL or path of the remote to list.
+            url: String,
         },
     }
 }


### PR DESCRIPTION
When two ref transactions update the same ref concurrently (e.g. two pushes doing main: `A` → `B`), both could read the old value `A`, serialize through the lock, and both pass the `MustExistAndMatch` check
  — silently losing one update. The fix reads the existing value after acquiring the lock, so the comparison is against a value that can't change underneath us. See: https://github.com/GitoxideLabs/gitoxide/issues/2600

  While rebasing this onto the current tree, one `gix-ref` test started failing. Moving the read under the lock meant a path-prefix collision (creating `a/b` while `a` is a ref file) was now hit by the
  lock's `create_dir_all` first, which reports `AlreadyExists` and surfaced as a misleading `"permanently locked"` error instead of the previous `NotADirectory`.

  My first pass restored the old behaviour with a small ref_contents probe before locking. That worked, but it added a filesystem read on every update just to produce a nicer error on a rare one — so I
  went looking for a better spot and found that `gix-fs`'s directory-creation loop already distinguishes a non-directory in the path (it does the `is_dir()` check) and was simply throwing that information
  away by forwarding the raw `AlreadyExists`. Reporting it as `NotADirectory` **there** lets `gix-ref` surface lock-acquisition I/O errors as `Error::Io` (keeping `Error::LockAcquire` for genuine contention), which
  fixes the error for every `gix-lock` caller and lets me drop the probe entirely, keeping the transaction code simpler.