### PR TITLE
fix: resolve remote HEAD fetches against remote refs

### DIFF
--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -234,12 +234,12 @@ pub(crate) fn update(
                             Mode::New,
                             reflog_msg,
                             name,
-                            PreviousValue::ExistingMustMatch(new_value_by_remote(repo, remote, mappings)?),
+                            PreviousValue::ExistingMustMatch(new_value_by_remote(remote, mappings)?),
                         )
                     }
                 };
 
-                let new = new_value_by_remote(repo, remote, mappings)?;
+                let new = new_value_by_remote(remote, mappings)?;
                 let type_change = match (&previous_value, &new) {
                     (
                         PreviousValue::ExistingMustMatch(Target::Object(_))
@@ -388,11 +388,12 @@ fn update_needs_adjustment_as_edits_symbolic_target_is_missing(
     }
 }
 
-fn new_value_by_remote(
-    repo: &Repository,
-    remote: &Source,
-    mappings: &[fetch::refmap::Mapping],
-) -> Result<Target, update::Error> {
+/// Convert the remote source into the value to write locally.
+///
+/// Symbolic remote refs are preserved only if their target is part of the ref mapping, in which case the
+/// remote target is rewritten to its corresponding local ref. Otherwise, use the advertised target object id
+/// and write a direct ref, as the remote symbolic target is outside the set of refs this fetch updates.
+fn new_value_by_remote(remote: &Source, mappings: &[fetch::refmap::Mapping]) -> Result<Target, update::Error> {
     let remote_id = remote.as_id();
     Ok(
         if let Source::Ref(
@@ -419,16 +420,7 @@ fn new_value_by_remote(
                     // If we can't map it, it's usually a an unborn branch causing this, or a the target isn't covered
                     // by any refspec so we don't officially pull it in.
                     match remote_id {
-                        Some(desired_id) => {
-                            if repo.try_find_reference(target)?.is_some() {
-                                // We are allowed to change a direct reference to a symbolic one, which may point to other objects
-                                // than the remote. The idea is that we are fine as long as the resulting refs are valid.
-                                Target::Symbolic(target.try_into()?)
-                            } else {
-                                // born branches that we don't have in our refspecs we create peeled. That way they can be used.
-                                Target::Object(desired_id.to_owned())
-                            }
-                        }
+                        Some(desired_id) => Target::Object(desired_id.to_owned()),
                         // Unborn branches we create as such, with the location they point to on the remote which helps mirroring.
                         None => Target::Symbolic(target.try_into()?),
                     }

--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -234,12 +234,12 @@ pub(crate) fn update(
                             Mode::New,
                             reflog_msg,
                             name,
-                            PreviousValue::ExistingMustMatch(new_value_by_remote(remote, mappings)?),
+                            PreviousValue::ExistingMustMatch(new_value_by_remote(remote)?),
                         )
                     }
                 };
 
-                let new = new_value_by_remote(remote, mappings)?;
+                let new = new_value_by_remote(remote)?;
                 let type_change = match (&previous_value, &new) {
                     (
                         PreviousValue::ExistingMustMatch(Target::Object(_))
@@ -390,41 +390,19 @@ fn update_needs_adjustment_as_edits_symbolic_target_is_missing(
 
 /// Convert the remote source into the value to write locally.
 ///
-/// Symbolic remote refs are preserved only if their target is part of the ref mapping, in which case the
-/// remote target is rewritten to its corresponding local ref. Otherwise, use the advertised target object id
-/// and write a direct ref, as the remote symbolic target is outside the set of refs this fetch updates.
-fn new_value_by_remote(remote: &Source, mappings: &[fetch::refmap::Mapping]) -> Result<Target, update::Error> {
+/// Born symbolic remote refs are written as direct refs to the advertised target object id.
+/// Unborn remote refs remain symbolic as there is no object id to write.
+fn new_value_by_remote(remote: &Source) -> Result<Target, update::Error> {
     let remote_id = remote.as_id();
     Ok(
         if let Source::Ref(
             gix_protocol::handshake::Ref::Symbolic { target, .. } | gix_protocol::handshake::Ref::Unborn { target, .. },
         ) = &remote
         {
-            match mappings.iter().find_map(|m| {
-                m.remote.as_name().and_then(|name| {
-                    (name == target)
-                        .then(|| m.local.as_ref().and_then(|local| local.try_into().ok()))
-                        .flatten()
-                })
-            }) {
-                // Map the target on the remote to the local branch name, which should be covered by refspecs.
-                Some(local_branch) => {
-                    // This is always safe because…
-                    // - the reference may exist already
-                    // - if it doesn't exist it will be created - we are here because it's in the list of mappings after all
-                    // - if it exists and is updated, and the update is rejected due to non-fastforward for instance, the
-                    //   target reference still exists and we can point to it.
-                    Target::Symbolic(local_branch)
-                }
-                None => {
-                    // If we can't map it, it's usually a an unborn branch causing this, or a the target isn't covered
-                    // by any refspec so we don't officially pull it in.
-                    match remote_id {
-                        Some(desired_id) => Target::Object(desired_id.to_owned()),
-                        // Unborn branches we create as such, with the location they point to on the remote which helps mirroring.
-                        None => Target::Symbolic(target.try_into()?),
-                    }
-                }
+            match remote_id {
+                Some(desired_id) => Target::Object(desired_id.to_owned()),
+                // Unborn branches we create as such, with the location they point to on the remote which helps mirroring.
+                None => Target::Symbolic(target.try_into()?),
             }
         } else {
             Target::Object(remote_id.expect("unborn case handled earlier").to_owned())

--- a/gix/src/remote/connection/fetch/update_refs/tests.rs
+++ b/gix/src/remote/connection/fetch/update_refs/tests.rs
@@ -649,9 +649,11 @@ mod update {
         match &edit.change {
             Change::Update { log, new, .. } => {
                 assert_eq!(log.message, "action: storing ref");
-                assert!(
-                    new.try_name().is_some(),
-                    "the remote symref target is mapped, so it is rewritten to the corresponding local tracking ref"
+                let target = hex_to_id("f99771fe6a1b535783af3163eba95a927aae21d5");
+                assert_eq!(
+                    new.try_id(),
+                    Some(target.as_ref()),
+                    "git writes fetched born remote symrefs as direct refs, even when the symref target is also mapped"
                 );
             }
             _ => unreachable!("only updates"),
@@ -734,7 +736,7 @@ mod update {
     }
 
     #[test]
-    fn remote_symbolic_refs_can_be_written_locally_and_point_to_tracking_branch() {
+    fn remote_symbolic_refs_are_peeled_even_if_their_target_is_mapped() {
         let repo = repo("two-origins");
         let (mut mappings, specs) = mapping_from_spec("HEAD:refs/remotes/origin/new-HEAD", &repo);
         mappings.push(Mapping {
@@ -777,10 +779,11 @@ mod update {
         match &edit.change {
             Change::Update { log, new, .. } => {
                 assert_eq!(log.message, "action: storing ref");
+                let target = hex_to_id("f99771fe6a1b535783af3163eba95a927aae21d5");
                 assert_eq!(
-                    new.try_name().expect("symbolic ref").as_bstr(),
-                    "refs/remotes/origin/main",
-                    "remote is symbolic, so local will be symbolic as well, but is rewritten to tracking branch"
+                    new.try_id(),
+                    Some(target.as_ref()),
+                    "git writes fetched born remote symrefs as direct refs, even when the symref target is also mapped"
                 );
             }
             _ => unreachable!("only updates"),

--- a/gix/src/remote/connection/fetch/update_refs/tests.rs
+++ b/gix/src/remote/connection/fetch/update_refs/tests.rs
@@ -481,10 +481,10 @@ mod update {
                             force_create_reflog: false,
                             message: "action: storing head".into(),
                         },
-                        expected: PreviousValue::ExistingMustMatch(Target::Symbolic(
-                            "refs/heads/main".try_into().expect("valid"),
-                        )),
-                        new: Target::Symbolic("refs/heads/main".try_into().expect("valid")),
+                        expected: PreviousValue::ExistingMustMatch(Target::Object(hex_to_id(
+                            "f99771fe6a1b535783af3163eba95a927aae21d5",
+                        ))),
+                        new: Target::Object(hex_to_id("f99771fe6a1b535783af3163eba95a927aae21d5")),
                     },
                     name: "refs/heads/HEAD".try_into().expect("valid"),
                     deref: false,
@@ -529,34 +529,9 @@ mod update {
                 }),
             ),
             (
-                // direct becomes symbolic
+                // unmapped symbolic refs are peeled, so the direct ref remains direct
                 "refs/heads/symbolic",
                 "refs/remotes/origin/a",
-                fetch::refs::Update {
-                    mode: fetch::refs::update::Mode::NoChangeNeeded,
-                    type_change: Some(TypeChange::DirectToSymbolic),
-                    edit_index: Some(0),
-                },
-                Some(RefEdit {
-                    change: Change::Update {
-                        log: LogChange {
-                            mode: RefLog::AndReference,
-                            force_create_reflog: false,
-                            message: "action: no update will be performed".into(),
-                        },
-                        expected: PreviousValue::MustExistAndMatch(Target::Object(hex_to_id(
-                            "f99771fe6a1b535783af3163eba95a927aae21d5",
-                        ))),
-                        new: Target::Symbolic("refs/heads/main".try_into().expect("valid")),
-                    },
-                    name: "refs/remotes/origin/a".try_into().expect("valid"),
-                    deref: false,
-                }),
-            ),
-            (
-                // symbolic to symbolic (same)
-                "refs/heads/symbolic",
-                "refs/heads/symbolic",
                 fetch::refs::Update {
                     mode: fetch::refs::update::Mode::NoChangeNeeded,
                     type_change: None,
@@ -569,10 +544,35 @@ mod update {
                             force_create_reflog: false,
                             message: "action: no update will be performed".into(),
                         },
+                        expected: PreviousValue::MustExistAndMatch(Target::Object(hex_to_id(
+                            "f99771fe6a1b535783af3163eba95a927aae21d5",
+                        ))),
+                        new: Target::Object(hex_to_id("f99771fe6a1b535783af3163eba95a927aae21d5")),
+                    },
+                    name: "refs/remotes/origin/a".try_into().expect("valid"),
+                    deref: false,
+                }),
+            ),
+            (
+                // symbolic refs with unmapped targets are peeled, even if source and destination names match
+                "refs/heads/symbolic",
+                "refs/heads/symbolic",
+                fetch::refs::Update {
+                    mode: fetch::refs::update::Mode::NoChangeNeeded,
+                    type_change: Some(TypeChange::SymbolicToDirect),
+                    edit_index: Some(0),
+                },
+                Some(RefEdit {
+                    change: Change::Update {
+                        log: LogChange {
+                            mode: RefLog::AndReference,
+                            force_create_reflog: false,
+                            message: "action: no update will be performed".into(),
+                        },
                         expected: PreviousValue::MustExistAndMatch(Target::Symbolic(
                             "refs/heads/main".try_into().expect("valid"),
                         )),
-                        new: Target::Symbolic("refs/heads/main".try_into().expect("valid")),
+                        new: Target::Object(hex_to_id("f99771fe6a1b535783af3163eba95a927aae21d5")),
                     },
                     name: "refs/heads/symbolic".try_into().expect("valid"),
                     deref: false,
@@ -593,10 +593,14 @@ mod update {
             )
             .unwrap();
 
-            assert_eq!(out.edits.len(), usize::from(expected_edit.is_some()));
-            assert_eq!(out.updates, vec![expected_update]);
+            assert_eq!(
+                out.edits.len(),
+                usize::from(expected_edit.is_some()),
+                "{source}:{destination}"
+            );
+            assert_eq!(out.updates, vec![expected_update], "{source}:{destination}");
             if let Some(expected) = expected_edit {
-                assert_eq!(out.edits, vec![expected]);
+                assert_eq!(out.edits, vec![expected], "{source}:{destination}");
             }
         }
     }
@@ -647,7 +651,7 @@ mod update {
                 assert_eq!(log.message, "action: storing ref");
                 assert!(
                     new.try_name().is_some(),
-                    "remote falls back to peeled id as it's the only thing we seem to have locally, it won't refer to a non-existing local ref"
+                    "the remote symref target is mapped, so it is rewritten to the corresponding local tracking ref"
                 );
             }
             _ => unreachable!("only updates"),
@@ -675,9 +679,14 @@ mod update {
             out.updates,
             vec![fetch::refs::Update {
                 mode: fetch::refs::update::Mode::NoChangeNeeded,
-                type_change: Some(fetch::refs::update::TypeChange::DirectToSymbolic),
+                type_change: None,
                 edit_index: Some(0)
             }],
+            concat!(
+                "the remote symref target is not mapped, so new_value_by_remote() stores the advertised object id ",
+                "instead of a symbolic target; the local destination is already direct, so the update is direct-to-direct ",
+                "and has no type_change"
+            )
         );
     }
 

--- a/gix/tests/gix/clone.rs
+++ b/gix/tests/gix/clone.rs
@@ -420,12 +420,12 @@ mod blocking_io {
             .expect("packed refs should be present");
         assert_eq!(
             repo.refs.loose_iter()?.count(),
-            2,
-            "HEAD and an actual symbolic ref we received"
+            1,
+            "HEAD is the only remaining loose symbolic ref as born remote symrefs are stored peeled"
         );
         assert_eq!(
             packed_refs.iter()?.count(),
-            14,
+            15,
             "all non-symbolic refs should be stored, if reachable from our refs"
         );
         let sig = repo
@@ -519,17 +519,15 @@ mod blocking_io {
             _ => unreachable!("clones are always causing changes and dry-runs aren't possible"),
         }
 
+        let remote_repo = remote::repo("base");
         let remote_head = repo
             .find_reference(&format!("refs/remotes/{remote_name}/HEAD"))
             .expect("remote HEAD present");
+        let remote_head_id = remote_repo.head_id()?;
         assert_eq!(
-            remote_head
-                .target()
-                .try_name()
-                .expect("remote HEAD is symbolic")
-                .as_bstr(),
-            format!("refs/remotes/{remote_name}/main"),
-            "it points to the local tracking branch of what the remote actually points to"
+            remote_head.target().try_id(),
+            Some(remote_head_id.as_ref()),
+            "remote HEAD is stored as the peeled object id advertised by the remote"
         );
 
         let head = repo.head()?;
@@ -545,7 +543,7 @@ mod blocking_io {
         );
         assert_eq!(
             referent.name().as_bstr(),
-            remote::repo("base").head_name()?.expect("symbolic").as_bstr(),
+            remote_repo.head_name()?.expect("symbolic").as_bstr(),
             "local clone always adopts the name of the remote"
         );
 

--- a/gix/tests/gix/remote/fetch.rs
+++ b/gix/tests/gix/remote/fetch.rs
@@ -85,6 +85,27 @@ mod blocking_and_async_io {
         try_repo_rw(name).unwrap()
     }
 
+    fn commit_empty(repo: &gix::Repository, message: &str) -> crate::Result<gix::ObjectId> {
+        Ok(repo
+            .commit(
+                "HEAD",
+                message,
+                gix::hash::ObjectId::empty_tree(repo.object_hash()),
+                gix::commit::NO_PARENT_IDS,
+            )?
+            .detach())
+    }
+
+    fn init_repo(path: &std::path::Path) -> crate::Result<gix::Repository> {
+        Ok(gix::ThreadSafeRepository::init_opts(
+            path,
+            gix::create::Kind::WithWorktree,
+            gix::create::Options::default(),
+            crate::restricted(),
+        )?
+        .to_thread_local())
+    }
+
     fn shallow_ids(repo: &gix::Repository, expected: &'static str) -> crate::Result<Vec<gix::ObjectId>> {
         let commits = repo.shallow_commits()?.expect(expected);
         Ok(std::iter::once(commits.head)
@@ -273,6 +294,59 @@ mod blocking_and_async_io {
             }
             _ => unreachable!("we get a pack as alternates are unrelated"),
         }
+        Ok(())
+    }
+
+    #[maybe_async::test(
+        feature = "blocking-network-client",
+        async(feature = "async-network-client-async-std", async_std::test)
+    )]
+    async fn local_transport_fetches_head_against_remote_refs() -> crate::Result {
+        let remote_dir = TempDir::new()?;
+        let remote_repo = init_repo(remote_dir.path())?;
+        let remote_main = commit_empty(&remote_repo, "remote-main")?;
+
+        let local_dir = TempDir::new()?;
+        let local_repo = init_repo(local_dir.path())?;
+        let local_main = commit_empty(&local_repo, "local-main")?;
+        assert_ne!(
+            remote_main, local_main,
+            "the regression requires matching refnames to resolve to different objects locally and remotely"
+        );
+
+        let daemon = spawn_git_daemon_if_async(remote_repo.workdir().expect("non-bare"))?;
+        let mut remote = into_daemon_remote_if_async(
+            local_repo
+                .remote_at(remote_repo.workdir().expect("non-bare"))?
+                .with_fetch_tags(fetch::Tags::None),
+            daemon.as_ref(),
+            None,
+        );
+        remote.replace_refspecs(Some("+HEAD:refs/test/repo"), Fetch)?;
+
+        let outcome = remote
+            .connect(Fetch)
+            .await?
+            .prepare_fetch(gix::progress::Discard, Default::default())
+            .await?
+            .receive(gix::progress::Discard, &AtomicBool::default())
+            .await?;
+
+        assert!(
+            matches!(outcome.status, Status::Change { .. }),
+            "the remote object is missing locally and must be fetched"
+        );
+        let fetched = local_repo.find_reference("refs/test/repo")?;
+        assert_eq!(
+            fetched.target().try_id(),
+            Some(remote_main.as_ref()),
+            "HEAD must resolve through the remote's symbolic target, not through the local ref with the same name"
+        );
+        assert_eq!(
+            local_repo.find_reference("refs/heads/main")?.id(),
+            local_main,
+            "the local HEAD branch remains distinct from the fetched remote HEAD"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew
- [x] remove special (made-up) handling of symrefs on the remote to avoid unintended behaviour. Stick to plain Git.

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #2613

## Summary

- Resolve unmapped born remote symbolic refs, including `HEAD`, to the object advertised by the remote instead of consulting same-named local refs.
- Preserve existing mapped symbolic-ref behavior and unborn symbolic-ref handling.
- Add a local transport regression where remote and local `HEAD` targets share a refname but point at different commits.

## Git Baseline

`git fetch <remote> +HEAD:refs/test/repo` writes the object advertised by the remote `HEAD`, not a symbolic ref through the local repository.

## Validation

- `cargo test -p gix --features blocking-network-client remote::connection::fetch::refs::tests::update -- --nocapture`
- `cargo test -p gix --features blocking-network-client --test gix remote::fetch::blocking_and_async_io -- --nocapture`
- `cargo test -p gix --features async-network-client-async-std --test gix remote::fetch::blocking_and_async_io::local_transport_fetches_head_against_remote_refs -- --nocapture`
- `git diff --check`

## Review

`codex review --commit 688619a513eed9e54a5285605e04b7b407ba78b7` reported no discrete introduced bug in the modified code paths.