### PR TITLE
fix: allow negative fetch refspec patterns

### DIFF
--- a/gix-refspec/src/match_group/mod.rs
+++ b/gix-refspec/src/match_group/mod.rs
@@ -114,9 +114,14 @@ impl<'spec> MatchGroup<'spec> {
         }
     }
 
-    /// Match all `items` against all *fetch* specs present in this group, returning deduplicated mappings from destination to source.
+    /// Match all `items` against the right-hand side of all *fetch* specs present in this group,
+    /// returning deduplicated mappings from destination to source.
     /// `items` are expected to be tracking references in the local clone, which will be matched and reverse-mapped to obtain their remote counterparts,
     /// i.e. *right side of refspecs is mapped to their left side*.
+    ///
+    /// Even though this method starts by matching `items` against the right-hand side of positive refspecs,
+    /// negative fetch refspecs still exclude refs by their left-hand/source side. For that reason, once a
+    /// mapping has been reverse-mapped to its source ref, negative refspecs are applied to the mapping's `lhs`.
     /// *Note that this method is correct only for fetch-specs*, even though it also *works for push-specs*.
     ///
     /// Note that negative matches are not part of the return value, so they are not observable but will be used to remove mappings.
@@ -164,7 +169,7 @@ impl<'spec> MatchGroup<'spec> {
                     SourceRef::ObjectId(_) => true,
                     SourceRef::FullName(name) => {
                         !matcher
-                            .matches_rhs(Item {
+                            .matches_lhs(Item {
                                 full_ref_name: name.as_ref(),
                                 target: &null_id,
                                 object: None,

--- a/gix-refspec/src/parse.rs
+++ b/gix-refspec/src/parse.rs
@@ -127,12 +127,12 @@ pub(crate) mod function {
         if mode == Mode::Negative {
             match src {
                 Some(spec) => {
-                    if src_had_pattern {
-                        return Err(Error::NegativeGlobPattern);
-                    } else if looks_like_object_hash(spec) {
+                    if looks_like_object_hash(spec) {
                         return Err(Error::NegativeObjectHash);
                     } else if !spec.starts_with(b"refs/") && spec != "HEAD" {
                         return Err(Error::NegativePartialName);
+                    } else if src_had_pattern {
+                        validate_negative_pattern(spec)?;
                     }
                 }
                 None => return Err(Error::NegativeEmpty),
@@ -149,6 +149,24 @@ pub(crate) mod function {
 
     fn looks_like_object_hash(spec: &BStr) -> bool {
         spec.len() >= gix_hash::Kind::shortest().len_in_hex() && spec.iter().all(u8::is_ascii_hexdigit)
+    }
+
+    fn validate_negative_pattern(spec: &BStr) -> Result<(), Error> {
+        if spec.iter().filter(|b| **b == b'*').take(2).count() > 1 {
+            return Err(Error::PatternUnsupported { pattern: spec.into() });
+        }
+
+        validate_partial_name_with_single_glob(spec)?;
+        Ok(())
+    }
+
+    fn validate_partial_name_with_single_glob(spec: &BStr) -> Result<(), Error> {
+        let mut buf = smallvec::SmallVec::<[u8; 256]>::with_capacity(spec.len());
+        buf.extend_from_slice(spec);
+        let glob_pos = buf.find_byte(b'*').expect("glob present");
+        buf[glob_pos] = b'a';
+        gix_validate::reference::name_partial(buf.as_bstr())?;
+        Ok(())
     }
 
     fn validated(
@@ -170,11 +188,7 @@ pub(crate) mod function {
                 if has_globs {
                     // For one-sided refspecs, skip validation of glob patterns
                     if !is_one_sided {
-                        let mut buf = smallvec::SmallVec::<[u8; 256]>::with_capacity(spec.len());
-                        buf.extend_from_slice(spec);
-                        let glob_pos = buf.find_byte(b'*').expect("glob present");
-                        buf[glob_pos] = b'a';
-                        gix_validate::reference::name_partial(buf.as_bstr())?;
+                        validate_partial_name_with_single_glob(spec)?;
                     }
                 } else {
                     gix_validate::reference::name_partial(spec)

--- a/gix-refspec/tests/fixtures/match_baseline.sh
+++ b/gix-refspec/tests/fixtures/match_baseline.sh
@@ -33,6 +33,7 @@ mkdir base
   git checkout -b sub/f4 main
   git checkout -b sub/subdir/f5 main
   git checkout -b suub/f6 main
+  git checkout -b deploy-deploy main
 )
 
 git clone --shared ./base clone
@@ -82,6 +83,7 @@ git clone --shared ./base clone
   baseline "^main" "refs/heads/*:refs/remotes/origin/*"
   baseline "^refs/heads/main" "refs/heads/*:refs/remotes/origin/*"
   baseline "refs/heads/*:refs/remotes/origin/*" "^refs/heads/main"
+  baseline "refs/heads/*:refs/remotes/origin/*" "^refs/heads/*-deploy"
   baseline "refs/heads/*:refs/remotes/origin/*" "refs/heads/main:refs/remotes/new-origin/main"
   baseline "refs/heads/*:refs/remotes/origin/*" "refs/heads/main:refs/remotes/origin/main"
   baseline "refs/heads/f1:refs/remotes/origin/conflict" "refs/heads/f2:refs/remotes/origin/conflict"

--- a/gix-refspec/tests/refspec/match_group.rs
+++ b/gix-refspec/tests/refspec/match_group.rs
@@ -63,7 +63,11 @@ mod single {
 }
 
 mod multiple {
+    use bstr::BString;
+    use gix_hash::ObjectId;
     use gix_refspec::{
+        MatchGroup,
+        match_group::Item,
         match_group::validate::Fix,
         parse::{Error, Operation},
     };
@@ -106,6 +110,45 @@ mod multiple {
         );
         baseline::agrees_with_fetch_specs(["^refs/heads/main", "refs/heads/*:refs/remotes/origin/*"]);
         baseline::agrees_with_fetch_specs(["refs/heads/*:refs/remotes/origin/*", "^refs/heads/main"]);
+        baseline::agrees_with_fetch_specs(["refs/heads/*:refs/remotes/origin/*", "^refs/heads/*-deploy"]);
+    }
+
+    #[test]
+    fn reverse_fetch_mapping_honors_negative_source_patterns() {
+        let specs = ["refs/heads/*:refs/remotes/origin/*", "^refs/heads/*-deploy"]
+            .into_iter()
+            .map(|spec| gix_refspec::parse(spec.into(), Operation::Fetch).expect("valid refspec"));
+        let target = ObjectId::from_hex(b"1111111111111111111111111111111111111111").expect("valid object id");
+        let refs = [
+            BString::from("refs/remotes/origin/main"),
+            BString::from("refs/remotes/origin/foo-deploy"),
+        ];
+        let items: Vec<_> = refs
+            .iter()
+            .map(|name| Item {
+                full_ref_name: name.as_ref(),
+                target: &target,
+                object: None,
+            })
+            .collect();
+
+        let outcome = MatchGroup::from_fetch_specs(specs).match_rhs(items.iter().copied());
+        insta::assert_debug_snapshot!(outcome.mappings, @r#"
+        [
+            Mapping {
+                item_index: Some(
+                    0,
+                ),
+                lhs: FullName(
+                    "refs/heads/main",
+                ),
+                rhs: Some(
+                    "refs/remotes/origin/main",
+                ),
+                spec_index: 0,
+            },
+        ]
+        "#);
     }
 
     #[test]

--- a/gix-refspec/tests/refspec/parse/fetch.rs
+++ b/gix-refspec/tests/refspec/parse/fetch.rs
@@ -72,11 +72,23 @@ fn exclude() {
     ));
     assert!(matches!(
         try_parse("^a*", Operation::Fetch).unwrap_err(),
-        Error::NegativeGlobPattern
+        Error::NegativePartialName
     ));
     assert_parse(
         "^refs/heads/a",
         Instruction::Fetch(Fetch::Exclude { src: b("refs/heads/a") }),
+    );
+    assert_parse(
+        "^refs/heads/*-deploy",
+        Instruction::Fetch(Fetch::Exclude {
+            src: b("refs/heads/*-deploy"),
+        }),
+    );
+    assert_parse(
+        "^refs/tags/*-deploy",
+        Instruction::Fetch(Fetch::Exclude {
+            src: b("refs/tags/*-deploy"),
+        }),
     );
 }
 

--- a/gix-refspec/tests/refspec/parse/invalid.rs
+++ b/gix-refspec/tests/refspec/parse/invalid.rs
@@ -40,11 +40,29 @@ fn complex_patterns_with_more_than_one_asterisk() {
         }
     }
 
-    // Negative specs with multiple patterns still fail
+    // Negative specs with partial patterns still fail.
     assert!(matches!(
         try_parse("^*/*", Operation::Fetch).unwrap_err(),
-        Error::NegativeGlobPattern
+        Error::NegativePartialName
     ));
+    // Negative refspec patterns follow Git's single-asterisk refspec-pattern rule.
+    for op in [Operation::Fetch, Operation::Push] {
+        assert!(matches!(
+            try_parse("^refs/heads/qa/*/*", op).unwrap_err(),
+            Error::PatternUnsupported { .. }
+        ));
+        for spec in [
+            "^refs/heads/a*?",
+            "^refs/heads/a[bc]*",
+            "^refs/heads/*..bad",
+            "^refs/heads/*/",
+        ] {
+            assert!(
+                matches!(try_parse(spec, op).unwrap_err(), Error::ReferenceName(_)),
+                "{spec}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/gix-refspec/tests/refspec/parse/push.rs
+++ b/gix-refspec/tests/refspec/parse/push.rs
@@ -39,11 +39,17 @@ fn exclude() {
     ));
     assert!(matches!(
         try_parse("^a*", Operation::Push).unwrap_err(),
-        Error::NegativeGlobPattern
+        Error::NegativePartialName
     ));
     assert_parse(
         "^refs/heads/a",
         Instruction::Push(Push::Exclude { src: b("refs/heads/a") }),
+    );
+    assert_parse(
+        "^refs/heads/*-deploy",
+        Instruction::Push(Push::Exclude {
+            src: b("refs/heads/*-deploy"),
+        }),
     );
 }
 


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Fixes #2210.

Repositories can configure negative fetch refspec patterns such as `^refs/heads/*-deploy` and `^refs/tags/*-deploy`. Git accepts those single-asterisk negative refspec patterns, but `gix-refspec` rejected all negative glob patterns while parsing remote configuration.

This change allows negative refspecs with a full `refs/...` source and one `*`, while preserving rejection of empty negative specs, object IDs, destinations, partial names, unsupported multi-asterisk patterns, and invalid refname-pattern syntax. It also makes reverse fetch matching apply negative source filters to the derived source ref, so tracking-branch reverse lookup honors the same exclusions.

## Git Baseline

Checked against Git's `refspec.c::parse_refspec()` behavior and `t/t5582-fetch-negative-refspec.sh`, which covers negative fetch refspecs. Added a Git-baseline fixture case with an actual `deploy-deploy` branch so `^refs/heads/*-deploy` is tested as an exclusion, not only as a parse case.

## Validation

- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix-refspec --test refspec`
- `cargo test -p gix-refspec --test refspec`
- `cargo fmt`
- `cargo test -p gix-refspec`
- `cargo check -p gix-refspec --no-default-features --features sha1`
- `cargo fmt --check`
- `codex review --commit 0efd26e2131ab0167d6181e2f4e99786c3c5a79c`
