### PR TITLE
fix: seed fast pseudo-random numbers to differ across processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,7 +1915,6 @@ version = "0.21.2"
 dependencies = [
  "bstr",
  "crossbeam-channel",
- "fastrand",
  "gix-features",
  "gix-path",
  "gix-utils",
@@ -2586,6 +2585,7 @@ version = "0.3.3"
 dependencies = [
  "bstr",
  "fastrand",
+ "getrandom 0.4.2",
  "unicode-normalization",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,7 +2585,7 @@ version = "0.3.3"
 dependencies = [
  "bstr",
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "unicode-normalization",
 ]
 

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -26,9 +26,6 @@ gix-utils = { version = "^0.3.3", path = "../gix-utils" }
 thiserror = "2.0.18"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }
 
-# For `Capabilities` to assure parallel operation works.
-fastrand = { version = "2.1.0", default-features = false, features = ["std"] }
-
 [dev-dependencies]
 crossbeam-channel = "0.5.15"
 is_ci = "1.1.1"

--- a/gix-fs/src/capabilities.rs
+++ b/gix-fs/src/capabilities.rs
@@ -82,7 +82,7 @@ impl Capabilities {
         // can change the executable bit.
         // The equivalent test by git itself is here:
         // https://github.com/git/git/blob/f0ef5b6d9bcc258e4cbef93839d1b7465d5212b9/setup.c#L2367-L2379
-        let rand = fastrand::usize(..);
+        let rand = gix_utils::rng::usize(..);
         let test_path = root.join(format!("_test_executable_bit{rand}"));
         let res = std::fs::OpenOptions::new()
             .create_new(true)
@@ -164,7 +164,7 @@ impl Capabilities {
     }
 
     fn probe_precompose_unicode(root: &Path) -> std::io::Result<bool> {
-        let rand = fastrand::usize(..);
+        let rand = gix_utils::rng::usize(..);
         let precomposed = format!("ä{rand}");
         let decomposed = format!("a\u{308}{rand}");
 
@@ -179,7 +179,7 @@ impl Capabilities {
     }
 
     fn probe_symlink(root: &Path) -> std::io::Result<bool> {
-        let rand = fastrand::usize(..);
+        let rand = gix_utils::rng::usize(..);
         let link_path = root.join(format!("__file_link{rand}"));
         if crate::symlink::create("dangling".as_ref(), &link_path).is_err() {
             return Ok(false);

--- a/gix-utils/Cargo.toml
+++ b/gix-utils/Cargo.toml
@@ -21,3 +21,9 @@ bstr = ["dep:bstr"]
 fastrand = "2.0.0"
 bstr = { version = "1.12.0", default-features = false, features = ["std"], optional = true }
 unicode-normalization = { version = "0.1.19", default-features = false }
+
+# Used by `rng` to obtain a high-entropy, process-distinct seed. Excluded on
+# `wasm32-unknown-unknown`, which has no entropy backend by default; there `rng` falls back to a
+# best-effort seed (see `src/rng.rs`).
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
+getrandom = "0.4"

--- a/gix-utils/Cargo.toml
+++ b/gix-utils/Cargo.toml
@@ -18,7 +18,9 @@ doctest = true
 bstr = ["dep:bstr"]
 
 [dependencies]
-fastrand = "2.0.0"
+# We seed our own thread-local `Rng` (see `src/rng.rs`), so `fastrand`'s global generator and its
+# `std` default feature aren't needed.
+fastrand = { version = "2.4.1", default-features = false }
 bstr = { version = "1.12.0", default-features = false, features = ["std"], optional = true }
 unicode-normalization = { version = "0.1.19", default-features = false }
 

--- a/gix-utils/src/backoff.rs
+++ b/gix-utils/src/backoff.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 fn randomize(backoff_ms: usize) -> usize {
-    let new_value = (fastrand::usize(750..=1250) * backoff_ms) / 1000;
+    let new_value = (crate::rng::usize(750..=1250) * backoff_ms) / 1000;
     if new_value == 0 { backoff_ms } else { new_value }
 }
 

--- a/gix-utils/src/lib.rs
+++ b/gix-utils/src/lib.rs
@@ -23,6 +23,9 @@
 pub mod backoff;
 
 ///
+pub mod rng;
+
+///
 pub mod buffers;
 
 ///

--- a/gix-utils/src/rng.rs
+++ b/gix-utils/src/rng.rs
@@ -1,0 +1,65 @@
+//! Fast pseudo-random numbers whose sequence differs across concurrently running processes.
+//!
+//! These numbers are *not* cryptographically secure. Unlike the global generators of the
+//! [`fastrand`] crate, whose per-thread seed is derived only from values that can coincide between
+//! separate processes (such as small thread IDs), the generator here is seeded from a high-entropy
+//! source so that concurrent processes don't share a sequence.
+//!
+//! This matters wherever a collision causes a real problem, such as the jitter used for retry
+//! backoff (to avoid a [thundering herd](https://en.wikipedia.org/wiki/Thundering_herd_problem)) or
+//! the temporary file names used while probing filesystem capabilities.
+//!
+//! See <https://github.com/GitoxideLabs/gitoxide/issues/1816> for details.
+
+use std::{cell::RefCell, ops::RangeBounds};
+
+thread_local! {
+    static RNG: RefCell<fastrand::Rng> = RefCell::new(fastrand::Rng::with_seed(seed()));
+}
+
+/// Return a `usize` in the given `range`, drawn from a per-thread generator that is seeded to differ
+/// across concurrently running processes.
+pub fn usize(range: impl RangeBounds<usize>) -> usize {
+    RNG.with(|rng| rng.borrow_mut().usize(range))
+}
+
+/// Obtain a high-entropy seed from the operating system, so that generators in separate processes
+/// don't share a sequence.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+fn seed() -> u64 {
+    getrandom::u64().unwrap_or_else(|_| fallback_seed())
+}
+
+/// `wasm32-unknown-unknown` has no entropy source available by default and runs a single process,
+/// so the cross-process concern doesn't apply; use a best-effort seed instead.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn seed() -> u64 {
+    fallback_seed()
+}
+
+/// A best-effort seed combining values that vary across threads and processes, used only when a
+/// high-entropy source is unavailable. `std::process::id()` is the reliable differentiator across
+/// concurrent processes; `Instant::now()` is deliberately avoided as it panics on
+/// `wasm32-unknown-unknown`.
+fn fallback_seed() -> u64 {
+    use std::hash::{BuildHasher, Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::RandomState::new().build_hasher();
+    std::process::id().hash(&mut hasher);
+    std::thread::current().id().hash(&mut hasher);
+    hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn values_are_in_range_and_not_constant() {
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..256 {
+            let n = super::usize(0..1_000);
+            assert!(n < 1_000, "value {n} must be within the requested range");
+            seen.insert(n);
+        }
+        assert!(seen.len() > 1, "the generator must not be constant");
+    }
+}

--- a/gix-utils/src/rng.rs
+++ b/gix-utils/src/rng.rs
@@ -3,13 +3,11 @@
 //! These numbers are *not* cryptographically secure. Unlike the global generators of the
 //! [`fastrand`] crate, whose per-thread seed is derived only from values that can coincide between
 //! separate processes (such as small thread IDs), the generator here is seeded from a high-entropy
-//! source so that concurrent processes don't share a sequence.
+//! source so that concurrent processes don't easily share a sequence.
 //!
 //! This matters wherever a collision causes a real problem, such as the jitter used for retry
 //! backoff (to avoid a [thundering herd](https://en.wikipedia.org/wiki/Thundering_herd_problem)) or
 //! the temporary file names used while probing filesystem capabilities.
-//!
-//! See <https://github.com/GitoxideLabs/gitoxide/issues/1816> for details.
 
 use std::{cell::Cell, ops::RangeBounds};
 
@@ -17,12 +15,10 @@ thread_local! {
     static RNG: Cell<fastrand::Rng> = Cell::new(new_rng());
 }
 
-/// Return a `usize` in the given `range`, drawn from a per-thread generator that is seeded to differ
+/// Return an unsigned number in the given `range`, drawn from a per-thread generator that is seeded to differ
 /// across concurrently running processes.
 pub fn usize(range: impl RangeBounds<usize>) -> usize {
     RNG.with(|cell| {
-        // `fastrand::Rng` is a single `u64`, so move it out behind a cheap placeholder, advance it,
-        // and put it back. A `Cell` is enough and avoids `RefCell`'s runtime borrow tracking.
         let mut rng = cell.replace(fastrand::Rng::with_seed(0));
         let n = rng.usize(range);
         cell.set(rng);
@@ -30,8 +26,6 @@ pub fn usize(range: impl RangeBounds<usize>) -> usize {
     })
 }
 
-/// Seed a generator from a high-entropy OS source, so that generators in separate processes don't
-/// share a sequence.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn new_rng() -> fastrand::Rng {
     fastrand::Rng::with_seed(seed())
@@ -45,6 +39,8 @@ fn new_rng() -> fastrand::Rng {
     fastrand::Rng::with_seed(0x9e37_79b9_7f4a_7c15)
 }
 
+/// Seed a generator from a high-entropy OS source, so that generators in separate processes don't
+/// share a sequence.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn seed() -> u64 {
     getrandom::u64().unwrap_or_else(|_| fallback_seed())
@@ -72,6 +68,9 @@ mod tests {
             assert!(n < 1_000, "value {n} must be within the requested range");
             seen.insert(n);
         }
-        assert!(seen.len() > 1, "the generator must not be constant");
+        assert!(
+            seen.len() > 1,
+            "the generator wasn't made for the Playstation 3 (imprecise, but still funny?)"
+        );
     }
 }

--- a/gix-utils/src/rng.rs
+++ b/gix-utils/src/rng.rs
@@ -11,36 +11,48 @@
 //!
 //! See <https://github.com/GitoxideLabs/gitoxide/issues/1816> for details.
 
-use std::{cell::RefCell, ops::RangeBounds};
+use std::{cell::Cell, ops::RangeBounds};
 
 thread_local! {
-    static RNG: RefCell<fastrand::Rng> = RefCell::new(fastrand::Rng::with_seed(seed()));
+    static RNG: Cell<fastrand::Rng> = Cell::new(new_rng());
 }
 
 /// Return a `usize` in the given `range`, drawn from a per-thread generator that is seeded to differ
 /// across concurrently running processes.
 pub fn usize(range: impl RangeBounds<usize>) -> usize {
-    RNG.with(|rng| rng.borrow_mut().usize(range))
+    RNG.with(|cell| {
+        // `fastrand::Rng` is a single `u64`, so move it out behind a cheap placeholder, advance it,
+        // and put it back. A `Cell` is enough and avoids `RefCell`'s runtime borrow tracking.
+        let mut rng = cell.replace(fastrand::Rng::with_seed(0));
+        let n = rng.usize(range);
+        cell.set(rng);
+        n
+    })
 }
 
-/// Obtain a high-entropy seed from the operating system, so that generators in separate processes
-/// don't share a sequence.
+/// Seed a generator from a high-entropy OS source, so that generators in separate processes don't
+/// share a sequence.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+fn new_rng() -> fastrand::Rng {
+    fastrand::Rng::with_seed(seed())
+}
+
+/// `wasm32-unknown-unknown` has no OS entropy source and traps at runtime on APIs like
+/// `std::process::id()` and `Instant::now()`; it also runs a single process, so the cross-process
+/// concern doesn't apply. Use a fixed seed there.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+fn new_rng() -> fastrand::Rng {
+    fastrand::Rng::with_seed(0x9e37_79b9_7f4a_7c15)
+}
+
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn seed() -> u64 {
     getrandom::u64().unwrap_or_else(|_| fallback_seed())
 }
 
-/// `wasm32-unknown-unknown` has no entropy source available by default and runs a single process,
-/// so the cross-process concern doesn't apply; use a best-effort seed instead.
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-fn seed() -> u64 {
-    fallback_seed()
-}
-
-/// A best-effort seed combining values that vary across threads and processes, used only when a
-/// high-entropy source is unavailable. `std::process::id()` is the reliable differentiator across
-/// concurrent processes; `Instant::now()` is deliberately avoided as it panics on
-/// `wasm32-unknown-unknown`.
+/// A best-effort seed used only when the OS entropy source is unavailable. `std::process::id()` is
+/// the reliable differentiator across concurrent processes.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 fn fallback_seed() -> u64 {
     use std::hash::{BuildHasher, Hash, Hasher};
 


### PR DESCRIPTION
## What

`gix-utils` and `gix-fs` draw fast pseudo-random numbers from `fastrand`'s global generators, whose per-thread seed is derived only from values that can coincide between separate processes — notably small thread IDs. Two concurrently running processes can therefore draw identical sequences, which:

- weakens the jitter on quadratic backoff (meant to avoid a thundering herd of retries, used e.g. in `gix-lock`), and
- makes the `gix-fs` capability probes collide on their temporary file names — the spurious "symlinks unsupported" failure seen on CI (#1789).

Fixes #1816.

## How

Adds a small `gix_utils::rng` module: a per-thread `fastrand::Rng` seeded once from a high-entropy OS source via `getrandom::u64()`, so sequences differ across processes. The two production call sites are routed through it — the backoff jitter in `gix-utils`, and the three capability probes in `gix-fs` (whose now-unused direct `fastrand` dependency is dropped).

### wasm handling

`getrandom` is added as a **target-specific dependency, excluded on `wasm32-unknown-unknown`**, which has no entropy backend by default (and is single-process, so the cross-process concern doesn't apply there). On that target the seed falls back to a best-effort value that deliberately avoids `Instant::now()`, since that panics on `wasm32-unknown-unknown` (#7319). On `wasm32-wasi*` targets `getrandom` is included and uses the wasi backend.

### Note on the public API

This adds a new public `gix_utils::rng` module (so `gix-fs` can use it across the crate boundary) — flagging in case it affects the version bump.

### Out of scope

The `gix-testtools` port-shuffle (case 3 in the issue) is left as-is — the issue notes it isn't really a problem, only a minor test slowdown.

## Verification

- `gix-utils` + `gix-fs` build and tests pass; `cargo clippy -- -D warnings` and `cargo fmt --check` are clean.
- Builds on `wasm32-unknown-unknown` (getrandom excluded, fallback seed used) and `wasm32-wasip1` (getrandom included). Note: these were verified as builds, not at runtime (no local wasm host).
