### PR TITLE
Document that writing the index does not refresh the tree-cache extension

### DIFF
--- a/gix-index/src/file/write.rs
+++ b/gix-index/src/file/write.rs
@@ -16,8 +16,9 @@ impl File {
     /// Write the index to `out` with `options`, to be readable by [`File::at()`], returning the version that was actually written
     /// to retain all information of this index.
     ///
-    /// Note that the `tree` (tree-cache) extension is written as-is and is **not** recomputed from the
-    /// current entries; see [`File::write()`] for the implications and the recommended workaround.
+    /// Note that the `tree` (tree-cache) extension is written as-is and is **not** recomputed or
+    /// invalidated to match the current entries; see [`File::write()`] for the implications and the
+    /// recommended workaround.
     pub fn write_to(
         &self,
         mut out: impl std::io::Write,
@@ -45,12 +46,15 @@ impl File {
     /// ### The `tree` (tree-cache) extension is written as-is
     ///
     /// The `tree` extension (tree-cache) is serialized from its current in-memory state; it is
-    /// **not** recomputed to match the entries. If entries were modified since the index was read,
-    /// the now-stale tree-cache is written out, which can leave the index in a state that other Git
-    /// implementations misread: they consult the tree-cache to decide what changed, so modifications
-    /// may appear invisible to `git status`, or be committed incorrectly.
+    /// **not** recomputed or invalidated to match the entries. So if entries were modified since the
+    /// index was read, the tree-cache is written back still marked valid even though it is now stale.
     ///
-    /// Until updating the tree-cache on write is implemented (see [issue #2421]), remove it with
+    /// Git uses the tree-cache to skip unchanged directories when building a tree (on `git commit` /
+    /// `git write-tree`), so a stale-but-valid tree-cache can make a later commit capture outdated
+    /// subtree content; more generally, `git status` and later commits can disagree about what is
+    /// staged.
+    ///
+    /// Until the tree-cache is updated on write (see [issue #2421]), remove it with
     /// [`State::remove_tree()`](crate::State::remove_tree()) before writing whenever entries were
     /// changed:
     ///

--- a/gix-index/src/file/write.rs
+++ b/gix-index/src/file/write.rs
@@ -15,6 +15,9 @@ pub enum Error {
 impl File {
     /// Write the index to `out` with `options`, to be readable by [`File::at()`], returning the version that was actually written
     /// to retain all information of this index.
+    ///
+    /// Note that the `tree` (tree-cache) extension is written as-is and is **not** recomputed from the
+    /// current entries; see [`File::write()`] for the implications and the recommended workaround.
     pub fn write_to(
         &self,
         mut out: impl std::io::Write,
@@ -38,6 +41,25 @@ impl File {
     /// Write ourselves to the path we were read from after acquiring a lock, using `options`.
     ///
     /// Note that the hash produced will be stored which is why we need to be mutable.
+    ///
+    /// ### The `tree` (tree-cache) extension is written as-is
+    ///
+    /// The `tree` extension (tree-cache) is serialized from its current in-memory state; it is
+    /// **not** recomputed to match the entries. If entries were modified since the index was read,
+    /// the now-stale tree-cache is written out, which can leave the index in a state that other Git
+    /// implementations misread: they consult the tree-cache to decide what changed, so modifications
+    /// may appear invisible to `git status`, or be committed incorrectly.
+    ///
+    /// Until updating the tree-cache on write is implemented (see [issue #2421]), remove it with
+    /// [`State::remove_tree()`](crate::State::remove_tree()) before writing whenever entries were
+    /// changed:
+    ///
+    /// ```ignore
+    /// index.remove_tree();
+    /// index.write(gix_index::write::Options::default())?;
+    /// ```
+    ///
+    /// [issue #2421]: https://github.com/GitoxideLabs/gitoxide/issues/2421
     pub fn write(&mut self, options: write::Options) -> Result<(), Error> {
         let _span = gix_features::trace::detail!("gix_index::File::write()", path = ?self.path);
         let mut lock = std::io::BufWriter::with_capacity(

--- a/gix-index/src/write.rs
+++ b/gix-index/src/write.rs
@@ -60,6 +60,10 @@ pub struct Options {
 
 impl State {
     /// Serialize this instance to `out` with [`options`][Options].
+    ///
+    /// Note that the `tree` (tree-cache) extension is written as-is and is **not** recomputed or
+    /// invalidated to match the entries; see [`File::write()`](crate::File::write()) for the
+    /// implications and the recommended workaround.
     pub fn write_to(
         &self,
         out: impl std::io::Write,


### PR DESCRIPTION
## What

Documents a footgun on the index write methods, per #2421.

`File::write`, `File::write_to`, and `State::write_to` serialize the `tree` (tree-cache) extension from its current in-memory state — it is **not** recomputed or invalidated to match the entries. So if entries were modified since the index was read, the tree-cache is written back *still marked valid* even though it is now stale.

Git uses the tree-cache to skip unchanged directories when building a tree (on `git commit` / `git write-tree`), so a stale-but-valid tree-cache can make a later commit capture outdated subtree content; more generally, `git status` and later commits can disagree about what is staged.

The note points to `State::remove_tree()` as the workaround until the tree-cache is updated on write:

```rust
index.remove_tree();
index.write(gix_index::write::Options::default())?;
```

This is the documentation route (option 1) you preferred in the issue, rather than a behavior change.

## Notes

- Doc-only. The caveat is placed on all three public index serializers (`File::write`, `File::write_to`, `State::write_to`), with the full explanation on `File::write` and cross-references on the other two.
- `cargo doc -p gix-index --features sha1` (with `RUSTDOCFLAGS=-D warnings`) and `cargo fmt --check` are clean.

Addresses #2421.
