### PR TITLE
fix: preserve the underlying error when a reqwest request fails without a status

### DIFF
--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -80,6 +80,11 @@ path = "tests/blocking-transport-http.rs"
 required-features = ["http-client-curl", "http-client-insecure-credentials", "maybe-async/is_sync"]
 
 [[test]]
+name = "blocking-transport-http-reqwest"
+path = "tests/blocking-transport-http-reqwest.rs"
+required-features = ["http-client-reqwest", "maybe-async/is_sync"]
+
+[[test]]
 name = "async-transport"
 path = "tests/async-transport.rs"
 required-features = ["async-client"]

--- a/gix-transport/src/client/blocking_io/http/reqwest/remote.rs
+++ b/gix-transport/src/client/blocking_io/http/reqwest/remote.rs
@@ -148,7 +148,7 @@ impl Default for Remote {
                 {
                     Ok(res) => res,
                     Err(err) => {
-                        let (kind, err) = match err.status() {
+                        let err = match err.status() {
                             Some(status) => {
                                 let kind = if status == reqwest::StatusCode::UNAUTHORIZED {
                                     std::io::ErrorKind::PermissionDenied
@@ -157,12 +157,14 @@ impl Default for Remote {
                                 } else {
                                     std::io::ErrorKind::Other
                                 };
-                                (kind, format!("Received HTTP status {}", status.as_str()))
+                                std::io::Error::new(kind, format!("Received HTTP status {}", status.as_str()))
                             }
-                            None => (std::io::ErrorKind::Other, err.to_string()),
+                            // Preserve the `reqwest::Error` as the source so the underlying cause -- e.g. a
+                            // connection or TLS failure -- isn't lost. It was previously stringified, which
+                            // dead-ended `source()` and hid the real reason a request failed. See #2140.
+                            None => std::io::Error::other(err),
                         };
-                        let err = Err(std::io::Error::new(kind, err));
-                        headers_tx.channel.send(err).ok();
+                        headers_tx.channel.send(Err(err)).ok();
                         continue;
                     }
                 };

--- a/gix-transport/tests/blocking-transport-http-reqwest.rs
+++ b/gix-transport/tests/blocking-transport-http-reqwest.rs
@@ -1,0 +1,38 @@
+//! Regression tests specific to the blocking `reqwest` HTTP backend.
+
+use std::error::Error;
+
+use gix_transport::{
+    Protocol, Service,
+    client::blocking_io::{Transport, http},
+};
+
+/// Regression for <https://github.com/GitoxideLabs/gitoxide/issues/2140>: when a request fails
+/// without an HTTP status (for example a connection or TLS failure), the underlying error must be
+/// kept as `source()` instead of being stringified, so callers can see the real cause.
+#[test]
+fn request_failure_without_status_preserves_error_source() {
+    // Bind then immediately drop a listener so the port reliably refuses connections: a failure
+    // with no HTTP status, exercising the path that previously stringified the error.
+    let addr = {
+        let server = std::net::TcpListener::bind("127.0.0.1:0").expect("can bind an ephemeral port");
+        server.local_addr().expect("listener has a local address")
+    };
+
+    let url = format!("http://{addr}/repo");
+    let mut client =
+        http::connect::<http::reqwest::Remote>(url.as_str().try_into().expect("the url is valid"), Protocol::V1, false);
+
+    let error = client
+        .handshake(Service::UploadPack, &[])
+        .err()
+        .expect("a refused connection must produce an error");
+    let io_error = error
+        .source()
+        .and_then(|source| source.downcast_ref::<std::io::Error>())
+        .expect("the transport error wraps an io::Error");
+    assert!(
+        io_error.source().is_some(),
+        "the underlying error must be preserved as source(), not stringified: {io_error:?}"
+    );
+}


### PR DESCRIPTION
## What

Addresses #2140. When the blocking `reqwest` HTTP backend failed a request **without an HTTP status** — a connection or TLS failure, e.g. using `http-client-reqwest` without a TLS feature against an `https://` URL — it stringified the `reqwest::Error` (`err.to_string()`) before wrapping it in an `io::Error`. A `String` has no `source()`, so the error chain dead-ended at *"An IO error occurred when talking to the server"*, hiding the real cause — the empty `.source()` the reporter observed.

The outer wrapper (`client::Error::Io(#[from] io::Error)`) already preserves the `io::Error` as its source; the only break was this stringification.

This resolves the part @Byron identified — *"what I'd be missing here is a clearer error message"*. It does not make plain `http-client-reqwest` perform HTTPS (that still requires a TLS feature); it makes the *reason* a request failed visible instead of swallowed.

## How

In the no-status branch, keep the `reqwest::Error` as the `io::Error`'s source via `io::Error::other(err)` rather than stringifying it. The HTTP-status branch is unchanged (it still reports `Received HTTP status N`). `.source()` now walks into reqwest's chain and surfaces the underlying cause.

## Tests

Adds a regression test (`tests/blocking-transport-http-reqwest.rs`) that drives a refused TCP connection through the reqwest backend and asserts the resulting error preserves its `source()`. This covers the **no-status (connection-failure) path** specifically — the existing reqwest http tests (run via `blocking-transport.rs`) already cover status-based errors like 401/404/500. It's wired as a `[[test]]` with `required-features = ["http-client-reqwest", "maybe-async/is_sync"]` so it builds and runs only under the reqwest test configuration.

## Verification

- The new regression test passes, and fails before the fix by construction (pre-fix `source()` is `None`; post-fix `Some`).
- `cargo clippy -p gix-transport --features http-client-reqwest,maybe-async/is_sync --tests` and `cargo fmt --check` are clean; `Cargo.lock` is unchanged (no dependency change).
- The `Some(status)` branch was only refactored (same kind, same message), so the existing http status tests are unaffected.

Scope is reqwest-specific — the reporter confirmed the curl backend works.
