### PR TITLE
Add a `local` build profile for offline/local-only builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,18 @@ small = ["hashes", "pretty-cli", "prodash-render-line", "is-terminal"]
 ## It uses, however, a fully asynchronous networking implementation which can serve a real-world example on how to implement custom async transports.
 lean-async = ["hashes", "fast", "tracing", "pretty-cli", "gitoxide-core-tools", "gitoxide-core-tools-query", "gitoxide-core-tools-corpus", "gitoxide-core-async-client", "prodash-render-line"]
 
+## A fast, pure-Rust build for local-only repository operations.
+##
+## Keeps local operations and the local `ein` tools with parallelism, but omits the HTTP/SSH client
+## stack, so there is no `clone`, `fetch` or `push`. Unlike `lean`/`max` it pulls in none of the
+## curl/reqwest/TLS backends, and unlike the analytics tools it needs no bundled SQLite -- so the
+## dependency graph stays pure Rust with no C toolchain required. A good fit for packaging in
+## constrained, audited, embedded or minimal-toolchain environments, and where a smaller all-Rust
+## graph reduces the chance an unrelated transitive crate forces a version bump.
+##
+## The pure-Rust transport abstraction crates remain in the graph, but no networked command is exposed.
+local = ["hashes", "fast", "tracing", "pretty-cli", "gitoxide-core-tools", "prodash-render-line"]
+
 #! ### Package Maintainers
 #! `*-control` features leave it to you to configure C libraries, involving choices for HTTP transport implementation.
 #!

--- a/justfile
+++ b/justfile
@@ -64,6 +64,7 @@ check:
         2>&1 >/dev/null | grep '^warning: nothing to print\>'
     ! cargo tree -p gix --no-default-features -i gix-credentials 2>/dev/null
     cargo check --no-default-features --features lean
+    cargo check --no-default-features --features local
     cargo check --no-default-features --features lean-async
     cargo check --no-default-features --features max
     cargo check -p gitoxide-core --features gix/sha1,blocking-client


### PR DESCRIPTION
## What

For #2672 — a documented build profile for local-only operation, so packagers don't have to reverse-engineer the feature graph to get there.

## Background

`small` is already local-only (it has no `clone`), but it's size-optimized and single-threaded; `max-pure` is pure-Rust but networked. There was no **fast, pure-Rust, local-only** profile — which is the gap this fills.

## The `local` profile

It's `lean` minus the HTTP/SSH client stack **and** the SQLite-backed `query`/`corpus` tools:

```toml
local = ["hashes", "fast", "tracing", "pretty-cli", "gitoxide-core-tools", "prodash-render-line"]
```

- Keeps local repository operations, the local `ein` tools (`organize`/`estimate-hours`/`archive`/`clean`), and parallelism.
- No `clone`/`fetch`/`push`; pulls in **none** of curl/reqwest/TLS, and needs **no C toolchain** (no bundled SQLite) — verified via `cargo tree -e build,normal` (no `cc`/`cmake`/`-sys` anywhere).
- The pure-Rust transport *abstraction* crates stay linked, but no networked command is exposed.

Also adds `cargo check --no-default-features --features local` to the justfile `check` recipe, next to the other presets. No new crates enter `Cargo.lock`.

## Verification

Builds; `cargo clippy --workspace --no-default-features --features local` is clean; `gix status`/`clean` work; `gix clone` is absent.

## Open questions — this is a proposal

You own this feature architecture, so I'm not attached to the specifics:

- **Name** — `local`, or `offline` / `local-only`?
- **Feature set** — I kept the local `ein` tools and `tracing`; happy to trim toward a more minimal, `small`-like core, or to expand it, whichever you prefer.
- Or, if you'd rather simply **document that `small` is the local build** rather than add a profile at all, I'm glad to redo it that way instead.
