### PR TITLE
Actually mark RelativePath as transparent

### DIFF
--- a/gix-path/src/relative_path.rs
+++ b/gix-path/src/relative_path.rs
@@ -12,7 +12,7 @@ pub(super) mod types {
     /// - The path separator always is `/`, independent of the platform.
     /// - Only normal components are allowed.
     /// - It is always represented as a bunch of bytes.
-    #[derive()]
+    #[repr(transparent)]
     pub struct RelativePath {
         inner: BStr,
     }
@@ -31,7 +31,7 @@ impl RelativePath {
         // SAFETY: `RelativePath` is transparent and equivalent to a `&BStr` if provided as reference.
         #[allow(unsafe_code)]
         unsafe {
-            std::mem::transmute(value)
+            Ok(std::mem::transmute(value))
         }
     }
 }

--- a/gix-path/src/relative_path.rs
+++ b/gix-path/src/relative_path.rs
@@ -31,7 +31,7 @@ impl RelativePath {
         // SAFETY: `RelativePath` is transparent and equivalent to a `&BStr` if provided as reference.
         #[allow(unsafe_code)]
         unsafe {
-            Ok(std::mem::transmute(value))
+            Ok(std::mem::transmute::<&BStr, &RelativePath>(value))
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/GitoxideLabs/gitoxide/issues/2692

I went ahead and cleaned up the Result there as well, the layout of Result is not well defined.

It worked anyway because of niche optimizations, I think, but we can't rely on that here.