### PR TITLE
gix-pack: respect configured zlib compression levels instead of a hard-coded fastest level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,6 +1572,7 @@ dependencies = [
  "gix-worktree",
  "gix-worktree-state",
  "gix-worktree-stream",
+ "gix-zlib",
  "insta",
  "is_ci",
  "nonempty",
@@ -2675,6 +2676,7 @@ name = "gix-zlib"
 version = "0.1.0"
 dependencies = [
  "bstr",
+ "serde",
  "thiserror 2.0.18",
  "zlib-rs",
 ]

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -109,6 +109,17 @@ where
     type ObjectIdIter = dyn Iterator<Item = Result<ObjectId, Box<dyn std::error::Error + Send + Sync>>> + Send;
 
     let repo = gix::discover(repository_path)?.into_sync();
+    let pack_compression = {
+        use gix::config::tree::{Core, Pack};
+        let repo = repo.to_thread_local();
+        let config = repo.config_snapshot();
+        config
+            .integer(Pack::COMPRESSION)
+            .or_else(|| config.integer(Core::COMPRESSION))
+            .map(|level| Pack::COMPRESSION.try_into_compression(Ok(level)))
+            .transpose()?
+            .unwrap_or(gix::zlib::Compression::DEFAULT)
+    };
     progress.init(Some(2), progress::steps());
     let tips = tips.into_iter();
     let make_cancellation_err = || anyhow!("Cancelled by user");
@@ -233,6 +244,7 @@ where
                 allow_thin_pack: thin,
                 chunk_size,
                 version: Default::default(),
+                compression: pack_compression,
             },
         ))
     };

--- a/gitoxide-core/src/pack/create.rs
+++ b/gitoxide-core/src/pack/create.rs
@@ -108,18 +108,9 @@ where
 {
     type ObjectIdIter = dyn Iterator<Item = Result<ObjectId, Box<dyn std::error::Error + Send + Sync>>> + Send;
 
-    let repo = gix::discover(repository_path)?.into_sync();
-    let pack_compression = {
-        use gix::config::tree::{Core, Pack};
-        let repo = repo.to_thread_local();
-        let config = repo.config_snapshot();
-        config
-            .integer(Pack::COMPRESSION)
-            .or_else(|| config.integer(Core::COMPRESSION))
-            .map(|level| Pack::COMPRESSION.try_into_compression(Ok(level)))
-            .transpose()?
-            .unwrap_or(gix::zlib::Compression::DEFAULT)
-    };
+    let repo = gix::discover(repository_path)?;
+    let pack_compression = repo.pack_compression()?;
+    let repo = repo.into_sync();
     progress.init(Some(2), progress::steps());
     let tips = tips.into_iter();
     let make_cancellation_err = || anyhow!("Cancelled by user");

--- a/gitoxide-core/src/pack/explode.rs
+++ b/gitoxide-core/src/pack/explode.rs
@@ -146,8 +146,15 @@ impl gix::objs::Write for OutputWriter {
 impl OutputWriter {
     fn new(path: Option<impl AsRef<Path>>, compress: bool, object_hash: gix::hash::Kind) -> Self {
         match path {
-            Some(path) => OutputWriter::Loose(loose::Store::at(path.as_ref(), object_hash, None)),
-            None => OutputWriter::Sink(odb::sink(object_hash).compress(compress)),
+            Some(path) => OutputWriter::Loose(loose::Store::at(
+                path.as_ref(),
+                object_hash,
+                None,
+                gix::zlib::Compression::BEST_SPEED,
+            )),
+            None => OutputWriter::Sink(
+                odb::sink(object_hash).compress(compress.then_some(gix::zlib::Compression::BEST_SPEED)),
+            ),
         }
     }
 }
@@ -217,7 +224,11 @@ pub fn pack_or_pack_index(
                 let object_path = object_path.map(|p| p.as_ref().to_owned());
                 let out = OutputWriter::new(object_path.clone(), sink_compress, object_hash);
                 let loose_odb = verify
-                    .then(|| object_path.as_ref().map(|path| loose::Store::at(path, object_hash, None)))
+                    .then(|| {
+                        object_path.as_ref().map(|path| {
+                            loose::Store::at(path, object_hash, None, gix::zlib::Compression::BEST_SPEED)
+                        })
+                    })
                     .flatten();
                 let mut read_buf = Vec::new();
                 move |object_kind, buf, index_entry, progress| {

--- a/gitoxide-core/src/pack/explode.rs
+++ b/gitoxide-core/src/pack/explode.rs
@@ -148,9 +148,10 @@ impl OutputWriter {
         match path {
             Some(path) => OutputWriter::Loose(loose::Store::at(
                 path.as_ref(),
-                object_hash,
-                None,
-                gix::zlib::Compression::BEST_SPEED,
+                loose::Options {
+                    object_hash,
+                    ..Default::default()
+                },
             )),
             None => OutputWriter::Sink(
                 odb::sink(object_hash).compress(compress.then_some(gix::zlib::Compression::BEST_SPEED)),
@@ -226,7 +227,13 @@ pub fn pack_or_pack_index(
                 let loose_odb = verify
                     .then(|| {
                         object_path.as_ref().map(|path| {
-                            loose::Store::at(path, object_hash, None, gix::zlib::Compression::BEST_SPEED)
+                            loose::Store::at(
+                                path,
+                                loose::Options {
+                                    object_hash,
+                                    ..Default::default()
+                                },
+                            )
                         })
                     })
                     .flatten();

--- a/gitoxide-core/src/pack/index.rs
+++ b/gitoxide-core/src/pack/index.rs
@@ -83,6 +83,7 @@ pub fn from_pack(
         index_version: pack::index::Version::default(),
         object_hash: ctx.object_hash,
         alloc_limit_bytes: None,
+        compression: gix::zlib::Compression::BEST_SPEED,
     };
     let out = ctx.out;
     let format = ctx.format;

--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -290,6 +290,7 @@ fn receive_pack_blocking(
         iteration_mode: pack::data::input::Mode::Verify,
         object_hash,
         alloc_limit_bytes: None,
+        compression: gix::zlib::Compression::BEST_SPEED,
     };
     let outcome = pack::Bundle::write_to_directory(
         &mut input,

--- a/gix-odb/src/lib.rs
+++ b/gix-odb/src/lib.rs
@@ -171,6 +171,8 @@ pub struct Store {
     object_hash: gix_hash::Kind,
     /// The maximum size of a single allocation caused by user-controlled on-disk pack data.
     alloc_limit_bytes: Option<usize>,
+    /// The compression level to use when writing loose objects.
+    loose_compression: gix_zlib::Compression,
 }
 
 /// Create a new cached handle to the object store with support for additional options.

--- a/gix-odb/src/sink.rs
+++ b/gix-odb/src/sink.rs
@@ -8,13 +8,9 @@ use gix_zlib::stream::deflate;
 use crate::Sink;
 
 impl Sink {
-    /// Enable or disable compression. Compression is disabled by default
-    pub fn compress(mut self, enable: bool) -> Self {
-        if enable {
-            self.compressor = Some(RefCell::new(deflate::Write::new(io::sink())));
-        } else {
-            self.compressor = None;
-        }
+    /// Compress with the given level, or disable compression with `None`. Compression is disabled by default.
+    pub fn compress(mut self, compression: Option<gix_zlib::Compression>) -> Self {
+        self.compressor = compression.map(|level| RefCell::new(deflate::Write::new(io::sink(), level)));
         self
     }
 }

--- a/gix-odb/src/store_impls/dynamic/find.rs
+++ b/gix-odb/src/store_impls/dynamic/find.rs
@@ -129,7 +129,7 @@ where
                                 }
                                 None => {
                                     // The pack wasn't available anymore so we are supposed to try another round with a fresh index
-                                    match self.store.load_one_index(self.refresh, snapshot.marker)? {
+                                    match self.store.load_one_index(self.index_ctx(snapshot.marker))? {
                                         Some(new_snapshot) => {
                                             *snapshot = new_snapshot;
                                             self.clear_cache();
@@ -297,7 +297,7 @@ where
                 }
             }
 
-            match self.store.load_one_index(self.refresh, snapshot.marker)? {
+            match self.store.load_one_index(self.index_ctx(snapshot.marker))? {
                 Some(new_snapshot) => {
                     *snapshot = new_snapshot;
                     self.clear_cache();
@@ -335,7 +335,7 @@ where
                 }
             }
 
-            match self.store.load_one_index(self.refresh, snapshot.marker) {
+            match self.store.load_one_index(self.index_ctx(snapshot.marker)) {
                 Ok(Some(new_snapshot)) => {
                     *snapshot = new_snapshot;
                     self.clear_cache();
@@ -390,7 +390,7 @@ where
                                 }
                                 None => {
                                     // The pack wasn't available anymore so we are supposed to try another round with a fresh index
-                                    match self.store.load_one_index(self.refresh, snapshot.marker).ok()? {
+                                    match self.store.load_one_index(self.index_ctx(snapshot.marker)).ok()? {
                                         Some(new_snapshot) => {
                                             *snapshot = new_snapshot;
                                             self.clear_cache();
@@ -434,7 +434,7 @@ where
             }
 
             {
-                let new_snapshot = self.store.load_one_index(self.refresh, snapshot.marker).ok()??;
+                let new_snapshot = self.store.load_one_index(self.index_ctx(snapshot.marker)).ok()??;
                 *snapshot = new_snapshot;
                 self.clear_cache();
             }
@@ -458,7 +458,7 @@ where
             }
 
             {
-                let new_snapshot = self.store.load_one_index(self.refresh, snapshot.marker).ok()??;
+                let new_snapshot = self.store.load_one_index(self.index_ctx(snapshot.marker)).ok()??;
                 drop(snapshot);
                 *self.snapshot.borrow_mut() = new_snapshot;
             }

--- a/gix-odb/src/store_impls/dynamic/handle.rs
+++ b/gix-odb/src/store_impls/dynamic/handle.rs
@@ -255,6 +255,7 @@ impl super::Store {
             store: self.clone(),
             refresh: RefreshMode::default(),
             ignore_replacements: false,
+            loose_compression: self.loose_compression,
             token: Some(token),
             inflate: RefCell::new(Default::default()),
             snapshot: RefCell::new(self.collect_snapshot()),
@@ -272,6 +273,7 @@ impl super::Store {
             store: self.clone(),
             refresh: Default::default(),
             ignore_replacements: false,
+            loose_compression: self.loose_compression,
             token: Some(token),
             inflate: RefCell::new(Default::default()),
             snapshot: RefCell::new(self.collect_snapshot()),
@@ -297,6 +299,14 @@ impl<S> super::Handle<S>
 where
     S: Deref<Target = super::Store> + Clone,
 {
+    pub(crate) fn index_ctx(&self, marker: types::SlotIndexMarker) -> super::IndexCtx {
+        super::IndexCtx {
+            refresh_mode: self.refresh,
+            marker,
+            loose_compression: self.loose_compression,
+        }
+    }
+
     /// Call once if pack ids are stored and later used for lookup, meaning they should always remain mapped and not be unloaded
     /// even if they disappear from disk.
     /// This must be called if there is a chance that git maintenance is happening while a pack is created.
@@ -362,10 +372,12 @@ impl TryFrom<&super::Store> for super::Store {
 impl super::Handle<Rc<super::Store>> {
     /// Convert a ref counted store into one that is ref-counted and thread-safe, by creating a new Store.
     pub fn into_arc(self) -> std::io::Result<super::Handle<Arc<super::Store>>> {
+        let loose_compression = self.loose_compression;
         let store = Arc::new(super::Store::try_from(self.store_ref())?);
         let mut cache = store.to_handle_arc();
         cache.refresh = self.refresh;
         cache.max_recursion_depth = self.max_recursion_depth;
+        cache.loose_compression = loose_compression;
         Ok(cache)
     }
 }
@@ -386,6 +398,7 @@ where
             store: self.store.clone(),
             refresh: self.refresh,
             ignore_replacements: self.ignore_replacements,
+            loose_compression: self.loose_compression,
             token: {
                 let token = self.store.register_handle();
                 match self.token.as_ref().expect("token is always set here ") {

--- a/gix-odb/src/store_impls/dynamic/handle.rs
+++ b/gix-odb/src/store_impls/dynamic/handle.rs
@@ -353,6 +353,7 @@ impl TryFrom<&super::Store> for super::Store {
                 use_multi_pack_index: false,
                 alloc_limit_bytes: s.alloc_limit_bytes,
                 current_dir: s.current_dir.clone().into(),
+                loose_compression: s.loose_compression,
             },
         )
     }

--- a/gix-odb/src/store_impls/dynamic/header.rs
+++ b/gix-odb/src/store_impls/dynamic/header.rs
@@ -55,7 +55,7 @@ where
                                 }
                                 None => {
                                     // The pack wasn't available anymore so we are supposed to try another round with a fresh index
-                                    match self.store.load_one_index(self.refresh, snapshot.marker)? {
+                                    match self.store.load_one_index(self.index_ctx(snapshot.marker))? {
                                         Some(new_snapshot) => {
                                             *snapshot = new_snapshot;
                                             self.clear_cache();
@@ -168,7 +168,7 @@ where
                 }
             }
 
-            match self.store.load_one_index(self.refresh, snapshot.marker)? {
+            match self.store.load_one_index(self.index_ctx(snapshot.marker))? {
                 Some(new_snapshot) => {
                     *snapshot = new_snapshot;
                     self.clear_cache();

--- a/gix-odb/src/store_impls/dynamic/init.rs
+++ b/gix-odb/src/store_impls/dynamic/init.rs
@@ -23,6 +23,11 @@ pub struct Options {
     /// The current directory of the process at the time of instantiation.
     /// If unset, it will be retrieved using `gix_fs::current_dir(false)`.
     pub current_dir: Option<std::path::PathBuf>,
+    /// The compression level to use when writing loose objects.
+    ///
+    /// Defaults to [`Compression::BEST_SPEED`](gix_zlib::Compression::BEST_SPEED), which is
+    /// also what `git` uses unless configured otherwise with `core.looseCompression` or `core.compression`.
+    pub loose_compression: gix_zlib::Compression,
 }
 
 impl Default for Options {
@@ -33,6 +38,7 @@ impl Default for Options {
             use_multi_pack_index: true,
             alloc_limit_bytes: None,
             current_dir: None,
+            loose_compression: gix_zlib::Compression::BEST_SPEED,
         }
     }
 }
@@ -83,6 +89,7 @@ impl Store {
             use_multi_pack_index,
             alloc_limit_bytes,
             current_dir,
+            loose_compression,
         }: Options,
     ) -> std::io::Result<Self> {
         let _span = gix_features::trace::detail!("gix_odb::Store::at()");
@@ -138,6 +145,7 @@ impl Store {
             use_multi_pack_index,
             object_hash,
             alloc_limit_bytes,
+            loose_compression,
             num_handles_stable: Default::default(),
             num_handles_unstable: Default::default(),
             num_disk_state_consolidation: Default::default(),

--- a/gix-odb/src/store_impls/dynamic/load_index.rs
+++ b/gix-odb/src/store_impls/dynamic/load_index.rs
@@ -231,7 +231,9 @@ impl super::Store {
             Arc::new(
                 db_paths
                     .iter()
-                    .map(|path| crate::loose::Store::at(path, self.object_hash, self.alloc_limit_bytes))
+                    .map(|path| {
+                        crate::loose::Store::at(path, self.object_hash, self.alloc_limit_bytes, self.loose_compression)
+                    })
                     .collect::<Vec<_>>(),
             )
         } else {

--- a/gix-odb/src/store_impls/dynamic/load_index.rs
+++ b/gix-odb/src/store_impls/dynamic/load_index.rs
@@ -10,7 +10,7 @@ use std::{
     time::SystemTime,
 };
 
-use crate::store::{RefreshMode, handle, types};
+use crate::store::{IndexCtx, RefreshMode, handle, types};
 
 pub(crate) struct Snapshot {
     /// Indices ready for object lookup or contains checks, ordered usually by modification data, recent ones first.
@@ -65,7 +65,11 @@ impl super::Store {
     /// Load all indices, refreshing from disk only if needed.
     pub(crate) fn load_all_indices(&self) -> Result<Snapshot, Error> {
         let mut snapshot = self.collect_snapshot();
-        while let Some(new_snapshot) = self.load_one_index(RefreshMode::Never, snapshot.marker)? {
+        while let Some(new_snapshot) = self.load_one_index(IndexCtx {
+            refresh_mode: RefreshMode::Never,
+            marker: snapshot.marker,
+            loose_compression: self.loose_compression,
+        })? {
             snapshot = new_snapshot;
         }
         Ok(snapshot)
@@ -75,12 +79,19 @@ impl super::Store {
     /// as here might be no change to pick up.
     pub(crate) fn load_one_index(
         &self,
-        refresh_mode: RefreshMode,
-        marker: types::SlotIndexMarker,
+        IndexCtx {
+            refresh_mode,
+            marker,
+            loose_compression,
+        }: IndexCtx,
     ) -> Result<Option<Snapshot>, Error> {
         let index = self.index.load();
         if !index.is_initialized() {
-            return self.consolidate_with_disk_state(true /* needs_init */, false /*load one new index*/);
+            return self.consolidate_with_disk_state(
+                true,  /* needs_init */
+                false, /* load one new index */
+                loose_compression,
+            );
         }
 
         if marker.generation != index.generation || marker.state_id != index.state_id() {
@@ -95,9 +106,11 @@ impl super::Store {
                 // …and if that didn't yield anything new consider refreshing our disk state.
                 match refresh_mode {
                     RefreshMode::Never => Ok(None),
-                    RefreshMode::AfterAllIndicesLoaded => {
-                        self.consolidate_with_disk_state(false /* needs init */, true /*load one new index*/)
-                    }
+                    RefreshMode::AfterAllIndicesLoaded => self.consolidate_with_disk_state(
+                        false, /* needs init */
+                        true,  /* load one new index */
+                        loose_compression,
+                    ),
                 }
             }
         }
@@ -189,6 +202,7 @@ impl super::Store {
         &self,
         needs_init: bool,
         load_new_index: bool,
+        loose_compression: gix_zlib::Compression,
     ) -> Result<Option<Snapshot>, Error> {
         let index = self.index.load();
         let previous_index_state = Arc::as_ptr(&index) as usize;
@@ -232,7 +246,14 @@ impl super::Store {
                 db_paths
                     .iter()
                     .map(|path| {
-                        crate::loose::Store::at(path, self.object_hash, self.alloc_limit_bytes, self.loose_compression)
+                        crate::loose::Store::at(
+                            path,
+                            crate::loose::Options {
+                                object_hash: self.object_hash,
+                                alloc_limit_bytes: self.alloc_limit_bytes,
+                                compression: loose_compression,
+                            },
+                        )
                     })
                     .collect::<Vec<_>>(),
             )

--- a/gix-odb/src/store_impls/dynamic/mod.rs
+++ b/gix-odb/src/store_impls/dynamic/mod.rs
@@ -22,10 +22,26 @@ where
     /// If true, replacements will not be performed even if these are available.
     pub ignore_replacements: bool,
 
+    /// The compression level to use when this handle causes a loose object database to be opened.
+    ///
+    /// Changing this value does not affect loose object databases that are already open or change the value in other handles.
+    pub loose_compression: gix_zlib::Compression,
+
     pub(crate) token: Option<handle::Mode>,
     snapshot: RefCell<load_index::Snapshot>,
     inflate: RefCell<gix_zlib::Inflate>,
     packed_object_count: RefCell<Option<u64>>,
+}
+
+/// Context for [`Store::load_one_index()`].
+///
+/// It is typically created by [`Handle::index_ctx()`] from handle-local settings and the marker of its current
+/// snapshot. [`Store::load_all_indices()`] creates it directly as that operation has no handle.
+#[derive(Clone, Copy)]
+pub(crate) struct IndexCtx {
+    refresh_mode: RefreshMode,
+    marker: types::SlotIndexMarker,
+    loose_compression: gix_zlib::Compression,
 }
 
 /// Decide what happens when all indices are loaded.

--- a/gix-odb/src/store_impls/dynamic/prefix.rs
+++ b/gix-odb/src/store_impls/dynamic/prefix.rs
@@ -163,7 +163,7 @@ where
                 }
             }
 
-            match self.store.load_one_index(self.refresh, snapshot.marker)? {
+            match self.store.load_one_index(self.index_ctx(snapshot.marker))? {
                 Some(new_snapshot) => {
                     drop(snapshot);
                     *self.snapshot.borrow_mut() = new_snapshot;

--- a/gix-odb/src/store_impls/dynamic/structure.rs
+++ b/gix-odb/src/store_impls/dynamic/structure.rs
@@ -55,7 +55,7 @@ impl Store {
         let _span = gix_features::trace::detail!("gix_odb::Store::structure()");
         let index = self.index.load();
         if !index.is_initialized() {
-            self.consolidate_with_disk_state(true, false /*load one new index*/)?;
+            self.consolidate_with_disk_state(true, false /*load one new index*/, self.loose_compression)?;
         }
         let index = self.index.load();
         let mut res: Vec<_> = index
@@ -103,7 +103,7 @@ impl Store {
     pub fn alternate_db_paths(&self) -> Result<Vec<PathBuf>, load_index::Error> {
         let index = self.index.load();
         if !index.is_initialized() {
-            self.consolidate_with_disk_state(true, false /*load one new index*/)?;
+            self.consolidate_with_disk_state(true, false /*load one new index*/, self.loose_compression)?;
         }
         let index = self.index.load();
         Ok(index

--- a/gix-odb/src/store_impls/dynamic/verify.rs
+++ b/gix-odb/src/store_impls/dynamic/verify.rs
@@ -122,7 +122,7 @@ impl super::Store {
         let _span = gix_features::trace::coarse!("gix_odb:Store::verify_integrity()");
         let mut index = self.index.load();
         if !index.is_initialized() {
-            self.consolidate_with_disk_state(true, false)?;
+            self.consolidate_with_disk_state(true, false, self.loose_compression)?;
             index = self.index.load();
             assert!(
                 index.is_initialized(),

--- a/gix-odb/src/store_impls/dynamic/write.rs
+++ b/gix-odb/src/store_impls/dynamic/write.rs
@@ -35,7 +35,7 @@ where
             None => {
                 let new_snapshot = self
                     .store
-                    .load_one_index(self.refresh, snapshot.marker)
+                    .load_one_index(self.index_ctx(snapshot.marker))
                     .map_err(Box::new)?
                     .expect("there is always at least one ODB, and this code runs only once for initialization");
                 *snapshot = new_snapshot;
@@ -56,7 +56,7 @@ where
             None => {
                 let new_snapshot = self
                     .store
-                    .load_one_index(self.refresh, snapshot.marker)
+                    .load_one_index(self.index_ctx(snapshot.marker))
                     .map_err(Box::new)?
                     .expect("there is always at least one ODB, and this code runs only once for initialization");
                 *snapshot = new_snapshot;
@@ -78,7 +78,7 @@ where
             None => {
                 let new_snapshot = self
                     .store
-                    .load_one_index(self.refresh, snapshot.marker)
+                    .load_one_index(self.index_ctx(snapshot.marker))
                     .map_err(Box::new)?
                     .expect("there is always at least one ODB, and this code runs only once for initialization");
                 *snapshot = new_snapshot;

--- a/gix-odb/src/store_impls/loose/mod.rs
+++ b/gix-odb/src/store_impls/loose/mod.rs
@@ -14,6 +14,8 @@ pub struct Store {
     pub(crate) object_hash: gix_hash::Kind,
     /// The maximum size of a single allocation caused by user-controlled loose object data.
     pub(crate) alloc_limit_bytes: Option<usize>,
+    /// The compression level to use when writing loose objects.
+    pub(crate) compression: gix_zlib::Compression,
 }
 
 /// Initialization
@@ -27,15 +29,21 @@ impl Store {
     ///
     /// `alloc_limit_bytes` limits allocations caused by loose object bodies declared on disk, useful for untrusted input.
     /// Use `None` to disable the limit.
+    ///
+    /// `compression` is the level to deflate loose objects with when writing them. `git` uses
+    /// [`Compression::BEST_SPEED`](gix_zlib::Compression::BEST_SPEED) unless configured
+    /// otherwise with `core.looseCompression` or `core.compression`.
     pub fn at(
         objects_directory: impl Into<PathBuf>,
         object_hash: gix_hash::Kind,
         alloc_limit_bytes: Option<usize>,
+        compression: gix_zlib::Compression,
     ) -> Store {
         Store {
             path: objects_directory.into(),
             object_hash,
             alloc_limit_bytes,
+            compression,
         }
     }
 

--- a/gix-odb/src/store_impls/loose/mod.rs
+++ b/gix-odb/src/store_impls/loose/mod.rs
@@ -5,6 +5,32 @@ use std::path::{Path, PathBuf};
 
 use gix_features::fs;
 
+/// Options for use in [`Store::at()`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Options {
+    /// The kind of hash to use when writing, finding, or iterating objects.
+    pub object_hash: gix_hash::Kind,
+    /// The maximum size of a single allocation caused by user-controlled loose object data.
+    ///
+    /// If `None`, no additional limit is enforced.
+    pub alloc_limit_bytes: Option<usize>,
+    /// The compression level to use when writing loose objects.
+    ///
+    /// Git uses [`Compression::BEST_SPEED`](gix_zlib::Compression::BEST_SPEED) unless configured otherwise with
+    /// `core.looseCompression` or `core.compression`.
+    pub compression: gix_zlib::Compression,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Options {
+            object_hash: Default::default(),
+            alloc_limit_bytes: None,
+            compression: gix_zlib::Compression::BEST_SPEED,
+        }
+    }
+}
+
 /// A database for reading and writing objects to disk, one file per object.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Store {
@@ -25,20 +51,12 @@ impl Store {
     ///
     /// In a git repository, this would be `.git/objects`.
     ///
-    /// The `object_hash` determines which hash to use when writing, finding or iterating objects.
-    ///
-    /// `alloc_limit_bytes` limits allocations caused by loose object bodies declared on disk, useful for untrusted input.
-    /// Use `None` to disable the limit.
-    ///
-    /// `compression` is the level to deflate loose objects with when writing them. `git` uses
-    /// [`Compression::BEST_SPEED`](gix_zlib::Compression::BEST_SPEED) unless configured
-    /// otherwise with `core.looseCompression` or `core.compression`.
-    pub fn at(
-        objects_directory: impl Into<PathBuf>,
-        object_hash: gix_hash::Kind,
-        alloc_limit_bytes: Option<usize>,
-        compression: gix_zlib::Compression,
-    ) -> Store {
+    pub fn at(objects_directory: impl Into<PathBuf>, options: Options) -> Store {
+        let Options {
+            object_hash,
+            alloc_limit_bytes,
+            compression,
+        } = options;
         Store {
             path: objects_directory.into(),
             object_hash,

--- a/gix-odb/src/store_impls/loose/write.rs
+++ b/gix-odb/src/store_impls/loose/write.rs
@@ -170,13 +170,14 @@ impl Store {
             let perms = std::fs::Permissions::from_mode(0o444);
             builder.permissions(perms);
         }
-        Ok(deflate::Write::new(builder.tempfile_in(&self.path).map_err(|err| {
-            Error::Io {
+        Ok(deflate::Write::new(
+            builder.tempfile_in(&self.path).map_err(|err| Error::Io {
                 source: err.into(),
                 message: "create named temp file in",
                 path: self.path.to_owned(),
-            }
-        })?))
+            })?,
+            self.compression,
+        ))
     }
 
     fn finalize_object(

--- a/gix-odb/tests/odb/store/loose.rs
+++ b/gix-odb/tests/odb/store/loose.rs
@@ -8,11 +8,21 @@ use pretty_assertions::assert_eq;
 use crate::hex_to_id;
 
 fn ldb() -> Store {
-    Store::at(fixture_path("objects"), gix_hash::Kind::Sha1, None)
+    Store::at(
+        fixture_path("objects"),
+        gix_hash::Kind::Sha1,
+        None,
+        gix_zlib::Compression::BEST_SPEED,
+    )
 }
 
 fn limited_ldb(limit: usize) -> Store {
-    Store::at(fixture_path("objects"), gix_hash::Kind::Sha1, Some(limit))
+    Store::at(
+        fixture_path("objects"),
+        gix_hash::Kind::Sha1,
+        Some(limit),
+        gix_zlib::Compression::BEST_SPEED,
+    )
 }
 
 pub fn object_ids() -> Vec<gix_hash::ObjectId> {
@@ -53,9 +63,39 @@ mod write {
     use crate::store::loose::{locate_oid, object_ids};
 
     #[test]
+    fn compression_level_is_respected() -> crate::Result {
+        use gix_zlib::Compression;
+        let data: Vec<u8> = (0..64 * 1024).map(|i| (i % 100) as u8).collect();
+        let mut sizes = Vec::new();
+        for level in [Compression::NONE, Compression::BEST] {
+            let dir = gix_testtools::tempfile::tempdir()?;
+            let db = loose::Store::at(dir.path(), gix_hash::Kind::Sha1, None, level);
+            let id = db.write_buf(gix_object::Kind::Blob, &data)?;
+            sizes.push(db.object_path(&id).metadata()?.len());
+
+            let mut buf = Vec::new();
+            assert_eq!(
+                db.try_find(&id, &mut buf)?.expect("just written").data,
+                data,
+                "written objects can be read back regardless of level"
+            );
+        }
+        assert!(
+            sizes[0] > sizes[1],
+            "the best level compresses better than no compression at all: {sizes:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn read_and_write() -> crate::Result {
         let dir = gix_testtools::tempfile::tempdir()?;
-        let db = loose::Store::at(dir.path(), gix_hash::Kind::Sha1, None);
+        let db = loose::Store::at(
+            dir.path(),
+            gix_hash::Kind::Sha1,
+            None,
+            gix_zlib::Compression::BEST_SPEED,
+        );
         let mut buf = Vec::new();
         let mut buf2 = Vec::new();
 
@@ -98,6 +138,7 @@ mod write {
             crate::scripted_fixture_read_only("repo_with_loose_objects.sh")?.join(".git/objects"),
             hk,
             None,
+            gix_zlib::Compression::BEST_SPEED,
         );
         let expected_perm = git_store
             .object_path(&gix_hash::ObjectId::empty_blob(hk))
@@ -105,7 +146,7 @@ mod write {
             .permissions();
 
         let tmp = gix_testtools::tempfile::TempDir::new()?;
-        let store = loose::Store::at(tmp.path(), hk, None);
+        let store = loose::Store::at(tmp.path(), hk, None, gix_zlib::Compression::BEST_SPEED);
         store.write_buf(gix_object::Kind::Blob, &[])?;
         let actual_perm = store
             .object_path(&gix_hash::ObjectId::empty_blob(hk))
@@ -123,7 +164,7 @@ mod write {
         let dir = gix_testtools::tempfile::tempdir()?;
 
         fn write_empty_trees(dir: &std::path::Path) {
-            let db = loose::Store::at(dir, gix_hash::Kind::Sha1, None);
+            let db = loose::Store::at(dir, gix_hash::Kind::Sha1, None, gix_zlib::Compression::BEST_SPEED);
             let empty_tree = gix_object::Tree::empty();
             for _ in 0..2 {
                 let id = db.write(&empty_tree).expect("works");
@@ -194,7 +235,12 @@ mod lookup_prefix {
             b"fake",
         )
         .unwrap();
-        let store = gix_odb::loose::Store::at(objects_dir.path(), gix_hash::Kind::Sha1, None);
+        let store = gix_odb::loose::Store::at(
+            objects_dir.path(),
+            gix_hash::Kind::Sha1,
+            None,
+            gix_zlib::Compression::BEST_SPEED,
+        );
         let input_id = hex_to_id("37d4e6c5c48ba0d245164c4e10d5f41140cab980");
         let prefix = gix_hash::Prefix::new(&input_id, 4).unwrap();
         assert_eq!(
@@ -259,7 +305,12 @@ mod find {
         let base = tmp.path().join("aa");
         std::fs::create_dir(&base)?;
         std::fs::write(base.join("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), [])?;
-        let db = loose::Store::at(tmp.path(), gix_hash::Kind::Sha1, None);
+        let db = loose::Store::at(
+            tmp.path(),
+            gix_hash::Kind::Sha1,
+            None,
+            gix_zlib::Compression::BEST_SPEED,
+        );
 
         let mut buf = Vec::new();
         let id = hex_to_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/gix-odb/tests/odb/store/loose.rs
+++ b/gix-odb/tests/odb/store/loose.rs
@@ -1,27 +1,23 @@
 use std::sync::atomic::AtomicBool;
 
 use gix_features::progress;
-use gix_odb::loose::Store;
+use gix_odb::loose::{Options, Store};
 use gix_testtools::fixture_path;
 use pretty_assertions::assert_eq;
 
 use crate::hex_to_id;
 
 fn ldb() -> Store {
-    Store::at(
-        fixture_path("objects"),
-        gix_hash::Kind::Sha1,
-        None,
-        gix_zlib::Compression::BEST_SPEED,
-    )
+    Store::at(fixture_path("objects"), Options::default())
 }
 
 fn limited_ldb(limit: usize) -> Store {
     Store::at(
         fixture_path("objects"),
-        gix_hash::Kind::Sha1,
-        Some(limit),
-        gix_zlib::Compression::BEST_SPEED,
+        Options {
+            alloc_limit_bytes: Some(limit),
+            ..Default::default()
+        },
     )
 }
 
@@ -69,7 +65,13 @@ mod write {
         let mut sizes = Vec::new();
         for level in [Compression::NONE, Compression::BEST] {
             let dir = gix_testtools::tempfile::tempdir()?;
-            let db = loose::Store::at(dir.path(), gix_hash::Kind::Sha1, None, level);
+            let db = loose::Store::at(
+                dir.path(),
+                loose::Options {
+                    compression: level,
+                    ..Default::default()
+                },
+            );
             let id = db.write_buf(gix_object::Kind::Blob, &data)?;
             sizes.push(db.object_path(&id).metadata()?.len());
 
@@ -90,12 +92,7 @@ mod write {
     #[test]
     fn read_and_write() -> crate::Result {
         let dir = gix_testtools::tempfile::tempdir()?;
-        let db = loose::Store::at(
-            dir.path(),
-            gix_hash::Kind::Sha1,
-            None,
-            gix_zlib::Compression::BEST_SPEED,
-        );
+        let db = loose::Store::at(dir.path(), loose::Options::default());
         let mut buf = Vec::new();
         let mut buf2 = Vec::new();
 
@@ -136,9 +133,10 @@ mod write {
         let hk = gix_testtools::object_hash();
         let git_store = loose::Store::at(
             crate::scripted_fixture_read_only("repo_with_loose_objects.sh")?.join(".git/objects"),
-            hk,
-            None,
-            gix_zlib::Compression::BEST_SPEED,
+            loose::Options {
+                object_hash: hk,
+                ..Default::default()
+            },
         );
         let expected_perm = git_store
             .object_path(&gix_hash::ObjectId::empty_blob(hk))
@@ -146,7 +144,13 @@ mod write {
             .permissions();
 
         let tmp = gix_testtools::tempfile::TempDir::new()?;
-        let store = loose::Store::at(tmp.path(), hk, None, gix_zlib::Compression::BEST_SPEED);
+        let store = loose::Store::at(
+            tmp.path(),
+            loose::Options {
+                object_hash: hk,
+                ..Default::default()
+            },
+        );
         store.write_buf(gix_object::Kind::Blob, &[])?;
         let actual_perm = store
             .object_path(&gix_hash::ObjectId::empty_blob(hk))
@@ -164,7 +168,7 @@ mod write {
         let dir = gix_testtools::tempfile::tempdir()?;
 
         fn write_empty_trees(dir: &std::path::Path) {
-            let db = loose::Store::at(dir, gix_hash::Kind::Sha1, None, gix_zlib::Compression::BEST_SPEED);
+            let db = loose::Store::at(dir, loose::Options::default());
             let empty_tree = gix_object::Tree::empty();
             for _ in 0..2 {
                 let id = db.write(&empty_tree).expect("works");
@@ -235,12 +239,7 @@ mod lookup_prefix {
             b"fake",
         )
         .unwrap();
-        let store = gix_odb::loose::Store::at(
-            objects_dir.path(),
-            gix_hash::Kind::Sha1,
-            None,
-            gix_zlib::Compression::BEST_SPEED,
-        );
+        let store = gix_odb::loose::Store::at(objects_dir.path(), gix_odb::loose::Options::default());
         let input_id = hex_to_id("37d4e6c5c48ba0d245164c4e10d5f41140cab980");
         let prefix = gix_hash::Prefix::new(&input_id, 4).unwrap();
         assert_eq!(
@@ -305,12 +304,7 @@ mod find {
         let base = tmp.path().join("aa");
         std::fs::create_dir(&base)?;
         std::fs::write(base.join("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), [])?;
-        let db = loose::Store::at(
-            tmp.path(),
-            gix_hash::Kind::Sha1,
-            None,
-            gix_zlib::Compression::BEST_SPEED,
-        );
+        let db = loose::Store::at(tmp.path(), loose::Options::default());
 
         let mut buf = Vec::new();
         let id = hex_to_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -36,7 +36,7 @@ pack-cache-lru-dynamic = ["dep:clru"]
 ## If set, select algorithms may additionally use a full-object cache which is queried before the pack itself.
 object-cache-dynamic = ["dep:clru", "dep:gix-hashtable"]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde = ["dep:serde", "gix-object/serde"]
+serde = ["dep:serde", "gix-object/serde", "gix-zlib/serde"]
 ## Enable parallel algorithms.
 parallel = ["gix-features/parallel"]
 ## Make it possible to compile to the `wasm32-unknown-unknown` target.

--- a/gix-pack/src/bundle/write/mod.rs
+++ b/gix-pack/src/bundle/write/mod.rs
@@ -101,6 +101,7 @@ impl crate::Bundle {
                         object_hash,
                     )?,
                     thin_pack_lookup,
+                    options.compression,
                 );
                 let pack_version = pack_entries_iter.inner.version();
                 let pack_entries_iter = data::input::EntriesToBytesIter::new(
@@ -209,6 +210,7 @@ impl crate::Bundle {
                         object_hash,
                     )?,
                     thin_pack_lookup,
+                    options.compression,
                 );
                 let pack_kind = pack_entries_iter.inner.version();
                 (Box::new(pack_entries_iter), pack_kind)
@@ -270,6 +272,7 @@ impl crate::Bundle {
             index_version: index_kind,
             object_hash,
             alloc_limit_bytes,
+            compression: _,
         }: Options,
         data_file: SharedTempFile,
         mut pack_entries_iter: Box<dyn Iterator<Item = Result<data::input::Entry, data::input::Error>> + 'a>,

--- a/gix-pack/src/bundle/write/types.rs
+++ b/gix-pack/src/bundle/write/types.rs
@@ -18,6 +18,12 @@ pub struct Options {
     /// entries into decoded object and delta result buffers to write the index.
     /// `Some(0)` rejects all non-empty allocations.
     pub alloc_limit_bytes: Option<usize>,
+    /// The compression level to use when deflating base objects that are added to the pack to complete a thin pack.
+    ///
+    /// Defaults to [`Compression::BEST_SPEED`](gix_zlib::Compression::BEST_SPEED) - `git` compresses
+    /// these with the same level it uses for loose objects, which is `core.looseCompression` or
+    /// `core.compression`, or level 1 if neither is set.
+    pub compression: gix_zlib::Compression,
 }
 
 impl Default for Options {
@@ -29,6 +35,7 @@ impl Default for Options {
             index_version: Default::default(),
             object_hash: Default::default(),
             alloc_limit_bytes: None,
+            compression: gix_zlib::Compression::BEST_SPEED,
         }
     }
 }

--- a/gix-pack/src/cache/delta/traverse/resolve.rs
+++ b/gix-pack/src/cache/delta/traverse/resolve.rs
@@ -620,7 +620,7 @@ mod tests {
     }
 
     fn deflate(bytes: &[u8]) -> Vec<u8> {
-        let mut out = gix_zlib::stream::deflate::Write::new(Vec::new());
+        let mut out = gix_zlib::stream::deflate::Write::new(Vec::new(), gix_zlib::Compression::BEST_SPEED);
         out.write_all(bytes).expect("writing to deflater succeeds");
         out.flush().expect("flushing deflater succeeds");
         out.into_inner()

--- a/gix-pack/src/data/input/entry.rs
+++ b/gix-pack/src/data/input/entry.rs
@@ -3,12 +3,17 @@ use std::io::Write;
 use crate::data::{entry::Header, input};
 
 impl input::Entry {
-    /// Create a new input entry from a given data `obj` set to be placed at the given `pack_offset`.
+    /// Create a new input entry from a given data `obj` set to be placed at the given `pack_offset`,
+    /// deflating its data with `compression`.
     ///
     /// This method is useful when arbitrary base entries are created
-    pub fn from_data_obj(obj: &gix_object::Data<'_>, pack_offset: u64) -> Result<Self, input::Error> {
+    pub fn from_data_obj(
+        obj: &gix_object::Data<'_>,
+        pack_offset: u64,
+        compression: gix_zlib::Compression,
+    ) -> Result<Self, input::Error> {
         let header = to_header(obj.kind);
-        let compressed = compress_data(obj)?;
+        let compressed = compress_data(obj, compression)?;
         let compressed_size = compressed.len() as u64;
         let mut entry = input::Entry {
             header,
@@ -50,8 +55,8 @@ fn to_header(kind: gix_object::Kind) -> Header {
     }
 }
 
-fn compress_data(obj: &gix_object::Data<'_>) -> Result<Vec<u8>, input::Error> {
-    let mut out = gix_zlib::stream::deflate::Write::new(Vec::new());
+fn compress_data(obj: &gix_object::Data<'_>, compression: gix_zlib::Compression) -> Result<Vec<u8>, input::Error> {
+    let mut out = gix_zlib::stream::deflate::Write::new(Vec::new(), compression);
     if let Err(err) = std::io::copy(&mut &*obj.data, &mut out) {
         match err.kind() {
             std::io::ErrorKind::Other => return Err(input::Error::Io(err.into())),

--- a/gix-pack/src/data/input/lookup_ref_delta_objects.rs
+++ b/gix-pack/src/data/input/lookup_ref_delta_objects.rs
@@ -7,6 +7,8 @@ pub struct LookupRefDeltaObjectsIter<I, Find> {
     /// The inner iterator whose entries we will resolve.
     pub inner: I,
     lookup: Find,
+    /// The compression level to use when deflating resolved base objects into entries.
+    compression: gix_zlib::Compression,
     /// The cached delta to provide next time we are called, it's the delta to go with the base we just resolved in its place.
     next_delta: Option<input::Entry>,
     /// Fuse to stop iteration after first missing object.
@@ -25,11 +27,12 @@ where
     Find: gix_object::Find,
 {
     /// Create a new instance wrapping `iter` and using `lookup` as function to retrieve objects that will serve as bases
-    /// for ref deltas seen while traversing `iter`.
-    pub fn new(iter: I, lookup: Find) -> Self {
+    /// for ref deltas seen while traversing `iter`, deflating them with `compression`.
+    pub fn new(iter: I, lookup: Find, compression: gix_zlib::Compression) -> Self {
         LookupRefDeltaObjectsIter {
             inner: iter,
             lookup,
+            compression,
             error: false,
             inserted_entry_length_at_offset: Vec::new(),
             inserted_entries_length_in_bytes: 0,
@@ -95,7 +98,7 @@ where
                             let base_entry = match self.lookup.try_find(&base_id, &mut self.buf).ok()? {
                                 Some(obj) => {
                                     let current_pack_offset = entry.pack_offset;
-                                    let mut entry = match input::Entry::from_data_obj(&obj, 0) {
+                                    let mut entry = match input::Entry::from_data_obj(&obj, 0, self.compression) {
                                         Ok(e) => e,
                                         Err(err) => return Some(Err(err)),
                                     };

--- a/gix-pack/src/data/output/entry/iter_from_counts.rs
+++ b/gix-pack/src/data/output/entry/iter_from_counts.rs
@@ -52,6 +52,7 @@ pub(crate) mod function {
             allow_thin_pack,
             thread_limit,
             chunk_size,
+            compression,
         }: Options,
     ) -> impl Iterator<Item = Result<(SequenceId, Vec<output::Entry>), Error>>
     + parallel::reduce::Finalize<Reduce = reduce::Statistics<Error>>
@@ -214,7 +215,7 @@ pub(crate) mod function {
                                     None => match db.try_find(&count.id, buf).map_err(Error::Find)? {
                                         Some((obj, _location)) => {
                                             stats.decoded_and_recompressed_objects += 1;
-                                            output::Entry::from_data(count, &obj)
+                                            output::Entry::from_data(count, &obj, compression)
                                         }
                                         None => {
                                             stats.missing_objects += 1;
@@ -226,7 +227,7 @@ pub(crate) mod function {
                             None => match db.try_find(&count.id, buf).map_err(Error::Find)? {
                                 Some((obj, _location)) => {
                                     stats.decoded_and_recompressed_objects += 1;
-                                    output::Entry::from_data(count, &obj)
+                                    output::Entry::from_data(count, &obj, compression)
                                 }
                                 None => {
                                     stats.missing_objects += 1;
@@ -385,6 +386,13 @@ mod types {
         pub chunk_size: usize,
         /// The pack data version to produce for each entry
         pub version: crate::data::Version,
+        /// The compression level to use for objects that are not copied from an existing pack,
+        /// but deflated from their object data.
+        ///
+        /// Defaults to [`Compression::DEFAULT`](gix_zlib::Compression::DEFAULT), which is
+        /// also the default that `git` uses when writing packs, unless configured otherwise
+        /// with `pack.compression`.
+        pub compression: gix_zlib::Compression,
     }
 
     impl Default for Options {
@@ -395,6 +403,7 @@ mod types {
                 allow_thin_pack: false,
                 chunk_size: 10,
                 version: Default::default(),
+                compression: gix_zlib::Compression::DEFAULT,
             }
         }
     }

--- a/gix-pack/src/data/output/entry/mod.rs
+++ b/gix-pack/src/data/output/entry/mod.rs
@@ -130,14 +130,22 @@ impl output::Entry {
         })
     }
 
-    /// Create a new instance from the given `oid` and its corresponding git object data `obj`.
-    pub fn from_data(count: &output::Count, obj: &gix_object::Data<'_>) -> Result<Self, Error> {
+    /// Create a new instance from the given `oid` and its corresponding git object data `obj`,
+    /// deflating it with `compression`.
+    ///
+    /// Note that `git` compresses pack entries with the level configured with `pack.compression`,
+    /// whose default is [`Compression::DEFAULT`](gix_zlib::Compression::DEFAULT).
+    pub fn from_data(
+        count: &output::Count,
+        obj: &gix_object::Data<'_>,
+        compression: gix_zlib::Compression,
+    ) -> Result<Self, Error> {
         Ok(output::Entry {
             id: count.id.to_owned(),
             kind: Kind::Base(obj.kind),
             decompressed_size: obj.data.len(),
             compressed_data: {
-                let mut out = gix_zlib::stream::deflate::Write::new(Vec::new());
+                let mut out = gix_zlib::stream::deflate::Write::new(Vec::new(), compression);
                 if let Err(err) = std::io::copy(&mut &*obj.data, &mut out) {
                     match err.kind() {
                         std::io::ErrorKind::Other => return Err(Error::ZlibDeflate(err)),

--- a/gix-pack/tests/pack/bundle.rs
+++ b/gix-pack/tests/pack/bundle.rs
@@ -169,6 +169,7 @@ mod write_to_directory {
                 index_version: pack::index::Version::V2,
                 object_hash: gix_hash::Kind::Sha1,
                 alloc_limit_bytes: prevent_allocation,
+                compression: gix_zlib::Compression::BEST_SPEED,
             },
         )
         .expect_err("a zero allocation limit rejects the first non-empty decoded object");
@@ -203,6 +204,7 @@ mod write_to_directory {
                 index_version: pack::index::Version::V2,
                 object_hash: gix_hash::Kind::Sha1,
                 alloc_limit_bytes: None,
+                compression: gix_zlib::Compression::BEST_SPEED,
             },
         )
         .map_err(Into::into)

--- a/gix-pack/tests/pack/data/fuzzed.rs
+++ b/gix-pack/tests/pack/data/fuzzed.rs
@@ -58,7 +58,7 @@ fn oversized_pack_entry_header_is_reported_without_panicking() {
 #[test]
 fn non_canonical_pack_entry_header_is_accepted() {
     fn deflate(bytes: &[u8]) -> Vec<u8> {
-        let mut out = gix_zlib::stream::deflate::Write::new(Vec::new());
+        let mut out = gix_zlib::stream::deflate::Write::new(Vec::new(), gix_zlib::Compression::BEST_SPEED);
         out.write_all(bytes).expect("writing to deflater succeeds");
         out.flush().expect("flushing deflater succeeds");
         out.into_inner()
@@ -136,7 +136,7 @@ fn oversized_declared_object_size_is_reported_without_panicking() {
 #[test]
 fn declared_object_size_over_alloc_limit_bytes_is_reported_as_out_of_memory() {
     fn deflate(bytes: &[u8]) -> Vec<u8> {
-        let mut out = gix_zlib::stream::deflate::Write::new(Vec::new());
+        let mut out = gix_zlib::stream::deflate::Write::new(Vec::new(), gix_zlib::Compression::BEST_SPEED);
         out.write_all(bytes).expect("writing to deflater succeeds");
         out.flush().expect("flushing deflater succeeds");
         out.into_inner()
@@ -508,7 +508,7 @@ fn overlong_delta_header_size_is_reported_without_panicking() {
 #[test]
 fn short_delta_application_is_reported_without_panicking() {
     fn deflate(bytes: &[u8]) -> Vec<u8> {
-        let mut out = gix_zlib::stream::deflate::Write::new(Vec::new());
+        let mut out = gix_zlib::stream::deflate::Write::new(Vec::new(), gix_zlib::Compression::BEST_SPEED);
         out.write_all(bytes).expect("writing to deflater succeeds");
         out.flush().expect("flushing deflater succeeds");
         out.into_inner()

--- a/gix-pack/tests/pack/data/input.rs
+++ b/gix-pack/tests/pack/data/input.rs
@@ -35,7 +35,7 @@ mod lookup_ref_delta_objects {
             object_hash: gix_testtools::object_hash(),
             data,
         };
-        let mut entry = input::Entry::from_data_obj(&obj, 0).expect("valid object");
+        let mut entry = input::Entry::from_data_obj(&obj, 0, gix_zlib::Compression::BEST_SPEED).expect("valid object");
         entry.header = header;
         entry.header_size = header.size(data.len() as u64) as u16;
         entry
@@ -99,8 +99,12 @@ mod lookup_ref_delta_objects {
     fn only_ref_deltas_are_handled() -> crate::Result {
         let input = compute_offsets(vec![entry(base(), D_A), entry(delta_ofs(100), D_B)]);
         let expected = input.clone();
-        let actual = LookupRefDeltaObjectsIter::new(into_results_iter(input), gix_object::find::Never)
-            .collect::<Result<Vec<_>, _>>()?;
+        let actual = LookupRefDeltaObjectsIter::new(
+            into_results_iter(input),
+            gix_object::find::Never,
+            gix_zlib::Compression::BEST_SPEED,
+        )
+        .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(actual, expected, "it won't change the input at all");
         validate_pack_offsets(&actual);
         Ok(())
@@ -124,7 +128,7 @@ mod lookup_ref_delta_objects {
         let input_entries = into_results_iter(input);
         let actual_size = input_entries.size_hint();
         let db = FindData::new(inserted_data, &calls);
-        let iter = LookupRefDeltaObjectsIter::new(input_entries, &db);
+        let iter = LookupRefDeltaObjectsIter::new(input_entries, &db, gix_zlib::Compression::BEST_SPEED);
         assert_eq!(
             iter.size_hint(),
             (actual_size.0, actual_size.1.map(|s| s * 2)),
@@ -182,7 +186,9 @@ mod lookup_ref_delta_objects {
         let input = vec![entry(delta_ref(gix_hash::Kind::Sha1.null()), D_A), entry(base(), D_B)];
         let calls = AtomicUsize::default();
         let db = FindData::new(None, &calls);
-        let mut result = LookupRefDeltaObjectsIter::new(into_results_iter(input), &db).collect::<Vec<_>>();
+        let mut result =
+            LookupRefDeltaObjectsIter::new(into_results_iter(input), &db, gix_zlib::Compression::BEST_SPEED)
+                .collect::<Vec<_>>();
         assert_eq!(calls.load(Ordering::Relaxed), 1, "it tries to lookup the object");
         assert_eq!(result.len(), 1, "the error stops iteration");
         assert!(matches!(
@@ -209,7 +215,12 @@ mod lookup_ref_delta_objects {
             }),
             Ok(entry(base(), D_B)),
         ];
-        let actual = LookupRefDeltaObjectsIter::new(input.into_iter(), gix_object::find::Never).collect::<Vec<_>>();
+        let actual = LookupRefDeltaObjectsIter::new(
+            input.into_iter(),
+            gix_object::find::Never,
+            gix_zlib::Compression::BEST_SPEED,
+        )
+        .collect::<Vec<_>>();
         for (actual, expected) in actual.into_iter().zip(expected) {
             assert_eq!(format!("{actual:?}"), format!("{expected:?}"));
         }

--- a/gix-pack/tests/pack/data/output/count_and_entries.rs
+++ b/gix-pack/tests/pack/data/output/count_and_entries.rs
@@ -367,6 +367,74 @@ fn traversals() -> crate::Result {
     Ok(())
 }
 
+/// Reproduces https://github.com/GitoxideLabs/gitoxide/issues/2024: with the default backend's
+/// level 1 being much weaker than it used to be, entries have to be compressed with the
+/// configured level, defaulting to what `git` uses.
+#[test]
+fn entry_sizes_depend_on_compression_level() -> crate::Result {
+    // Deterministic pseudo-random bytes (xorshift64*), so tree content is stable across runs.
+    struct Rng(u64);
+    impl Rng {
+        fn next_byte(&mut self) -> u8 {
+            self.0 ^= self.0 >> 12;
+            self.0 ^= self.0 << 25;
+            self.0 ^= self.0 >> 27;
+            (self.0.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 56) as u8
+        }
+    }
+    let mut rng = Rng(0x2024);
+    let mut files = (0..1500)
+        .map(|_| {
+            use std::fmt::Write;
+            (0..10).fold(String::new(), |mut buf, _| {
+                write!(buf, "{:02x}", rng.next_byte()).expect("writing to a string never fails");
+                buf
+            })
+        })
+        .collect::<Vec<_>>();
+    files.sort();
+    files.dedup();
+
+    let blob_id = gix_object::compute_hash(gix_hash::Kind::Sha1, gix_object::Kind::Blob, b"xoxo")?;
+    let tree = gix_object::Tree {
+        entries: files
+            .iter()
+            .map(|name| gix_object::tree::Entry {
+                mode: gix_object::tree::EntryKind::Blob.into(),
+                oid: blob_id,
+                filename: name.as_str().into(),
+            })
+            .collect(),
+    };
+    let mut buf = Vec::new();
+    gix_object::WriteTo::write_to(&tree, &mut buf)?;
+    let tree_id = gix_object::compute_hash(gix_hash::Kind::Sha1, gix_object::Kind::Tree, &buf)?;
+
+    let entry_size = |compression| -> Result<usize, output::entry::Error> {
+        Ok(output::Entry::from_data(
+            &output::Count::from_data(tree_id, None),
+            &gix_object::Data::new(&buf, gix_object::Kind::Tree, gix_hash::Kind::Sha1),
+            compression,
+        )?
+        .compressed_data
+        .len())
+    };
+
+    use gix_zlib::Compression;
+    let default = entry_size(Compression::DEFAULT)?;
+    let fastest = entry_size(Compression::BEST_SPEED)?;
+    let none = entry_size(Compression::NONE)?;
+    assert!(
+        default < 25_000,
+        "the default compression level keeps this ~72KB tree below the issue's regression threshold: {default}"
+    );
+    assert!(
+        none > fastest && fastest >= default,
+        "higher levels compress at least as well as lower ones: none={none} fastest={fastest} default={default}"
+    );
+    Ok(())
+}
+
 #[test]
 #[cfg(all(not(feature = "wasm"), feature = "streaming-input"))]
 fn empty_pack_is_allowed() {

--- a/gix-pack/tests/pack/data/output/count_and_entries.rs
+++ b/gix-pack/tests/pack/data/output/count_and_entries.rs
@@ -372,43 +372,47 @@ fn traversals() -> crate::Result {
 /// configured level, defaulting to what `git` uses.
 #[test]
 fn entry_sizes_depend_on_compression_level() -> crate::Result {
-    // Deterministic pseudo-random bytes (xorshift64*), so tree content is stable across runs.
-    struct Rng(u64);
-    impl Rng {
-        fn next_byte(&mut self) -> u8 {
-            self.0 ^= self.0 >> 12;
-            self.0 ^= self.0 << 25;
-            self.0 ^= self.0 >> 27;
-            (self.0.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 56) as u8
+    use gix_object::WriteTo;
+    let (tree_id, buf) = {
+        // Deterministic pseudo-random bytes (xorshift64*), so tree content is stable across runs.
+        struct Rng(u64);
+        impl Rng {
+            fn next_byte(&mut self) -> u8 {
+                self.0 ^= self.0 >> 12;
+                self.0 ^= self.0 << 25;
+                self.0 ^= self.0 >> 27;
+                (self.0.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 56) as u8
+            }
         }
-    }
-    let mut rng = Rng(0x2024);
-    let mut files = (0..1500)
-        .map(|_| {
-            use std::fmt::Write;
-            (0..10).fold(String::new(), |mut buf, _| {
-                write!(buf, "{:02x}", rng.next_byte()).expect("writing to a string never fails");
-                buf
+        let mut rng = Rng(0x2024);
+        let mut files = (0..1500)
+            .map(|_| {
+                use std::fmt::Write;
+                (0..10).fold(String::new(), |mut buf, _| {
+                    write!(buf, "{:02x}", rng.next_byte()).expect("writing to a string never fails");
+                    buf
+                })
             })
-        })
-        .collect::<Vec<_>>();
-    files.sort();
-    files.dedup();
+            .collect::<Vec<_>>();
+        files.sort();
+        files.dedup();
 
-    let blob_id = gix_object::compute_hash(gix_hash::Kind::Sha1, gix_object::Kind::Blob, b"xoxo")?;
-    let tree = gix_object::Tree {
-        entries: files
-            .iter()
-            .map(|name| gix_object::tree::Entry {
-                mode: gix_object::tree::EntryKind::Blob.into(),
-                oid: blob_id,
-                filename: name.as_str().into(),
-            })
-            .collect(),
+        let blob_id = gix_object::compute_hash(gix_hash::Kind::Sha1, gix_object::Kind::Blob, b"xoxo")?;
+        let tree = gix_object::Tree {
+            entries: files
+                .iter()
+                .map(|name| gix_object::tree::Entry {
+                    mode: gix_object::tree::EntryKind::Blob.into(),
+                    oid: blob_id,
+                    filename: name.as_str().into(),
+                })
+                .collect(),
+        };
+        let mut buf = Vec::new();
+        tree.write_to(&mut buf)?;
+        let tree_id = gix_object::compute_hash(gix_hash::Kind::Sha1, gix_object::Kind::Tree, &buf)?;
+        (tree_id, buf)
     };
-    let mut buf = Vec::new();
-    gix_object::WriteTo::write_to(&tree, &mut buf)?;
-    let tree_id = gix_object::compute_hash(gix_hash::Kind::Sha1, gix_object::Kind::Tree, &buf)?;
 
     let entry_size = |compression| -> Result<usize, output::entry::Error> {
         Ok(output::Entry::from_data(

--- a/gix-pack/tests/pack/malformed.rs
+++ b/gix-pack/tests/pack/malformed.rs
@@ -254,7 +254,7 @@ fn encode_delta_size(mut size: u64) -> Vec<u8> {
 }
 
 fn deflate(bytes: &[u8]) -> crate::Result<Vec<u8>> {
-    let mut write = gix_zlib::stream::deflate::Write::new(Vec::new());
+    let mut write = gix_zlib::stream::deflate::Write::new(Vec::new(), gix_zlib::Compression::BEST_SPEED);
     write.write_all(bytes)?;
     write.flush()?;
     Ok(write.into_inner())

--- a/gix-zlib/Cargo.toml
+++ b/gix-zlib/Cargo.toml
@@ -15,9 +15,13 @@ include = ["/src/**/*", "/LICENSE-*"]
 doctest = false
 test = false
 
+[features]
+serde = ["dep:serde"]
+
 [dependencies]
 zlib-rs = "0.6.2"
 thiserror = "2.0.18"
+serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 bstr = { version = "1.12.0", default-features = false }

--- a/gix-zlib/src/lib.rs
+++ b/gix-zlib/src/lib.rs
@@ -35,6 +35,12 @@ impl Compression {
     }
 }
 
+impl Default for Compression {
+    fn default() -> Self {
+        Compression::DEFAULT
+    }
+}
+
 /// A type to hold all state needed for decompressing a ZLIB encoded stream.
 pub struct Decompress(zlib_rs::Inflate);
 

--- a/gix-zlib/src/lib.rs
+++ b/gix-zlib/src/lib.rs
@@ -1,6 +1,40 @@
 #![deny(missing_docs)]
 //! Streaming compression and decompression utilities used by gitoxide.
 
+/// The compression level to use for zlib-based streams, in the range from 0 (no compression)
+/// to 9 (best compression, slowest).
+///
+/// Note that `git` maps its configured level of `-1` to the zlib default, which is level 6
+/// and available as [`Compression::DEFAULT`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Compression(i32);
+
+impl Compression {
+    /// Do not compress at all, while still producing a valid zlib stream.
+    pub const NONE: Compression = Compression(0);
+    /// The fastest compression, with the lowest compression ratio, also known as level 1.
+    ///
+    /// This is what `git` uses for loose objects unless configured otherwise with `core.looseCompression`.
+    pub const BEST_SPEED: Compression = Compression(1);
+    /// The default compromise between speed and compression ratio, also known as level 6.
+    ///
+    /// This is what `git` uses when writing packs unless configured otherwise with `pack.compression`.
+    pub const DEFAULT: Compression = Compression(6);
+    /// The best compression ratio at the expense of speed, also known as level 9.
+    pub const BEST: Compression = Compression(9);
+
+    /// Create a new instance from `level` if it is within the valid range from 0 to 9, inclusive.
+    pub fn new(level: i32) -> Option<Self> {
+        (0..=9).contains(&level).then_some(Compression(level))
+    }
+
+    /// Return the compression level as integer in the range from 0 to 9, inclusive.
+    pub fn level(&self) -> i32 {
+        self.0
+    }
+}
+
 /// A type to hold all state needed for decompressing a ZLIB encoded stream.
 pub struct Decompress(zlib_rs::Inflate);
 

--- a/gix-zlib/src/stream/deflate.rs
+++ b/gix-zlib/src/stream/deflate.rs
@@ -1,6 +1,6 @@
 //! Compression state and a [`std::io::Write`] adapter for producing zlib streams.
 
-use crate::Status;
+use crate::{Compression, Status};
 use zlib_rs::DeflateError;
 
 const BUF_SIZE: usize = 4096 * 8;
@@ -10,6 +10,7 @@ const BUF_SIZE: usize = 4096 * 8;
 /// Be sure to call `flush()` when done to finalize the deflate stream.
 pub struct Write<W> {
     compressor: Compress,
+    compression: Compression,
     inner: W,
     buf: [u8; BUF_SIZE],
 }
@@ -20,7 +21,8 @@ where
 {
     fn clone(&self) -> Self {
         Write {
-            compressor: impls::new_compress(),
+            compressor: impls::new_compress(self.compression),
+            compression: self.compression,
             inner: self.inner.clone(),
             buf: self.buf,
         }
@@ -29,12 +31,6 @@ where
 
 /// Hold all state needed for compressing data.
 pub struct Compress(zlib_rs::Deflate);
-
-impl Default for Compress {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 impl Compress {
     /// The number of bytes that were read from the input.
@@ -47,9 +43,9 @@ impl Compress {
         self.0.total_out()
     }
 
-    /// Create a new instance - this allocates so should be done with care.
-    pub fn new() -> Self {
-        let config = zlib_rs::DeflateConfig::best_speed();
+    /// Create a new instance compressing with `level` - this allocates so should be done with care.
+    pub fn new(level: Compression) -> Self {
+        let config = zlib_rs::DeflateConfig::new(level.level());
         let header = true;
         let inner = zlib_rs::Deflate::new(config.level, header, config.window_bits as u8);
         Self(inner)
@@ -148,21 +144,22 @@ pub enum FlushCompress {
 mod impls {
     use std::io;
 
-    use crate::Status;
     use crate::stream::deflate::{self, Compress, FlushCompress};
+    use crate::{Compression, Status};
 
-    pub(crate) fn new_compress() -> Compress {
-        Compress::new()
+    pub(crate) fn new_compress(level: Compression) -> Compress {
+        Compress::new(level)
     }
 
     impl<W> deflate::Write<W>
     where
         W: io::Write,
     {
-        /// Create a new instance writing compressed bytes to `inner`.
-        pub fn new(inner: W) -> deflate::Write<W> {
+        /// Create a new instance writing bytes compressed with `level` to `inner`.
+        pub fn new(inner: W, level: Compression) -> deflate::Write<W> {
             deflate::Write {
-                compressor: new_compress(),
+                compressor: new_compress(level),
+                compression: level,
                 inner,
                 buf: [0; deflate::BUF_SIZE],
             }

--- a/gix-zlib/tests/zlib/stream/deflate.rs
+++ b/gix-zlib/tests/zlib/stream/deflate.rs
@@ -5,11 +5,11 @@ use std::{
 
 use bstr::ByteSlice;
 
-use gix_zlib::Decompress;
 use gix_zlib::stream::deflate::{self, Compress, FlushCompress};
+use gix_zlib::{Compression, Decompress};
 
 pub(crate) fn compressed(data: &[u8]) -> Vec<u8> {
-    let mut writer = deflate::Write::new(Vec::new());
+    let mut writer = deflate::Write::new(Vec::new(), Compression::BEST_SPEED);
     writer.write_all(data).expect("in-memory writes never fail");
     writer.flush().expect("in-memory flushes never fail");
     writer.into_inner()
@@ -63,7 +63,7 @@ fn small_file_decompress() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn all_at_once() -> Result<(), Box<dyn std::error::Error>> {
-    let mut w = deflate::Write::new(Vec::new());
+    let mut w = deflate::Write::new(Vec::new(), Compression::BEST_SPEED);
     assert_eq!(w.write(b"hello")?, 5);
     w.flush()?;
 
@@ -81,8 +81,27 @@ fn assert_deflate_buffer(out: Vec<u8>, expected: &[u8]) -> Result<(), Box<dyn st
 }
 
 #[test]
+fn higher_levels_compress_better() -> Result<(), Box<dyn std::error::Error>> {
+    let data: Vec<u8> = (0..128 * 1024).map(|i| (i % 100) as u8).collect();
+    let mut sizes = Vec::new();
+    for level in [Compression::NONE, Compression::BEST_SPEED, Compression::DEFAULT] {
+        let mut writer = deflate::Write::new(Vec::new(), level);
+        writer.write_all(&data)?;
+        writer.flush()?;
+        let compressed = writer.into_inner();
+        assert_deflate_buffer(compressed.clone(), &data)?;
+        sizes.push(compressed.len());
+    }
+    assert!(
+        sizes[0] > sizes[1] && sizes[1] > sizes[2],
+        "each level compresses better than the one before it: {sizes:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn big_file_small_writes() -> Result<(), Box<dyn std::error::Error>> {
-    let mut w = deflate::Write::new(Vec::new());
+    let mut w = deflate::Write::new(Vec::new(), Compression::BEST_SPEED);
     let bytes = include_bytes!(
         "../../../../gix-odb/tests/fixtures/objects/pack/pack-11fdfa9e156ab73caae3b6da867192221f2089c2.pack"
     );
@@ -96,7 +115,7 @@ fn big_file_small_writes() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn big_file_a_few_big_writes() -> Result<(), Box<dyn std::error::Error>> {
-    let mut w = deflate::Write::new(Vec::new());
+    let mut w = deflate::Write::new(Vec::new(), Compression::BEST_SPEED);
     let bytes = include_bytes!(
         "../../../../gix-odb/tests/fixtures/objects/pack/pack-11fdfa9e156ab73caae3b6da867192221f2089c2.pack"
     );
@@ -116,7 +135,7 @@ fn compressor_lifecycle_counters_and_flush_modes() -> Result<(), Box<dyn std::er
         FlushCompress::Sync,
         FlushCompress::Full,
     ] {
-        let mut compressor = Compress::default();
+        let mut compressor = Compress::new(Compression::BEST_SPEED);
         assert_eq!(compressor.total_in(), 0);
         assert_eq!(compressor.total_out(), 0);
 
@@ -146,14 +165,14 @@ fn compressor_lifecycle_counters_and_flush_modes() -> Result<(), Box<dyn std::er
 
 #[test]
 fn writer_clone_and_reset() -> Result<(), Box<dyn std::error::Error>> {
-    let original = deflate::Write::new(Vec::new());
+    let original = deflate::Write::new(Vec::new(), Compression::BEST_SPEED);
     let mut cloned = original.clone();
     cloned.write_all(b"clone owns a fresh compressor")?;
     cloned.flush()?;
     assert_deflate_buffer(cloned.into_inner(), b"clone owns a fresh compressor")?;
     assert!(original.into_inner().is_empty());
 
-    let mut writer = deflate::Write::new(Vec::new());
+    let mut writer = deflate::Write::new(Vec::new(), Compression::BEST_SPEED);
     writer.write_all(b"first")?;
     writer.flush()?;
     writer.reset();

--- a/gix-zlib/tests/zlib/stream/inflate.rs
+++ b/gix-zlib/tests/zlib/stream/inflate.rs
@@ -21,7 +21,7 @@ fn errors_keep_the_underlying_cause() {
 }
 
 fn deflated(data: &[u8]) -> Vec<u8> {
-    let mut out = deflate::Write::new(Vec::new());
+    let mut out = deflate::Write::new(Vec::new(), gix_zlib::Compression::BEST_SPEED);
     out.write_all(data).expect("in-memory writes never fail");
     out.flush().expect("in-memory flushes never fail");
     out.into_inner()

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -339,6 +339,7 @@ gix-dir = { version = "^0.27.0", path = "../gix-dir", optional = true }
 
 gix-config = { version = "^0.58.0", path = "../gix-config" }
 gix-odb = { version = "^0.82.0", path = "../gix-odb" }
+gix-zlib = { version = "^0.1.0", path = "../gix-zlib" }
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-shallow = { version = "^0.12.1", path = "../gix-shallow" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }

--- a/gix/src/config/cache/access.rs
+++ b/gix/src/config/cache/access.rs
@@ -525,6 +525,57 @@ impl Cache {
     }
 }
 
+fn compression(
+    config: &gix_config::File<'static>,
+    lenient: bool,
+    mut filter_config_section: fn(&gix_config::file::Metadata) -> bool,
+    key: &'static config::tree::keys::Compression,
+    default: gix_zlib::Compression,
+) -> Result<gix_zlib::Compression, config::Error> {
+    let level = match config
+        .integer_filter(key, &mut filter_config_section)
+        .map(|value| key.try_into_compression(value))
+        .transpose()
+        .with_leniency(lenient)?
+    {
+        Some(level) => Some(level),
+        None => config
+            .integer_filter(Core::COMPRESSION, &mut filter_config_section)
+            .map(|value| Core::COMPRESSION.try_into_compression(value))
+            .transpose()
+            .with_leniency(lenient)?,
+    };
+    Ok(level.unwrap_or(default))
+}
+
+pub(crate) fn loose_compression(
+    config: &gix_config::File<'static>,
+    lenient: bool,
+    filter_config_section: fn(&gix_config::file::Metadata) -> bool,
+) -> Result<gix_zlib::Compression, config::Error> {
+    compression(
+        config,
+        lenient,
+        filter_config_section,
+        &config::tree::Core::LOOSE_COMPRESSION,
+        gix_zlib::Compression::BEST_SPEED,
+    )
+}
+
+pub(crate) fn pack_compression(
+    config: &gix_config::File<'static>,
+    lenient: bool,
+    filter_config_section: fn(&gix_config::file::Metadata) -> bool,
+) -> Result<gix_zlib::Compression, config::Error> {
+    compression(
+        config,
+        lenient,
+        filter_config_section,
+        &config::tree::Pack::COMPRESSION,
+        gix_zlib::Compression::DEFAULT,
+    )
+}
+
 pub(crate) fn trusted_file_path<'config>(
     config: &'config gix_config::File<'_>,
     key: impl gix_config::AsKey,

--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -158,6 +158,7 @@ impl Cache {
         let object_kind_hint = util::disambiguate_hint(&config, lenient_config)?;
         let (static_pack_cache_limit_bytes, pack_cache_bytes, object_cache_bytes, alloc_limit_bytes) =
             util::parse_object_caches(&config, lenient_config, filter_config_section)?;
+        let loose_compression = util::parse_loose_compression(&config, lenient_config, filter_config_section)?;
         // NOTE: When adding a new initial cache, consider adjusting `reread_values_and_clear_caches()` as well.
         Ok(Cache {
             resolved: config.into(),
@@ -169,6 +170,7 @@ impl Cache {
             pack_cache_bytes,
             object_cache_bytes,
             alloc_limit_bytes,
+            loose_compression,
             reflog,
             refs_namespace,
             is_bare,
@@ -248,6 +250,8 @@ impl Cache {
             self.object_cache_bytes,
             self.alloc_limit_bytes,
         ) = util::parse_object_caches(config, self.lenient_config, self.filter_config_section)?;
+        self.loose_compression =
+            util::parse_loose_compression(config, self.lenient_config, self.filter_config_section)?;
         #[cfg(any(feature = "blocking-network-client", feature = "async-network-client"))]
         {
             self.url_scheme = Default::default();

--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -158,7 +158,7 @@ impl Cache {
         let object_kind_hint = util::disambiguate_hint(&config, lenient_config)?;
         let (static_pack_cache_limit_bytes, pack_cache_bytes, object_cache_bytes, alloc_limit_bytes) =
             util::parse_object_caches(&config, lenient_config, filter_config_section)?;
-        let loose_compression = util::parse_loose_compression(&config, lenient_config, filter_config_section)?;
+        let loose_compression = super::access::loose_compression(&config, lenient_config, filter_config_section)?;
         // NOTE: When adding a new initial cache, consider adjusting `reread_values_and_clear_caches()` as well.
         Ok(Cache {
             resolved: config.into(),
@@ -250,8 +250,9 @@ impl Cache {
             self.object_cache_bytes,
             self.alloc_limit_bytes,
         ) = util::parse_object_caches(config, self.lenient_config, self.filter_config_section)?;
-        self.loose_compression =
-            util::parse_loose_compression(config, self.lenient_config, self.filter_config_section)?;
+        let loose_compression =
+            super::access::loose_compression(config, self.lenient_config, self.filter_config_section)?;
+        self.loose_compression = loose_compression;
         #[cfg(any(feature = "blocking-network-client", feature = "async-network-client"))]
         {
             self.url_scheme = Default::default();
@@ -292,18 +293,29 @@ impl crate::Repository {
         &mut self,
         config: crate::Config,
     ) -> Result<(), Error> {
-        let (a, b, c) = (
+        let (
+            previous_static_pack_cache_limit_bytes,
+            previous_pack_cache_bytes,
+            previous_object_cache_bytes,
+            previous_loose_compression,
+        ) = (
             self.config.static_pack_cache_limit_bytes,
             self.config.pack_cache_bytes,
             self.config.object_cache_bytes,
+            self.config.loose_compression,
         );
         self.config.reread_values_and_clear_caches_replacing_config(config)?;
         self.apply_changed_values();
-        if a != self.config.static_pack_cache_limit_bytes
-            || b != self.config.pack_cache_bytes
-            || c != self.config.object_cache_bytes
+        if previous_static_pack_cache_limit_bytes != self.config.static_pack_cache_limit_bytes
+            || previous_pack_cache_bytes != self.config.pack_cache_bytes
+            || previous_object_cache_bytes != self.config.object_cache_bytes
         {
             setup_objects(&mut self.objects, &self.config);
+        }
+        if previous_loose_compression != self.config.loose_compression {
+            // This will only affect newly opened object databases.
+            // This is fine for now, it's not expected to be changed at runtime.
+            self.objects.loose_compression = self.config.loose_compression;
         }
         Ok(())
     }

--- a/gix/src/config/cache/util.rs
+++ b/gix/src/config/cache/util.rs
@@ -100,6 +100,27 @@ pub(crate) fn reflog_or_default(
 pub(crate) type ObjectCaches = (Option<usize>, Option<usize>, usize, Option<usize>);
 
 /// Return `(static_pack_cache_limit, pack_cache_bytes, object_cache_bytes, alloc_limit_bytes)` as parsed from gix-config.
+pub(crate) fn parse_loose_compression(
+    config: &gix_config::File<'static>,
+    lenient: bool,
+    mut filter_config_section: fn(&gix_config::file::Metadata) -> bool,
+) -> Result<gix_zlib::Compression, Error> {
+    let level = match config
+        .integer_filter("core.looseCompression", &mut filter_config_section)
+        .map(|res| Core::LOOSE_COMPRESSION.try_into_compression(res))
+        .transpose()
+        .with_leniency(lenient)?
+    {
+        Some(level) => Some(level),
+        None => config
+            .integer_filter("core.compression", &mut filter_config_section)
+            .map(|res| Core::COMPRESSION.try_into_compression(res))
+            .transpose()
+            .with_leniency(lenient)?,
+    };
+    Ok(level.unwrap_or(gix_zlib::Compression::BEST_SPEED))
+}
+
 pub(crate) fn parse_object_caches(
     config: &gix_config::File<'static>,
     lenient: bool,

--- a/gix/src/config/cache/util.rs
+++ b/gix/src/config/cache/util.rs
@@ -100,27 +100,6 @@ pub(crate) fn reflog_or_default(
 pub(crate) type ObjectCaches = (Option<usize>, Option<usize>, usize, Option<usize>);
 
 /// Return `(static_pack_cache_limit, pack_cache_bytes, object_cache_bytes, alloc_limit_bytes)` as parsed from gix-config.
-pub(crate) fn parse_loose_compression(
-    config: &gix_config::File<'static>,
-    lenient: bool,
-    mut filter_config_section: fn(&gix_config::file::Metadata) -> bool,
-) -> Result<gix_zlib::Compression, Error> {
-    let level = match config
-        .integer_filter("core.looseCompression", &mut filter_config_section)
-        .map(|res| Core::LOOSE_COMPRESSION.try_into_compression(res))
-        .transpose()
-        .with_leniency(lenient)?
-    {
-        Some(level) => Some(level),
-        None => config
-            .integer_filter("core.compression", &mut filter_config_section)
-            .map(|res| Core::COMPRESSION.try_into_compression(res))
-            .transpose()
-            .with_leniency(lenient)?,
-    };
-    Ok(level.unwrap_or(gix_zlib::Compression::BEST_SPEED))
-}
-
 pub(crate) fn parse_object_caches(
     config: &gix_config::File<'static>,
     lenient: bool,

--- a/gix/src/config/mod.rs
+++ b/gix/src/config/mod.rs
@@ -83,6 +83,8 @@ pub enum Error {
     #[error(transparent)]
     ConfigTypedString(#[from] key::GenericErrorWithValue),
     #[error(transparent)]
+    ConfigCompression(#[from] key::GenericError),
+    #[error(transparent)]
     RefsNamespace(#[from] refs_namespace::Error),
     #[error("Cannot handle objects formatted as {:?}", .name)]
     UnsupportedObjectFormat { name: BString },
@@ -629,6 +631,8 @@ pub(crate) struct Cache {
     pub(crate) object_cache_bytes: usize,
     /// The maximum size of a single allocation caused by user-controlled on-disk packed object data.
     pub(crate) alloc_limit_bytes: Option<usize>,
+    /// The compression level to use when writing loose objects, from `core.looseCompression` or `core.compression`.
+    pub(crate) loose_compression: gix_zlib::Compression,
     /// The amount of bytes we can hold in our static LRU cache. Otherwise, go with the defaults.
     pub(crate) static_pack_cache_limit_bytes: Option<usize>,
     /// The config section filter from the options used to initialize this instance. Keep these in sync!

--- a/gix/src/config/tree/keys.rs
+++ b/gix/src/config/tree/keys.rs
@@ -177,6 +177,9 @@ pub type Time = Any<validate::Time>;
 /// The `core.(filesRefLockTimeout|packedRefsTimeout)` keys, or any other lock timeout for that matter.
 pub type LockTimeout = Any<validate::LockTimeout>;
 
+/// The `core.compression`, `core.looseCompression` and `pack.compression` keys.
+pub type Compression = Any<validate::Compression>;
+
 /// Keys specifying durations in milliseconds.
 pub type DurationInMilliseconds = Any<validate::DurationInMilliseconds>;
 
@@ -277,6 +280,36 @@ mod lock_timeout {
                     val.try_into().expect("i64 to u64 always works if positive"),
                 )),
             })
+        }
+    }
+}
+
+mod compression {
+    use crate::{
+        config,
+        config::tree::{Section, keys::Compression},
+    };
+
+    impl Compression {
+        /// Create a new instance.
+        pub const fn new_compression(name: &'static str, section: &'static dyn Section) -> Self {
+            Self::new_with_validate(name, section, super::validate::Compression)
+        }
+
+        /// Convert `value` into a zlib compression level, where `-1` is mapped to the
+        /// zlib default, just like `git` does.
+        pub fn try_into_compression(
+            &'static self,
+            value: Result<i64, gix_config::value::Error>,
+        ) -> Result<gix_zlib::Compression, config::key::GenericError> {
+            let value = value.map_err(|err| config::key::GenericError::from(self).with_source(err))?;
+            match value {
+                -1 => Ok(gix_zlib::Compression::DEFAULT),
+                level => i32::try_from(level)
+                    .ok()
+                    .and_then(gix_zlib::Compression::new)
+                    .ok_or_else(|| config::key::GenericError::from(self)),
+            }
         }
     }
 }
@@ -629,6 +662,19 @@ pub mod validate {
                 .to_decimal()
                 .ok_or_else(|| format!("integer {value} cannot be represented as integer"));
             super::super::Core::FILES_REF_LOCK_TIMEOUT.try_into_lock_timeout(Ok(value?))?;
+            Ok(())
+        }
+    }
+
+    /// A zlib compression level.
+    #[derive(Clone, Copy)]
+    pub struct Compression;
+    impl Validate for Compression {
+        fn validate(&self, value: &BStr) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+            let value = gix_config::Integer::try_from(value)?
+                .to_decimal()
+                .ok_or_else(|| format!("integer {value} cannot be represented as integer"));
+            super::super::Core::COMPRESSION.try_into_compression(Ok(value?))?;
             Ok(())
         }
     }

--- a/gix/src/config/tree/keys.rs
+++ b/gix/src/config/tree/keys.rs
@@ -177,7 +177,7 @@ pub type Time = Any<validate::Time>;
 /// The `core.(filesRefLockTimeout|packedRefsTimeout)` keys, or any other lock timeout for that matter.
 pub type LockTimeout = Any<validate::LockTimeout>;
 
-/// The `core.compression`, `core.looseCompression` and `pack.compression` keys.
+/// The `core.compression`, `core.looseCompression` and `pack.compression` keys to validate compression values.
 pub type Compression = Any<validate::Compression>;
 
 /// Keys specifying durations in milliseconds.

--- a/gix/src/config/tree/sections/core.rs
+++ b/gix/src/config/tree/sections/core.rs
@@ -12,6 +12,13 @@ impl Core {
     pub const BIG_FILE_THRESHOLD: keys::UnsignedInteger =
         keys::UnsignedInteger::new_unsigned_integer("bigFileThreshold", &config::Tree::CORE);
     /// The `core.checkStat` key.
+    /// The `core.compression` key.
+    pub const COMPRESSION: keys::Compression = keys::Compression::new_compression("compression", &config::Tree::CORE)
+        .with_deviation("git defaults to -1 (zlib default) for packed and 1 for loose objects, gitoxide uses the same values but rejects levels outside of -1..=9 early");
+    /// The `core.looseCompression` key.
+    pub const LOOSE_COMPRESSION: keys::Compression =
+        keys::Compression::new_compression("looseCompression", &config::Tree::CORE);
+    /// The `core.checkStat` key.
     pub const CHECK_STAT: CheckStat =
         CheckStat::new_with_validate("checkStat", &config::Tree::CORE, validate::CheckStat);
     /// The `core.deltaBaseCacheLimit` key.
@@ -107,6 +114,8 @@ impl Section for Core {
             &Self::ABBREV,
             &Self::BARE,
             &Self::BIG_FILE_THRESHOLD,
+            &Self::COMPRESSION,
+            &Self::LOOSE_COMPRESSION,
             &Self::CHECK_STAT,
             &Self::DELTA_BASE_CACHE_LIMIT,
             &Self::DISAMBIGUATE,

--- a/gix/src/config/tree/sections/core.rs
+++ b/gix/src/config/tree/sections/core.rs
@@ -11,10 +11,8 @@ impl Core {
     /// The `core.bigFileThreshold` key.
     pub const BIG_FILE_THRESHOLD: keys::UnsignedInteger =
         keys::UnsignedInteger::new_unsigned_integer("bigFileThreshold", &config::Tree::CORE);
-    /// The `core.checkStat` key.
     /// The `core.compression` key.
-    pub const COMPRESSION: keys::Compression = keys::Compression::new_compression("compression", &config::Tree::CORE)
-        .with_deviation("git defaults to -1 (zlib default) for packed and 1 for loose objects, gitoxide uses the same values but rejects levels outside of -1..=9 early");
+    pub const COMPRESSION: keys::Compression = keys::Compression::new_compression("compression", &config::Tree::CORE);
     /// The `core.looseCompression` key.
     pub const LOOSE_COMPRESSION: keys::Compression =
         keys::Compression::new_compression("looseCompression", &config::Tree::CORE);

--- a/gix/src/config/tree/sections/pack.rs
+++ b/gix/src/config/tree/sections/pack.rs
@@ -12,6 +12,9 @@ impl Pack {
     /// The `pack.indexVersion` key.
     pub const INDEX_VERSION: IndexVersion =
         IndexVersion::new_with_validate("indexVersion", &config::Tree::PACK, validate::IndexVersion);
+
+    /// The `pack.compression` key.
+    pub const COMPRESSION: keys::Compression = keys::Compression::new_compression("compression", &config::Tree::PACK);
 }
 
 /// The `pack.indexVersion` key.
@@ -42,7 +45,7 @@ impl Section for Pack {
     }
 
     fn keys(&self) -> &[&dyn Key] {
-        &[&Self::THREADS, &Self::INDEX_VERSION]
+        &[&Self::THREADS, &Self::INDEX_VERSION, &Self::COMPRESSION]
     }
 }
 

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -159,6 +159,7 @@ pub use gix_url as url;
 pub use gix_url::Url;
 pub use gix_utils as utils;
 pub use gix_validate as validate;
+pub use gix_zlib as zlib;
 pub use hash::{ObjectId, oid};
 
 pub use gix_error::{Error, Exn};

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -493,6 +493,7 @@ impl ThreadSafeRepository {
                     object_hash: config.object_hash,
                     use_multi_pack_index: config.use_multi_pack_index,
                     alloc_limit_bytes: config.alloc_limit_bytes,
+                    loose_compression: config.loose_compression,
                     current_dir: current_dir.to_owned().into(),
                 },
             )?),

--- a/gix/src/remote/connection/fetch/receive_pack.rs
+++ b/gix/src/remote/connection/fetch/receive_pack.rs
@@ -173,6 +173,7 @@ where
             iteration_mode: gix_pack::data::input::Mode::Verify,
             object_hash: repo.object_hash(),
             alloc_limit_bytes: repo.config.alloc_limit_bytes,
+            compression: repo.config.loose_compression,
         };
         let mut write_pack_bundle = None;
 

--- a/gix/src/repository/config/mod.rs
+++ b/gix/src/repository/config/mod.rs
@@ -4,6 +4,20 @@ use crate::{bstr::ByteSlice, config};
 
 /// General Configuration
 impl crate::Repository {
+    /// Return the compression level used when writing loose objects.
+    pub fn loose_compression(&self) -> gix_zlib::Compression {
+        self.config.loose_compression
+    }
+
+    /// Return the effective compression level used when writing pack entries.
+    pub fn pack_compression(&self) -> Result<gix_zlib::Compression, config::Error> {
+        config::cache::access::pack_compression(
+            &self.config.resolved,
+            self.config.lenient_config,
+            self.filter_config_section(),
+        )
+    }
+
     /// Return a snapshot of the configuration as seen upon opening the repository.
     ///
     /// Use [`reload()`](Self::reload()) to refresh it from disk.

--- a/gix/tests/gix/config/tree.rs
+++ b/gix/tests/gix/config/tree.rs
@@ -104,6 +104,50 @@ mod keys {
     }
 }
 
+mod compression {
+    use gix::config::tree::Key;
+
+    #[test]
+    fn validate_and_convert() {
+        for key in [
+            &gix::config::tree::Core::COMPRESSION,
+            &gix::config::tree::Core::LOOSE_COMPRESSION,
+            &gix::config::tree::Pack::COMPRESSION,
+        ] {
+            for valid in -1..=9 {
+                assert!(key.validate(valid.to_string().as_str().into()).is_ok());
+            }
+            for invalid in [-2, 10, 100] {
+                assert!(key.validate(invalid.to_string().as_str().into()).is_err());
+            }
+        }
+
+        assert_eq!(
+            gix::config::tree::Core::COMPRESSION
+                .try_into_compression(Ok(-1))
+                .expect("git maps -1 to the zlib default"),
+            gix::zlib::Compression::DEFAULT
+        );
+        assert_eq!(
+            gix::config::tree::Core::COMPRESSION
+                .try_into_compression(Ok(1))
+                .unwrap(),
+            gix::zlib::Compression::BEST_SPEED
+        );
+        assert_eq!(
+            gix::config::tree::Pack::COMPRESSION
+                .try_into_compression(Ok(9))
+                .unwrap(),
+            gix::zlib::Compression::BEST
+        );
+        assert!(
+            gix::config::tree::Pack::COMPRESSION
+                .try_into_compression(Ok(10))
+                .is_err()
+        );
+    }
+}
+
 mod branch {
     use gix::config::tree::{Branch, Key, branch};
 

--- a/gix/tests/gix/repository/config/config_snapshot/mod.rs
+++ b/gix/tests/gix/repository/config/config_snapshot/mod.rs
@@ -1,4 +1,4 @@
-use gix::config::tree::{Branch, Core, Key, gitoxide};
+use gix::config::tree::{Branch, Core, Key, Pack, gitoxide};
 
 use crate::{named_repo, repo_rw};
 
@@ -7,7 +7,7 @@ mod credential_helpers;
 
 #[test]
 fn commit_auto_rollback() -> crate::Result {
-    let mut repo: gix::Repository = named_repo("make_basic_repo.sh")?;
+    let mut repo = named_repo("make_basic_repo.sh")?;
     let default_abbrev = repo.head_id()?.to_string()[..7].to_owned();
     let short_abbrev = repo.head_id()?.to_string()[..4].to_owned();
     assert_eq!(repo.head_id()?.shorten()?.to_string(), default_abbrev);
@@ -40,7 +40,7 @@ mod trusted_path {
 
     #[test]
     fn optional_is_respected() -> crate::Result {
-        let mut repo: gix::Repository = named_repo("make_basic_repo.sh")?;
+        let mut repo = named_repo("make_basic_repo.sh")?;
         repo.config_snapshot_mut().set_raw_value("my.path", "does-not-exist")?;
 
         let actual = repo
@@ -64,7 +64,7 @@ mod trusted_path {
 
 #[test]
 fn snapshot_mut_commit_and_forget() -> crate::Result {
-    let mut repo: gix::Repository = named_repo("make_basic_repo.sh")?;
+    let mut repo = named_repo("make_basic_repo.sh")?;
     let repo = {
         let mut repo = repo.config_snapshot_mut();
         repo.set_value(&Core::ABBREV, "4")?;
@@ -77,6 +77,69 @@ fn snapshot_mut_commit_and_forget() -> crate::Result {
         repo.forget();
     }
     assert_eq!(repo.config_snapshot().integer("core.abbrev"), Some(4));
+    Ok(())
+}
+
+#[test]
+fn committing_loose_compression_requires_reopening_the_object_store() -> crate::Result {
+    use gix::objs::Write;
+
+    fn loose_object_size(repo: &gix::Repository, id: gix::ObjectId) -> std::io::Result<u64> {
+        let hex = id.to_string();
+        std::fs::metadata(repo.git_dir().join("objects").join(&hex[..2]).join(&hex[2..])).map(|meta| meta.len())
+    }
+
+    let (mut repo, _tmp) = repo_rw("make_basic_repo.sh")?;
+    let mut data = vec![b'a'; 128 * 1024];
+    let compressed = repo.objects.write_buf(gix::objs::Kind::Blob, &data)?;
+    let compressed_size = loose_object_size(&repo, compressed)?;
+
+    let mut config = repo.config_snapshot_mut();
+    config.set_value(&Core::LOOSE_COMPRESSION, "0")?;
+    config.commit()?;
+
+    data[0] = b'b';
+    let still_compressed = repo.objects.write_buf(gix::objs::Kind::Blob, &data)?;
+    let still_compressed_size = loose_object_size(&repo, still_compressed)?;
+
+    let git_dir = repo.git_dir().to_owned();
+    let options = repo
+        .open_options()
+        .clone()
+        .config_overrides(["core.looseCompression=0"]);
+    repo = gix::open_opts(git_dir, options)?;
+
+    data[1] = b'b';
+    let uncompressed = repo.write_blob(&data)?;
+    let uncompressed_size = loose_object_size(&repo, uncompressed.detach())?;
+    assert!(
+        uncompressed_size > compressed_size * 10 && uncompressed_size > still_compressed_size * 10,
+        "the override should take effect after reopening the object store: {compressed_size}, {still_compressed_size} vs {uncompressed_size}"
+    );
+    Ok(())
+}
+
+#[test]
+fn compression_levels() -> crate::Result {
+    use gix::zlib::Compression;
+
+    let mut repo = named_repo("make_basic_repo.sh")?;
+    assert_eq!(repo.loose_compression(), Compression::BEST_SPEED);
+    assert_eq!(repo.pack_compression()?, Compression::DEFAULT);
+
+    let mut config = repo.config_snapshot_mut();
+    config.set_value(&Core::COMPRESSION, "4")?;
+    config.commit()?;
+    assert_eq!(repo.loose_compression(), Compression::new(4).expect("valid level"));
+    assert_eq!(repo.pack_compression()?, Compression::new(4).expect("valid level"));
+
+    let mut config = repo.config_snapshot_mut();
+    config.set_value(&Core::LOOSE_COMPRESSION, "2")?;
+    config.set_value(&Pack::COMPRESSION, "8")?;
+    config.commit()?;
+    assert_eq!(repo.loose_compression(), Compression::new(2).expect("valid level"));
+    assert_eq!(repo.pack_compression()?, Compression::new(8).expect("valid level"));
+
     Ok(())
 }
 

--- a/gix/tests/gix/repository/object.rs
+++ b/gix/tests/gix/repository/object.rs
@@ -402,9 +402,10 @@ fn writes_avoid_io_using_duplicate_check() -> crate::Result {
     let mut repo = crate::named_repo("make_packed_and_loose.sh")?;
     let store = gix::odb::loose::Store::at(
         repo.git_dir().join("objects"),
-        repo.object_hash(),
-        None,
-        gix::zlib::Compression::BEST_SPEED,
+        gix::odb::loose::Options {
+            object_hash: repo.object_hash(),
+            ..Default::default()
+        },
     );
     let loose_count = store.iter().count();
     assert_eq!(loose_count, 3, "there are some loose objects");

--- a/gix/tests/gix/repository/object.rs
+++ b/gix/tests/gix/repository/object.rs
@@ -400,7 +400,12 @@ mod write_blob {
 #[test]
 fn writes_avoid_io_using_duplicate_check() -> crate::Result {
     let mut repo = crate::named_repo("make_packed_and_loose.sh")?;
-    let store = gix::odb::loose::Store::at(repo.git_dir().join("objects"), repo.object_hash(), None);
+    let store = gix::odb::loose::Store::at(
+        repo.git_dir().join("objects"),
+        repo.object_hash(),
+        None,
+        gix::zlib::Compression::BEST_SPEED,
+    );
     let loose_count = store.iter().count();
     assert_eq!(loose_count, 3, "there are some loose objects");
     assert_eq!(


### PR DESCRIPTION
Fixes #2024.

### Problem

The deflate stream used for pack entries, loose objects and thin-pack completion was hard-coded to the fastest compression level (`DeflateConfig::best_speed()`). That was fine in `miniz_oxide` times, whose level 1 follows stock zlib — but `zlib-rs`'s level 1 is deliberately tuned for speed at the cost of ratio (as @folkertdev explained in the issue), so after the backend switch that the issue bisected to, pack entries grew by ~50%: the issue's 72kB tree compresses to 29,547 bytes on `main`.

### Changes

This implements the full fix discussed in the issue — no hidden compression default at the lower levels, with configuration wired through:

- **`gix-features`**: a new `zlib::Compression` type (levels 0–9, with `NONE`/`BEST_SPEED`/`DEFAULT`/`BEST`); `Compress::new()`, `deflate::Write::new()` now take it explicitly, and `Default for Compress` is gone. `Write` remembers its level so `Clone` recreates it faithfully. `BEST_SPEED` is field-identical to the previous `best_speed()` config, so existing loose-object output is byte-for-byte unchanged.
- **`gix-pack`**: `output::Entry::from_data()`, `input::Entry::from_data_obj()` and `LookupRefDeltaObjectsIter` take the level; `iter_from_counts::Options` and `bundle::write::Options` gained a `compression` field.
- **`gix-odb`**: `loose::Store::at()` and the dynamic store's `init::Options` carry the loose compression level; `Sink::compress()` takes `Option<Compression>`.
- **`gix`**: the `core.compression`, `core.looseCompression` and `pack.compression` keys are now understood and validated (rejecting anything outside `-1..=9` early), and respected when writing loose objects, creating packs, and completing thin packs during fetch. The level is picked up when the repository is opened, like the other object-database options.
- **`gitoxide-core`**: `gix free pack create` reads `pack.compression`/`core.compression` from the repository.

### Defaults match `git` exactly (verified against its source)

| operation | level source | unset default |
|---|---|---|
| pack entries | `pack.compression` → `core.compression` | `-1` → zlib default (6) |
| loose objects | `core.looseCompression` → `core.compression` | 1 (best speed) — unchanged behaviour |
| thin-pack base completion | same as loose objects | 1 — like `index-pack`, which deflates appended bases with `zlib_compression_level` |

`-1` maps to the zlib default at parse time for all keys, exactly as `environment.c` does it.

### Results

- The issue's reproduction drops from **29,547 to 18,724 bytes** for the 72kB tree entry, back in line with the reporter's zlib table.
- End-to-end: `gix free pack create` with `pack.compression=0` → 2.4MB pack, `=9` → 187KB on the same objects.

### Validation

- New tests: entry-size regression test shaped like the issue's reproduction (`< 25000` threshold), a loose-store level test (round-trip + size ordering), and config-key validation/conversion tests including the `-1` mapping.
- `cargo test` for `gix-features`, `gix-pack`, `gix-odb`, `gix`, `gitoxide-core`; `cargo clippy --workspace --all-targets -- -D warnings` (also `--no-default-features --features max-pure`); `cargo fmt --all -- --check`; `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`.