### PR TITLE
fix: keep `core.worktree`-derived worktree paths in the caller's path namespace

### DIFF
--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -300,9 +300,7 @@ impl ThreadSafeRepository {
                     | gix_config::Source::Cli
                     | gix_config::Source::Api
                     | gix_config::Source::EnvOverride => wt_path,
-                    _ => git_dir_resolving_symlinks_for_worktree_base(&git_dir, current_dir)
-                        .join(wt_path)
-                        .into(),
+                    _ => worktree_dir_from_repository_config(&git_dir, wt_path, current_dir),
                 };
                 worktree_dir = gix_path::normalize(wt_path, current_dir).map(Cow::into_owned);
                 #[allow(unused_variables)]
@@ -513,12 +511,27 @@ impl ThreadSafeRepository {
     }
 }
 
-/// Return the path that should be used as base for `core.worktree` values from repository-owned config.
+/// Return the worktree directory implied by the `core.worktree` value `wt_path` from repository-owned
+/// configuration, resolved against `git_dir`.
 ///
-/// Git resolves symlinks in the `.git` directory before interpreting these relative worktree paths. Preserve the
-/// original `git_dir` unless realpathing actually changes it, both to avoid needless allocation and to keep existing
-/// paths stable when no symlink needs to be accounted for.
-fn git_dir_resolving_symlinks_for_worktree_base<'a>(git_dir: &'a Path, current_dir: &Path) -> Cow<'a, Path> {
+/// Git resolves symlinks in the `.git` directory before interpreting relative worktree paths, which matters
+/// when the `.git` directory itself is reached through a symlink: traversing `..` from the symlink and from
+/// its target yields different directories. When both ways of resolving `wt_path` denote the same directory
+/// on disk, however - for instance if only an ancestor of the repository is a symlink, like the temporary
+/// directory on macOS - prefer the symlink-preserving path so all paths of the opened repository remain
+/// consistent with the path the repository was opened with.
+fn worktree_dir_from_repository_config<'a>(
+    git_dir: &Path,
+    wt_path: Cow<'a, Path>,
+    current_dir: &Path,
+) -> Cow<'a, Path> {
+    fn realpath(path: &Path, current_dir: &Path) -> Option<PathBuf> {
+        crate::path::realpath_opts(path, current_dir, crate::path::realpath::MAX_SYMLINKS).ok()
+    }
+    if wt_path.is_absolute() {
+        return wt_path;
+    }
+    let symlink_preserving = git_dir.join(wt_path.as_ref());
     let logical_git_dir = gix_path::normalize(
         Cow::Owned(if git_dir.is_relative() {
             current_dir.join(git_dir)
@@ -528,12 +541,20 @@ fn git_dir_resolving_symlinks_for_worktree_base<'a>(git_dir: &'a Path, current_d
         current_dir,
     )
     .map(Cow::into_owned);
-    match (
-        crate::path::realpath_opts(git_dir, current_dir, crate::path::realpath::MAX_SYMLINKS),
-        logical_git_dir,
-    ) {
-        (Ok(real_git_dir), Some(logical_git_dir)) if real_git_dir != logical_git_dir => Cow::Owned(real_git_dir),
-        _ => Cow::Borrowed(git_dir),
+    let real_git_dir = match (realpath(git_dir, current_dir), logical_git_dir) {
+        (Some(real_git_dir), Some(logical_git_dir)) if real_git_dir != logical_git_dir => real_git_dir,
+        // There is no symlink to account for - keep existing paths stable.
+        _ => return Cow::Owned(symlink_preserving),
+    };
+    let resolved = real_git_dir.join(wt_path.as_ref());
+    let denotes_same_directory = gix_path::normalize(Cow::Borrowed(symlink_preserving.as_path()), current_dir)
+        .and_then(|normalized| realpath(&normalized, current_dir))
+        .zip(realpath(&resolved, current_dir))
+        .is_some_and(|(symlink_preserving, resolved)| symlink_preserving == resolved);
+    if denotes_same_directory {
+        Cow::Owned(symlink_preserving)
+    } else {
+        Cow::Owned(resolved)
     }
 }
 

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -526,12 +526,11 @@ fn worktree_dir_from_repository_config<'a>(
     current_dir: &Path,
 ) -> Cow<'a, Path> {
     fn realpath(path: &Path, current_dir: &Path) -> Option<PathBuf> {
-        crate::path::realpath_opts(path, current_dir, crate::path::realpath::MAX_SYMLINKS).ok()
+        gix_path::realpath_opts(path, current_dir, crate::path::realpath::MAX_SYMLINKS).ok()
     }
     if wt_path.is_absolute() {
         return wt_path;
     }
-    let symlink_preserving = git_dir.join(wt_path.as_ref());
     let logical_git_dir = gix_path::normalize(
         Cow::Owned(if git_dir.is_relative() {
             current_dir.join(git_dir)
@@ -541,6 +540,7 @@ fn worktree_dir_from_repository_config<'a>(
         current_dir,
     )
     .map(Cow::into_owned);
+    let symlink_preserving = git_dir.join(wt_path.as_ref());
     let real_git_dir = match (realpath(git_dir, current_dir), logical_git_dir) {
         (Some(real_git_dir), Some(logical_git_dir)) if real_git_dir != logical_git_dir => real_git_dir,
         // There is no symlink to account for - keep existing paths stable.
@@ -551,11 +551,12 @@ fn worktree_dir_from_repository_config<'a>(
         .and_then(|normalized| realpath(&normalized, current_dir))
         .zip(realpath(&resolved, current_dir))
         .is_some_and(|(symlink_preserving, resolved)| symlink_preserving == resolved);
-    if denotes_same_directory {
-        Cow::Owned(symlink_preserving)
+    let wt_path = if denotes_same_directory {
+        symlink_preserving
     } else {
-        Cow::Owned(resolved)
-    }
+        resolved
+    };
+    Cow::Owned(wt_path)
 }
 
 // TODO: tests

--- a/gix/tests/fixtures/make_core_worktree_repo.sh
+++ b/gix/tests/fixtures/make_core_worktree_repo.sh
@@ -26,6 +26,10 @@ git clone --shared base relative-worktree
   git status --porcelain > .git/status.baseline
 )
 
+# Opening relative-worktree through this symlink exercises preservation of the
+# caller's path namespace when only an ancestor of the Git directory is linked.
+ln -s . symlinked-ancestor
+
 git clone --shared base absolute-worktree
 (cd absolute-worktree
   git config --local core.worktree "$WORKTREE_ABS"

--- a/gix/tests/fixtures/make_submodules.sh
+++ b/gix/tests/fixtures/make_submodules.sh
@@ -199,6 +199,17 @@ git clone --bare with-submodules with-submodules-after-clone.git
   git clone --bare ../module1 modules/m1
 )
 
+git init with-submodule-uninitialized-checkout
+(cd with-submodule-uninitialized-checkout
+  git submodule add ../module1 m1
+  git submodule add ../module1 m2
+  git commit -m "add modules"
+  # The module clones in `.git/modules` remain, but the checkouts don't exist yet,
+  # like just before a fresh worktree checkout.
+  rm m1/.git
+  rm -rf m2
+)
+
 git clone with-submodules not-a-submodule
 (cd not-a-submodule
   git submodule update --init

--- a/gix/tests/fixtures/make_submodules.sh
+++ b/gix/tests/fixtures/make_submodules.sh
@@ -221,3 +221,7 @@ git clone with-submodules not-a-submodule
 )
 
 git init unborn
+
+# Opening repositories through this symlink exercises preservation of the
+# caller's path namespace when only an ancestor of the Git directory is linked.
+ln -s . symlinked-ancestor

--- a/gix/tests/gix/repository/worktree.rs
+++ b/gix/tests/gix/repository/worktree.rs
@@ -145,6 +145,24 @@ mod with_core_worktree_config {
 
     #[test]
     #[cfg(unix)] // symlinks are used here, let's not try our luck on Windows.
+    fn relative_through_symlinked_ancestor_keeps_callers_path_namespace() -> crate::Result {
+        let fixture = std::path::absolute(gix_testtools::scripted_fixture_read_only("make_core_worktree_repo.sh")?)?;
+        let tmp = gix_testtools::tempfile::tempdir()?;
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&fixture, &link)?;
+
+        let repo = gix::open_opts(link.join("relative-worktree"), crate::restricted())?;
+        assert_eq!(
+            repo.workdir(),
+            Some(link.join("worktree").as_path()),
+            "a symlink in an ancestor changes nothing about how the relative worktree resolves, \
+             so the caller's path namespace is kept instead of jumping to the canonicalized one"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)] // symlinks are used here, let's not try our luck on Windows.
     fn relative_from_symlinked_git_dir() -> crate::Result {
         let fixture = gix_testtools::scripted_fixture_read_only("make_core_worktree_repo.sh")?;
         let root = fixture.join("linked-git-dir-detached-worktree");

--- a/gix/tests/gix/repository/worktree.rs
+++ b/gix/tests/gix/repository/worktree.rs
@@ -146,17 +146,14 @@ mod with_core_worktree_config {
     #[test]
     #[cfg(unix)] // symlinks are used here, let's not try our luck on Windows.
     fn relative_through_symlinked_ancestor_keeps_callers_path_namespace() -> crate::Result {
-        let fixture = std::path::absolute(gix_testtools::scripted_fixture_read_only("make_core_worktree_repo.sh")?)?;
-        let tmp = gix_testtools::tempfile::tempdir()?;
-        let link = tmp.path().join("link");
-        std::os::unix::fs::symlink(&fixture, &link)?;
+        let link = gix_testtools::scripted_fixture_read_only("make_core_worktree_repo.sh")?.join("symlinked-ancestor");
 
         let repo = gix::open_opts(link.join("relative-worktree"), crate::restricted())?;
         assert_eq!(
             repo.workdir(),
             Some(link.join("worktree").as_path()),
-            "a symlink in an ancestor changes nothing about how the relative worktree resolves, \
-             so the caller's path namespace is kept instead of jumping to the canonicalized one"
+            "if a symlink in an ancestor changes nothing about how the relative worktree resolves, \
+             the caller's path namespace is kept instead of jumping to the canonicalized one"
         );
         Ok(())
     }

--- a/gix/tests/gix/submodule.rs
+++ b/gix/tests/gix/submodule.rs
@@ -258,6 +258,41 @@ mod open {
     }
 
     #[test]
+    #[cfg(unix)] // symlinks are used here, let's not try our luck on Windows.
+    fn keeps_callers_path_namespace_when_opened_through_symlinked_ancestor() -> crate::Result {
+        let fixture = std::path::absolute(gix_testtools::scripted_fixture_read_only("make_submodules.sh")?)?;
+        let tmp = gix_testtools::tempfile::tempdir()?;
+        let link = tmp.path().join("link");
+        std::os::unix::fs::symlink(&fixture, &link)?;
+
+        for parent_name in ["with-submodules", "with-submodule-uninitialized-checkout"] {
+            let worktree = link.join(parent_name);
+            let repo = gix::open_opts(&worktree, gix::open::Options::isolated())?;
+            assert_eq!(
+                repo.workdir(),
+                Some(worktree.as_path()),
+                "the parent repository keeps the path it was opened with"
+            );
+            for sm in repo.submodules()?.expect("modules present") {
+                let sm_repo = sm.open()?.expect("submodule repository exists");
+                let sm_git_dir = sm_repo.path();
+                assert!(
+                    sm_git_dir.starts_with(&worktree),
+                    "the submodule git dir stays in the namespace of the path the parent was opened with: {sm_git_dir:?}"
+                );
+                assert_eq!(
+                    sm_repo.workdir(),
+                    Some(worktree.join(gix_path::from_bstr(sm.path()?).as_ref())).as_deref(),
+                    "the submodule workdir stays in the same namespace instead of being canonicalized, \
+                     so it can be related to the parent worktree and the submodule git dir with prefix logic"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
     fn broken_gitlink_target_is_reported() -> crate::Result {
         let repo = repo("submodule-with-missing-gitlink-target")?;
         let sm = repo

--- a/gix/tests/gix/submodule.rs
+++ b/gix/tests/gix/submodule.rs
@@ -260,10 +260,7 @@ mod open {
     #[test]
     #[cfg(unix)] // symlinks are used here, let's not try our luck on Windows.
     fn keeps_callers_path_namespace_when_opened_through_symlinked_ancestor() -> crate::Result {
-        let fixture = std::path::absolute(gix_testtools::scripted_fixture_read_only("make_submodules.sh")?)?;
-        let tmp = gix_testtools::tempfile::tempdir()?;
-        let link = tmp.path().join("link");
-        std::os::unix::fs::symlink(&fixture, &link)?;
+        let link = gix_testtools::scripted_fixture_read_only("make_submodules.sh")?.join("symlinked-ancestor");
 
         for parent_name in ["with-submodules", "with-submodule-uninitialized-checkout"] {
             let worktree = link.join(parent_name);


### PR DESCRIPTION
Hey, discovered a problem in GitButler repo that resolves with this patch. If it immediately makes sense to you, great, and if not, I'll tell you more shortly.

### What's wrong (AI)

Since b1c1cce7 (#2671, fixing #2052), a relative `core.worktree` from repo-owned config gets resolved against the *symlink-resolved* git dir whenever `realpath(git_dir)` differs from the logical git dir. Makes sense when `.git` itself is a symlink. But it also fires when merely some *ancestor* is a symlink — e.g. macOS, where `TMPDIR` lives under the symlinked `/var/folders`.

The fallout: open a submodule via `Submodule::open()` through such a path and `workdir()` comes back canonicalized (`/private/var/…`) while `path()` and everything else stays in the namespace you opened with (`/var/…`). So they no longer relate:

```rust
let repo = submodule.open()?.expect("exists");
repo.path().strip_prefix(parent)     // ok:  /var/folders/…
repo.workdir()?.strip_prefix(parent) // Err: /private/var/folders/…
```

Found this downstream in GitButler bumping gix 0.80 → 0.85 — 4 macOS test failures, all `prefix not found`.

### What this does

Only fall back to the symlink-resolved git dir when it actually changes where the relative worktree lands on disk (the #2052 case, where `..` diverges between the symlink and its target). If both resolve to the same directory, keep the symlink-preserving path so all of the repo's paths stay consistent with what you opened it with. Both #2052 tests still pass.

Worth calling out: Git *does* canonicalize the worktree it reports (`rev-parse --show-toplevel` goes through `getcwd`), so this isn't about matching Git — it's about gix's own `path()`/`workdir()` staying in one namespace, which is the existing behavior everywhere except this one spot.

### Tests

Two regression tests, each builds its own `link -> fixture` symlink so it runs anywhere (not relying on macOS's `TMPDIR`), both fail before the change:

- direct `core.worktree` via the existing `relative-worktree` fixture through a symlinked ancestor
- submodule via a new `with-submodule-uninitialized-checkout` fixture — module clone present, checkout not yet there (exactly the state just before a fresh checkout; with a checkout present the git dir comes from the worktree's `.git` file and this path isn't hit)

Verified downstream too: with gix patched to this branch, GitButler's failing `but-workspace` tests go green (4 failed → 21 passed).

### Alternative you might prefer

If you'd rather gix canonicalize *everything* for consistency instead of preserving the caller's namespace, that's a bigger call with more blast radius — happy to go that way instead if you think it's more correct.
