### PR TITLE
fix: make `Repository::kind()` detect linked worktrees of bare repos

### DIFF
--- a/gix-discover/src/path.rs
+++ b/gix-discover/src/path.rs
@@ -72,6 +72,9 @@ fn read_plain_file_content(path: &std::path::Path) -> Option<std::io::Result<Vec
 /// Return `None` if `git_dir` isn't called `.git` or isn't within `.git/worktrees` or `.git/modules`, or if it's
 /// a `.git` suffix like in `foo.git`.
 /// The check for markers is case-sensitive under the assumption that nobody meddles with standard directories.
+///
+/// As this considers only the path, it cannot recognize linked worktrees of repositories whose Git directory isn't
+/// named `.git`, such as natively bare repositories. Inspect the worktree's `commondir` file to identify those.
 pub fn repository_kind(git_dir: &Path) -> Option<RepositoryKind> {
     if git_dir.file_name() == Some(OsStr::new(DOT_GIT_DIR)) {
         return Some(RepositoryKind::Common);

--- a/gix/src/repository/location.rs
+++ b/gix/src/repository/location.rs
@@ -129,7 +129,11 @@ impl crate::Repository {
         match gix_discover::path::repository_kind(self.git_dir()) {
             Some(Submodule) => crate::repository::Kind::Submodule,
             Some(LinkedWorktree) => crate::repository::Kind::LinkedWorkTree,
-            None | Some(Common) if self.git_dir() != self.common_dir() => crate::repository::Kind::LinkedWorkTree,
+            // Opening a linked worktree resolves its `commondir` file, making its private Git directory
+            // differ from the shared one. This also detects worktrees of natively bare repositories, whose
+            // private Git directory isn't below a directory named `.git` and thus isn't recognized by the path
+            // heuristic in `repository_kind()`.
+            None if self.git_dir() != self.common_dir() => crate::repository::Kind::LinkedWorkTree,
             None | Some(Common) => crate::repository::Kind::Common,
         }
     }

--- a/gix/src/repository/location.rs
+++ b/gix/src/repository/location.rs
@@ -127,9 +127,10 @@ impl crate::Repository {
     pub fn kind(&self) -> crate::repository::Kind {
         use gix_discover::path::RepositoryKind::*;
         match gix_discover::path::repository_kind(self.git_dir()) {
-            None | Some(Common) => crate::repository::Kind::Common,
             Some(Submodule) => crate::repository::Kind::Submodule,
             Some(LinkedWorktree) => crate::repository::Kind::LinkedWorkTree,
+            None | Some(Common) if self.git_dir() != self.common_dir() => crate::repository::Kind::LinkedWorkTree,
+            None | Some(Common) => crate::repository::Kind::Common,
         }
     }
 

--- a/gix/tests/fixtures/make_worktree_repo.sh
+++ b/gix/tests/fixtures/make_worktree_repo.sh
@@ -64,3 +64,8 @@ git init non-bare-turned-bare
 
   git worktree add ../worktree-of-bare-repo
 )
+
+git clone --bare --shared repo natively-bare-repo
+(cd natively-bare-repo
+  git worktree add ../worktree-of-natively-bare-repo
+)

--- a/gix/tests/gix/repository/open.rs
+++ b/gix/tests/gix/repository/open.rs
@@ -191,6 +191,51 @@ fn worktree_of_bare_repo() -> crate::Result {
 }
 
 #[test]
+fn worktree_of_natively_bare_repo() -> crate::Result {
+    let repo = named_subrepo_opts(
+        "make_worktree_repo.sh",
+        "worktree-of-natively-bare-repo",
+        gix::open::Options::isolated(),
+    )?;
+    assert_ne!(
+        repo.workdir(),
+        None,
+        "we have opened the repo through a worktree, which is never bare"
+    );
+    assert!(
+        !repo
+            .worktree()
+            .expect("the worktree is available, it's linked")
+            .is_main(),
+        "linked worktrees can exist for any repository, even bare"
+    );
+    assert!(
+        repo.is_bare(),
+        "the shared config has core.bare=true, which a linked worktree inherits even though it has a workdir"
+    );
+    assert_eq!(repo.kind(), gix::repository::Kind::LinkedWorkTree);
+    Ok(())
+}
+
+#[test]
+fn natively_bare_repo_itself_is_common() -> crate::Result {
+    let repo = named_subrepo_opts(
+        "make_worktree_repo.sh",
+        "natively-bare-repo",
+        gix::open::Options::isolated(),
+    )?;
+    assert!(repo.is_bare());
+    assert_eq!(repo.workdir(), None, "the bare repository itself has no worktree");
+    assert_eq!(
+        repo.git_dir(),
+        repo.common_dir(),
+        "there is no linked-worktree redirection"
+    );
+    assert_eq!(repo.kind(), gix::repository::Kind::Common);
+    Ok(())
+}
+
+#[test]
 fn non_bare_non_git_repo_without_worktree() -> crate::Result {
     let repo = named_subrepo_opts(
         "make_basic_repo.sh",


### PR DESCRIPTION
## Description

While bumping `gix` to v0.85 in [tmux-sessionizer](https://github.com/jrmoulton/tmux-sessionizer), I hit a misclassification for worktrees of bare repositories. Calling `Repository::kind()` returns `Kind::Common`, but it should be `Kind::LinkedWorkTree`.

## Steps to Reproduce

```bash
mkdir -p /tmp/gix-bug && cd /tmp/gix-bug
git init --bare project
cd project
git worktree add ../worktree-of-project
```

```rust
// Move to `gix/examples/gix_bug.rs`.
// Usage: `cargo run -p gix --example gix_bug -- <path-to-worktree>`

use std::path::PathBuf;

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let path = std::env::args_os()
        .nth(1)
        .map(PathBuf::from)
        .unwrap_or_else(|| ".".into());
    let repo = gix::open(&path)?;

    println!("kind(): {:?}", repo.kind());
    Ok(())
}
```

### Before

```
$ cargo run -p gix --example gix_bug -- /tmp/gix-bug/worktree-of-project
kind(): Common
```

### After

```
$ cargo run -p gix --example gix_bug -- /tmp/gix-bug/worktree-of-project
kind(): LinkedWorkTree
```