### PR TITLE
gix-transport: run git-upload-pack for local repositories even if it's not in PATH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2536,6 +2536,7 @@ dependencies = [
  "gix-hash",
  "gix-pack",
  "gix-packetline",
+ "gix-path",
  "gix-quote",
  "gix-sec",
  "gix-transport",

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -139,7 +139,7 @@ pub fn core_dir() -> Option<&'static Path> {
     GIT_CORE_DIR.as_deref()
 }
 
-/// Return the path at which the Git-provided program with `name` resides within the [`core_dir()`],
+/// Return the path at which the Git-provided program with bare `name` resides within the [`core_dir()`],
 /// or `None` if it doesn't exist there or if Git could not be found.
 ///
 /// This is the location `git` itself uses to find the programs implementing its subcommands, and is
@@ -150,6 +150,10 @@ pub fn core_dir() -> Option<&'static Path> {
 /// with `SKIP_DASHED_BUILT_INS`, like Git for Windows, omit programs for builtin subcommands, which
 /// can then still be run through `git` itself.
 pub fn core_dir_program(name: &str) -> Option<PathBuf> {
+    let mut components = Path::new(name).components();
+    if !matches!(components.next(), Some(std::path::Component::Normal(_))) || components.next().is_some() {
+        return None;
+    }
     let path = core_dir()?.join(format!("{name}{}", std::env::consts::EXE_SUFFIX));
     path.is_file().then_some(path)
 }

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -139,6 +139,21 @@ pub fn core_dir() -> Option<&'static Path> {
     GIT_CORE_DIR.as_deref()
 }
 
+/// Return the path at which the Git-provided program with `name` resides within the [`core_dir()`],
+/// or `None` if it doesn't exist there or if Git could not be found.
+///
+/// This is the location `git` itself uses to find the programs implementing its subcommands, and is
+/// useful to invoke programs like `git-upload-pack` that are shipped with Git but aren't necessarily
+/// present in `PATH`.
+///
+/// Note that installations differ in which programs they provide as separate executables - builds
+/// with `SKIP_DASHED_BUILT_INS`, like Git for Windows, omit programs for builtin subcommands, which
+/// can then still be run through `git` itself.
+pub fn core_dir_program(name: &str) -> Option<PathBuf> {
+    let path = core_dir()?.join(format!("{name}{}", std::env::consts::EXE_SUFFIX));
+    path.is_file().then_some(path)
+}
+
 fn system_prefix_from_core_dir<F>(core_dir_func: F) -> Option<PathBuf>
 where
     F: Fn() -> Option<&'static Path>,

--- a/gix-path/tests/path/env.rs
+++ b/gix-path/tests/path/env.rs
@@ -56,6 +56,36 @@ fn core_dir() {
 }
 
 #[test]
+fn core_dir_program() {
+    let core_dir = gix_path::env::core_dir().expect("Git is always in PATH when we run tests");
+    let program = std::fs::read_dir(core_dir)
+        .expect("the core directory can be listed")
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_ok_and(|t| t.is_file()))
+        .find_map(|entry| {
+            let name = entry.file_name();
+            let stem = name.to_str()?.strip_suffix(std::env::consts::EXE_SUFFIX)?;
+            stem.starts_with("git-").then(|| stem.to_owned())
+        });
+    // Which programs are present as separate executables depends on how Git was built -
+    // Git for Windows, for instance, may not provide programs for builtin subcommands.
+    if let Some(stem) = program {
+        let path =
+            gix_path::env::core_dir_program(&stem).expect("a program listed in the core directory is found there");
+        assert!(path.is_file(), "the returned path refers to an existing file");
+        assert!(
+            path.is_absolute(),
+            "the path is absolute as it is based on `git --exec-path`"
+        );
+    }
+    assert_eq!(
+        gix_path::env::core_dir_program("git-program-that-does-not-exist"),
+        None,
+        "programs that don't exist in the core directory are not found"
+    );
+}
+
+#[test]
 fn system_prefix() {
     assert_ne!(
         gix_path::env::system_prefix(),

--- a/gix-path/tests/path/env.rs
+++ b/gix-path/tests/path/env.rs
@@ -58,18 +58,18 @@ fn core_dir() {
 #[test]
 fn core_dir_program() {
     let core_dir = gix_path::env::core_dir().expect("Git is always in PATH when we run tests");
-    let program = std::fs::read_dir(core_dir)
+    let programs = std::fs::read_dir(core_dir)
         .expect("the core directory can be listed")
         .filter_map(Result::ok)
         .filter(|entry| entry.file_type().is_ok_and(|t| t.is_file()))
-        .find_map(|entry| {
+        .filter_map(|entry| {
             let name = entry.file_name();
             let stem = name.to_str()?.strip_suffix(std::env::consts::EXE_SUFFIX)?;
             stem.starts_with("git-").then(|| stem.to_owned())
         });
     // Which programs are present as separate executables depends on how Git was built -
     // Git for Windows, for instance, may not provide programs for builtin subcommands.
-    if let Some(stem) = program {
+    for stem in programs {
         let path =
             gix_path::env::core_dir_program(&stem).expect("a program listed in the core directory is found there");
         assert!(path.is_file(), "the returned path refers to an existing file");
@@ -82,6 +82,21 @@ fn core_dir_program() {
         gix_path::env::core_dir_program("git-program-that-does-not-exist"),
         None,
         "programs that don't exist in the core directory are not found"
+    );
+
+    for name in ["", ".", "..", "../git", "git/program", "/git"] {
+        assert_eq!(
+            gix_path::env::core_dir_program(name),
+            None,
+            "program names with path components are rejected"
+        );
+    }
+
+    #[cfg(windows)]
+    assert_eq!(
+        gix_path::env::core_dir_program(r"git\program"),
+        None,
+        "Windows path separators in program names are rejected"
     );
 }
 

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -92,6 +92,7 @@ required-features = ["async-client"]
 
 [dependencies]
 gix-command = { version = "^0.9.1", path = "../gix-command" }
+gix-path = { version = "^0.12.1", path = "../gix-path" }
 gix-features = { version = "^0.48.1", path = "../gix-features" }
 gix-url = { version = "^0.36.1", path = "../gix-url" }
 gix-sec = { version = "^0.14.1", path = "../gix-sec" }

--- a/gix-transport/src/client/blocking_io/file.rs
+++ b/gix-transport/src/client/blocking_io/file.rs
@@ -134,25 +134,22 @@ impl SpawnProcessOnDemand {
     /// being directly available (#2313).
     ///
     /// Prefer the same program from git's own `--exec-path`, which is where `git` itself finds it, and
-    /// otherwise let the `git` we can always find run it as subcommand.
+    /// otherwise let the `git` itself run it as subcommand.
     /// This is only used for local repositories - remote shells keep the standard invocation.
     fn prepare_fallback_command(&self, service: Service) -> (gix_command::Prepare, OsString) {
         let (mut cmd, cmd_name) = match gix_path::env::core_dir_program(service.as_str()) {
             Some(program) => {
-                let cmd_name: OsString = program.clone().into();
+                let cmd_name = program.clone().into_os_string();
                 (gix_command::prepare(program).stderr(Stdio::null()), cmd_name)
             }
             None => {
-                let subcommand = service
-                    .as_str()
-                    .strip_prefix("git-")
-                    .expect("all services are 'git-*' subcommands");
+                let subcommand = service.as_git_subcommand();
                 let git = gix_path::env::exe_invocation();
+                let cmd = gix_command::prepare(git).stderr(Stdio::null()).arg(subcommand);
+
                 let mut cmd_name: OsString = git.into();
                 cmd_name.push(" ");
                 cmd_name.push(subcommand);
-                let mut cmd = gix_command::prepare(git).stderr(Stdio::null());
-                cmd.args.push(subcommand.into());
                 (cmd, cmd_name)
             }
         };

--- a/gix-transport/src/client/blocking_io/file.rs
+++ b/gix-transport/src/client/blocking_io/file.rs
@@ -128,6 +128,37 @@ impl SpawnProcessOnDemand {
         cmd.args.push(repo_path);
         Ok((cmd, ssh_kind, cmd_name))
     }
+
+    /// Prepare an invocation for when the program of `service`, e.g. `git-upload-pack`, isn't present in `PATH`,
+    /// which can happen on Windows in particular, where `git` may be installed without its subcommands
+    /// being directly available (#2313).
+    ///
+    /// Prefer the same program from git's own `--exec-path`, which is where `git` itself finds it, and
+    /// otherwise let the `git` we can always find run it as subcommand.
+    /// This is only used for local repositories - remote shells keep the standard invocation.
+    fn prepare_fallback_command(&self, service: Service) -> (gix_command::Prepare, OsString) {
+        let (mut cmd, cmd_name) = match gix_path::env::core_dir_program(service.as_str()) {
+            Some(program) => {
+                let cmd_name: OsString = program.clone().into();
+                (gix_command::prepare(program).stderr(Stdio::null()), cmd_name)
+            }
+            None => {
+                let subcommand = service
+                    .as_str()
+                    .strip_prefix("git-")
+                    .expect("all services are 'git-*' subcommands");
+                let git = gix_path::env::exe_invocation();
+                let mut cmd_name: OsString = git.into();
+                cmd_name.push(" ");
+                cmd_name.push(subcommand);
+                let mut cmd = gix_command::prepare(git).stderr(Stdio::null());
+                cmd.args.push(subcommand.into());
+                (cmd, cmd_name)
+            }
+        };
+        cmd.args.push(self.path.to_os_str_lossy().into_owned());
+        (cmd, cmd_name)
+    }
 }
 
 impl client::TransportWithoutIO for SpawnProcessOnDemand {
@@ -241,21 +272,42 @@ impl client::blocking_io::Transport for SpawnProcessOnDemand {
         service: Service,
         extra_parameters: &'a [(&'a str, Option<&'a str>)],
     ) -> Result<SetServiceResponse<'_>, client::Error> {
-        let (mut cmd, ssh_kind, cmd_name) = self.prepare_command(service)?;
-        cmd.stdin = Stdio::piped();
-        cmd.stdout = Stdio::piped();
+        let (cmd, ssh_kind, cmd_name) = self.prepare_command(service)?;
+        let envs = std::mem::take(&mut self.envs);
+        let into_std_command = |mut cmd: gix_command::Prepare| {
+            cmd.stdin = Stdio::piped();
+            cmd.stdout = Stdio::piped();
 
-        let mut cmd = std::process::Command::from(cmd);
-        for env_to_remove in ENV_VARS_TO_REMOVE {
-            cmd.env_remove(env_to_remove);
-        }
-        cmd.envs(std::mem::take(&mut self.envs));
+            let mut cmd = std::process::Command::from(cmd);
+            for env_to_remove in ENV_VARS_TO_REMOVE {
+                cmd.env_remove(env_to_remove);
+            }
+            cmd.envs(envs.iter().map(|(k, v)| (k, v)));
+            cmd
+        };
 
+        let mut cmd = into_std_command(cmd);
         gix_features::trace::debug!(command = ?cmd, "gix_transport::SpawnProcessOnDemand");
-        let mut child = cmd.spawn().map_err(|err| client::Error::InvokeProgram {
-            source: err,
-            command: cmd_name,
-        })?;
+        let mut child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(err) if ssh_kind.is_none() && err.kind() == std::io::ErrorKind::NotFound => {
+                // The service program wasn't found in `PATH`, but as `git` itself can be found,
+                // the service can still be run through it (#2313).
+                let (cmd, cmd_name) = self.prepare_fallback_command(service);
+                let mut cmd = into_std_command(cmd);
+                gix_features::trace::debug!(command = ?cmd, "gix_transport::SpawnProcessOnDemand (fallback)");
+                cmd.spawn().map_err(|err| client::Error::InvokeProgram {
+                    source: err,
+                    command: cmd_name,
+                })?
+            }
+            Err(err) => {
+                return Err(client::Error::InvokeProgram {
+                    source: err,
+                    command: cmd_name,
+                });
+            }
+        };
         let stdout: Box<dyn std::io::Read + Send> = match ssh_kind {
             Some(ssh_kind) => Box::new(supervise_stderr(
                 ssh_kind,
@@ -305,6 +357,51 @@ pub fn connect(
 
 #[cfg(test)]
 mod tests {
+    mod local {
+        use crate::{Protocol, Service, client::blocking_io::file::SpawnProcessOnDemand};
+
+        #[test]
+        fn fallback_command_prefers_the_core_dir_program_and_can_always_run_git_itself() {
+            let transport = SpawnProcessOnDemand::new_local("/repo/path".into(), Protocol::V2, false);
+            let (cmd, name) = transport.prepare_fallback_command(Service::UploadPack);
+
+            assert!(!cmd.use_shell, "a shell is never used to run the local service program");
+            assert_eq!(
+                cmd.args.last().map(std::path::Path::new),
+                Some(std::path::Path::new("/repo/path")),
+                "the repository path is the final argument"
+            );
+            match gix_path::env::core_dir_program(Service::UploadPack.as_str()) {
+                Some(program) => {
+                    assert_eq!(
+                        std::path::Path::new(&cmd.command),
+                        program,
+                        "the program shipped with Git in its `--exec-path` is used directly"
+                    );
+                    assert!(
+                        std::path::Path::new(&cmd.command).is_absolute(),
+                        "which also means it's an absolute path"
+                    );
+                    assert_eq!(cmd.args.len(), 1, "there is no sub-command, just the repo path");
+                    assert_eq!(name, program.into_os_string());
+                }
+                None => {
+                    assert_eq!(
+                        std::path::Path::new(&cmd.command),
+                        gix_path::env::exe_invocation(),
+                        "without it, `git` itself runs the service as subcommand"
+                    );
+                    assert_eq!(
+                        cmd.args.first().and_then(|arg| arg.to_str()),
+                        Some("upload-pack"),
+                        "the sub-command is passed as separate argument, without the 'git-' prefix"
+                    );
+                    assert_eq!(cmd.args.len(), 2, "sub-command and repo path");
+                }
+            }
+        }
+    }
+
     mod ssh {
         mod connect {
             use crate::{Protocol, client::blocking_io::ssh};

--- a/gix-transport/src/lib.rs
+++ b/gix-transport/src/lib.rs
@@ -44,12 +44,19 @@ pub enum Service {
 }
 
 impl Service {
-    /// Render this instance as string recognized by the git transport layer.
+    /// Render this instance as a string recognized by the git transport layer, like `git-upload-pack`.
     pub fn as_str(&self) -> &'static str {
         match self {
             Service::ReceivePack => "git-receive-pack",
             Service::UploadPack => "git-upload-pack",
         }
+    }
+
+    /// Render this instance as a subcommand understood by the `git` program, like `upload-pack`.
+    pub fn as_git_subcommand(&self) -> &'static str {
+        self.as_str()
+            .strip_prefix("git-")
+            .expect("all services are 'git-*' subcommands")
     }
 }
 


### PR DESCRIPTION
Fixes #2313.

### Problem

Local clones spawn the service program, like `git-upload-pack`, by name, and fail with `NotFound` when it isn't in `PATH` — even though `git` itself is findable. As @EliahKagan's analysis in the issue lays out, this is common on Windows, where installations like scoop's put `git` in `PATH` but not its subcommands, and where we already support `git` not being in `PATH` at all.

### Changes

Following the resolution order discussed in the issue:

1. **Unchanged first attempt**: spawn the service program by name, using `PATH` as before.
2. **On `NotFound`, find it where `git` finds it**: the new `gix_path::env::core_dir_program(name)` looks the program up in the directory reported by `git --exec-path` (via the cached `core_dir()`), which is the location `git` itself uses to run its subcommands — and run it from there by absolute path. This works on all platforms and is the "conscious choice" variant: it's very clear which program runs.
3. **Otherwise, let `git` run it**: spawn `exe_invocation()` with the service as its subcommand — passed as a separate argument, no shell involved.

The fallback can only ever engage for local repositories: it is gated on the non-SSH arm of the transport, so remote invocations keep the standard `git-upload-pack` command name that servers may customize. The async client has no file transport, so nothing changes there. As the retry is keyed on the failed spawn itself, there is no TOCTOU between checking and running. `git-receive-pack` gets the same treatment as the logic is service-generic.

The `auxiliary.rs` machinery for Git-for-Windows directories is deliberately left untouched — `--exec-path` already answers this particular question on every platform, while the broader executable-finding facility discussed in the issue (and #1886) remains open for its own design.

### Validation

Reproduced the issue and verified the fix end-to-end on macOS with a `PATH` containing only a `git` symlink:
- before: `gix clone file://…` fails with `No such file or directory (os error 2)`
- after: the clone fully succeeds via the exec-path program
- with `GIT_EXEC_PATH` additionally pointing at an empty directory, the clone still succeeds via the `git upload-pack` form, exercising the last fallback.

Tests:
- `gix-path`: `core_dir_program` returns an existing absolute path for `git-upload-pack` and `None` for programs that don't exist.
- `gix-transport`: the fallback invocation shape is asserted for both branches — never a shell, repository path as final argument, sub-command as a separate argument in the `git`-run form.
- `cargo test -p gix-path -p gix-transport --features blocking-client -p gix -p gitoxide-core`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all pass.