### PR TITLE
fix: make `gix exclude query` consult the index like `git check-ignore` (#2562)

### DIFF
--- a/gitoxide-core/src/repository/exclude.rs
+++ b/gitoxide-core/src/repository/exclude.rs
@@ -15,6 +15,9 @@ pub mod query {
         pub overrides: Vec<OsString>,
         pub show_ignore_patterns: bool,
         pub statistics: bool,
+        /// If set, do not consult the index, reporting matches purely from the
+        /// ignore stack (like `git check-ignore --no-index`).
+        pub no_index: bool,
     }
 }
 
@@ -28,6 +31,7 @@ pub fn query(
         format,
         show_ignore_patterns,
         statistics,
+        no_index,
     }: query::Options,
 ) -> anyhow::Result<()> {
     if format != OutputFormat::Human {
@@ -55,7 +59,7 @@ pub fn query(
                 let match_ = entry
                     .matching_exclude_pattern()
                     .and_then(|m| (show_ignore_patterns || !m.pattern.is_negative()).then_some(m));
-                print_match(match_, path.as_ref(), &mut out)?;
+                print_match(match_, path.as_ref(), &index, no_index, &mut out)?;
             }
         }
         PathsOrPatterns::Patterns(patterns) => {
@@ -75,7 +79,7 @@ pub fn query(
                     let match_ = entry
                         .matching_exclude_pattern()
                         .and_then(|m| (show_ignore_patterns || !m.pattern.is_negative()).then_some(m));
-                    print_match(match_, path, &mut out)?;
+                    print_match(match_, path, &index, no_index, &mut out)?;
                 }
             }
 
@@ -103,7 +107,7 @@ pub fn query(
                     let match_ = entry
                         .matching_exclude_pattern()
                         .and_then(|m| (show_ignore_patterns || !m.pattern.is_negative()).then_some(m));
-                    print_match(match_, path, &mut out)?;
+                    print_match(match_, path, &index, no_index, &mut out)?;
                 }
             }
         }
@@ -119,8 +123,16 @@ pub fn query(
 fn print_match(
     m: Option<gix::ignore::search::Match<'_>>,
     path: &BStr,
+    index: &gix::worktree::Index,
+    no_index: bool,
     mut out: impl std::io::Write,
 ) -> std::io::Result<()> {
+    // Like `git check-ignore` (without `--no-index`): a path that is tracked in
+    // the index - a file entry, or a directory that contains index entries - is
+    // never reported as excluded, even if an ignore rule matches it.
+    let m = m.filter(|_| {
+        no_index || !(index.entry_by_path(path).is_some() || index.path_is_directory(path))
+    });
     match m {
         Some(m) => writeln!(
             out,

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -1604,6 +1604,7 @@ pub fn main() -> Result<()> {
                 patterns,
                 pathspec,
                 show_ignore_patterns,
+                no_index,
             } => prepare_and_run(
                 "exclude-query",
                 trace,
@@ -1630,6 +1631,7 @@ pub fn main() -> Result<()> {
                             show_ignore_patterns,
                             overrides: patterns,
                             statistics,
+                            no_index,
                         },
                     )
                 },

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -1186,6 +1186,12 @@ pub mod exclude {
             /// That way one can understand why an entry might not be excluded.
             #[clap(long, short = 'i')]
             show_ignore_patterns: bool,
+            /// Do not consult the index, reporting matches purely from the ignore stack.
+            ///
+            /// Like `git check-ignore --no-index`. By default, tracked paths are not
+            /// reported as excluded, matching `git check-ignore`.
+            #[clap(long)]
+            no_index: bool,
             /// Additional patterns to use for exclusions. They have the highest priority.
             ///
             /// Useful for undoing previous patterns using the '!' prefix.


### PR DESCRIPTION
This addresses the `gix exclude query` mismatch reported in #2562 — thanks @Byron for the detailed analysis and the exact fix direction.

### Problem

`gix exclude query <path>` consulted only the exclude stack and reported paths that are **tracked in the index** (a file entry, or a directory that contains index entries) as excluded — unlike `git check-ignore` (normal mode), which never reports tracked paths.

### Fix

Consult the index before reporting a match, suppressing it when the path is tracked (`index.entry_by_path(path).is_some() || index.path_is_directory(path)`), matching `git check-ignore`. This is applied uniformly in `print_match`, so all three query paths (stdin, index-entries, and the pattern fallback) become index-aware. A new `--no-index` flag keeps the previous pure-ignore-stack behavior, mirroring `git check-ignore --no-index`.

### Verification

Using the reproduction from the issue:

```sh
git init; mkdir -p src/bin other/bin
printf 'bin/\n' > .gitignore
printf 'fn main() {}\n' > src/bin/stub_gen.rs
git add -f .gitignore src/bin/stub_gen.rs && git commit -m init
printf 'extra\n' > src/bin/extra.txt; printf 'other\n' > other/bin/file.txt
```

Default (index-aware) now matches `git check-ignore`:

| path | tracked? | before | after (`gix`) | `git check-ignore` |
| --- | --- | --- | --- | --- |
| `src/bin/stub_gen.rs` | yes | **excluded** | not excluded | not ignored |
| `src/bin` | yes (dir) | — | not excluded | not ignored |
| `src/bin/extra.txt` | no | excluded | excluded | ignored |
| `other/bin` | no | excluded | excluded | ignored |

`gix exclude query --no-index …` reports all matches, matching `git check-ignore --no-index`.

### Notes

- `gix exclude query` currently has no journey-test coverage. I'm happy to add one — is there a preferred spot / fixture + snapshot convention you'd like me to follow (e.g. a new sandbox under `tests/`)?
- This fixes the CLI. Exposing index-abiding exclude queries from `gix::Repository` (the "real fix" you mentioned) could be a good follow-up.
