### PR TITLE
fix: consume open_path_as_is after repository path resolution

### DIFF
--- a/gix/src/open/options.rs
+++ b/gix/src/open/options.rs
@@ -70,10 +70,11 @@ impl Options {
         self
     }
 
-    /// If `true`, default `false`, we will not modify the incoming path to open to assure it is a `.git` directory.
+    /// If `true`, default `false`, we will not modify the incoming path for this open call to assure it is a `.git` directory.
     ///
     /// If `true`, we will try to open the input directory as is, even though it doesn't appear to be a `git` repository
     /// due to the lack of `.git` suffix or because its basename is not `.git` as in `worktree/.git`.
+    /// This option is consumed while resolving the path and isn't retained in the opened repository's options.
     pub fn open_path_as_is(mut self, enable: bool) -> Self {
         self.open_path_as_is = enable;
         self

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -163,6 +163,7 @@ impl ThreadSafeRepository {
         mut options: Options,
     ) -> Result<Self, Error> {
         let _span = gix_trace::detail!("open_from_paths()");
+        options.open_path_as_is = false;
         let Options {
             ref mut git_dir_trust,
             object_store_slots,

--- a/gix/tests/gix/repository/filter.rs
+++ b/gix/tests/gix/repository/filter.rs
@@ -94,6 +94,49 @@ fn pipeline_worktree_file_to_object() -> crate::Result {
 }
 
 #[test]
+#[cfg(unix)]
+fn worktree_file_to_object_opens_submodules_after_path_options_were_consumed() -> crate::Result {
+    let repo = named_repo("repo_with_untracked_files.sh")?;
+    let submodule = gix::open_opts(
+        repo.workdir().expect("non-bare").join("submodule"),
+        gix::open::Options::isolated(),
+    )?;
+    let checked_out_head = submodule.head_id()?;
+    let mut repo = gix::open_opts(repo.git_dir(), gix::open::Options::isolated().open_path_as_is(true))?;
+
+    fn submodule_entry(repo: &gix::Repository) -> crate::Result<Option<(gix::ObjectId, gix::object::tree::EntryKind)>> {
+        let (mut pipe, index) = repo.filter_pipeline(None)?;
+        Ok(pipe
+            .worktree_file_to_object("submodule".into(), &index)?
+            .map(|(id, kind, _)| (id, kind)))
+    }
+
+    let (id, kind) = submodule_entry(&repo)?.expect("the submodule can be opened");
+    assert_eq!(
+        id, checked_out_head,
+        "the ID comes from the opened submodule's HEAD, not the superproject's index"
+    );
+    assert_eq!(
+        kind,
+        gix::object::tree::EntryKind::Commit,
+        "an option used to open the parent repository must not affect opening its submodule"
+    );
+
+    repo.reload()?;
+    let (id, kind) = submodule_entry(&repo)?.expect("the submodule can still be opened after reload");
+    assert_eq!(
+        id, checked_out_head,
+        "reload-only options must not prevent reading the opened submodule's HEAD"
+    );
+    assert_eq!(
+        kind,
+        gix::object::tree::EntryKind::Commit,
+        "reload-only options must not affect opening a submodule afterward"
+    );
+    Ok(())
+}
+
+#[test]
 fn pipeline_with_autocrlf() -> crate::Result {
     let repo = named_repo("make_config_repo.sh")?;
     let (mut pipe, index) = repo.filter_pipeline(None)?;


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- consume `open_path_as_is` after the current repository path has been resolved
- prevent reload and explicit path-as-is opens from poisoning later submodule or linked-worktree opens
- reproduce the dropped-gitlink behavior with a gitfile-backed submodule test

## Reported issue

Address the following issue by adding a test as reproducer. The `options` of reload should most certainly not be altered permanently. It's also worth looking into the behaviour related to submodules (or opening worktrees) when the user has set open_path_as_is themselves. It seems this needs special treatment in these cases, beyond fixing `reload()`.

## TL;DR

`but commit` drops staged submodules because CLI `init_ctx` calls `gix::Repository::reload()`, which leaves `open_path_as_is=true` on the parent repo. `worktree_file_to_object` then opens the submodule with those inherited options, does not follow `submodule_path/.git`, fails with `MissingHead`, returns `None`, and the change is rejected. The GUI does not reload that way, so nested open succeeds.

Special-casing `None` in `apply_worktree_changes` (https://github.com/gitbutlerapp/gitbutler/pull/14572) is a workaround around that. `open_path_as_is` is only used while resolving the path for **this** open call (gix already ignores it afterward in `open_from_paths`). It must not stay `true` on the stored `Options` that later nested opens clone. Smallest fix **without changing gix**: in `but`, clear the flag after `reload()` (or reopen with discovery-friendly options before commit). Ideally in gix it would not be stored state at all (one-shot open argument only), but that would be an API change with consequences.

What follows is the original report in a downstream project, we are fixing gitoxide here.

---

## Why `but commit` drops a staged submodule

CLI and GUI both build commits through `apply_worktree_changes`. For a submodule, that path asks gix `worktree_file_to_object` to turn the worktree path into a tree entry.

A healthy submodule checkout is a **directory**. The correct branch in `worktree_file_to_object` is `md.is_dir()`: open the nested repo, read HEAD, return `EntryKind::Commit`. Entering that branch is expected. The bug is leaving it with `None`.

Inside that branch, gix does:

```rust
crate::open_opts(&path, repo.open_options().clone())
```

So the nested open **inherits the parent repo’s open options**. If that open fails, the error is swallowed (`.ok()`) and the function returns `None`. `apply_worktree_changes` then rejects the change (`WorktreeFileMissingForObjectConversion`), and the CLI soft-continues, commit is created without the gitlink.

`None` here does **not** mean “not a submodule.” It means “nested open failed.”

## Why the nested open fails

A normal submodule checkout looks like:

```
submodule_path/
  .git    ← file: "gitdir: ../.git/modules/submodule_path"
  …
```

There is no `HEAD` directly under `submodule_path`. HEAD lives in the real module dir. Opening it correctly requires following the `.git` gitdir file.

gix `open_opts` has two modes:

| Parent `open_path_as_is` | Candidate | Result for a submodule |
|---|---|---|
| `false` (normal) | `submodule_path/.git` | Follows gitdir → Ok |
| `true` | `submodule_path` itself | Looks for HEAD there → `MissingHead` → fail → `None` |

We measured this on a healthy `git submodule add` under `but commit`:

- nested open with **parent** options → `MissingHead`
- nested open with **default** options → Ok
- nested open with parent options but `open_path_as_is(false)` → Ok

Parent options are wrong for nested opens.

## How the parent gets `open_path_as_is = true`

1. Every legacy `but` command goes through `init_ctx`.
2. That always calls `ctx.reload_repo_and_invalidate_workspace(...)`.
3. Which calls `gix::Repository::reload()`.
4. `reload()` reopens with `options.clone().open_path_as_is(true)`, correct for reloading a known git dir, and **stores those options on the repo handle**.

So by the time `but commit` runs `worktree_file_to_object`, the parent already has a reload-only flag. Nested open inherits it and cannot follow `submodule_path/.git`.

The GUI commit path does not run this CLI `init_ctx` reload, so the parent often still has clean options → nested open succeeds → gitlink recorded. Same `apply_worktree_changes`; different open-option state on the parent.

## What we should / shouldn’t fix

Special-casing `None` in `apply_worktree_changes` as “maybe a staged submodule” (https://github.com/gitbutlerapp/gitbutler/pull/14572) is a workaround around a failed nested open.

The real bug: `open_path_as_is` is consumed only during open path resolution, then left `true` on the stored `Options`. Nested opens clone that and fail.

Fix direction:

- gix (smallest accurate fix): clear `open_path_as_is` before storing options on the repo after path resolution / after `reload()`, same behavioral effect for nested opens, without changing the public `Options` API
- until/unless that lands: `but` can avoid leaving a poisoned handle (e.g. clear the flag after reload, or reopen with discovery-friendly options before commit)

Ideally `open_path_as_is` would not be stored state at all (one-shot open argument only), but that would be an API change with consequences for callers of `Options::open_path_as_is()`.

Once nested open succeeds, `worktree_file_to_object` returns `Some(…, Commit)` and the existing commit path records the gitlink, same as the GUI.

## Git baseline

Git `734639a266` follows gitfiles through `read_gitfile_gently()` during repository setup in `setup.c`.

## Validation

- `cargo fmt --all -- --check`
- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix --test gix repository::filter`
- focused regression test
- existing `repository::open::open_path_as_is` tests
- existing reload configuration tests
- `cargo clippy -p gix --all-targets -- -D warnings`
- `codex review --commit 62c757cf5ce6e007feaabe8d17582fd1efe34a86` (no findings)
