### PR TITLE
fix: reject carriage returns in credential contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.38.1"
+version = "0.38.2"
 dependencies = [
  "bstr",
  "document-features",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "bstr",
  "document-features",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "bstr",
  "gix-testtools",
@@ -2575,7 +2575,7 @@ version = "0.0.0"
 
 [[package]]
 name = "gix-url"
-version = "0.36.1"
+version = "0.36.2"
 dependencies = [
  "assert_matches",
  "bstr",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bstr",
  "fastrand",

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -55,7 +55,7 @@ gix-transport-configuration-only = { package = "gix-transport", version = "^0.57
 gix-archive-for-configuration-only = { package = "gix-archive", version = "^0.34.0", path = "../gix-archive", optional = true, features = ["tar", "tar_gz"] }
 gix-status = { version = "^0.32.0", path = "../gix-status" }
 gix-fsck = { version = "^0.23.0", path = "../gix-fsck" }
-gix-error-for-configuration-only = { package = "gix-error", version = "^0.2.4", path = "../gix-error", features = ["anyhow"] }
+gix-error-for-configuration-only = { package = "gix-error", version = "^0.2.5", path = "../gix-error", features = ["anyhow"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 anyhow = "1.0.102"
 thiserror = "2.0.18"
@@ -72,7 +72,7 @@ futures-io = { version = "0.3.32", optional = true }
 blocking = { version = "1.6.2", optional = true }
 
 # for 'organize' functionality
-gix-url = { version = "^0.36.1", path = "../gix-url", optional = true }
+gix-url = { version = "^0.36.2", path = "../gix-url", optional = true }
 jwalk = { version = "0.8.0", optional = true }
 
 # for 'hours'

--- a/gix-actor/Cargo.toml
+++ b/gix-actor/Cargo.toml
@@ -19,8 +19,8 @@ doctest = true
 serde = ["dep:serde", "bstr/serde", "gix-date/serde"]
 
 [dependencies]
-gix-date = { version = "^0.15.4", path = "../gix-date" }
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 
 bstr = { version = "1.12.0", default-features = false, features = [
     "std",

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -33,13 +33,13 @@ zip = ["dep:rawzip", "dep:flate2"]
 [dependencies]
 gix-worktree-stream = { version = "^0.34.0", path = "../gix-worktree-stream" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
-gix-path = { version = "^0.12.1", path = "../gix-path", optional = true }
-gix-date = { version = "^0.15.5", path = "../gix-date" }
+gix-path = { version = "^0.12.2", path = "../gix-path", optional = true }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
 
 flate2 = { version = "1.1.9", optional = true, default-features = false, features = ["zlib-rs"] }
 rawzip = { version = "0.4.3", optional = true }
 
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 bstr = { version = "1.12.0", default-features = false }
 
 tar = { version = "0.4.46", optional = true }

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -19,7 +19,7 @@ doctest = true
 serde = ["dep:serde", "bstr/serde", "gix-glob/serde", "kstring/serde"]
 
 [dependencies]
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-quote = { version = "^0.7.2", path = "../gix-quote" }
 gix-glob = { version = "^0.26.1", path = "../gix-glob" }
 gix-trace = { version = "^0.1.20", path = "../gix-trace" }

--- a/gix-bitmap/Cargo.toml
+++ b/gix-bitmap/Cargo.toml
@@ -16,7 +16,7 @@ doctest = true
 test = true
 
 [dependencies]
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }

--- a/gix-blame/Cargo.toml
+++ b/gix-blame/Cargo.toml
@@ -18,11 +18,11 @@ sha1 = ["gix-hash/sha1"]
 sha256 = ["gix-hash/sha256"]
 
 [dependencies]
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 gix-commitgraph = { version = "^0.37.1", path = "../gix-commitgraph" }
 gix-revwalk = { version = "^0.33.0", path = "../gix-revwalk" }
 gix-trace = { version = "^0.1.20", path = "../gix-trace" }
-gix-date = { version = "^0.15.5", path = "../gix-date" }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
 gix-diff = { version = "^0.65.0", path = "../gix-diff", default-features = false, features = ["blob"] }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }

--- a/gix-chunk/Cargo.toml
+++ b/gix-chunk/Cargo.toml
@@ -17,4 +17,4 @@ doctest = true
 test = false
 
 [dependencies]
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }

--- a/gix-commitgraph/Cargo.toml
+++ b/gix-commitgraph/Cargo.toml
@@ -26,7 +26,7 @@ serde = ["dep:serde", "gix-hash/serde", "bstr/serde"]
 [dependencies]
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-chunk = { version = "^0.7.2", path = "../gix-chunk" }
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 memmap2 = "0.9.11"

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -24,7 +24,7 @@ serde = ["dep:serde", "bstr/serde", "gix-sec/serde", "gix-ref/serde", "gix-glob/
 [dependencies]
 gix-features = { version = "^0.48.1", path = "../gix-features" }
 gix-config-value = { version = "^0.18.1", path = "../gix-config-value" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-sec = { version = "^0.14.1", path = "../gix-sec" }
 gix-ref = { version = "^0.65.0", path = "../gix-ref" }
 gix-glob = { version = "^0.26.1", path = "../gix-glob" }

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-credentials"
-version = "0.38.1"
+version = "0.38.2"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project to interact with git credentials helpers"
@@ -20,12 +20,12 @@ serde = ["dep:serde", "bstr/serde", "gix-sec/serde"]
 
 [dependencies]
 gix-sec = { version = "^0.14.1", path = "../gix-sec" }
-gix-url = { version = "^0.36.1", path = "../gix-url" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-url = { version = "^0.36.2", path = "../gix-url" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-command = { version = "^0.9.1", path = "../gix-command" }
 gix-config-value = { version = "^0.18.1", path = "../gix-config-value" }
 gix-prompt = { version = "^0.15.1", path = "../gix-prompt" }
-gix-date = { version = "^0.15.4", path = "../gix-date" }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
 gix-trace = { version = "^0.1.20", path = "../gix-trace" }
 
 thiserror = "2.0.18"

--- a/gix-credentials/src/helper/cascade.rs
+++ b/gix-credentials/src/helper/cascade.rs
@@ -1,4 +1,9 @@
-use crate::{Program, helper, helper::Cascade, protocol, protocol::Context};
+use crate::{
+    Program, helper,
+    helper::Cascade,
+    protocol,
+    protocol::{Context, ContextOptions},
+};
 
 impl Default for Cascade {
     fn default() -> Self {
@@ -6,6 +11,7 @@ impl Default for Cascade {
             programs: Vec::new(),
             stderr: true,
             use_http_path: false,
+            protect_protocol: true,
             query_user_only: false,
         }
     }
@@ -86,7 +92,7 @@ impl Cascade {
 
         for program in &mut self.programs {
             program.stderr = self.stderr;
-            match helper::invoke::raw(program, &action) {
+            match helper::invoke::raw(program, &action, self.protect_protocol) {
                 Ok(None) => {}
                 Ok(Some(stdout)) => {
                     let Context {
@@ -99,7 +105,12 @@ impl Cascade {
                         password_expiry_utc,
                         url: ctx_url,
                         quit,
-                    } = Context::from_bytes(&stdout)?;
+                    } = Context::from_bytes_opts(
+                        &stdout,
+                        ContextOptions {
+                            protect_protocol: self.protect_protocol,
+                        },
+                    )?;
                     if let Some(dst_ctx) = action.context_mut() {
                         if let Some(src) = path {
                             dst_ctx.path = Some(src);

--- a/gix-credentials/src/helper/invoke.rs
+++ b/gix-credentials/src/helper/invoke.rs
@@ -1,12 +1,20 @@
 use std::io::Read;
 
-use crate::helper::{Action, Context, Error, NextAction, Outcome, Result};
+use crate::{
+    helper::{Action, Context, Error, NextAction, Outcome, Result},
+    protocol::ContextOptions,
+};
 
 impl Action {
     /// Send ourselves to the given `write` which is expected to be credentials-helper compatible
     pub fn send(&self, write: &mut dyn std::io::Write) -> std::io::Result<()> {
+        self.send_opts(write, ContextOptions::default())
+    }
+
+    /// Send ourselves like [`send()`][Self::send()], with configurable context encoding `options`.
+    pub fn send_opts(&self, write: &mut dyn std::io::Write, options: ContextOptions) -> std::io::Result<()> {
         match self {
-            Action::Get(ctx) => ctx.write_to(write),
+            Action::Get(ctx) => ctx.write_to_opts(write, options),
             Action::Store(last) | Action::Erase(last) => {
                 write.write_all(last).ok();
                 write.write_all(b"\n").ok();
@@ -23,7 +31,7 @@ impl Action {
 /// On successful usage, use [`NextAction::store()`], otherwise [`NextAction::erase()`], which is when this function
 /// returns `Ok(None)` as no outcome is expected.
 pub fn invoke(helper: &mut crate::Program, action: &Action) -> Result {
-    match raw(helper, action)? {
+    match raw(helper, action, true)? {
         None => Ok(None),
         Some(stdout) => {
             let ctx = Context::from_bytes(stdout.as_slice())?;
@@ -40,12 +48,16 @@ pub fn invoke(helper: &mut crate::Program, action: &Action) -> Result {
     }
 }
 
-pub(crate) fn raw(helper: &mut crate::Program, action: &Action) -> std::result::Result<Option<Vec<u8>>, Error> {
+pub(crate) fn raw(
+    helper: &mut crate::Program,
+    action: &Action,
+    protect_protocol: bool,
+) -> std::result::Result<Option<Vec<u8>>, Error> {
     let (mut stdin, stdout) = helper.start(action)?;
     if let (Action::Get(_), None) = (&action, &stdout) {
         panic!("BUG: `Helper` impls must return an output handle to read output from if Action::Get is provided")
     }
-    action.send(&mut stdin)?;
+    action.send_opts(&mut stdin, ContextOptions { protect_protocol })?;
     drop(stdin);
     let stdout = stdout
         .map(|mut stdout| {

--- a/gix-credentials/src/helper/mod.rs
+++ b/gix-credentials/src/helper/mod.rs
@@ -13,6 +13,8 @@ pub struct Cascade {
     /// If true, http(s) urls will take their path portion into account when obtaining credentials. Default is false.
     /// Other protocols like ssh will always use the path portion.
     pub use_http_path: bool,
+    /// If true, the default, carriage returns in credential values are rejected.
+    pub protect_protocol: bool,
     /// If true, default false, when getting credentials, we will set a bogus password to only obtain the user name.
     /// Storage and cancellation work the same, but without a password set.
     pub query_user_only: bool,

--- a/gix-credentials/src/protocol/context/serde.rs
+++ b/gix-credentials/src/protocol/context/serde.rs
@@ -144,7 +144,13 @@ pub mod decode {
 }
 
 fn validate(key: &str, value: &BStr) -> Result<(), Error> {
-    if key.contains('\0') || key.contains('\n') || value.contains(&0) || value.contains(&b'\n') {
+    if key.contains('\0')
+        || key.contains('\n')
+        || key.contains('\r')
+        || value.contains(&0)
+        || value.contains(&b'\n')
+        || value.contains(&b'\r')
+    {
         return Err(Error::Encoding {
             key: key.to_owned(),
             value: value.to_owned(),

--- a/gix-credentials/src/protocol/context/serde.rs
+++ b/gix-credentials/src/protocol/context/serde.rs
@@ -5,11 +5,20 @@ use crate::protocol::context::Error;
 mod write {
     use bstr::{BStr, BString};
 
-    use crate::protocol::{Context, context::serde::validate};
+    use crate::protocol::{Context, ContextOptions, context::serde::validate};
 
     impl Context {
         /// Write ourselves to `out` such that [`from_bytes()`][Self::from_bytes()] can decode it losslessly.
         pub fn write_to(&self, mut out: impl std::io::Write) -> std::io::Result<()> {
+            self.write_to_opts(&mut out, ContextOptions::default())
+        }
+
+        /// Write ourselves like [`write_to()`][Self::write_to()], with options.
+        pub fn write_to_opts(
+            &self,
+            mut out: impl std::io::Write,
+            ContextOptions { protect_protocol }: ContextOptions,
+        ) -> std::io::Result<()> {
             use bstr::ByteSlice;
             fn write_key(out: &mut impl std::io::Write, key: &str, value: &BStr) -> std::io::Result<()> {
                 out.write_all(key.as_bytes())?;
@@ -32,7 +41,7 @@ mod write {
             } = self;
             for (key, value) in [("url", url), ("path", path)] {
                 if let Some(value) = value {
-                    validate(key, value.as_slice().into()).map_err(std::io::Error::other)?;
+                    validate(key, value.as_slice().into(), protect_protocol).map_err(std::io::Error::other)?;
                     write_key(&mut out, key, value.as_ref()).ok();
                 }
             }
@@ -44,14 +53,14 @@ mod write {
                 ("oauth_refresh_token", oauth_refresh_token),
             ] {
                 if let Some(value) = value {
-                    validate(key, value.as_str().into()).map_err(std::io::Error::other)?;
+                    validate(key, value.as_str().into(), protect_protocol).map_err(std::io::Error::other)?;
                     write_key(&mut out, key, value.as_bytes().as_bstr()).ok();
                 }
             }
             if let Some(value) = password_expiry_utc {
                 let key = "password_expiry_utc";
                 let value = value.to_string();
-                validate(key, value.as_str().into()).map_err(std::io::Error::other)?;
+                validate(key, value.as_str().into(), protect_protocol).map_err(std::io::Error::other)?;
                 write_key(&mut out, key, value.as_bytes().as_bstr()).ok();
             }
             Ok(())
@@ -70,7 +79,7 @@ mod write {
 pub mod decode {
     use bstr::{BString, ByteSlice};
 
-    use crate::protocol::{Context, context, context::serde::validate};
+    use crate::protocol::{Context, ContextOptions, context, context::serde::validate};
 
     /// The error returned by [`from_bytes()`][Context::from_bytes()].
     #[derive(Debug, thiserror::Error)]
@@ -87,6 +96,14 @@ pub mod decode {
     impl Context {
         /// Decode ourselves from `input` which is the format written by [`write_to()`][Self::write_to()].
         pub fn from_bytes(input: &[u8]) -> Result<Self, Error> {
+            Self::from_bytes_opts(input, ContextOptions::default())
+        }
+
+        /// Decode ourselves like [`from_bytes()`][Self::from_bytes()], with additional options.
+        pub fn from_bytes_opts(
+            input: &[u8],
+            ContextOptions { protect_protocol }: ContextOptions,
+        ) -> Result<Self, Error> {
             let mut ctx = Context::default();
             let Context {
                 protocol,
@@ -105,7 +122,7 @@ pub mod decode {
                     it.next().and_then(|k| k.to_str().ok()),
                     it.next().map(ByteSlice::as_bstr),
                 ) {
-                    (Some(key), Some(value)) => validate(key, value)
+                    (Some(key), Some(value)) => validate(key, value, protect_protocol)
                         .map(|_| (key, value.to_owned()))
                         .map_err(Into::into),
                     _ => Err(Error::Syntax { line: line.into() }),
@@ -143,13 +160,13 @@ pub mod decode {
     }
 }
 
-fn validate(key: &str, value: &BStr) -> Result<(), Error> {
+fn validate(key: &str, value: &BStr, protect_protocol: bool) -> Result<(), Error> {
     if key.contains('\0')
         || key.contains('\n')
         || key.contains('\r')
         || value.contains(&0)
         || value.contains(&b'\n')
-        || value.contains(&b'\r')
+        || (protect_protocol && value.contains(&b'\r'))
     {
         return Err(Error::Encoding {
             key: key.to_owned(),

--- a/gix-credentials/src/protocol/mod.rs
+++ b/gix-credentials/src/protocol/mod.rs
@@ -65,6 +65,21 @@ pub struct Context {
     pub quit: Option<bool>,
 }
 
+/// Options for encoding and decoding a [`Context`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ContextOptions {
+    /// If true, carriage returns in credential values are rejected to protect credential-protocol parsing.
+    ///
+    /// NUL bytes and newlines are always rejected.
+    pub protect_protocol: bool,
+}
+
+impl Default for ContextOptions {
+    fn default() -> Self {
+        ContextOptions { protect_protocol: true }
+    }
+}
+
 /// Convert the outcome of a helper invocation to a helper result, assuring that the identity is complete in the process.
 #[allow(clippy::result_large_err)]
 pub fn helper_outcome_to_result(outcome: Option<helper::Outcome>, action: helper::Action) -> Result {

--- a/gix-credentials/tests/helper/context.rs
+++ b/gix-credentials/tests/helper/context.rs
@@ -22,7 +22,7 @@ fn encode_decode_roundtrip_works_only_for_serializing_fields() {
 }
 
 mod write_to {
-    use gix_credentials::protocol::Context;
+    use gix_credentials::protocol::{Context, ContextOptions};
 
     #[test]
     fn quit_is_not_serialized_but_can_be_parsed() {
@@ -56,10 +56,27 @@ mod write_to {
             assert_eq!(err.kind(), std::io::ErrorKind::Other);
         }
     }
+
+    #[test]
+    fn carriage_returns_can_be_allowed() {
+        let ctx = Context {
+            url: Some(b"https://example.com/with\rreturn".as_slice().into()),
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        ctx.write_to_opts(
+            &mut buf,
+            ContextOptions {
+                protect_protocol: false,
+            },
+        )
+        .expect("CR protection is disabled");
+        assert_eq!(buf, b"url=https://example.com/with\rreturn\n");
+    }
 }
 
 mod from_bytes {
-    use gix_credentials::protocol::Context;
+    use gix_credentials::protocol::{Context, ContextOptions};
 
     #[test]
     fn empty_newlines_cause_skipping_remaining_input() {
@@ -119,5 +136,20 @@ username=bob";
             err,
             gix_credentials::protocol::context::decode::Error::Encoding(_)
         ));
+    }
+
+    #[test]
+    fn carriage_returns_can_be_allowed() {
+        assert_eq!(
+            Context::from_bytes_opts(
+                b"url=https://example.com/with\rreturn\n",
+                ContextOptions {
+                    protect_protocol: false,
+                },
+            )
+            .expect("CR protection is disabled")
+            .url,
+            Some(b"https://example.com/with\rreturn".as_slice().into())
+        );
     }
 }

--- a/gix-credentials/tests/helper/context.rs
+++ b/gix-credentials/tests/helper/context.rs
@@ -45,10 +45,10 @@ mod write_to {
     }
 
     #[test]
-    fn null_bytes_and_newlines_are_invalid() {
-        for input in [&b"foo\0"[..], b"foo\n"] {
+    fn record_delimiters_are_invalid() {
+        for input in [&b"foo\0"[..], b"foo\n", b"foo\r"] {
             let ctx = Context {
-                path: Some(input.into()),
+                url: Some(input.into()),
                 ..Default::default()
             };
             let mut buf = Vec::<u8>::new();

--- a/gix-date/CHANGELOG.md
+++ b/gix-date/CHANGELOG.md
@@ -5,13 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.15.6 (2026-07-15)
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 3 commits contributed to the release.
+ - 23 days passed between releases.
+ - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Thanks Clippy
+
+<csr-read-only-do-not-edit/>
+
+[Clippy](https://github.com/rust-lang/rust-clippy) helped 1 time to make code idiomatic. 
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Merge pull request #2702 from ameyypawar/fix/2694-exn-source-chain ([`e9c973d`](https://github.com/GitoxideLabs/gitoxide/commit/e9c973d9476bef293bec89cd683cb60b02a85e52))
+    - Thanks clippy ([`d533f0c`](https://github.com/GitoxideLabs/gitoxide/commit/d533f0c7a6a6b20cbcfe5a755d472b921e38b4a1))
+    - Merge pull request #2646 from GitoxideLabs/report ([`1b1541e`](https://github.com/GitoxideLabs/gitoxide/commit/1b1541ed7a457afd48385c1ee39113949a9f5263))
+</details>
+
 ## 0.15.5 (2026-06-22)
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 3 commits contributed to the release over the course of 27 calendar days.
+ - 4 commits contributed to the release over the course of 27 calendar days.
  - 27 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -23,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-date v0.15.5, gix-hashtable v0.15.2, gix-object v0.62.0, gix-attributes v0.33.2, gix-filter v0.32.0, gix-revwalk v0.33.0, gix-traverse v0.59.0, gix-worktree-stream v0.34.0, gix-archive v0.34.0, gix-tempfile v23.0.2, gix-index v0.53.0, gix-worktree v0.54.0, gix-imara-diff v0.2.3, gix-diff v0.65.0, gix-blame v0.15.0, gix-ref v0.65.0, gix-config v0.58.0, gix-discover v0.53.0, gix-dir v0.27.0, gix-revision v0.47.0, gix-merge v0.18.0, gix-negotiate v0.33.0, gix-pack v0.72.0, gix-odb v0.82.0, gix-refspec v0.43.0, gix-transport v0.57.2, gix-protocol v0.63.0, gix-status v0.32.0, gix-submodule v0.32.0, gix-worktree-state v0.32.0, gix v0.85.0, gix-fsck v0.23.0, gitoxide-core v0.59.0, gitoxide v0.55.0, safety bump 28 crates ([`6428edc`](https://github.com/GitoxideLabs/gitoxide/commit/6428edc82fc8a16d5ef34ca2d49aa6fdff3645fe))
     - Merge pull request #2635 from GitoxideLabs/dependabot/cargo/cargo-7b971a5e8c ([`155ff6d`](https://github.com/GitoxideLabs/gitoxide/commit/155ff6d345ba49ff72cb25c08a8b9dfae8c41bc7))
     - Bump the cargo group with 40 updates ([`9402adc`](https://github.com/GitoxideLabs/gitoxide/commit/9402adc4c854f72906392a157b848a0ff36900a2))
     - Merge pull request #2618 from GitoxideLabs/report ([`f7d4f33`](https://github.com/GitoxideLabs/gitoxide/commit/f7d4f33b58503996ae90497b69ce4c3a757982ac))
@@ -70,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release over the course of 2 calendar days.
- - 3 days passed between releases.
+ - 4 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -127,6 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
+ - 28 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -235,7 +266,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release over the course of 5 calendar days.
- - 5 days passed between releases.
+ - 6 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -296,7 +327,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
- - 29 days passed between releases.
+ - 30 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -335,6 +366,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 8 commits contributed to the release.
+ - 30 days passed between releases.
  - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -433,7 +465,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release over the course of 7 calendar days.
- - 7 days passed between releases.
+ - 8 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -488,7 +520,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 7 commits contributed to the release over the course of 65 calendar days.
- - 65 days passed between releases.
+ - 66 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -545,6 +577,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -585,6 +618,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 15 commits contributed to the release.
+ - 21 days passed between releases.
  - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -627,6 +661,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 10 commits contributed to the release.
+ - 103 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -906,6 +941,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 9 commits contributed to the release.
+ - 33 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1058,6 +1094,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release over the course of 24 calendar days.
+ - 61 days passed between releases.
  - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#1367](https://github.com/GitoxideLabs/gitoxide/issues/1367)
 
@@ -1137,6 +1174,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1161,7 +1199,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 7 commits contributed to the release over the course of 17 calendar days.
- - 22 days passed between releases.
+ - 23 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1190,6 +1228,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 9 commits contributed to the release.
+ - 89 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1250,7 +1289,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release over the course of 9 calendar days.
- - 9 days passed between releases.
+ - 10 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1307,7 +1346,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release over the course of 4 calendar days.
- - 15 days passed between releases.
+ - 16 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#961](https://github.com/GitoxideLabs/gitoxide/issues/961)
 
@@ -1366,7 +1405,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release.
- - 6 days passed between releases.
+ - 7 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1402,7 +1441,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 9 commits contributed to the release over the course of 11 calendar days.
- - 15 days passed between releases.
+ - 16 days passed between releases.
  - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1468,6 +1507,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release over the course of 2 calendar days.
+ - 58 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#814](https://github.com/GitoxideLabs/gitoxide/issues/814)
 

--- a/gix-date/Cargo.toml
+++ b/gix-date/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-date"
-version = "0.15.5"
+version = "0.15.6"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project parsing dates the way git does"
@@ -19,7 +19,7 @@ doctest = true
 serde = ["dep:serde", "bstr/serde"]
 
 [dependencies]
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 itoa = "1.0.17"

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -60,7 +60,7 @@ gix-object = { version = "^0.62.0", path = "../gix-object" }
 gix-filter = { version = "^0.32.0", path = "../gix-filter", optional = true }
 gix-worktree = { version = "^0.54.0", path = "../gix-worktree", default-features = false, features = ["attributes"], optional = true }
 gix-command = { version = "^0.9.1", path = "../gix-command", optional = true }
-gix-path = { version = "^0.12.1", path = "../gix-path", optional = true }
+gix-path = { version = "^0.12.2", path = "../gix-path", optional = true }
 gix-fs = { version = "^0.21.2", path = "../gix-fs", optional = true }
 gix-tempfile = { version = "^23.0.0", path = "../gix-tempfile", optional = true }
 gix-trace = { version = "^0.1.20", path = "../gix-trace", optional = true }

--- a/gix-dir/Cargo.toml
+++ b/gix-dir/Cargo.toml
@@ -26,12 +26,12 @@ gix-trace = { version = "^0.1.20", path = "../gix-trace" }
 gix-index = { version = "^0.53.0", path = "../gix-index" }
 gix-discover = { version = "^0.53.0", path = "../gix-discover" }
 gix-fs = { version = "^0.21.2", path = "../gix-fs" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-pathspec = { version = "^0.18.1", path = "../gix-pathspec" }
 gix-worktree = { version = "^0.54.0", path = "../gix-worktree", default-features = false }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
 gix-ignore = { version = "^0.21.1", path = "../gix-ignore" }
-gix-utils = { version = "^0.3.3", path = "../gix-utils", features = ["bstr"] }
+gix-utils = { version = "^0.3.4", path = "../gix-utils", features = ["bstr"] }
 
 bstr = { version = "1.12.0", default-features = false }
 thiserror = "2.0.18"

--- a/gix-discover/Cargo.toml
+++ b/gix-discover/Cargo.toml
@@ -22,7 +22,7 @@ sha256 = ["gix-ref/sha256"]
 
 [dependencies]
 gix-sec = { version = "^0.14.1", path = "../gix-sec" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-ref = { version = "^0.65.0", path = "../gix-ref" }
 gix-fs = { version = "^0.21.2", path = "../gix-fs" }
 

--- a/gix-error/Cargo.toml
+++ b/gix-error/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-error"
-version = "0.2.4"
+version = "0.2.5"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project to provide common errors and error-handling utilities"

--- a/gix-features/Cargo.toml
+++ b/gix-features/Cargo.toml
@@ -84,8 +84,8 @@ required-features = ["io-pipe"]
 gix-trace = { version = "^0.1.20", path = "../gix-trace" }
 
 # for walkdir
-gix-path = { version = "^0.12.1", path = "../gix-path", optional = true }
-gix-utils = { version = "^0.3.3", path = "../gix-utils", optional = true }
+gix-path = { version = "^0.12.2", path = "../gix-path", optional = true }
+gix-utils = { version = "^0.3.4", path = "../gix-utils", optional = true }
 
 # 'parallel' feature
 crossbeam-channel = { version = "0.5.15", optional = true }

--- a/gix-filter/Cargo.toml
+++ b/gix-filter/Cargo.toml
@@ -43,8 +43,8 @@ gix-trace = { version = "^0.1.20", path = "../gix-trace" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
 gix-command = { version = "^0.9.1", path = "../gix-command" }
 gix-quote = { version = "^0.7.2", path = "../gix-quote" }
-gix-utils = { version = "^0.3.3", path = "../gix-utils" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-utils = { version = "^0.3.4", path = "../gix-utils" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-packetline = { version = "^0.21.5", path = "../gix-packetline", features = ["blocking-io"] }
 gix-attributes = { version = "^0.33.2", path = "../gix-attributes" }
 

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -20,9 +20,9 @@ serde = ["dep:serde"]
 
 [dependencies]
 bstr = "1.12.0"
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-features = { version = "^0.48.1", path = "../gix-features", features = ["fs-read-dir"] }
-gix-utils = { version = "^0.3.3", path = "../gix-utils" }
+gix-utils = { version = "^0.3.4", path = "../gix-utils" }
 thiserror = "2.0.18"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }
 

--- a/gix-glob/Cargo.toml
+++ b/gix-glob/Cargo.toml
@@ -24,7 +24,7 @@ path = "./benches/wildmatch.rs"
 serde = ["dep:serde", "bstr/serde", "bitflags/serde"]
 
 [dependencies]
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-features = { version = "^0.48.1", path = "../gix-features" }
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 bitflags = "2"

--- a/gix-ignore/Cargo.toml
+++ b/gix-ignore/Cargo.toml
@@ -20,7 +20,7 @@ serde = ["dep:serde", "bstr/serde", "gix-glob/serde"]
 
 [dependencies]
 gix-glob = { version = "^0.26.1", path = "../gix-glob" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-trace = { version = "^0.1.20", path = "../gix-trace" }
 
 bstr = { version = "1.12.0", default-features = false, features = ["std", "unicode"] }

--- a/gix-index/Cargo.toml
+++ b/gix-index/Cargo.toml
@@ -43,7 +43,7 @@ gix-validate = { version = "^0.11.2", path = "../gix-validate" }
 gix-traverse = { version = "^0.59.0", path = "../gix-traverse" }
 gix-lock = { version = "^23.0.0", path = "../gix-lock" }
 gix-fs = { version = "^0.21.2", path = "../gix-fs" }
-gix-utils = { version = "^0.3.3", path = "../gix-utils" }
+gix-utils = { version = "^0.3.4", path = "../gix-utils" }
 
 hashbrown = "0.17.1"
 fnv = "1.0.7"

--- a/gix-lock/Cargo.toml
+++ b/gix-lock/Cargo.toml
@@ -16,7 +16,7 @@ doctest = true
 test = true
 
 [dependencies]
-gix-utils = { version = "^0.3.3", default-features = false, path = "../gix-utils" }
+gix-utils = { version = "^0.3.4", default-features = false, path = "../gix-utils" }
 gix-tempfile = { version = "^23.0.0", default-features = false, path = "../gix-tempfile" }
 thiserror = "2.0.18"
 

--- a/gix-mailmap/Cargo.toml
+++ b/gix-mailmap/Cargo.toml
@@ -20,9 +20,9 @@ serde = ["dep:serde", "bstr/serde", "gix-actor/serde"]
 
 [dependencies]
 gix-actor = { version = "^0.41.1", path = "../gix-actor" }
-gix-date = { version = "^0.15.4", path = "../gix-date" }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
 bstr = { version = "1.12.0", default-features = false, features = ["std", "unicode"] }
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 
 document-features = { version = "0.2.0", optional = true }

--- a/gix-merge/Cargo.toml
+++ b/gix-merge/Cargo.toml
@@ -29,7 +29,7 @@ gix-object = { version = "^0.62.0", path = "../gix-object" }
 gix-filter = { version = "^0.32.0", path = "../gix-filter" }
 gix-worktree = { version = "^0.54.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }
 gix-command = { version = "^0.9.1", path = "../gix-command" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-fs = { version = "^0.21.2", path = "../gix-fs" }
 gix-tempfile = { version = "^23.0.0", path = "../gix-tempfile" }
 gix-trace = { version = "^0.1.20", path = "../gix-trace" }

--- a/gix-negotiate/Cargo.toml
+++ b/gix-negotiate/Cargo.toml
@@ -24,7 +24,7 @@ sha256 = ["gix-hash/sha256"]
 [dependencies]
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
-gix-date = { version = "^0.15.5", path = "../gix-date" }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
 gix-commitgraph = { version = "^0.37.1", path = "../gix-commitgraph" }
 gix-revwalk = { version = "^0.33.0", path = "../gix-revwalk" }
 bitflags = "2"

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -46,8 +46,8 @@ gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-hashtable = { version = "^0.15.2", path = "../gix-hashtable" }
 gix-validate = { version = "^0.11.2", path = "../gix-validate" }
 gix-actor = { version = "^0.41.1", path = "../gix-actor" }
-gix-date = { version = "^0.15.5", path = "../gix-date" }
-gix-utils = { version = "^0.3.3", path = "../gix-utils" }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
+gix-utils = { version = "^0.3.4", path = "../gix-utils" }
 
 itoa = "1.0.17"
 thiserror = "2.0.18"

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -30,7 +30,7 @@ gix-features = { version = "^0.48.1", path = "../gix-features", features = ["wal
 gix-zlib = { version = "^0.1.0", path = "../gix-zlib" }
 gix-hashtable = { version = "^0.15.2", path = "../gix-hashtable" }
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-quote = { version = "^0.7.2", path = "../gix-quote" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
 gix-pack = { version = "^0.72.0", path = "../gix-pack", default-features = false }

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -45,10 +45,10 @@ wasm = ["gix-diff?/wasm"]
 [dependencies]
 gix-features = { version = "^0.48.1", path = "../gix-features", features = ["crc32", "progress"] }
 gix-zlib = { version = "^0.1.0", path = "../gix-zlib" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-chunk = { version = "^0.7.2", path = "../gix-chunk" }
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
 gix-hashtable = { version = "^0.15.2", path = "../gix-hashtable", optional = true }
 

--- a/gix-path/Cargo.toml
+++ b/gix-path/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-path"
-version = "0.12.1"
+version = "0.12.2"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing paths and their conversions"

--- a/gix-pathspec/Cargo.toml
+++ b/gix-pathspec/Cargo.toml
@@ -16,7 +16,7 @@ doctest = true
 
 [dependencies]
 gix-glob = { version = "^0.26.1", path = "../gix-glob" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-attributes = { version = "^0.33.1", path = "../gix-attributes" }
 gix-config-value = { version = "^0.18.1", path = "../gix-config-value" }
 

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -78,15 +78,15 @@ gix-features = { version = "^0.48.1", path = "../gix-features", features = [
 gix-transport = { version = "^0.57.2", path = "../gix-transport" }
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-shallow = { version = "^0.12.1", path = "../gix-shallow" }
-gix-date = { version = "^0.15.5", path = "../gix-date" }
-gix-utils = { version = "^0.3.3", path = "../gix-utils" }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
+gix-utils = { version = "^0.3.4", path = "../gix-utils" }
 gix-ref = { version = "^0.65.0", path = "../gix-ref" }
 
 gix-trace = { version = "^0.1.20", path = "../gix-trace", optional = true }
 gix-negotiate = { version = "^0.33.0", path = "../gix-negotiate", optional = true }
 gix-object = { version = "^0.62.0", path = "../gix-object", optional = true }
 gix-revwalk = { version = "^0.33.0", path = "../gix-revwalk", optional = true }
-gix-credentials = { version = "^0.38.1", path = "../gix-credentials", optional = true }
+gix-credentials = { version = "^0.38.2", path = "../gix-credentials", optional = true }
 gix-refspec = { version = "^0.43.0", path = "../gix-refspec", optional = true }
 gix-lock = { version = "^23.0.0", path = "../gix-lock", optional = true }
 

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -28,10 +28,10 @@ parallel = ["gix-features/parallel"]
 [dependencies]
 gix-features = { version = "^0.48.1", path = "../gix-features", features = ["walkdir"] }
 gix-fs = { version = "^0.21.2", path = "../gix-fs" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
-gix-utils = { version = "^0.3.3", path = "../gix-utils" }
+gix-utils = { version = "^0.3.4", path = "../gix-utils" }
 gix-validate = { version = "^0.11.2", path = "../gix-validate" }
 gix-actor = { version = "^0.41.1", path = "../gix-actor" }
 gix-lock = { version = "^23.0.0", path = "../gix-lock" }

--- a/gix-refspec/Cargo.toml
+++ b/gix-refspec/Cargo.toml
@@ -21,7 +21,7 @@ sha1 = ["gix-hash/sha1"]
 sha256 = ["gix-hash/sha256"]
 
 [dependencies]
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 gix-revision = { version = "^0.47.0", path = "../gix-revision", default-features = false }
 gix-validate = { version = "^0.11.2", path = "../gix-validate" }
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -31,10 +31,10 @@ merge_base = ["dep:gix-trace", "dep:bitflags"]
 serde = ["dep:serde", "gix-hash/serde", "gix-object/serde"]
 
 [dependencies]
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
-gix-date = { version = "^0.15.5", path = "../gix-date" }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
 gix-hashtable = { version = "^0.15.2", path = "../gix-hashtable", optional = true }
 gix-revwalk = { version = "^0.33.0", path = "../gix-revwalk" }
 gix-commitgraph = { version = "^0.37.1", path = "../gix-commitgraph" }

--- a/gix-revwalk/Cargo.toml
+++ b/gix-revwalk/Cargo.toml
@@ -22,9 +22,9 @@ sha256 = ["gix-hash/sha256"]
 
 [dependencies]
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
-gix-date = { version = "^0.15.5", path = "../gix-date" }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
 gix-hashtable = { version = "^0.15.2", path = "../gix-hashtable" }
 gix-commitgraph = { version = "^0.37.1", path = "../gix-commitgraph" }
 

--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -29,7 +29,7 @@ gix-index = { version = "^0.53.0", path = "../gix-index" }
 gix-fs = { version = "^0.21.2", path = "../gix-fs" }
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-features = { version = "^0.48.1", path = "../gix-features", features = ["progress"] }
 gix-filter = { version = "^0.32.0", path = "../gix-filter" }
 gix-worktree = { version = "^0.54.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }

--- a/gix-submodule/Cargo.toml
+++ b/gix-submodule/Cargo.toml
@@ -24,8 +24,8 @@ sha256 = ["gix-refspec/sha256"]
 gix-pathspec = { version = "^0.18.1", path = "../gix-pathspec" }
 gix-refspec = { version = "^0.43.0", path = "../gix-refspec" }
 gix-config = { version = "^0.58.0", path = "../gix-config" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
-gix-url = { version = "^0.36.1", path = "../gix-url" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
+gix-url = { version = "^0.36.2", path = "../gix-url" }
 
 bstr = { version = "1.12.0", default-features = false }
 thiserror = "2.0.18"

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -92,12 +92,12 @@ required-features = ["async-client"]
 
 [dependencies]
 gix-command = { version = "^0.9.1", path = "../gix-command" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-features = { version = "^0.48.1", path = "../gix-features" }
-gix-url = { version = "^0.36.1", path = "../gix-url" }
+gix-url = { version = "^0.36.2", path = "../gix-url" }
 gix-sec = { version = "^0.14.1", path = "../gix-sec" }
 gix-packetline = { version = "^0.21.5", path = "../gix-packetline" }
-gix-credentials = { version = "^0.38.1", path = "../gix-credentials", optional = true }
+gix-credentials = { version = "^0.38.2", path = "../gix-credentials", optional = true }
 gix-quote = { version = "^0.7.2", path = "../gix-quote" }
 
 serde = { version = "1.0.114", optional = true, default-features = false, features = [

--- a/gix-traverse/Cargo.toml
+++ b/gix-traverse/Cargo.toml
@@ -23,7 +23,7 @@ sha256 = ["gix-hash/sha256"]
 [dependencies]
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
-gix-date = { version = "^0.15.5", path = "../gix-date" }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
 gix-hashtable = { version = "^0.15.2", path = "../gix-hashtable" }
 gix-revwalk = { version = "^0.33.0", path = "../gix-revwalk" }
 gix-commitgraph = { version = "^0.37.1", path = "../gix-commitgraph" }

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-url"
-version = "0.36.1"
+version = "0.36.2"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing parsing and serialization of gix-url"
@@ -19,7 +19,7 @@ doctest = true
 serde = ["dep:serde", "bstr/serde"]
 
 [dependencies]
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }
 thiserror = "2.0.18"

--- a/gix-utils/Cargo.toml
+++ b/gix-utils/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-utils"
-version = "0.3.3"
+version = "0.3.4"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate with `gitoxide` utilities that don't need feature toggles"

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -27,7 +27,7 @@ gix-worktree = { version = "^0.54.0", path = "../gix-worktree", default-features
 gix-index = { version = "^0.53.0", path = "../gix-index" }
 gix-fs = { version = "^0.21.2", path = "../gix-fs" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-features = { version = "^0.48.1", path = "../gix-features" }
 gix-filter = { version = "^0.32.0", path = "../gix-filter" }
 

--- a/gix-worktree-stream/Cargo.toml
+++ b/gix-worktree-stream/Cargo.toml
@@ -28,9 +28,9 @@ gix-attributes = { version = "^0.33.2", path = "../gix-attributes" }
 gix-filter = { version = "^0.32.0", path = "../gix-filter" }
 gix-traverse = { version = "^0.59.0", path = "../gix-traverse" }
 gix-fs = { version = "^0.21.2", path = "../gix-fs" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 
-gix-error = { version = "^0.2.4", path = "../gix-error" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
 parking_lot = "0.12.4"
 
 [dev-dependencies]

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -33,7 +33,7 @@ gix-fs = { version = "^0.21.2", path = "../gix-fs" }
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
 gix-glob = { version = "^0.26.1", path = "../gix-glob" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-attributes = { version = "^0.33.2", path = "../gix-attributes", optional = true }
 gix-validate = { version = "^0.11.2", path = "../gix-validate", optional = true }
 gix-ignore = { version = "^0.21.1", path = "../gix-ignore" }

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -323,8 +323,8 @@ progress-tree = ["prodash/progress-tree"]
 cache-efficiency-debug = ["gix-features/cache-efficiency-debug"]
 
 [dependencies]
-gix-error = { version = "^0.2.4", path = "../gix-error" }
-gix-utils = { version = "^0.3.3", path = "../gix-utils" }
+gix-error = { version = "^0.2.5", path = "../gix-error" }
+gix-utils = { version = "^0.3.4", path = "../gix-utils" }
 gix-fs = { version = "^0.21.2", path = "../gix-fs" }
 gix-ref = { version = "^0.65.0", path = "../gix-ref" }
 gix-discover = { version = "^0.53.0", path = "../gix-discover" }
@@ -332,7 +332,7 @@ gix-tempfile = { version = "^23.0.0", path = "../gix-tempfile", default-features
 gix-lock = { version = "^23.0.0", path = "../gix-lock" }
 gix-validate = { version = "^0.11.2", path = "../gix-validate" }
 gix-sec = { version = "^0.14.1", path = "../gix-sec" }
-gix-date = { version = "^0.15.5", path = "../gix-date" }
+gix-date = { version = "^0.15.6", path = "../gix-date" }
 gix-refspec = { version = "^0.43.0", path = "../gix-refspec" }
 gix-filter = { version = "^0.32.0", path = "../gix-filter", optional = true }
 gix-dir = { version = "^0.27.0", path = "../gix-dir", optional = true }
@@ -351,8 +351,8 @@ gix-revision = { version = "^0.47.0", path = "../gix-revision", default-features
 gix-revwalk = { version = "^0.33.0", path = "../gix-revwalk" }
 gix-negotiate = { version = "^0.33.0", path = "../gix-negotiate", optional = true }
 
-gix-path = { version = "^0.12.1", path = "../gix-path" }
-gix-url = { version = "^0.36.1", path = "../gix-url" }
+gix-path = { version = "^0.12.2", path = "../gix-path" }
+gix-url = { version = "^0.36.2", path = "../gix-url" }
 gix-traverse = { version = "^0.59.0", path = "../gix-traverse" }
 gix-diff = { version = "^0.65.0", path = "../gix-diff", default-features = false }
 gix-merge = { version = "^0.18.0", path = "../gix-merge", default-features = false, optional = true }
@@ -364,7 +364,7 @@ gix-features = { version = "^0.48.1", path = "../gix-features", features = [
 gix-trace = { version = "^0.1.20", path = "../gix-trace" }
 
 gix-glob = { version = "^0.26.1", path = "../gix-glob" }
-gix-credentials = { version = "^0.38.1", path = "../gix-credentials", optional = true }
+gix-credentials = { version = "^0.38.2", path = "../gix-credentials", optional = true }
 gix-prompt = { version = "^0.15.1", path = "../gix-prompt", optional = true }
 gix-index = { version = "^0.53.0", path = "../gix-index", optional = true }
 gix-attributes = { version = "^0.33.2", path = "../gix-attributes", optional = true }

--- a/gix/src/config/snapshot/credential_helpers.rs
+++ b/gix/src/config/snapshot/credential_helpers.rs
@@ -106,6 +106,7 @@ pub(super) mod function {
         Error,
     > {
         let mut programs = Vec::new();
+        let mut protect_protocol = true;
         let url_had_user_initially = url.user().is_some();
         normalize(&mut url);
 
@@ -135,6 +136,7 @@ pub(super) mod function {
                             &credential::UrlParameter::HELPER,
                             &credential::UrlParameter::USERNAME,
                             &credential::UrlParameter::USE_HTTP_PATH,
+                            &credential::UrlParameter::PROTECT_PROTOCOL,
                         ))
                     }),
                     None => Some((
@@ -142,9 +144,10 @@ pub(super) mod function {
                         &Credential::HELPER,
                         &Credential::USERNAME,
                         &Credential::USE_HTTP_PATH,
+                        &Credential::PROTECT_PROTOCOL,
                     )),
                 };
-                if let Some((section, helper_key, username_key, use_http_path_key)) = section {
+                if let Some((section, helper_key, username_key, use_http_path_key, protect_protocol_key)) = section {
                     for value in section.values(helper_key.name) {
                         if value.trim().is_empty() {
                             programs.clear();
@@ -177,6 +180,15 @@ pub(super) mod function {
                     {
                         use_http_path = toggle;
                     }
+                    if let Some(toggle) = section
+                        .value(protect_protocol_key.name)
+                        .map(|value| {
+                            protect_protocol_key.enrich_error(gix_config::Boolean::try_from(value).map(|value| value.0))
+                        })
+                        .transpose()?
+                    {
+                        protect_protocol = toggle;
+                    }
                 }
             }
         }
@@ -207,6 +219,7 @@ pub(super) mod function {
             gix_credentials::helper::Cascade {
                 programs,
                 use_http_path,
+                protect_protocol,
                 // The default ssh implementation uses binaries that do their own auth, so our passwords aren't used.
                 query_user_only: url.scheme == gix_url::Scheme::Ssh,
                 stderr: config

--- a/gix/src/config/tree/sections/credential.rs
+++ b/gix/src/config/tree/sections/credential.rs
@@ -10,6 +10,9 @@ impl Credential {
     pub const USERNAME: keys::Any = keys::Any::new("username", &config::Tree::CREDENTIAL);
     /// The `credential.useHttpPath` key.
     pub const USE_HTTP_PATH: keys::Boolean = keys::Boolean::new_boolean("useHttpPath", &config::Tree::CREDENTIAL);
+    /// The `credential.protectProtocol` key.
+    pub const PROTECT_PROTOCOL: keys::Boolean =
+        keys::Boolean::new_boolean("protectProtocol", &config::Tree::CREDENTIAL);
 
     /// The `credential.<url>` subsection
     pub const URL_PARAMETER: UrlParameter = UrlParameter;
@@ -25,6 +28,9 @@ impl UrlParameter {
     pub const USERNAME: keys::Any = keys::Any::new("username", &Credential::URL_PARAMETER);
     /// The `credential.<url>.useHttpPath` key.
     pub const USE_HTTP_PATH: keys::Boolean = keys::Boolean::new_boolean("useHttpPath", &Credential::URL_PARAMETER);
+    /// The `credential.<url>.protectProtocol` key.
+    pub const PROTECT_PROTOCOL: keys::Boolean =
+        keys::Boolean::new_boolean("protectProtocol", &Credential::URL_PARAMETER);
 }
 
 impl Section for UrlParameter {
@@ -33,7 +39,12 @@ impl Section for UrlParameter {
     }
 
     fn keys(&self) -> &[&dyn Key] {
-        &[&Self::HELPER, &Self::USERNAME, &Self::USE_HTTP_PATH]
+        &[
+            &Self::HELPER,
+            &Self::USERNAME,
+            &Self::USE_HTTP_PATH,
+            &Self::PROTECT_PROTOCOL,
+        ]
     }
 
     fn parent(&self) -> Option<&dyn Section> {
@@ -47,7 +58,12 @@ impl Section for Credential {
     }
 
     fn keys(&self) -> &[&dyn Key] {
-        &[&Self::HELPER, &Self::USERNAME, &Self::USE_HTTP_PATH]
+        &[
+            &Self::HELPER,
+            &Self::USERNAME,
+            &Self::USE_HTTP_PATH,
+            &Self::PROTECT_PROTOCOL,
+        ]
     }
 
     fn sub_sections(&self) -> &[&dyn Section] {

--- a/gix/tests/gix/repository/config/config_snapshot/credential_helpers.rs
+++ b/gix/tests/gix/repository/config/config_snapshot/credential_helpers.rs
@@ -127,6 +127,25 @@ fn any_url_calls_global() {
 }
 
 #[test]
+fn protect_protocol_defaults_to_true_and_can_be_overridden_per_url() -> crate::Result {
+    let mut repo = remote::repo("credential-helpers");
+    let url = "https://example.com";
+    let cascade = repo.config_snapshot().credential_helpers(url.try_into()?)?.0;
+    assert!(cascade.protect_protocol, "protocol protection is enabled by default");
+
+    repo.config_snapshot_mut()
+        .set_raw_value("credential.protectProtocol", "false")?;
+    let cascade = repo.config_snapshot().credential_helpers(url.try_into()?)?.0;
+    assert!(!cascade.protect_protocol, "global configuration is honored");
+
+    repo.config_snapshot_mut()
+        .set_raw_value("credential.https://example.com.protectProtocol", "true")?;
+    let cascade = repo.config_snapshot().credential_helpers(url.try_into()?)?.0;
+    assert!(cascade.protect_protocol, "URL-specific configuration wins");
+    Ok(())
+}
+
+#[test]
 fn http_port_defaulting() {
     baseline::agrees_with("https://example.com");
     baseline::agrees_with("https://example.com/");


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew
- [x] non-breaking release of fix

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Reject carriage returns in serialized credential-context keys and values, alongside existing NUL and newline validation. Add regression coverage for URL context values containing all record delimiters.

## Validation

- `cargo test -p gix-credentials --test credentials`