### PR TITLE
fix: preserve protocol options across credential actions

### DIFF
--- a/gitoxide-core/src/repository/credential.rs
+++ b/gitoxide-core/src/repository/credential.rs
@@ -16,6 +16,7 @@ pub fn function(repo: Option<gix::Repository>, action: gix::credentials::program
         Some(action.as_str().into()),
         std::io::stdin(),
         std::io::stdout(),
+        gix::credentials::protocol::ContextOptions::default(),
         |action, context| -> Result<_, Error> {
             let url = context
                 .url

--- a/gix-credentials/examples/custom-helper.rs
+++ b/gix-credentials/examples/custom-helper.rs
@@ -6,6 +6,7 @@ pub fn main() -> Result<(), gix_credentials::program::main::Error> {
         std::env::args_os().skip(1),
         std::io::stdin(),
         std::io::stdout(),
+        protocol::ContextOptions::default(),
         |action, context| -> std::io::Result<_> {
             match action {
                 program::main::Action::Get => Ok(Some(protocol::Context {

--- a/gix-credentials/examples/git-credential-lite.rs
+++ b/gix-credentials/examples/git-credential-lite.rs
@@ -4,6 +4,7 @@ pub fn main() -> Result<(), gix_credentials::program::main::Error> {
         std::env::args_os().skip(1),
         std::io::stdin(),
         std::io::stdout(),
+        gix_credentials::protocol::ContextOptions::default(),
         |action, context| {
             use gix_credentials::program::main::Action::*;
             gix_credentials::helper::Cascade::default()

--- a/gix-credentials/fuzz/fuzz_targets/context.rs
+++ b/gix-credentials/fuzz/fuzz_targets/context.rs
@@ -1,11 +1,11 @@
 #![no_main]
 
-use gix_credentials::protocol::Context;
+use gix_credentials::protocol::{Context, ContextOptions};
 use libfuzzer_sys::fuzz_target;
 use std::hint::black_box;
 
 fn fuzz(input: &[u8]) {
-    if let Ok(ctx) = Context::from_bytes(input) {
+    if let Ok(ctx) = Context::from_bytes(input, ContextOptions::default()) {
         inspect_context(ctx.clone());
 
         let mut with_http = ctx.clone();
@@ -19,6 +19,7 @@ fn fuzz(input: &[u8]) {
 }
 
 fn inspect_context(mut ctx: Context) {
+    let options = ctx.options;
     let mut out = Vec::new();
     _ = black_box(ctx.write_to(&mut out));
     _ = black_box(ctx.to_bstring());
@@ -27,7 +28,7 @@ fn inspect_context(mut ctx: Context) {
     _ = black_box(ctx.clone().redacted());
     ctx.clear_secrets();
     _ = black_box(ctx);
-    if let Ok(roundtrip) = Context::from_bytes(&out) {
+    if let Ok(roundtrip) = Context::from_bytes(&out, options) {
         _ = black_box(roundtrip);
     }
 }

--- a/gix-credentials/src/helper/cascade.rs
+++ b/gix-credentials/src/helper/cascade.rs
@@ -11,7 +11,7 @@ impl Default for Cascade {
             programs: Vec::new(),
             stderr: true,
             use_http_path: false,
-            protect_protocol: true,
+            context_options: ContextOptions::default(),
             query_user_only: false,
         }
     }
@@ -76,6 +76,9 @@ impl Cascade {
     /// When _storing_ or _erasing_ all programs are instructed in order.
     #[allow(clippy::result_large_err)]
     pub fn invoke(&mut self, mut action: helper::Action, mut prompt: gix_prompt::Options<'_>) -> protocol::Result {
+        if let Some(ctx) = action.context_mut() {
+            ctx.options = self.context_options;
+        }
         let mut url = action
             .context_mut()
             .map(|ctx| {
@@ -92,10 +95,11 @@ impl Cascade {
 
         for program in &mut self.programs {
             program.stderr = self.stderr;
-            match helper::invoke::raw(program, &action, self.protect_protocol) {
+            match helper::invoke::raw(program, &action) {
                 Ok(None) => {}
                 Ok(Some(stdout)) => {
                     let Context {
+                        options: _,
                         protocol,
                         host,
                         path,
@@ -105,12 +109,7 @@ impl Cascade {
                         password_expiry_utc,
                         url: ctx_url,
                         quit,
-                    } = Context::from_bytes_opts(
-                        &stdout,
-                        ContextOptions {
-                            protect_protocol: self.protect_protocol,
-                        },
-                    )?;
+                    } = Context::from_bytes(&stdout, self.context_options)?;
                     if let Some(dst_ctx) = action.context_mut() {
                         if let Some(src) = path {
                             dst_ctx.path = Some(src);

--- a/gix-credentials/src/helper/invoke.rs
+++ b/gix-credentials/src/helper/invoke.rs
@@ -1,20 +1,12 @@
 use std::io::Read;
 
-use crate::{
-    helper::{Action, Context, Error, NextAction, Outcome, Result},
-    protocol::ContextOptions,
-};
+use crate::helper::{Action, Context, Error, NextAction, Outcome, Result};
 
 impl Action {
     /// Send ourselves to the given `write` which is expected to be credentials-helper compatible
     pub fn send(&self, write: &mut dyn std::io::Write) -> std::io::Result<()> {
-        self.send_opts(write, ContextOptions::default())
-    }
-
-    /// Send ourselves like [`send()`][Self::send()], with configurable context encoding `options`.
-    pub fn send_opts(&self, write: &mut dyn std::io::Write, options: ContextOptions) -> std::io::Result<()> {
         match self {
-            Action::Get(ctx) => ctx.write_to_opts(write, options),
+            Action::Get(ctx) => ctx.write_to(write),
             Action::Store(last) | Action::Erase(last) => {
                 write.write_all(last).ok();
                 write.write_all(b"\n").ok();
@@ -31,10 +23,11 @@ impl Action {
 /// On successful usage, use [`NextAction::store()`], otherwise [`NextAction::erase()`], which is when this function
 /// returns `Ok(None)` as no outcome is expected.
 pub fn invoke(helper: &mut crate::Program, action: &Action) -> Result {
-    match raw(helper, action, true)? {
+    let options = action.context().map(|ctx| ctx.options).unwrap_or_default();
+    match raw(helper, action)? {
         None => Ok(None),
         Some(stdout) => {
-            let ctx = Context::from_bytes(stdout.as_slice())?;
+            let ctx = Context::from_bytes(stdout.as_slice(), options)?;
             Ok(Some(Outcome {
                 username: ctx.username,
                 password: ctx.password,
@@ -42,22 +35,19 @@ pub fn invoke(helper: &mut crate::Program, action: &Action) -> Result {
                 quit: ctx.quit.unwrap_or(false),
                 next: NextAction {
                     previous_output: stdout.into(),
+                    options,
                 },
             }))
         }
     }
 }
 
-pub(crate) fn raw(
-    helper: &mut crate::Program,
-    action: &Action,
-    protect_protocol: bool,
-) -> std::result::Result<Option<Vec<u8>>, Error> {
+pub(crate) fn raw(helper: &mut crate::Program, action: &Action) -> std::result::Result<Option<Vec<u8>>, Error> {
     let (mut stdin, stdout) = helper.start(action)?;
     if let (Action::Get(_), None) = (&action, &stdout) {
         panic!("BUG: `Helper` impls must return an output handle to read output from if Action::Get is provided")
     }
-    action.send_opts(&mut stdin, ContextOptions { protect_protocol })?;
+    action.send(&mut stdin)?;
     drop(stdin);
     let stdout = stdout
         .map(|mut stdout| {

--- a/gix-credentials/src/helper/mod.rs
+++ b/gix-credentials/src/helper/mod.rs
@@ -13,8 +13,8 @@ pub struct Cascade {
     /// If true, http(s) urls will take their path portion into account when obtaining credentials. Default is false.
     /// Other protocols like ssh will always use the path portion.
     pub use_http_path: bool,
-    /// If true, the default, carriage returns in credential values are rejected.
-    pub protect_protocol: bool,
+    /// Options controlling how credential contexts are encoded and decoded.
+    pub context_options: protocol::ContextOptions,
     /// If true, default false, when getting credentials, we will set a bogus password to only obtain the user name.
     /// Storage and cancellation work the same, but without a password set.
     pub query_user_only: bool,
@@ -82,13 +82,14 @@ pub enum Action {
 
 /// Initialization
 impl Action {
-    /// Create a `Get` action with context containing the given URL.
-    /// Note that this creates an `Action` suitable for the credential helper cascade only.
+    /// Create a `Get` action with a default context containing only the given URL.
+    ///
+    /// This initializes [`Context::options`] with its default. Use it when only the URL is needed
+    /// and the default options are suitable. Otherwise, configure the context options afterwards
+    /// and before invoking a helper. Credential cascades do this automatically from
+    /// [`Cascade::context_options`].
     pub fn get_for_url(url: impl Into<BString>) -> Action {
-        Action::Get(Context {
-            url: Some(url.into()),
-            ..Default::default()
-        })
+        Action::Get(Context::from_url(url, protocol::ContextOptions::default()))
     }
 }
 
@@ -143,22 +144,25 @@ impl Action {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NextAction {
     previous_output: BString,
+    options: protocol::ContextOptions,
 }
 
 impl TryFrom<&NextAction> for Context {
     type Error = protocol::context::decode::Error;
 
     fn try_from(value: &NextAction) -> std::result::Result<Self, Self::Error> {
-        Context::from_bytes(value.previous_output.as_ref())
+        Context::from_bytes(value.previous_output.as_ref(), value.options)
     }
 }
 
 impl From<Context> for NextAction {
     fn from(ctx: Context) -> Self {
+        let options = ctx.options;
         let mut buf = Vec::<u8>::new();
         ctx.write_to(&mut buf).expect("cannot fail");
         NextAction {
             previous_output: buf.into(),
+            options,
         }
     }
 }

--- a/gix-credentials/src/lib.rs
+++ b/gix-credentials/src/lib.rs
@@ -32,7 +32,6 @@ pub mod protocol;
 /// Call the `git credential` helper program performing the given `action`, which reads all context from the git configuration
 /// and does everything `git` typically does. The `action` should have been created with [`helper::Action::get_for_url()`] to
 /// contain only the URL to kick off the process, or should be created by [`helper::NextAction`].
-///
 /// If more control is required, use the [`Cascade`][helper::Cascade] type.
 #[allow(clippy::result_large_err)]
 pub fn builtin(action: helper::Action) -> protocol::Result {

--- a/gix-credentials/src/program/main.rs
+++ b/gix-credentials/src/program/main.rs
@@ -64,7 +64,7 @@ pub(crate) mod function {
 
     use crate::{
         program::main::{Action, Error},
-        protocol::Context,
+        protocol::{Context, ContextOptions},
     };
 
     /// Invoke a custom credentials helper which receives program `args`, with the first argument being the
@@ -74,11 +74,12 @@ pub(crate) mod function {
     /// no credentials could be found for `url`, which is always set when called.
     ///
     /// Call this function from a programs `main`, passing `std::env::args_os()`, `stdin()` and `stdout` accordingly, along with
-    /// your own helper implementation.
+    /// the context encoding `options` and your own helper implementation.
     pub fn main<CredentialsFn, E>(
         args: impl IntoIterator<Item = OsString>,
         mut stdin: impl std::io::Read,
         stdout: impl std::io::Write,
+        options: ContextOptions,
         credentials: CredentialsFn,
     ) -> Result<(), Error>
     where
@@ -88,7 +89,7 @@ pub(crate) mod function {
         let action: Action = args.into_iter().next().ok_or(Error::ActionMissing)?.try_into()?;
         let mut buf = Vec::<u8>::with_capacity(512);
         stdin.read_to_end(&mut buf)?;
-        let ctx = Context::from_bytes(&buf)?;
+        let ctx = Context::from_bytes(&buf, options)?;
         if ctx.url.is_none() && (ctx.protocol.is_none() || ctx.host.is_none()) {
             return Err(Error::UrlMissing);
         }
@@ -103,7 +104,10 @@ pub(crate) mod function {
                     .expect("URL is available either directly or via protocol+host which we checked for");
                 return Err(Error::CredentialsMissing { url });
             }
-            (Action::Get, Some(ctx)) => ctx.write_to(stdout)?,
+            (Action::Get, Some(mut ctx)) => {
+                ctx.options = options;
+                ctx.write_to(stdout)?;
+            }
             (Action::Erase | Action::Store, None) => {}
             (Action::Erase | Action::Store, Some(_)) => {
                 panic!("BUG: credentials helper must not return context for erase or store actions")

--- a/gix-credentials/src/protocol/context/mod.rs
+++ b/gix-credentials/src/protocol/context/mod.rs
@@ -1,11 +1,24 @@
 use bstr::BString;
 
+use crate::protocol::{Context, ContextOptions};
+
 /// Indicates key or values contain errors that can't be encoded.
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
 pub enum Error {
     #[error("{key:?}={value:?} must not contain null bytes or newlines neither in key nor in value.")]
     Encoding { key: String, value: BString },
+}
+
+impl Context {
+    /// Create a context containing `url`, encoded and decoded according to `options`.
+    pub fn from_url(url: impl Into<BString>, options: ContextOptions) -> Self {
+        Context {
+            options,
+            url: Some(url.into()),
+            ..Default::default()
+        }
+    }
 }
 
 mod access {
@@ -17,6 +30,7 @@ mod access {
         /// Clear all fields that are considered secret.
         pub fn clear_secrets(&mut self) {
             let Context {
+                options: _,
                 protocol: _,
                 host: _,
                 path: _,
@@ -34,6 +48,7 @@ mod access {
         /// Replace existing secrets with the word `<redacted>`.
         pub fn redacted(mut self) -> Self {
             let Context {
+                options: _,
                 protocol: _,
                 host: _,
                 path: _,

--- a/gix-credentials/src/protocol/context/serde.rs
+++ b/gix-credentials/src/protocol/context/serde.rs
@@ -10,15 +10,6 @@ mod write {
     impl Context {
         /// Write ourselves to `out` such that [`from_bytes()`][Self::from_bytes()] can decode it losslessly.
         pub fn write_to(&self, mut out: impl std::io::Write) -> std::io::Result<()> {
-            self.write_to_opts(&mut out, ContextOptions::default())
-        }
-
-        /// Write ourselves like [`write_to()`][Self::write_to()], with options.
-        pub fn write_to_opts(
-            &self,
-            mut out: impl std::io::Write,
-            ContextOptions { protect_protocol }: ContextOptions,
-        ) -> std::io::Result<()> {
             use bstr::ByteSlice;
             fn write_key(out: &mut impl std::io::Write, key: &str, value: &BStr) -> std::io::Result<()> {
                 out.write_all(key.as_bytes())?;
@@ -27,6 +18,7 @@ mod write {
                 out.write_all(b"\n")
             }
             let Context {
+                options: ContextOptions { protect_protocol },
                 protocol,
                 host,
                 path,
@@ -41,7 +33,7 @@ mod write {
             } = self;
             for (key, value) in [("url", url), ("path", path)] {
                 if let Some(value) = value {
-                    validate(key, value.as_slice().into(), protect_protocol).map_err(std::io::Error::other)?;
+                    validate(key, value.as_slice().into(), *protect_protocol).map_err(std::io::Error::other)?;
                     write_key(&mut out, key, value.as_ref()).ok();
                 }
             }
@@ -53,14 +45,14 @@ mod write {
                 ("oauth_refresh_token", oauth_refresh_token),
             ] {
                 if let Some(value) = value {
-                    validate(key, value.as_str().into(), protect_protocol).map_err(std::io::Error::other)?;
+                    validate(key, value.as_str().into(), *protect_protocol).map_err(std::io::Error::other)?;
                     write_key(&mut out, key, value.as_bytes().as_bstr()).ok();
                 }
             }
             if let Some(value) = password_expiry_utc {
                 let key = "password_expiry_utc";
                 let value = value.to_string();
-                validate(key, value.as_str().into(), protect_protocol).map_err(std::io::Error::other)?;
+                validate(key, value.as_str().into(), *protect_protocol).map_err(std::io::Error::other)?;
                 write_key(&mut out, key, value.as_bytes().as_bstr()).ok();
             }
             Ok(())
@@ -95,17 +87,14 @@ pub mod decode {
 
     impl Context {
         /// Decode ourselves from `input` which is the format written by [`write_to()`][Self::write_to()].
-        pub fn from_bytes(input: &[u8]) -> Result<Self, Error> {
-            Self::from_bytes_opts(input, ContextOptions::default())
-        }
-
-        /// Decode ourselves like [`from_bytes()`][Self::from_bytes()], with additional options.
-        pub fn from_bytes_opts(
-            input: &[u8],
-            ContextOptions { protect_protocol }: ContextOptions,
-        ) -> Result<Self, Error> {
-            let mut ctx = Context::default();
+        /// `options` control what to support during deserialization.
+        pub fn from_bytes(input: &[u8], options: ContextOptions) -> Result<Self, Error> {
+            let mut ctx = Context {
+                options,
+                ..Context::default()
+            };
             let Context {
+                options: _,
                 protocol,
                 host,
                 path,
@@ -122,7 +111,7 @@ pub mod decode {
                     it.next().and_then(|k| k.to_str().ok()),
                     it.next().map(ByteSlice::as_bstr),
                 ) {
-                    (Some(key), Some(value)) => validate(key, value, protect_protocol)
+                    (Some(key), Some(value)) => validate(key, value, options.protect_protocol)
                         .map(|_| (key, value.to_owned()))
                         .map_err(Into::into),
                     _ => Err(Error::Syntax { line: line.into() }),

--- a/gix-credentials/src/protocol/mod.rs
+++ b/gix-credentials/src/protocol/mod.rs
@@ -42,6 +42,8 @@ pub enum Error {
 /// Additional context to be passed to the credentials helper.
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Context {
+    /// Options controlling how this context is encoded and decoded.
+    pub options: ContextOptions,
     /// The protocol over which the credential will be used (e.g., https).
     pub protocol: Option<String>,
     /// The remote hostname for a network credential. This includes the port number if one was specified (e.g., "example.com:8088").

--- a/gix-credentials/tests/fixtures/carriage-return.sh
+++ b/gix-credentials/tests/fixtures/carriage-return.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+printf 'username=user\rname\npassword=pass\n'

--- a/gix-credentials/tests/helper/cascade.rs
+++ b/gix-credentials/tests/helper/cascade.rs
@@ -17,6 +17,41 @@ mod invoke {
     }
 
     #[test]
+    fn disabled_protocol_protection_is_preserved_for_the_next_action() {
+        let actual = Cascade {
+            context_options: protocol::ContextOptions {
+                protect_protocol: false,
+            },
+            ..Default::default()
+        }
+        .extend(fixtures(["carriage-return"]))
+        .invoke(
+            action_get(),
+            gix_prompt::Options {
+                mode: gix_prompt::Mode::Disable,
+                askpass: None,
+            },
+        )
+        .expect("CR is allowed")
+        .expect("credentials are complete");
+
+        assert_eq!(actual.identity, identity("user\rname", "pass"));
+        let context: Context = (&actual.next).try_into().expect("the next action retains its options");
+        assert_eq!(context.username.as_deref(), Some("user\rname"));
+        let mut serialized = Vec::new();
+        actual
+            .next
+            .store()
+            .send(&mut serialized)
+            .expect("in-memory write succeeds");
+        assert!(
+            serialized
+                .windows(b"username=user\rname".len())
+                .any(|value| value == b"username=user\rname")
+        );
+    }
+
+    #[test]
     fn usernames_in_urls_are_kept_if_the_helper_does_not_overwrite_it() {
         let actual = invoke_cascade(
             ["password", "custom-helper"],

--- a/gix-credentials/tests/helper/context.rs
+++ b/gix-credentials/tests/helper/context.rs
@@ -1,4 +1,4 @@
-use gix_credentials::protocol::Context;
+use gix_credentials::protocol::{Context, ContextOptions};
 
 #[test]
 fn encode_decode_roundtrip_works_only_for_serializing_fields() {
@@ -16,7 +16,7 @@ fn encode_decode_roundtrip_works_only_for_serializing_fields() {
     ] {
         let mut buf = Vec::<u8>::new();
         ctx.write_to(&mut buf).unwrap();
-        let actual = Context::from_bytes(&buf).unwrap();
+        let actual = Context::from_bytes(&buf, ContextOptions::default()).unwrap();
         assert_eq!(actual, ctx, "ctx should encode itself losslessly");
     }
 }
@@ -33,9 +33,12 @@ mod write_to {
         }
         .write_to(&mut buf)
         .unwrap();
-        assert_eq!(Context::from_bytes(&buf).unwrap(), Context::default());
         assert_eq!(
-            Context::from_bytes(b"quit=true\nurl=https://example.com").unwrap(),
+            Context::from_bytes(&buf, ContextOptions::default()).unwrap(),
+            Context::default()
+        );
+        assert_eq!(
+            Context::from_bytes(b"quit=true\nurl=https://example.com", ContextOptions::default()).unwrap(),
             Context {
                 quit: Some(true),
                 url: Some("https://example.com".into()),
@@ -60,17 +63,14 @@ mod write_to {
     #[test]
     fn carriage_returns_can_be_allowed() {
         let ctx = Context {
+            options: ContextOptions {
+                protect_protocol: false,
+            },
             url: Some(b"https://example.com/with\rreturn".as_slice().into()),
             ..Default::default()
         };
         let mut buf = Vec::new();
-        ctx.write_to_opts(
-            &mut buf,
-            ContextOptions {
-                protect_protocol: false,
-            },
-        )
-        .expect("CR protection is disabled");
+        ctx.write_to(&mut buf).expect("CR protection is disabled");
         assert_eq!(buf, b"url=https://example.com/with\rreturn\n");
     }
 }
@@ -85,7 +85,7 @@ host=example.com\n
 password=secr3t
 username=bob";
         assert_eq!(
-            Context::from_bytes(input).unwrap(),
+            Context::from_bytes(input, ContextOptions::default()).unwrap(),
             Context {
                 protocol: Some("https".into()),
                 host: Some("example.com".into()),
@@ -100,7 +100,7 @@ username=bob";
 unknown=value
 username=bob";
         assert_eq!(
-            Context::from_bytes(input).unwrap(),
+            Context::from_bytes(input, ContextOptions::default()).unwrap(),
             Context {
                 protocol: Some("https".into()),
                 username: Some("bob".into()),
@@ -114,7 +114,9 @@ username=bob";
         for true_value in ["1", "42", "-42", "true", "on", "yes"] {
             let input = format!("quit={true_value}");
             assert_eq!(
-                Context::from_bytes(input.as_bytes()).unwrap().quit,
+                Context::from_bytes(input.as_bytes(), ContextOptions::default())
+                    .unwrap()
+                    .quit,
                 Some(true),
                 "{input}"
             );
@@ -122,7 +124,9 @@ username=bob";
         for false_value in ["0", "false", "off", "no"] {
             let input = format!("quit={false_value}");
             assert_eq!(
-                Context::from_bytes(input.as_bytes()).unwrap().quit,
+                Context::from_bytes(input.as_bytes(), ContextOptions::default())
+                    .unwrap()
+                    .quit,
                 Some(false),
                 "{input}"
             );
@@ -131,7 +135,7 @@ username=bob";
 
     #[test]
     fn null_bytes_when_decoding() {
-        let err = Context::from_bytes(b"url=https://foo\0").unwrap_err();
+        let err = Context::from_bytes(b"url=https://foo\0", ContextOptions::default()).unwrap_err();
         assert!(matches!(
             err,
             gix_credentials::protocol::context::decode::Error::Encoding(_)
@@ -140,16 +144,25 @@ username=bob";
 
     #[test]
     fn carriage_returns_can_be_allowed() {
+        let ctx = Context::from_bytes(
+            b"url=https://example.com/with\rreturn\n",
+            ContextOptions {
+                protect_protocol: false,
+            },
+        )
+        .expect("CR protection is disabled");
+        assert_eq!(ctx.url, Some(b"https://example.com/with\rreturn".as_slice().into()));
         assert_eq!(
-            Context::from_bytes_opts(
-                b"url=https://example.com/with\rreturn\n",
-                ContextOptions {
-                    protect_protocol: false,
-                },
-            )
-            .expect("CR protection is disabled")
-            .url,
-            Some(b"https://example.com/with\rreturn".as_slice().into())
+            ctx.options,
+            ContextOptions {
+                protect_protocol: false
+            },
+            "decoding retains the options needed to encode the context again"
         );
+
+        let mut out = Vec::new();
+        ctx.write_to(&mut out)
+            .expect("retained options allow the same value to be encoded again");
+        assert_eq!(out, b"url=https://example.com/with\rreturn\n");
     }
 }

--- a/gix-credentials/tests/helper/invoke.rs
+++ b/gix-credentials/tests/helper/invoke.rs
@@ -1,5 +1,8 @@
 use bstr::BString;
-use gix_credentials::{helper, protocol::Context};
+use gix_credentials::{
+    helper,
+    protocol::{Context, ContextOptions},
+};
 
 use crate::helper::script_helper;
 
@@ -23,6 +26,24 @@ fn get() {
         outcome.next.store().payload().unwrap(),
         "username=user\npassword=pass\nquit=1\n"
     );
+}
+
+#[test]
+fn get_uses_context_options_for_the_entire_exchange() {
+    let action = helper::Action::Get(Context::from_url(
+        "https://github.com/byron/gitoxide",
+        ContextOptions {
+            protect_protocol: false,
+        },
+    ));
+    let outcome = gix_credentials::helper::invoke(&mut script_helper("carriage-return"), &action)
+        .expect("CR is allowed")
+        .expect("mock provides credentials");
+
+    assert_eq!(outcome.username.as_deref(), Some("user\rname"));
+    let context: Context = (&outcome.next).try_into().expect("the next action retains its options");
+    assert_eq!(context.options, action.context().expect("get action").options);
+    assert_eq!(context.username.as_deref(), Some("user\rname"));
 }
 
 #[test]
@@ -114,7 +135,7 @@ mod program {
         assert_eq!(
             gix_credentials::helper::invoke(
                 &mut script_helper("custom-helper"),
-                &helper::Action::get_for_url("/does/not/matter")
+                &helper::Action::get_for_url("/does/not/matter"),
             )?
             .expect("present")
             .consume_identity()

--- a/gix-credentials/tests/program/main.rs
+++ b/gix-credentials/tests/program/main.rs
@@ -6,6 +6,35 @@ use std::io::Cursor;
 struct TestError;
 
 #[test]
+fn context_options_apply_to_input_and_output() {
+    let input = b"url=https://github.com/with\rreturn\n";
+    let mut output = Vec::new();
+    let options = gix_credentials::protocol::ContextOptions {
+        protect_protocol: false,
+    };
+
+    main(
+        ["get".into()],
+        Cursor::new(input),
+        &mut output,
+        options,
+        |_action, context| -> Result<Option<gix_credentials::protocol::Context>, TestError> {
+            assert_eq!(
+                context.url.as_ref().map(|url| url.as_slice()),
+                Some(&input[4..input.len() - 1])
+            );
+            Ok(Some(gix_credentials::protocol::Context {
+                username: Some("user\rname".into()),
+                ..Default::default()
+            }))
+        },
+    )
+    .expect("carriage returns are allowed");
+
+    assert!(output.windows(9).any(|window| window == b"user\rname"));
+}
+
+#[test]
 fn protocol_and_host_without_url_is_valid() {
     let input = b"protocol=https\nhost=github.com\n";
     let mut output = Vec::new();
@@ -15,6 +44,7 @@ fn protocol_and_host_without_url_is_valid() {
         ["get".into()],
         Cursor::new(input),
         &mut output,
+        gix_credentials::protocol::ContextOptions::default(),
         |_action, context| -> Result<Option<gix_credentials::protocol::Context>, TestError> {
             assert_eq!(context.protocol.as_deref(), Some("https"));
             assert_eq!(context.host.as_deref(), Some("github.com"));
@@ -48,6 +78,7 @@ fn missing_protocol_with_only_host_or_protocol_fails() {
             ["get".into()],
             Cursor::new(input),
             &mut output,
+            gix_credentials::protocol::ContextOptions::default(),
             |_action, _context| -> Result<Option<gix_credentials::protocol::Context>, TestError> {
                 called = true;
                 Ok(None)
@@ -73,6 +104,7 @@ fn url_alone_is_valid() {
         ["get".into()],
         Cursor::new(input),
         &mut output,
+        gix_credentials::protocol::ContextOptions::default(),
         |_action, context| -> Result<Option<gix_credentials::protocol::Context>, TestError> {
             called = true;
             assert_eq!(context.url.unwrap(), "https://github.com");

--- a/gix/src/config/snapshot/credential_helpers.rs
+++ b/gix/src/config/snapshot/credential_helpers.rs
@@ -106,7 +106,7 @@ pub(super) mod function {
         Error,
     > {
         let mut programs = Vec::new();
-        let mut protect_protocol = true;
+        let mut context_options = gix_credentials::protocol::ContextOptions::default();
         let url_had_user_initially = url.user().is_some();
         normalize(&mut url);
 
@@ -187,7 +187,7 @@ pub(super) mod function {
                         })
                         .transpose()?
                     {
-                        protect_protocol = toggle;
+                        context_options.protect_protocol = toggle;
                     }
                 }
             }
@@ -215,11 +215,15 @@ pub(super) mod function {
                 .unwrap_or_default(),
         }
         .apply_environment(allow_git_env, allow_ssh_env, false /* terminal prompt */);
+        let action = gix_credentials::helper::Action::Get(gix_credentials::protocol::Context::from_url(
+            url.to_bstring(),
+            context_options,
+        ));
         Ok((
             gix_credentials::helper::Cascade {
                 programs,
                 use_http_path,
-                protect_protocol,
+                context_options,
                 // The default ssh implementation uses binaries that do their own auth, so our passwords aren't used.
                 query_user_only: url.scheme == gix_url::Scheme::Ssh,
                 stderr: config
@@ -229,7 +233,7 @@ pub(super) mod function {
                     .with_leniency(is_lenient_config)?
                     .unwrap_or(true),
             },
-            gix_credentials::helper::Action::get_for_url(url.to_bstring()),
+            action,
             prompt_options,
         ))
     }

--- a/gix/tests/gix/repository/config/config_snapshot/credential_helpers.rs
+++ b/gix/tests/gix/repository/config/config_snapshot/credential_helpers.rs
@@ -130,18 +130,30 @@ fn any_url_calls_global() {
 fn protect_protocol_defaults_to_true_and_can_be_overridden_per_url() -> crate::Result {
     let mut repo = remote::repo("credential-helpers");
     let url = "https://example.com";
-    let cascade = repo.config_snapshot().credential_helpers(url.try_into()?)?.0;
-    assert!(cascade.protect_protocol, "protocol protection is enabled by default");
+    let (cascade, action, _) = repo.config_snapshot().credential_helpers(url.try_into()?)?;
+    assert!(
+        cascade.context_options.protect_protocol,
+        "protocol protection is enabled by default"
+    );
+    assert_eq!(action.context().expect("get action").options, cascade.context_options);
 
     repo.config_snapshot_mut()
         .set_raw_value("credential.protectProtocol", "false")?;
-    let cascade = repo.config_snapshot().credential_helpers(url.try_into()?)?.0;
-    assert!(!cascade.protect_protocol, "global configuration is honored");
+    let (cascade, action, _) = repo.config_snapshot().credential_helpers(url.try_into()?)?;
+    assert!(
+        !cascade.context_options.protect_protocol,
+        "global configuration is honored"
+    );
+    assert_eq!(action.context().expect("get action").options, cascade.context_options);
 
     repo.config_snapshot_mut()
         .set_raw_value("credential.https://example.com.protectProtocol", "true")?;
-    let cascade = repo.config_snapshot().credential_helpers(url.try_into()?)?.0;
-    assert!(cascade.protect_protocol, "URL-specific configuration wins");
+    let (cascade, action, _) = repo.config_snapshot().credential_helpers(url.try_into()?)?;
+    assert!(
+        cascade.context_options.protect_protocol,
+        "URL-specific configuration wins"
+    );
+    assert_eq!(action.context().expect("get action").options, cascade.context_options);
     Ok(())
 }
 


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

Look at the changes in /Users/byron/dev/github.com/GitoxideLabs/gitoxide.fix-credentials-parsing and port them here. These should come only from `stg` patch 3..5, and it would be good if you could reproduce the respective commits here, but with updated commit messages.

## Summary

- Preserve `ContextOptions` across credential helper parsing, follow-up actions, and credential program input/output.
- Adapt the `gitoxide-core` credential command to the explicit context-option APIs.
- Keep the final tree byte-for-byte identical to the requested source worktree tip.
- The middle source change was already merged on `main` as `d89bda0a87`; its stable patch ID matches the source commit, so no empty duplicate commit was created.

## Commits

- `c24775e98f` fix: preserve protocol options across credential actions
- `99f29a3462` Adapt the credential command to explicit context options

## Git baseline

Git commit `b01b9b81d367` introduced carriage-return protection and the `credential.protectProtocol=false` opt-out, with coverage in `t/t0300-credentials.sh`.

## Validation

- `cargo fmt --all -- --check`
- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix-credentials`
- `cargo check -p gitoxide-core --features gix/sha1`
- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gitoxide-core --features gix/sha1 repository::credential`
- `cargo check -p gitoxide --no-default-features --features small`
- `git diff --exit-code HEAD fix-credentials-parsing`
- One Codex review per resulting commit hash