### PR TITLE
fix: always treat submodule names as relative.

### DIFF
--- a/gix/src/submodule/mod.rs
+++ b/gix/src/submodule/mod.rs
@@ -4,7 +4,7 @@
 use std::{
     borrow::Cow,
     cell::{Ref, RefCell, RefMut},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 pub use gix_submodule::*;
@@ -208,12 +208,7 @@ impl Submodule<'_> {
     ///
     /// The retunred directory might not exist yet.
     pub fn git_dir(&self) -> Result<PathBuf, gix_validate::submodule::name::Error> {
-        Ok(self
-            .state
-            .repo
-            .common_dir()
-            .join("modules")
-            .join(gix_path::from_bstr(self.validated_name()?)))
+        Ok(git_dir_from_name(self.state.repo.common_dir(), self.validated_name()?))
     }
 
     /// Return the path to the location at which the workdir would be checked out.
@@ -341,6 +336,48 @@ impl Submodule<'_> {
 
     fn worktree_gitdir(&self) -> Result<PathBuf, config::path::Error> {
         Ok(self.work_dir()?.join(gix_discover::DOT_GIT_DIR))
+    }
+}
+
+/// Append the name textually, like Git's `repo_git_path_append(..., "modules/%s", name)`.
+///
+/// In particular, don't use `Path::join()` for `name`: absolute-looking names are valid in Git,
+/// but joining them as a path would discard the `.git/modules` prefix.
+fn git_dir_from_name(common_dir: &Path, name: &BStr) -> PathBuf {
+    let mut git_dir = common_dir.join("modules").into_os_string();
+    git_dir.push(std::path::MAIN_SEPARATOR_STR);
+    git_dir.push(gix_path::from_bstr(name).as_os_str());
+    git_dir.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::bstr::ByteSlice;
+
+    #[test]
+    fn git_dir_from_name_keeps_git_compatible_names_below_modules() {
+        let common_dir = Path::new("repo").join(".git");
+        let modules_dir = common_dir.join("modules");
+
+        for name in [
+            b"/etc/cron.d/x" as &[u8],
+            br"\Windows\Temp\x",
+            br"\\host\share\x",
+            b"//host/share/x",
+            br"C:\Windows\Temp\x",
+            b"C:/Windows/Temp/x",
+            b"C:x",
+        ] {
+            let actual = super::git_dir_from_name(&common_dir, name.as_bstr());
+            assert!(
+                actual.starts_with(&modules_dir),
+                "Git-compatible name {name:?} must remain below {} instead of producing {}",
+                modules_dir.display(),
+                actual.display()
+            );
+        }
     }
 }
 

--- a/gix/tests/fixtures/make_submodules.sh
+++ b/gix/tests/fixtures/make_submodules.sh
@@ -120,6 +120,25 @@ git init with-submodules
   git submodule add ../module1 dir/m1
 )
 
+# Git permits absolute-looking submodule names because it appends them textually below
+# `.git/modules/` instead of joining them as paths. Keep committed gitlinks for both Unix and
+# Windows spellings so consumers can verify that these are ordinary submodules made by Git.
+git init absolute-looking-submodule-names
+(cd absolute-looking-submodule-names
+  # Use portable names while cloning, then change only the committed configuration. Passing a
+  # leading slash through Git Bash on Windows would be translated to its installation directory.
+  git submodule add ../module1 unix
+  git submodule add ../module1 windows
+  git config -f .gitmodules --rename-section submodule.unix submodule./absolute/unix
+  git config -f .gitmodules --rename-section submodule.windows 'submodule.\absolute\windows'
+  git commit -m "add submodules with absolute-looking names"
+
+  # A backslash is a filename character on Unix but a separator on Windows. The test only needs
+  # Git's committed configuration and gitlinks, so omit the cloned repositories from the fixture
+  # to keep its generated representation portable.
+  rm -rf .git/modules
+)
+
 git init submodule-with-divergent-gitlink
 (cd submodule-with-divergent-gitlink
   git submodule add ../module1 outer/inner

--- a/gix/tests/gix/submodule.rs
+++ b/gix/tests/gix/submodule.rs
@@ -127,6 +127,28 @@ mod open {
         Ok(())
     }
 
+    #[test]
+    fn absolute_looking_names_remain_below_the_modules_directory() -> crate::Result {
+        let repo = repo("absolute-looking-submodule-names")?;
+        let modules_dir = repo.common_dir().join("modules");
+        let mut count = 0;
+        for sm in repo.submodules()?.expect("submodule configuration present") {
+            let git_dir = sm.git_dir()?;
+            assert!(
+                git_dir.starts_with(&modules_dir),
+                "Git-compatible name {:?} must remain below {} instead of producing {}",
+                sm.name(),
+                modules_dir.display(),
+                git_dir.display()
+            );
+            assert!(sm.index_id()?.is_some(), "Git added the submodule to the index");
+            assert!(sm.head_id()?.is_some(), "Git committed the submodule as a gitlink");
+            count += 1;
+        }
+        assert_eq!(count, 2, "both absolute-looking names were parsed as submodules");
+        Ok(())
+    }
+
     /// Reproducer for GHSA-p3hw-mv63-rf9w: `Submodule::open()` must not inherit
     /// `git_dir_trust` from the parent repository because doing so skips recomputing
     /// trust for the submodule git-dir and can bypass ownership-based trust checks.


### PR DESCRIPTION
Previously it would assume they are relative, join them with a base path, which could promptly be overridden by an absolute submodule name, which is valid for Git as well.

Code handling submodule paths is now aware and won't accidentally break out of the repository anymore.
