### PR TITLE
Remove kstring from gix-attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,13 +1632,13 @@ dependencies = [
  "bstr",
  "criterion",
  "document-features",
+ "gix-features",
  "gix-fs",
  "gix-glob",
  "gix-path",
  "gix-quote",
  "gix-testtools",
  "gix-trace",
- "kstring",
  "serde",
  "smallvec",
  "thiserror 2.0.18",
@@ -3416,16 +3416,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "serde",
- "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,7 @@ name = "gix-attributes"
 version = "0.33.2"
 dependencies = [
  "bstr",
+ "criterion",
  "document-features",
  "gix-fs",
  "gix-glob",

--- a/gitoxide-core/src/repository/attributes/validate_baseline.rs
+++ b/gitoxide-core/src/repository/attributes/validate_baseline.rs
@@ -18,7 +18,11 @@ pub(crate) mod function {
     };
 
     use anyhow::{anyhow, bail};
-    use gix::{Count, Progress, attrs::Assignment, bstr::BString};
+    use gix::{
+        Count, Progress,
+        attrs::{Assignment, NameRef},
+        bstr::{BString, ByteSlice},
+    };
 
     use crate::{
         OutputFormat,
@@ -200,11 +204,11 @@ pub(crate) mod function {
                     let fast_path_mismatch = matches
                         .iter()
                         .map(|m| m.assignment)
-                        .zip(expected.iter().map(Assignment::as_ref))
+                        .zip(expected.iter().map(ThreadSafeAssignment::as_ref))
                         .any(|(a, b)| a != b);
                     if fast_path_mismatch {
                         let actual_set = BTreeSet::from_iter(matches.iter().map(|m| m.assignment));
-                        let expected_set = BTreeSet::from_iter(expected.iter().map(Assignment::as_ref));
+                        let expected_set = BTreeSet::from_iter(expected.iter().map(ThreadSafeAssignment::as_ref));
                         let too_few_or_too_many =
                             !(expected_set.sub(&actual_set).is_empty() && actual_set.sub(&expected_set).is_empty());
                         if too_few_or_too_many {
@@ -212,7 +216,7 @@ pub(crate) mod function {
                                 rela_path,
                                 Mismatch::Attributes {
                                     actual: matches.iter().map(|m| m.assignment.to_owned()).collect(),
-                                    expected,
+                                    expected: expected.into_iter().map(Into::into).collect(),
                                 },
                             ));
                         }
@@ -256,8 +260,34 @@ pub(crate) mod function {
     }
 
     enum Baseline {
-        Attribute { assignments: Vec<gix::attrs::Assignment> },
+        Attribute { assignments: Vec<ThreadSafeAssignment> },
         Exclude { location: Option<ExcludeLocation> },
+    }
+
+    struct ThreadSafeAssignment {
+        name: String,
+        state: gix::attrs::State,
+    }
+
+    impl ThreadSafeAssignment {
+        fn as_ref(&self) -> gix::attrs::AssignmentRef<'_> {
+            gix::attrs::AssignmentRef {
+                name: NameRef::try_from(self.name.as_bytes().as_bstr())
+                    .expect("names from git check-attr were validated while parsing"),
+                state: self.state.as_ref(),
+            }
+        }
+    }
+
+    impl From<ThreadSafeAssignment> for Assignment {
+        fn from(value: ThreadSafeAssignment) -> Self {
+            Assignment {
+                name: NameRef::try_from(value.name.as_bytes().as_bstr())
+                    .expect("names from git check-attr were validated while parsing")
+                    .to_owned(),
+                state: value.state,
+            }
+        }
     }
 
     #[derive(Debug)]
@@ -329,7 +359,7 @@ pub(crate) mod function {
         let (path, assignment) = parse_attribute_line(&first)?;
 
         let current = path.to_owned();
-        out.push(assignment.to_owned());
+        out.push(assignment);
         loop {
             let next_line = match lines.peek() {
                 None => break,
@@ -339,15 +369,15 @@ pub(crate) mod function {
             if next_path != current {
                 return Some((current, Baseline::Attribute { assignments: out }));
             } else {
-                out.push(next_assignment.to_owned());
+                out.push(next_assignment);
                 lines.next();
             }
         }
         Some((current, Baseline::Attribute { assignments: out }))
     }
 
-    fn parse_attribute_line(line: &str) -> Option<(&str, gix::attrs::AssignmentRef<'_>)> {
-        use gix::{attrs::StateRef, bstr::ByteSlice};
+    fn parse_attribute_line(line: &str) -> Option<(&str, ThreadSafeAssignment)> {
+        use gix::attrs::StateRef;
 
         let mut prev = None;
         let mut tokens = line.splitn(3, |b| {
@@ -364,9 +394,9 @@ pub(crate) mod function {
             };
             path = path.trim_end_matches(':');
             let attr = attr.trim_end_matches(':');
-            let assignment = gix::attrs::AssignmentRef {
-                name: gix::attrs::NameRef::try_from(attr.as_bytes().as_bstr()).ok()?,
-                state,
+            let assignment = ThreadSafeAssignment {
+                name: NameRef::try_from(attr.as_bytes().as_bstr()).ok()?.as_str().to_owned(),
+                state: state.to_owned(),
             };
             Some((path, assignment))
         } else {

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -14,11 +14,19 @@ rust-version = "1.85"
 [lib]
 doctest = true
 
+[[bench]]
+name = "lookup"
+harness = false
+path = "./benches/lookup.rs"
+
 [features]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
-serde = ["dep:serde", "bstr/serde", "gix-glob/serde", "kstring/serde"]
+serde = ["dep:serde", "bstr/serde", "gix-glob/serde"]
+## Enable thread-safety, otherwise the Search cannot be passed between threads.
+parallel = ["gix-features/parallel"]
 
 [dependencies]
+gix-features = { version = "^0.48.1", path = "../gix-features" }
 gix-path = { version = "^0.12.2", path = "../gix-path" }
 gix-quote = { version = "^0.7.2", path = "../gix-quote" }
 gix-glob = { version = "^0.26.1", path = "../gix-glob" }
@@ -26,7 +34,6 @@ gix-trace = { version = "^0.1.20", path = "../gix-trace" }
 
 bstr = { version = "1.12.0", default-features = false, features = ["std", "unicode"] }
 smallvec = "1.15.1"
-kstring = "2.0.0"
 unicode-bom = { version = "2.0.3" }
 thiserror = "2.0.18"
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
@@ -35,14 +42,9 @@ document-features = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.8.2"
-gix-testtools = { path = "../tests/tools" }
+gix-testtools = { path = "../tests/tools", default-features = false }
 gix-fs = { path = "../gix-fs" }
 
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
-[[bench]]
-name = "lookup"
-harness = false
-path = "./benches/lookup.rs"
-

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -34,9 +34,15 @@ serde = { version = "1.0.114", optional = true, default-features = false, featur
 document-features = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
+criterion = "0.8.2"
 gix-testtools = { path = "../tests/tools" }
 gix-fs = { path = "../gix-fs" }
 
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]
+[[bench]]
+name = "lookup"
+harness = false
+path = "./benches/lookup.rs"
+

--- a/gix-attributes/benches/lookup.rs
+++ b/gix-attributes/benches/lookup.rs
@@ -1,0 +1,109 @@
+use std::{fmt::Write, hint::black_box, path::Path};
+
+use bstr::ByteSlice;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use gix_attributes::{
+    Search,
+    search::{MetadataCollection, Outcome},
+};
+use gix_glob::pattern::Case;
+
+fn attributes(num_entries: usize, file_index: usize) -> Vec<u8> {
+    let mut out = String::with_capacity(num_entries * 32);
+    for entry_index in 0..num_entries {
+        writeln!(out, "*.rs attr-{file_index}-{entry_index}").expect("writing to a string cannot fail");
+    }
+    out.into_bytes()
+}
+
+fn lookup(search: &Search, collection: &MetadataCollection, path: &str) -> usize {
+    let mut outcome = Outcome::default();
+    outcome.initialize(collection);
+    assert!(search.pattern_matching_relative_path(
+        path.as_bytes().as_bstr(),
+        Case::Sensitive,
+        Some(false),
+        &mut outcome
+    ));
+    outcome.iter().count()
+}
+
+fn single_file(c: &mut Criterion) {
+    let mut group = c.benchmark_group("attribute lookup/single file");
+    for num_entries in [1, 10, 100, 1_000] {
+        let mut search = Search::default();
+        let mut collection = MetadataCollection::default();
+        search.add_patterns_buffer(
+            &attributes(num_entries, 0),
+            ".gitattributes".into(),
+            None,
+            &mut collection,
+            true,
+        );
+
+        assert_eq!(lookup(&search, &collection, "file.rs"), num_entries);
+        group.throughput(Throughput::Elements(num_entries as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(num_entries), &num_entries, |b, _| {
+            let mut outcome = Outcome::default();
+            outcome.initialize(&collection);
+            b.iter(|| {
+                outcome.reset();
+                assert!(search.pattern_matching_relative_path(
+                    black_box(b"file.rs".as_bstr()),
+                    Case::Sensitive,
+                    Some(false),
+                    &mut outcome,
+                ));
+                assert_eq!(black_box(outcome.iter().count()), num_entries);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn five_file_hierarchy(c: &mut Criterion) {
+    const ENTRIES: [usize; 5] = [1_024, 512, 256, 128, 64];
+    const DIRECTORIES: [&str; 5] = ["", "a", "a/b", "a/b/c", "a/b/c/d"];
+
+    let mut search = Search::default();
+    let mut collection = MetadataCollection::default();
+    for (file_index, (num_entries, directory)) in ENTRIES.into_iter().zip(DIRECTORIES).enumerate() {
+        let source = if directory.is_empty() {
+            ".gitattributes".into()
+        } else {
+            Path::new(directory).join(".gitattributes")
+        };
+        search.add_patterns_buffer(
+            &attributes(num_entries, file_index),
+            source,
+            Some(Path::new("")),
+            &mut collection,
+            true,
+        );
+    }
+
+    let num_entries = ENTRIES.into_iter().sum::<usize>();
+    let path = "a/b/c/d/file.rs";
+    assert_eq!(lookup(&search, &collection, path), num_entries);
+
+    let mut group = c.benchmark_group("attribute lookup/five file hierarchy");
+    group.throughput(Throughput::Elements(num_entries as u64));
+    group.bench_function("1024-512-256-128-64", |b| {
+        let mut outcome = Outcome::default();
+        outcome.initialize(&collection);
+        b.iter(|| {
+            outcome.reset();
+            assert!(search.pattern_matching_relative_path(
+                black_box(path.as_bytes().as_bstr()),
+                Case::Sensitive,
+                Some(false),
+                &mut outcome,
+            ));
+            assert_eq!(black_box(outcome.iter().count()), num_entries);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, single_file, five_file_hierarchy);
+criterion_main!(benches);

--- a/gix-attributes/src/lib.rs
+++ b/gix-attributes/src/lib.rs
@@ -37,7 +37,6 @@
 #![forbid(unsafe_code)]
 
 pub use gix_glob as glob;
-use kstring::{KString, KStringRef};
 
 mod assignment;
 ///
@@ -93,14 +92,16 @@ pub enum State {
     Unspecified,
 }
 
-/// Represents a validated attribute name
+/// Represents a validated attribute name.
+///
+/// Enable the `parallel` feature to make this type thread-safe. Without it, the name is backed by an `Rc<str>` and is
+/// neither `Send` nor `Sync`; with `parallel`, it is backed by an `Arc<str>` instead.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Name(pub(crate) KString);
+pub struct Name(pub(crate) gix_features::threading::OwnShared<str>);
 
 /// Holds a validated attribute name as a reference
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Ord, PartialOrd)]
-pub struct NameRef<'a>(KStringRef<'a>);
+pub struct NameRef<'a>(&'a str);
 
 /// Name an attribute and describe it's assigned state.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]

--- a/gix-attributes/src/name.rs
+++ b/gix-attributes/src/name.rs
@@ -1,23 +1,25 @@
+use std::borrow::Borrow;
+
 use bstr::{BStr, BString, ByteSlice};
-use kstring::KStringRef;
+use gix_features::threading::OwnShared;
 
 use crate::{Name, NameRef};
 
 impl NameRef<'_> {
     /// Turn this ref into its owned counterpart.
     pub fn to_owned(self) -> Name {
-        Name(self.0.into())
+        Name(OwnShared::from(self.0))
     }
 
     /// Return the inner `str`.
     pub fn as_str(&self) -> &str {
-        self.0.as_str()
+        self.0
     }
 }
 
 impl AsRef<str> for NameRef<'_> {
     fn as_ref(&self) -> &str {
-        self.0.as_ref()
+        self.0
     }
 }
 
@@ -35,7 +37,7 @@ impl<'a> TryFrom<&'a BStr> for NameRef<'a> {
         }
 
         attr_valid(attr)
-            .then(|| NameRef(KStringRef::from_ref(attr.to_str().expect("no illformed utf8"))))
+            .then(|| NameRef(attr.to_str().expect("no illformed utf8")))
             .ok_or_else(|| Error { attribute: attr.into() })
     }
 }
@@ -43,18 +45,49 @@ impl<'a> TryFrom<&'a BStr> for NameRef<'a> {
 impl<'a> Name {
     /// Provide our ref-type.
     pub fn as_ref(&'a self) -> NameRef<'a> {
-        NameRef(self.0.as_ref())
+        NameRef(self.as_str())
     }
 
     /// Return the inner `str`.
     pub fn as_str(&self) -> &str {
-        self.0.as_str()
+        &self.0
     }
 }
 
 impl AsRef<str> for Name {
     fn as_ref(&self) -> &str {
-        self.0.as_str()
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for Name {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Name {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_newtype_struct("Name", self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Name {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(rename = "Name")]
+        struct NameDef(String);
+
+        let NameDef(value) = <NameDef as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(Name(OwnShared::from(value)))
     }
 }
 

--- a/gix-attributes/src/parse.rs
+++ b/gix-attributes/src/parse.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use bstr::{BStr, ByteSlice};
-use kstring::KStringRef;
 
 use crate::{AssignmentRef, Name, NameRef, StateRef, name};
 
@@ -76,7 +75,7 @@ fn check_attr(attr: &BStr) -> Result<NameRef<'_>, name::Error> {
     }
 
     attr_valid(attr)
-        .then(|| NameRef(KStringRef::from_ref(attr.to_str().expect("no illformed utf8"))))
+        .then(|| NameRef(attr.to_str().expect("no illformed utf8")))
         .ok_or_else(|| name::Error { attribute: attr.into() })
 }
 

--- a/gix-attributes/src/search/mod.rs
+++ b/gix-attributes/src/search/mod.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use kstring::KString;
+use gix_features::threading::OwnShared;
 use smallvec::SmallVec;
 
-use crate::{Assignment, AssignmentRef};
+use crate::{Assignment, AssignmentRef, Name};
 
 mod attributes;
 mod outcome;
@@ -99,7 +99,7 @@ pub struct Outcome {
     /// A stack of attributes to use for processing attributes of matched patterns and for resolving their macros.
     attrs_stack: SmallVec<[(AttributeId, Assignment, Option<AttributeId>); 8]>,
     /// A set of attributes we should limit ourselves to, or empty if we should fill in all attributes, made of
-    selected: SmallVec<[(KString, Option<AttributeId>); AVERAGE_NUM_ATTRS]>,
+    selected: SmallVec<[(OwnShared<str>, Option<AttributeId>); AVERAGE_NUM_ATTRS]>,
     /// storage for all patterns we have matched so far (in order to avoid referencing them, we copy them, but only once).
     patterns: RefMap<gix_glob::Pattern>,
     /// storage for all assignments we have matched so far (in order to avoid referencing them, we copy them, but only once).
@@ -135,7 +135,7 @@ pub struct MetadataCollection {
     /// A mapping of an attribute or macro name to its order, that is the time when it was *first* seen.
     ///
     /// This is the inverse of the order attributes are searched.
-    name_to_meta: HashMap<KString, Metadata>,
+    name_to_meta: HashMap<Name, Metadata>,
 }
 
 /// Metadata associated with an attribute or macro name.

--- a/gix-attributes/src/search/outcome.rs
+++ b/gix-attributes/src/search/outcome.rs
@@ -1,6 +1,6 @@
 use bstr::{BString, ByteSlice};
+use gix_features::threading::OwnShared;
 use gix_glob::Pattern;
-use kstring::{KString, KStringRef};
 
 use crate::{
     AssignmentRef, NameRef, StateRef,
@@ -30,7 +30,7 @@ impl Outcome {
             }
 
             for (name, id) in self.selected.iter_mut().filter(|(_, id)| id.is_none()) {
-                *id = collection.name_to_meta.get(name.as_str()).map(|meta| meta.id);
+                *id = collection.name_to_meta.get(name.as_ref()).map(|meta| meta.id);
             }
         }
         self.reset();
@@ -41,25 +41,16 @@ impl Outcome {
     /// Users of this instance should prefer to limit their search as this would allow it to finish earlier.
     ///
     /// Note that `attribute_names` aren't validated to be valid names here, as invalid names definitely will always be unspecified.
-    pub fn initialize_with_selection<'a>(
+    pub fn initialize_with_selection(
         &mut self,
         collection: &MetadataCollection,
-        attribute_names: impl IntoIterator<Item = impl Into<KStringRef<'a>>>,
-    ) {
-        self.initialize_with_selection_inner(collection, &mut attribute_names.into_iter().map(Into::into));
-    }
-
-    fn initialize_with_selection_inner(
-        &mut self,
-        collection: &MetadataCollection,
-        attribute_names: &mut dyn Iterator<Item = KStringRef<'_>>,
+        attribute_names: impl IntoIterator<Item = impl AsRef<str>>,
     ) {
         self.selected.clear();
-        self.selected.extend(attribute_names.map(|name| {
-            (
-                name.to_owned(),
-                collection.name_to_meta.get(name.as_str()).map(|meta| meta.id),
-            )
+        self.selected.extend(attribute_names.into_iter().map(|name| {
+            let name: OwnShared<str> = name.as_ref().into();
+            let id = collection.name_to_meta.get(name.as_ref()).map(|meta| meta.id);
+            (name, id)
         }));
 
         self.initialize(collection);
@@ -137,8 +128,7 @@ impl Outcome {
                 .unwrap_or_else(|| crate::search::Match {
                     pattern: &DUMMY,
                     assignment: AssignmentRef {
-                        name: NameRef::try_from(name.as_bytes().as_bstr())
-                            .unwrap_or_else(|_| NameRef("invalid".into())),
+                        name: NameRef::try_from(name.as_ref().as_bytes().as_bstr()).unwrap_or(NameRef("invalid")),
                         state: StateRef::Unspecified,
                     },
                     kind: MatchKind::Attribute { macro_id: None },
@@ -310,7 +300,7 @@ impl MetadataCollection {
             None => {
                 let order = AttributeId(self.name_to_meta.len());
                 self.name_to_meta.insert(
-                    KString::from_ref(name),
+                    NameRef(name).to_owned(),
                     Metadata {
                         id: order,
                         macro_attributes: Default::default(),
@@ -334,7 +324,7 @@ impl MetadataCollection {
             Some(meta) => meta.id,
             None => {
                 let order = AttributeId(self.name_to_meta.len());
-                self.name_to_meta.insert(KString::from_ref(name), order.into());
+                self.name_to_meta.insert(NameRef(name).to_owned(), order.into());
                 order
             }
         }
@@ -345,7 +335,7 @@ impl MetadataCollection {
             inner: crate::Assignment { name, .. },
         } in attributes
         {
-            *order = self.id_for_attribute(&name.0);
+            *order = self.id_for_attribute(name.as_str());
         }
     }
 }

--- a/gix-attributes/tests/attributes/search.rs
+++ b/gix-attributes/tests/attributes/search.rs
@@ -303,7 +303,7 @@ fn macro_attributes_expand_only_when_macro_is_set() -> crate::Result {
 #[test]
 fn size_of_outcome() {
     let actual = std::mem::size_of::<Outcome>();
-    let expected = 840;
+    let expected = 752;
     assert!(
         size_ok(actual, expected),
         "it's quite big, shouldn't change without us noticing: {actual} <~ {expected}"

--- a/gix-filter/Cargo.toml
+++ b/gix-filter/Cargo.toml
@@ -34,6 +34,8 @@ doc = false
 sha1 = ["gix-hash/sha1"]
 ## Enable support for the SHA-256 hash by forwarding the feature to dependencies.
 sha256 = ["gix-hash/sha256"]
+## Enable thread-safety, make data structures `Send`.
+parallel = ["gix-attributes/parallel"]
 ## Internal feature for building binaries referenced by integration tests through CARGO_BIN_EXE_*.
 test-helper = []
 

--- a/gix-filter/tests/filter/pipeline/mod.rs
+++ b/gix-filter/tests/filter/pipeline/mod.rs
@@ -70,3 +70,10 @@ fn pipeline(
     );
     Ok((cache, pipe))
 }
+
+#[cfg(feature = "parallel")]
+#[test]
+fn is_send_with_parallel_enabled() {
+    fn assert_send<T: Send>() {}
+    assert_send::<gix_filter::Pipeline>();
+}

--- a/gix-pathspec/Cargo.toml
+++ b/gix-pathspec/Cargo.toml
@@ -14,6 +14,10 @@ include = ["/src/**/*", "/LICENSE-*", "/README.md"]
 [lib]
 doctest = true
 
+[features]
+## Enable thread-safety.
+parallel = ["gix-attributes/parallel"]
+
 [dependencies]
 gix-glob = { version = "^0.26.1", path = "../gix-glob" }
 gix-path = { version = "^0.12.2", path = "../gix-path" }

--- a/gix-pathspec/src/lib.rs
+++ b/gix-pathspec/src/lib.rs
@@ -100,6 +100,10 @@ pub struct Search {
     /// During matching, this order is reversed.
     patterns: Vec<gix_glob::search::pattern::Mapping<search::Spec>>,
 
+    /// The synthetic pattern returned when an empty search matches everything.
+    /// Can't be static as it's not (always) `Send` due to `gix-attributes/?parallel`.
+    match_all: Pattern,
+
     /// The path from which the patterns were read, or `None` if the patterns
     /// don't originate in a file on disk.
     pub source: Option<PathBuf>,

--- a/gix-pathspec/src/search/init.rs
+++ b/gix-pathspec/src/search/init.rs
@@ -132,6 +132,10 @@ impl Search {
             Ok(Search {
                 all_patterns_are_excluded: patterns.iter().all(|s| s.value.pattern.is_excluded()),
                 patterns,
+                match_all: Pattern {
+                    nil: true,
+                    ..Default::default()
+                },
                 source: None,
                 common_prefix_len,
             })

--- a/gix-pathspec/src/search/matching.rs
+++ b/gix-pathspec/src/search/matching.rs
@@ -1,8 +1,8 @@
-use bstr::{BStr, BString, ByteSlice};
+use bstr::{BStr, ByteSlice};
 use gix_glob::pattern::Case;
 
 use crate::{
-    MagicSignature, Pattern, Search, SearchMode,
+    MagicSignature, Search, SearchMode,
     search::{Match, MatchKind, MatchKind::*, Spec},
 };
 
@@ -13,7 +13,8 @@ impl Search {
     /// the underlying pathspec defined an attribute filter, to be stored in `outcome`, returning true if there was a match.
     /// All attributes of the pathspec have to be present in the defined value for the pathspec to match.
     ///
-    /// Note that `relative_path` is expected to be starting at the same root as is assumed for this pattern, see [`Pattern::normalize()`].
+    /// Note that `relative_path` is expected to be starting at the same root as is assumed for this pattern, see
+    /// [`crate::Pattern::normalize()`].
     /// Further, empty searches match everything, as if `:` was provided.
     ///
     /// ### Deviation
@@ -29,17 +30,9 @@ impl Search {
         is_dir: Option<bool>,
         attributes: &mut dyn FnMut(&BStr, Case, bool, &mut gix_attributes::search::Outcome) -> bool,
     ) -> Option<Match<'_>> {
-        static MATCH_ALL_STAND_IN: Pattern = Pattern {
-            path: BString::new(Vec::new()),
-            signature: MagicSignature::empty(),
-            search_mode: SearchMode::ShellGlob,
-            attributes: Vec::new(),
-            prefix_len: 0,
-            nil: true,
-        };
         if relative_path.is_empty() {
             return Some(Match {
-                pattern: &MATCH_ALL_STAND_IN,
+                pattern: &self.match_all,
                 sequence_number: 0,
                 kind: Always,
             });
@@ -120,7 +113,7 @@ impl Search {
 
         if res.is_none() && self.all_patterns_are_excluded {
             Some(Match {
-                pattern: &MATCH_ALL_STAND_IN,
+                pattern: &self.match_all,
                 sequence_number: patterns_len,
                 kind: Always,
             })

--- a/gix-pathspec/tests/search/mod.rs
+++ b/gix-pathspec/tests/search/mod.rs
@@ -3,6 +3,13 @@ use std::path::Path;
 use bstr::BStr;
 use gix_pathspec::search::MatchKind::*;
 
+#[cfg(feature = "parallel")]
+#[test]
+fn is_send_with_parallel_enabled() {
+    fn assert_send<T: Send>() {}
+    assert_send::<gix_pathspec::Search>();
+}
+
 #[test]
 fn directories() -> crate::Result {
     baseline::run("directory", true, baseline::directories)

--- a/gix-worktree-stream/Cargo.toml
+++ b/gix-worktree-stream/Cargo.toml
@@ -21,10 +21,10 @@ sha1 = ["gix-hash/sha1"]
 sha256 = ["gix-hash/sha256"]
 
 [dependencies]
-gix-features = { version = "^0.48.1", path = "../gix-features", features = ["progress", "io-pipe"] }
+gix-features = { version = "^0.48.1", path = "../gix-features", features = ["progress", "io-pipe", "parallel"] }
 gix-hash = { version = "^0.25.1", path = "../gix-hash" }
 gix-object = { version = "^0.62.0", path = "../gix-object" }
-gix-attributes = { version = "^0.33.2", path = "../gix-attributes" }
+gix-attributes = { version = "^0.33.2", path = "../gix-attributes", features = ["parallel"] }
 gix-filter = { version = "^0.32.0", path = "../gix-filter" }
 gix-traverse = { version = "^0.59.0", path = "../gix-traverse" }
 gix-fs = { version = "^0.21.2", path = "../gix-fs" }

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -25,7 +25,7 @@ attributes = ["dep:gix-attributes", "dep:gix-validate"]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde = ["dep:serde", "bstr/serde", "gix-index/serde", "gix-hash/serde", "gix-object/serde", "gix-attributes?/serde", "gix-ignore/serde"]
 ## Enable thread-safety.
-parallel = ["gix-features/parallel"]
+parallel = ["gix-features/parallel", "gix-attributes?/parallel"]
 
 [dependencies]
 gix-index = { version = "^0.53.0", path = "../gix-index" }

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -267,7 +267,13 @@ hp-tempfile-registry = ["gix-tempfile/hp-hashmap"]
 ## Make certain data structure threadsafe (or `Sync`) to facilitate multithreading. Further, many algorithms will now use multiple threads by default.
 ##
 ## If unset, most of `gix` can only be used in a single thread as data structures won't be `Send` anymore.
-parallel = ["gix-features/parallel"]
+parallel = [
+    "gix-features/parallel",
+    "gix-attributes?/parallel",
+    "gix-filter?/parallel",
+    "gix-pathspec?/parallel",
+    "gix-worktree?/parallel",
+]
 
 ## Provide a fixed-size allocation-free LRU cache for packs. It's useful if caching is desired while keeping the memory footprint
 ## for the LRU-cache itself low.

--- a/src/porcelain/main.rs
+++ b/src/porcelain/main.rs
@@ -73,7 +73,13 @@ pub fn main() -> Result<()> {
                         match cmd {
                             None => writeln!(err, "Choose a command for the query engine")?,
                             Some(crate::porcelain::options::tools::query::Command::TracePath { path }) => {
-                                engine.run(query::Command::TracePath { spec: path }, out, progress)?;
+                                engine.run(
+                                    query::Command::TracePath {
+                                        spec: crate::shared::parse_pathspec_argument(path),
+                                    },
+                                    out,
+                                    progress,
+                                )?;
                             }
                         }
                         Ok(())

--- a/src/porcelain/options.rs
+++ b/src/porcelain/options.rs
@@ -136,8 +136,9 @@ pub mod tools {
             #[command(visible_alias = "trace-file")]
             TracePath {
                 /// The path to trace through history.
+                // This can't be here anymore as we also need to compile without `Send` support.
                 #[clap(value_parser = AsPathSpec)]
-                path: gix::pathspec::Pattern,
+                path: gix::bstr::BString,
             },
         }
     }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -332,16 +332,22 @@ mod clap {
     });
 
     impl TypedValueParser for AsPathSpec {
-        type Value = gix::pathspec::Pattern;
+        type Value = BString;
 
         fn parse_ref(&self, cmd: &Command, arg: Option<&Arg>, value: &OsStr) -> Result<Self::Value, Error> {
             OsStringValueParser::new()
-                .try_map(|arg| {
-                    let arg: &std::path::Path = arg.as_os_str().as_ref();
-                    gix::pathspec::parse(gix::path::into_bstr(arg).as_ref(), *PATHSPEC_DEFAULTS)
+                .try_map(|arg| -> Result<_, gix::pathspec::parse::Error> {
+                    let arg = gix::path::into_bstr(std::path::PathBuf::from(arg));
+                    gix::pathspec::parse(arg.as_ref(), *PATHSPEC_DEFAULTS)?;
+                    Ok(arg.into_owned())
                 })
                 .parse_ref(cmd, arg, value)
         }
+    }
+
+    pub fn parse_pathspec_argument(value: BString) -> gix::pathspec::Pattern {
+        gix::pathspec::parse(value.as_ref(), *PATHSPEC_DEFAULTS)
+            .expect("AsPathSpec validated the pathspec before storing its argument")
     }
 
     #[derive(Clone)]
@@ -436,7 +442,7 @@ mod clap {
 }
 pub use self::clap::{
     AsBString, AsHashKind, AsOutputFormat, AsPartialRefName, AsPathSpec, AsRange, AsTime, CheckPathSpec,
-    ParseRenameFraction,
+    ParseRenameFraction, parse_pathspec_argument,
 };
 
 #[cfg(test)]

--- a/tests/it/Cargo.toml
+++ b/tests/it/Cargo.toml
@@ -17,5 +17,5 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.102"
 clap = { version = "4.5.60", features = ["derive"] }
-gix = { version = "^0.85.0", path = "../../gix", default-features = false, features = ["attributes", "blame", "blob-diff", "revision", "sha1"] }
+gix = { version = "^0.85.0", path = "../../gix", default-features = false, features = ["attributes", "blame", "blob-diff", "parallel", "revision", "sha1"] }
 regex = { version = "1.12.3", default-features = false, features = ["std"] }

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -30,7 +30,7 @@ xz = ["dep:xz2"]
 gix-hash = { version = "^0.25.1", path = "../../gix-hash", features = ["sha1", "sha256"] }
 gix-lock = { version = "^23.0.0", path = "../../gix-lock" }
 gix-discover = { version = "^0.53.0", path = "../../gix-discover", optional = true }
-gix-worktree = { version = "^0.54.0", path = "../../gix-worktree", optional = true }
+gix-worktree = { version = "^0.54.0", path = "../../gix-worktree", optional = true, features = ["parallel"] }
 gix-fs = { version = "^0.21.2", path = "../../gix-fs", optional = true }
 gix-tempfile = { version = "^23.0.0", path = "../../gix-tempfile", default-features = false, features = ["signals"] }
 


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- add Criterion attribute-lookup benchmarks for one file with 1, 10, 100, and 1000 entries
- add a five-file hierarchy benchmark with 1024, 512, 256, 128, and 64 entries
- remove `kstring` and store owned attribute names in `gix_features::threading::OwnShared<str>`
- use `Rc` in default builds and `Arc` only when the `parallel` feature is enabled
- keep owned-name clones allocation-free and leak-free while preserving validated-name and serde-newtype behavior
- forward the parallel opt-in through dependent public crates and retain `Send` for parallel pathspec searches and filter pipelines
- keep default-mode consumers Rc-compatible across the CLI, pathspec, test tools, and worktree stream
- shrink `gix_attributes::search::Outcome` from 840 to 752 bytes

## Benchmark results

| Scenario | `kstring` baseline | `OwnShared` (Rc) | Change | `OwnShared` (Arc) | Change |
| --- | ---: | ---: | ---: | ---: | ---: |
| Single file, 1 entry | 58.393 ns | 55.115 ns | -5.6% | 57.324 ns | -1.8% |
| Single file, 10 entries | 670.48 ns | 643.63 ns | -4.0% | 668.03 ns | -0.4% |
| Single file, 100 entries | 8.0138 us | 7.9572 us | -0.7% | 7.8143 us | -2.5% |
| Single file, 1000 entries | 96.207 us | 95.431 us | -0.8% | 94.853 us | -1.4% |
| Five-file hierarchy | 209.72 us | 207.61 us | -1.0% | 204.28 us | -2.6% |

Measured on the same machine with `cargo bench -p gix-attributes --bench lookup -- --noplot` and again with `--features parallel`. Criterion 0.7 retains the crate Rust 1.85 MSRV.

## Reported issue

Add a benchmark for `gix-attributes` for attribute lookup in two scenarios, one with a single file with varying amounts of entries, and one with a hierarchy of 5 files, each with decreasing amounts of entries in the attribute files.

Use these benchmark results as baseline to implement an alternative to `kstring`, which should be removed as dependency. This overview https://github.com/rosetta-rs/string-rosetta-rs/ might help for alternatives, if these are needed at all. The benchmark should be the driver.

Note that `kstring` is supposed to avoid allocations, maybe there can be a dependency-free way to do it, without leaking memory.

Follow-up: use `gix-features::threading::OwnShared` instead of a direct `Arc`, allowing non-parallel builds to use `Rc`.

## Review follow-up

- make the archive exclusion cache thread-local and key it by the canonical repository discovered from each archive path
- cover archive exclusion for a temporary repository with a regression test
- forward parallel features through `gix-pathspec`, `gix-filter`, `gix-worktree`, and `gix`
- add compile-time `Send` assertions for parallel `gix_pathspec::Search` and `gix_filter::Pipeline`

## Validation

- `just check`
- `cargo +1.85.0 test -p gix-attributes --lib --tests`
- `cargo +1.85.0 test -p gix-attributes --lib --tests --features parallel`
- `cargo test -p gix-attributes`
- `cargo test -p gix-attributes --all-features --lib --tests`
- `cargo test -p gix-pathspec --features parallel`
- `cargo test -p gix-filter --features sha1,parallel`
- `cargo test -p gix-testtools --lib --tests`
- `cargo test -p gitoxide-core --lib`
- `cargo test --no-default-features --features small --lib`
- `cargo clippy -p gix-attributes --all-targets --all-features -- -D warnings`
- `cargo clippy -p gix-pathspec --all-targets --features parallel -- -D warnings`
- `cargo clippy -p gix-filter --all-targets --features sha1,parallel -- -D warnings`
- `cargo clippy --no-default-features --features small -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo build -p gix-pathspec --target wasm32-wasip1`
- `cargo build -p gix-pathspec --target wasm32-wasip2`
- `cargo build -p gix-pathspec --target wasm32-unknown-unknown`
- both benchmark commands above

The local pure journey build steps passed. Its runtime snapshot hit the existing macOS no-TTY `Device not configured` condition; Linux CI is the authoritative runtime result. The Rust 1.85 small-feature check also reaches the pre-existing zlib NEON `target_feature` incompatibility outside this patch.

Commit: `1a92ad27ab1ca2b1ecd4440722b838398caf3f2b`