### PR TITLE
Replace lint allowances with expectations

### DIFF
--- a/gitoxide-core/src/commitgraph/verify.rs
+++ b/gitoxide-core/src/commitgraph/verify.rs
@@ -40,7 +40,7 @@ pub(crate) mod function {
     {
         let g = Graph::at(path.as_ref())?;
 
-        #[allow(clippy::unnecessary_wraps, unknown_lints)]
+        #[expect(clippy::unnecessary_wraps)]
         fn noop_processor(_commit: &gix::commitgraph::file::Commit<'_>) -> std::result::Result<(), std::fmt::Error> {
             Ok(())
         }

--- a/gitoxide-core/src/corpus/engine.rs
+++ b/gitoxide-core/src/corpus/engine.rs
@@ -66,7 +66,7 @@ impl Engine {
 }
 
 impl Engine {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn perform_run(
         &mut self,
         corpus_path: &Path,

--- a/gitoxide-core/src/pack/explode.rs
+++ b/gitoxide-core/src/pack/explode.rs
@@ -90,7 +90,10 @@ enum Error {
     WrittenFileCorrupt { source: loose::find::Error, id: ObjectId },
 }
 
-#[allow(clippy::large_enum_variant)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 #[derive(Clone)]
 enum OutputWriter {
     Loose(loose::Store),

--- a/gitoxide-core/src/pack/receive.rs
+++ b/gitoxide-core/src/pack/receive.rs
@@ -271,7 +271,7 @@ fn write_raw_refs(refs: &[Ref], directory: PathBuf) -> std::io::Result<()> {
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn receive_pack_blocking(
     mut directory: Option<PathBuf>,
     mut refs_directory: Option<PathBuf>,

--- a/gitoxide-core/src/repository/attributes/validate_baseline.rs
+++ b/gitoxide-core/src/repository/attributes/validate_baseline.rs
@@ -114,7 +114,7 @@ pub(crate) mod function {
         };
         let work_dir = ignore
             .then(|| {
-                #[allow(clippy::unnecessary_debug_formatting)]
+                #[expect(clippy::unnecessary_debug_formatting)]
                 repo.workdir()
                     .map(ToOwned::to_owned)
                     .ok_or_else(|| anyhow!("repository at {:?} must have a worktree checkout", repo.path()))
@@ -262,7 +262,7 @@ pub(crate) mod function {
 
     #[derive(Debug)]
     // See note on `Mismatch`
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub struct ExcludeLocation {
         pub line: usize,
         pub rela_source_file: String,
@@ -272,7 +272,7 @@ pub(crate) mod function {
     #[derive(Debug)]
     // We debug-print this structure, which makes all fields 'used', but it doesn't count.
     // TODO: find a way to not have to do more work, but make the warning go away.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub enum Mismatch {
         Attributes {
             actual: Vec<gix::attrs::Assignment>,
@@ -286,7 +286,7 @@ pub(crate) mod function {
 
     #[derive(Debug)]
     // See note on `Mismatch`
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub struct ExcludeMatch {
         pub pattern: gix::glob::Pattern,
         pub source: Option<PathBuf>,

--- a/gitoxide-core/src/repository/commitgraph/verify.rs
+++ b/gitoxide-core/src/repository/commitgraph/verify.rs
@@ -29,7 +29,7 @@ pub(crate) mod function {
     {
         let g = repo.commit_graph()?;
 
-        #[allow(clippy::unnecessary_wraps, unknown_lints)]
+        #[expect(clippy::unnecessary_wraps)]
         fn noop_processor(_commit: &gix::commitgraph::file::Commit<'_>) -> std::result::Result<(), std::fmt::Error> {
             Ok(())
         }

--- a/gitoxide-core/src/repository/index/entries.rs
+++ b/gitoxide-core/src/repository/index/entries.rs
@@ -89,7 +89,7 @@ pub(crate) mod function {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn print_entries(
         repo: &Repository,
         attributes: Option<Attributes>,
@@ -245,7 +245,7 @@ pub(crate) mod function {
         Ok(stats)
     }
 
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn init_cache(
         repo: &Repository,
         attributes: Option<Attributes>,
@@ -305,7 +305,7 @@ pub(crate) mod function {
     #[cfg_attr(feature = "serde", derive(serde::Serialize))]
     #[derive(Default, Debug)]
     struct Statistics {
-        #[allow(dead_code)] // Not really dead, but Debug doesn't count for it even though it's crucial.
+        // Not really dead, but Debug doesn't count for it even though it's crucial.
         pub entries: usize,
         pub entries_after_prune: usize,
         pub excluded: usize,

--- a/gitoxide-core/src/repository/index/mod.rs
+++ b/gitoxide-core/src/repository/index/mod.rs
@@ -51,7 +51,7 @@ pub fn from_list(
     let mut index = gix::index::State::new(object_hash);
     for path in std::io::BufReader::new(std::fs::File::open(entries_file)?).lines() {
         let path: PathBuf = path?.into();
-        #[allow(clippy::unnecessary_debug_formatting)]
+        #[expect(clippy::unnecessary_debug_formatting)]
         if !path.is_relative() {
             bail!("Input paths need to be relative, but {path:?} is not.")
         }

--- a/gitoxide-core/src/repository/merge/commit.rs
+++ b/gitoxide-core/src/repository/merge/commit.rs
@@ -8,7 +8,6 @@ use gix::{
 use super::tree::Options;
 use crate::OutputFormat;
 
-#[allow(clippy::too_many_arguments)]
 pub fn commit(
     mut repo: gix::Repository,
     out: &mut dyn std::io::Write,

--- a/gitoxide-core/src/repository/merge/tree.rs
+++ b/gitoxide-core/src/repository/merge/tree.rs
@@ -24,7 +24,6 @@ pub(super) mod function {
     use super::Options;
     use crate::OutputFormat;
 
-    #[allow(clippy::too_many_arguments)]
     pub fn tree(
         mut repo: gix::Repository,
         out: &mut dyn std::io::Write,

--- a/gix-actor/src/signature/decode.rs
+++ b/gix-actor/src/signature/decode.rs
@@ -15,7 +15,7 @@ pub(crate) mod function {
         let (time, rest) = i.split_at(time_len);
         *i = rest;
         // SAFETY: The parser validated that there are only ASCII characters with `is_time_byte()`.
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         let time = unsafe { std::str::from_utf8_unchecked(time) };
 
         Ok(SignatureRef {

--- a/gix-archive/src/write.rs
+++ b/gix-archive/src/write.rs
@@ -131,7 +131,10 @@ where
         let _ = (next_entry, out);
         return Err(message!("Support for the format '{:?}' was not compiled in", opts.format).raise());
     }
-    #[allow(unreachable_code)]
+    #[allow(
+        unreachable_code,
+        reason = "Reachability depends on the enabled archive format features."
+    )]
     Ok(())
 }
 
@@ -176,7 +179,10 @@ where
     #[cfg(not(feature = "zip"))]
     {
         let _ = compression_level;
-        #[allow(clippy::needless_return)]
+        #[expect(
+            clippy::needless_return,
+            reason = "the explicit return keeps feature-dependent branches structurally consistent"
+        )]
         return Err(message!(
             "Support for the format '{:?}' was not compiled in",
             Format::Zip {

--- a/gix-attributes/src/parse.rs
+++ b/gix-attributes/src/parse.rs
@@ -19,7 +19,7 @@ mod error {
     use bstr::BString;
     /// The error returned by [`parse::Lines`][crate::parse::Lines].
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(r"Line {line_number} has a negative pattern, for literal characters use \!: {line}")]
         PatternNegation { line_number: usize, line: BString },

--- a/gix-attributes/src/search/attributes.rs
+++ b/gix-attributes/src/search/attributes.rs
@@ -199,7 +199,6 @@ fn macro_mode() -> gix_glob::pattern::Mode {
 /// `case` specifies whether cases should be folded during matching or not.
 /// `is_dir` is true if `relative_path` is a directory.
 /// Return `true` if at least one pattern matched.
-#[allow(unused_variables)]
 fn pattern_matching_relative_path(
     list: &gix_glob::search::pattern::List<Attributes>,
     relative_path: &BStr,

--- a/gix-attributes/tests/attributes/state.rs
+++ b/gix-attributes/tests/attributes/state.rs
@@ -15,7 +15,7 @@ mod value {
 }
 
 #[test]
-#[allow(invalid_from_utf8)]
+#[expect(invalid_from_utf8)]
 fn from_value() {
     assert!(std::str::from_utf8(ILLFORMED_UTF8).is_err());
     assert!(

--- a/gix-bitmap/src/ewah.rs
+++ b/gix-bitmap/src/ewah.rs
@@ -172,7 +172,6 @@ mod access {
 }
 
 /// A growable collection of u64 that are seen as stream of individual bits.
-#[allow(dead_code)]
 #[derive(Clone)]
 pub struct Vec {
     num_bits: u32,

--- a/gix-blame/src/error.rs
+++ b/gix-blame/src/error.rs
@@ -2,7 +2,7 @@ use gix_object::bstr::BString;
 
 /// The error returned by [file()](crate::file()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("No commit was given")]
     EmptyTraversal,

--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -549,7 +549,7 @@ impl From<gix_diff::tree_with_rewrites::Change> for TreeDiffChange {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn tree_diff_at_file_path(
     odb: impl gix_object::Find + gix_object::FindHeader,
     file_path: &BStr,
@@ -603,7 +603,6 @@ fn tree_diff_at_file_path(
     Ok(result)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn tree_diff_without_rewrites_at_file_path(
     odb: impl gix_object::Find + gix_object::FindHeader,
     file_path: &BStr,
@@ -704,7 +703,7 @@ fn tree_diff_without_rewrites_at_file_path(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn tree_diff_with_rewrites_at_file_path(
     odb: impl gix_object::Find + gix_object::FindHeader,
     file_path: &BStr,
@@ -747,7 +746,7 @@ fn tree_diff_with_rewrites_at_file_path(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn blob_changes(
     odb: impl gix_object::Find + gix_object::FindHeader,
     resource_cache: &mut gix_diff::blob::Platform,

--- a/gix-commitgraph/src/file/init.rs
+++ b/gix-commitgraph/src/file/init.rs
@@ -181,7 +181,7 @@ impl TryFrom<&Path> for File {
         let data = std::fs::File::open(path)
             .and_then(|file| {
                 // SAFETY: we have to take the risk of somebody changing the file underneath. Git never writes into the same file.
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 unsafe {
                     memmap2::MmapOptions::new().map_copy_read_only(&file)
                 }

--- a/gix-config-value/src/lib.rs
+++ b/gix-config-value/src/lib.rs
@@ -27,7 +27,7 @@
 
 /// The error returned when any config value couldn't be instantiated due to malformed input.
 #[derive(Debug, thiserror::Error, Eq, PartialEq)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[error("Could not decode '{input}': {message}")]
 pub struct Error {
     pub message: &'static str,

--- a/gix-config-value/src/path.rs
+++ b/gix-config-value/src/path.rs
@@ -31,7 +31,7 @@ pub mod interpolate {
 
     /// The error returned by [`Path::interpolate()`][crate::Path::interpolate()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("{} is missing", .what)]
         Missing { what: &'static str },
@@ -62,7 +62,7 @@ pub mod interpolate {
             let cname = std::ffi::CString::new(name).ok()?;
             // SAFETY: calling this in a threaded program that modifies the pw database is not actually safe.
             //         TODO: use the `*_r` version, but it's much harder to use.
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             let pwd = unsafe { libc::getpwnam(cname.as_ptr()) };
             if pwd.is_null() {
                 None
@@ -70,7 +70,7 @@ pub mod interpolate {
                 use std::os::unix::ffi::OsStrExt;
                 // SAFETY: pw_dir is a cstr and it lives as long as… well, we hope nobody changes the pw database while we are at it
                 //         from another thread. Otherwise it lives long enough.
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 let cstr = unsafe { std::ffi::CStr::from_ptr((*pwd).pw_dir) };
                 Some(std::ffi::OsStr::from_bytes(cstr.to_bytes()).into())
             }

--- a/gix-config/src/file/access/mutate.rs
+++ b/gix-config/src/file/access/mutate.rs
@@ -433,7 +433,6 @@ impl File {
         mut insert_after: Option<SectionId>,
     ) -> Result<&mut Self, crate::parse::span::Error> {
         let nl = self.detect_newline_style_smallvec();
-        #[allow(clippy::unnecessary_lazy_evaluations)]
         let our_last_section_before_append =
             insert_after.or_else(|| (self.section_id_counter != 0).then(|| SectionId(self.section_id_counter - 1)));
         let needs_separator = if other.frontmatter_events.is_empty() {

--- a/gix-config/src/file/includes/types.rs
+++ b/gix-config/src/file/includes/types.rs
@@ -4,7 +4,7 @@ use crate::{parse, path::interpolate};
 
 /// The error returned when following includes.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Failed to copy configuration file into buffer")]
     CopyBuffer(#[source] std::io::Error),

--- a/gix-config/src/file/init/from_env.rs
+++ b/gix-config/src/file/init/from_env.rs
@@ -6,7 +6,7 @@ use crate::{File, KeyRef, file, file::init, parse::section, path::interpolate};
 
 /// Represents the errors that may occur when calling [`File::from_env()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Configuration {kind} at index {index} contained illformed UTF-8")]
     IllformedUtf8 { index: usize, kind: &'static str },

--- a/gix-config/src/file/init/from_paths.rs
+++ b/gix-config/src/file/init/from_paths.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// The error returned by [`File::from_paths_metadata()`] and [`File::from_path_no_includes()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("The configuration file at \"{}\" could not be read", path.display())]
     Io {

--- a/gix-config/src/file/init/types.rs
+++ b/gix-config/src/file/init/types.rs
@@ -2,7 +2,7 @@ use crate::{file::init, parse, parse::EventRef, path::interpolate};
 
 /// The error returned by [`File::from_bytes_no_includes()`][crate::File::from_bytes_no_includes()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Parse(#[from] parse::Error),

--- a/gix-config/src/file/mod.rs
+++ b/gix-config/src/file/mod.rs
@@ -28,7 +28,7 @@ pub mod section;
 pub mod rename_section {
     /// The error returned by [`File::rename_section(…)`][crate::File::rename_section()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Lookup(#[from] crate::lookup::existing::Error),
@@ -41,7 +41,7 @@ pub mod rename_section {
 pub mod set_raw_value {
     /// The error returned by [`File::set_raw_value(…)`][crate::File::set_raw_value()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Lookup(#[from] crate::lookup::existing::Error),

--- a/gix-config/src/file/section/body.rs
+++ b/gix-config/src/file/section/body.rs
@@ -206,7 +206,6 @@ impl BodyData {
         key_start.map(|key_start| {
             // value end needs to be offset by one so that the last value's index
             // is included in the range
-            #[allow(clippy::range_plus_one)]
             let value_range = value_range.start..value_range.end + 1;
             let key_range = key_start..value_range.end;
             (key_range, (value_range.start != key_start + 1).then_some(value_range))

--- a/gix-config/src/lookup.rs
+++ b/gix-config/src/lookup.rs
@@ -1,6 +1,6 @@
 /// The error when looking up a value, for example via [`File::try_value()`][crate::File::try_value()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error<E> {
     #[error(transparent)]
     ValueMissing(#[from] existing::Error),
@@ -12,7 +12,7 @@ pub enum Error<E> {
 pub mod existing {
     /// The error when looking up a value that doesn't exist, for example via [`File::value()`][crate::File::value()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The requested section does not exist")]
         SectionMissing,

--- a/gix-config/src/parse/events.rs
+++ b/gix-config/src/parse/events.rs
@@ -262,7 +262,10 @@ impl Events {
     ///
     /// Prefer the [`from_bytes()`](Self::from_bytes()) method if UTF8 encoding
     /// isn't guaranteed.
-    #[allow(clippy::should_implement_trait)]
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "the method has domain-specific semantics despite sharing a standard trait method name"
+    )]
     pub fn from_str(input: &str) -> Result<Events, parse::Error> {
         Self::from_bytes(input.as_bytes(), None)
     }

--- a/gix-config/src/parse/from_bytes/tests.rs
+++ b/gix-config/src/parse/from_bytes/tests.rs
@@ -934,7 +934,6 @@ mod value_no_continuation {
     }
 
     #[test]
-    #[allow(clippy::needless_raw_string_hashes)]
     fn trans_escaped_comment_marker_not_consumed() {
         let mut events = Vec::new();
         assert_eq!(value(br##"hello"#"world; a"##, &mut events).unwrap().0, b"; a");

--- a/gix-config/src/parse/section/header.rs
+++ b/gix-config/src/parse/section/header.rs
@@ -4,7 +4,7 @@ use crate::parse::{Span, section::HeaderData};
 
 /// The error returned when creating a section header.
 #[derive(Debug, PartialOrd, PartialEq, Eq, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("section names can only be ascii, '-'")]
     InvalidName,

--- a/gix-credentials/src/helper/cascade.rs
+++ b/gix-credentials/src/helper/cascade.rs
@@ -74,7 +74,10 @@ impl Cascade {
     ///
     /// When _getting_ credentials, all programs are asked until the credentials are complete, stopping the cascade.
     /// When _storing_ or _erasing_ all programs are instructed in order.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     pub fn invoke(&mut self, mut action: helper::Action, mut prompt: gix_prompt::Options) -> protocol::Result {
         if let Some(ctx) = action.context_mut() {
             ctx.options = self.context_options;
@@ -82,7 +85,10 @@ impl Cascade {
         let mut url = action
             .context_mut()
             .map(|ctx| {
-                #[allow(clippy::manual_inspect)] /* false positive */
+                #[expect(
+                    clippy::manual_inspect,
+                    reason = "the suggested rewrite is a false positive for this mutation"
+                )] /* false positive */
                 ctx.destructure_url_in_place(self.use_http_path).map(|ctx| {
                     if self.query_user_only && ctx.password.is_none() {
                         ctx.password = Some("".into());

--- a/gix-credentials/src/helper/mod.rs
+++ b/gix-credentials/src/helper/mod.rs
@@ -3,7 +3,6 @@ use bstr::{BStr, BString};
 use crate::{Program, protocol, protocol::Context};
 
 /// A list of helper programs to run in order to obtain credentials.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct Cascade {
     /// The programs to run in order to obtain credentials
@@ -59,7 +58,7 @@ pub type Result = std::result::Result<Option<Outcome>, Error>;
 
 /// The error used in the [credentials helper invocation][crate::helper::invoke()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     ContextDecode(#[from] protocol::context::decode::Error),

--- a/gix-credentials/src/lib.rs
+++ b/gix-credentials/src/lib.rs
@@ -33,7 +33,10 @@ pub mod protocol;
 /// and does everything `git` typically does. The `action` should have been created with [`helper::Action::get_for_url()`] to
 /// contain only the URL to kick off the process, or should be created by [`helper::NextAction`].
 /// If more control is required, use the [`Cascade`][helper::Cascade] type.
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 pub fn builtin(action: helper::Action) -> protocol::Result {
     protocol::helper_outcome_to_result(
         helper::invoke(&mut Program::from_kind(program::Kind::Builtin), &action)?,

--- a/gix-credentials/src/program/main.rs
+++ b/gix-credentials/src/program/main.rs
@@ -39,7 +39,7 @@ impl Action {
 
 /// The error of [`main()`][crate::program::main()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Action named {name:?} is invalid, need 'get', 'store', 'erase' or 'fill', 'approve', 'reject'")]
     ActionInvalid { name: OsString },

--- a/gix-credentials/src/protocol/context/mod.rs
+++ b/gix-credentials/src/protocol/context/mod.rs
@@ -4,7 +4,7 @@ use crate::protocol::{Context, ContextOptions};
 
 /// Indicates key or values contain errors that can't be encoded.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("{key:?}={value:?} must not contain null bytes or newlines neither in key nor in value.")]
     Encoding { key: String, value: BString },
@@ -105,7 +105,10 @@ mod mutate {
         /// Destructure the url at our `url` field into parts like protocol, host, username and path and store
         /// them in our respective fields. If `use_http_path` is set, http paths are significant even though
         /// normally this isn't the case.
-        #[allow(clippy::result_large_err)]
+        #[expect(
+            clippy::result_large_err,
+            reason = "will be removed once `gix-error` is used consistently"
+        )]
         pub fn destructure_url_in_place(&mut self, use_http_path: bool) -> Result<&mut Self, protocol::Error> {
             if self.url.is_none() {
                 self.url = Some(self.to_url().ok_or(protocol::Error::UrlMissing)?);

--- a/gix-credentials/src/protocol/context/serde.rs
+++ b/gix-credentials/src/protocol/context/serde.rs
@@ -75,7 +75,7 @@ pub mod decode {
 
     /// The error returned by [`from_bytes()`][Context::from_bytes()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Illformed UTF-8 in value of key {key:?}: {value:?}")]
         IllformedUtf8InValue { key: String, value: BString },

--- a/gix-credentials/src/protocol/mod.rs
+++ b/gix-credentials/src/protocol/mod.rs
@@ -16,7 +16,7 @@ pub type Result = std::result::Result<Option<Outcome>, Error>;
 
 /// The error returned top-level credential functions.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     UrlParse(#[from] gix_url::parse::Error),
@@ -83,7 +83,10 @@ impl Default for ContextOptions {
 }
 
 /// Convert the outcome of a helper invocation to a helper result, assuring that the identity is complete in the process.
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 pub fn helper_outcome_to_result(outcome: Option<helper::Outcome>, action: helper::Action) -> Result {
     match (action, outcome) {
         (helper::Action::Get(ctx), None) => Err(Error::IdentityMissing {

--- a/gix-credentials/tests/helper/cascade.rs
+++ b/gix-credentials/tests/helper/cascade.rs
@@ -201,7 +201,7 @@ mod invoke {
         }
     }
 
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     fn invoke_cascade<'a>(names: impl IntoIterator<Item = &'a str>, action: Action) -> protocol::Result {
         Cascade::default().use_http_path(true).extend(fixtures(names)).invoke(
             action,

--- a/gix-diff/src/blob/pipeline.rs
+++ b/gix-diff/src/blob/pipeline.rs
@@ -131,7 +131,7 @@ pub mod convert_to_diffable {
 
     /// The error returned by [Pipeline::convert_to_diffable()](super::Pipeline::convert_to_diffable()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Entry at '{rela_path}' must be regular file or symlink, but was {actual:?}")]
         InvalidEntryKind { rela_path: BString, actual: EntryKind },
@@ -229,7 +229,7 @@ impl Pipeline {
     ///
     /// As these files are ultimately named tempfiles, they will be leaked unless the [gix_tempfile] is configured with
     /// a signal handler. If they leak, they would remain in the system's `$TMP` directory.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn convert_to_diffable(
         &mut self,
         id: &gix_hash::oid,

--- a/gix-diff/src/blob/platform.rs
+++ b/gix-diff/src/blob/platform.rs
@@ -246,7 +246,7 @@ pub mod set_resource {
 
     /// The error returned by [Platform::set_resource](super::Platform::set_resource).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Can only diff blobs and links, not {mode:?}")]
         InvalidMode { mode: gix_object::tree::EntryKind },
@@ -336,7 +336,7 @@ pub mod prepare_diff {
 
     /// The error returned by [Platform::prepare_diff()](super::Platform::prepare_diff()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Either the source or the destination of the diff operation were not set")]
         SourceOrDestinationUnset,
@@ -353,7 +353,7 @@ pub mod prepare_diff_command {
 
     /// The error returned by [Platform::prepare_diff_command()](super::Platform::prepare_diff_command()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Either the source or the destination of the diff operation were not set")]
         SourceOrDestinationUnset,

--- a/gix-diff/src/index/mod.rs
+++ b/gix-diff/src/index/mod.rs
@@ -4,7 +4,7 @@ use bstr::BStr;
 
 /// The error returned by [`index()`](crate::index()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Cannot diff indices that contain sparse entries")]
     IsSparse,

--- a/gix-diff/src/rewrites/tracker.rs
+++ b/gix-diff/src/rewrites/tracker.rs
@@ -137,7 +137,7 @@ pub mod visit {
 pub mod emit {
     /// The error returned by [Tracker::emit()](super::Tracker::emit()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not find blob for similarity checking")]
         FindExistingBlob(#[from] gix_object::find::existing_object::Error),
@@ -366,7 +366,7 @@ impl<T: Change> Tracker<T> {
         });
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn match_pairs_of_kind(
         &mut self,
         kind: visit::SourceKind,
@@ -417,7 +417,7 @@ impl<T: Change> Tracker<T> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn match_pairs(
         &mut self,
         cb: &mut impl FnMut(visit::Destination<'_, T>, Option<visit::Source<'_, T>>) -> Action,
@@ -695,7 +695,7 @@ type SourceTuple<'a, T> = (usize, &'a Item<T>, Option<DiffLineStats>);
 /// any non-deletion otherwise.
 /// Note that we always try to find by identity first even if a percentage is given as it's much faster and may reduce the set
 /// of items to be searched.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn find_match<'a, T: Change>(
     items: &'a [Item<T>],
     item: &Item<T>,

--- a/gix-diff/src/tree/mod.rs
+++ b/gix-diff/src/tree/mod.rs
@@ -8,7 +8,7 @@ use crate::tree::visit::Relation;
 
 /// The error returned by [`tree()`](super::tree()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Find(#[from] gix_object::find::existing_iter::Error),

--- a/gix-diff/src/tree/recorder.rs
+++ b/gix-diff/src/tree/recorder.rs
@@ -20,7 +20,7 @@ pub enum Location {
 /// A Change as observed by a call to [`visit(…)`](Visit::visit()), enhanced with the path affected by the change.
 /// Its similar to [`visit::Change`] but includes the path that changed.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Change {
     Addition {
         entry_mode: tree::EntryMode,

--- a/gix-diff/src/tree_with_rewrites/mod.rs
+++ b/gix-diff/src/tree_with_rewrites/mod.rs
@@ -5,7 +5,7 @@ pub use change::{Change, ChangeRef};
 
 /// The error returned by [`tree_with_rewrites()`](super::tree_with_rewrites()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Diff(#[from] crate::tree::Error),

--- a/gix-diff/tests/diff/blob/unified_diff.rs
+++ b/gix-diff/tests/diff/blob/unified_diff.rs
@@ -490,7 +490,7 @@ where
 }
 
 struct Recorder {
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     hunks: Vec<((u32, u32), (u32, u32), String)>,
     newline: &'static str,
 }

--- a/gix-dir/src/walk/function.rs
+++ b/gix-dir/src/walk/function.rs
@@ -175,7 +175,6 @@ pub(super) fn can_recurse(
 }
 
 /// Possibly emit an entry to `for_each` in case the provided information makes that possible.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn emit_entry(
     rela_path: Cow<'_, BStr>,
     info: classify::Outcome,

--- a/gix-dir/src/walk/mod.rs
+++ b/gix-dir/src/walk/mod.rs
@@ -275,7 +275,7 @@ pub struct Outcome {
 
 /// The error returned by [`walk()`](function::walk()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Interrupted")]
     Interrupted,

--- a/gix-dir/src/walk/readdir.rs
+++ b/gix-dir/src/walk/readdir.rs
@@ -21,7 +21,7 @@ use crate::{
 /// ### Deviation
 ///
 /// Git mostly silently ignores IO errors and stops iterating seemingly quietly, while we error loudly.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(super) fn recursive(
     may_collapse: bool,
     current: &mut PathBuf,
@@ -215,7 +215,7 @@ struct Mark {
 }
 
 impl Mark {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn reduce_held_entries(
         mut self,
         num_entries: usize,
@@ -287,7 +287,7 @@ impl Mark {
         std::ops::ControlFlow::Continue(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn try_collapse(
         &self,
         dir_rela_path: &BStr,

--- a/gix-dir/tests/walk_utils/mod.rs
+++ b/gix-dir/tests/walk_utils/mod.rs
@@ -270,7 +270,7 @@ pub fn collect_filtered_with_cwd(
     (outcome, dlg.into_entries_by_path())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn try_collect_filtered_opts(
     worktree_root: &Path,
     root: Option<&Path>,

--- a/gix-discover/src/lib.rs
+++ b/gix-discover/src/lib.rs
@@ -43,7 +43,7 @@ pub mod is_git {
 
     /// The error returned by [`crate::is_git()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not find a valid HEAD reference")]
         FindHeadRef(#[from] gix_ref::file::find::existing::Error),
@@ -71,7 +71,10 @@ pub mod is_git {
 }
 
 mod is;
-#[allow(deprecated)]
+#[expect(
+    deprecated,
+    reason = "this re-export preserves compatibility with the deprecated API"
+)]
 pub use is::submodule_git_dir as is_submodule_git_dir;
 pub use is::{bare as is_bare, git as is_git};
 

--- a/gix-discover/src/parse.rs
+++ b/gix-discover/src/parse.rs
@@ -8,7 +8,7 @@ pub mod gitdir {
 
     /// The error returned by [`parse::gitdir()`][super::gitdir()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Format should be 'gitdir: <path>', but got: {:?}", .input)]
         InvalidFormat { input: BString },

--- a/gix-discover/src/path.rs
+++ b/gix-discover/src/path.rs
@@ -18,7 +18,7 @@ pub enum RepositoryKind {
 pub mod from_gitdir_file {
     /// The error returned by [`from_gitdir_file()`][crate::path::from_gitdir_file()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Io(#[from] std::io::Error),

--- a/gix-discover/src/upwards/types.rs
+++ b/gix-discover/src/upwards/types.rs
@@ -2,7 +2,7 @@ use std::{env, ffi::OsStr, path::PathBuf};
 
 /// The error returned by [`gix_discover::upwards()`][crate::upwards()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not obtain the current working directory")]
     CurrentDir(#[from] std::io::Error),

--- a/gix-features/src/parallel/in_parallel.rs
+++ b/gix-features/src/parallel/in_parallel.rs
@@ -236,7 +236,7 @@ where
 
             // SAFETY: I is Send, and we only use the pointer for creating new
             // pointers (within the input slice) from the threads.
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             unsafe impl<I> Send for Input<I> where I: Send {}
 
             let threads: Vec<_> = (0..num_threads)
@@ -264,7 +264,7 @@ where
                                         // SAFETY: our atomic counter for `input_index` is only ever incremented, yielding
                                         //         each item exactly once.
                                         let item = {
-                                            #[allow(unsafe_code)]
+                                            #[expect(unsafe_code)]
                                             unsafe {
                                                 &mut *input.0.add(input_index)
                                             }

--- a/gix-features/src/parallel/serial.rs
+++ b/gix-features/src/parallel/serial.rs
@@ -22,7 +22,7 @@ mod not_parallel {
         ThreadBuilder
     }
 
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     unsafe impl Sync for Scope<'_, '_> {}
 
     impl ThreadBuilder {

--- a/gix-filter/src/driver/apply.rs
+++ b/gix-filter/src/driver/apply.rs
@@ -25,7 +25,7 @@ pub enum Delay {
 
 /// The error returned by [State::apply()][super::State::apply()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Init(#[from] driver::init::Error),

--- a/gix-filter/src/driver/delayed.rs
+++ b/gix-filter/src/driver/delayed.rs
@@ -11,7 +11,7 @@ pub mod list {
 
     /// The error returned by [State::list_delayed_paths()][super::State::list_delayed_paths()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not get process named '{}' which should be running and tracked", wanted.0)]
         ProcessMissing { wanted: driver::Key },
@@ -28,7 +28,7 @@ pub mod fetch {
 
     /// The error returned by [State::fetch_delayed()][super::State::fetch_delayed()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not get process named '{}' which should be running and tracked", wanted.0)]
         ProcessMissing { wanted: driver::Key },

--- a/gix-filter/src/driver/init.rs
+++ b/gix-filter/src/driver/init.rs
@@ -9,7 +9,7 @@ use crate::{
 
 /// The error returned by [State::maybe_launch_process()][super::State::maybe_launch_process()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Failed to spawn driver: {command:?}")]
     SpawnCommand {

--- a/gix-filter/src/driver/process/client.rs
+++ b/gix-filter/src/driver/process/client.rs
@@ -12,7 +12,7 @@ use crate::driver::{
 pub mod handshake {
     /// The error returned by [Client::handshake()][super::Client::handshake()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Failed to read or write to the process")]
         Io(#[from] std::io::Error),
@@ -27,7 +27,7 @@ pub mod handshake {
 pub mod invoke {
     /// The error returned by [Client::invoke()][super::Client::invoke()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Failed to read or write to the process")]
         Io(#[from] std::io::Error),
@@ -37,7 +37,7 @@ pub mod invoke {
     pub mod without_content {
         /// The error returned by [Client::invoke_without_content()][super::super::Client::invoke_without_content()].
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("Failed to read or write to the process")]
             Io(#[from] std::io::Error),

--- a/gix-filter/src/driver/process/server.rs
+++ b/gix-filter/src/driver/process/server.rs
@@ -20,7 +20,7 @@ pub mod next_request {
 
     /// The error returned by [Server::next_request()][super::Server::next_request()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Failed to read from the client")]
         Io(#[from] std::io::Error),
@@ -35,7 +35,7 @@ pub mod next_request {
 pub mod handshake {
     /// The error returned by [Server::handshake()][super::Server::handshake()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Failed to read or write to the client")]
         Io(#[from] std::io::Error),

--- a/gix-filter/src/eol/convert_to_git.rs
+++ b/gix-filter/src/eol/convert_to_git.rs
@@ -28,7 +28,7 @@ pub enum RoundTripCheck<'a> {
 
 /// The error returned by [convert_to_git()][super::convert_to_git()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("{msg} in '{}'", path.display())]
     RoundTrip { msg: &'static str, path: PathBuf },
@@ -117,7 +117,7 @@ pub(crate) mod function {
                             path: rela_path.to_owned(),
                         });
                     }
-                    #[allow(unused_variables)]
+                    #[allow(unused_variables, reason = "Used when tracing is enabled at compile time.")]
                     RoundTripCheck::Warn { rela_path } => {
                         gix_trace::warn!(
                             "in the working copy of '{}', CRLF will be replaced by LF next time git touches it",
@@ -134,7 +134,7 @@ pub(crate) mod function {
                             path: rela_path.to_owned(),
                         });
                     }
-                    #[allow(unused_variables)]
+                    #[allow(unused_variables, reason = "Used when tracing is enabled at compile time.")]
                     RoundTripCheck::Warn { rela_path } => {
                         gix_trace::warn!(
                             "in the working copy of '{}', LF will be replaced by CRLF next time git touches it",

--- a/gix-filter/src/eol/convert_to_worktree.rs
+++ b/gix-filter/src/eol/convert_to_worktree.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// The error produced by [`convert_to_worktree()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not allocate buffer")]
     OutOfMemory(#[from] std::collections::TryReserveError),

--- a/gix-filter/src/ident.rs
+++ b/gix-filter/src/ident.rs
@@ -44,7 +44,7 @@ pub fn undo(src: &[u8], buf: &mut Vec<u8>) -> Result<bool, std::collections::Try
 pub mod apply {
     /// The error produced by [`super::apply()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not allocate buffer")]
         OutOfMemory(#[from] std::collections::TryReserveError),

--- a/gix-filter/src/pipeline/convert.rs
+++ b/gix-filter/src/pipeline/convert.rs
@@ -10,7 +10,7 @@ pub mod configuration {
 
     /// Errors related to the configuration of filter attributes.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The encoding named '{name}' isn't available")]
         UnknownEncoding { name: BString },
@@ -26,7 +26,7 @@ pub mod to_git {
 
     /// The error returned by [Pipeline::convert_to_git()][super::Pipeline::convert_to_git()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Eol(#[from] crate::eol::convert_to_git::Error),
@@ -47,7 +47,7 @@ pub mod to_git {
 pub mod to_worktree {
     /// The error returned by [Pipeline::convert_to_worktree()][super::Pipeline::convert_to_worktree()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Ident(#[from] crate::ident::apply::Error),

--- a/gix-filter/src/worktree/encode_to_git.rs
+++ b/gix-filter/src/worktree/encode_to_git.rs
@@ -9,7 +9,7 @@ pub enum RoundTripCheck {
 
 /// The error returned by [`encode_to_git()][super::encode_to_git()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Cannot convert input of {input_len} bytes to UTF-8 without overflowing")]
     Overflow { input_len: usize },
@@ -64,7 +64,7 @@ pub(crate) mod function {
         match round_trip {
             RoundTripCheck::Fail => {
                 // SAFETY: we trust `encoding_rs` to output valid UTF-8 only if we ask it to.
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 let str = unsafe { std::str::from_utf8_unchecked(buf) };
                 let (should_equal_src, _actual_encoding, _had_errors) = src_encoding.encode(str);
                 if should_equal_src != src {

--- a/gix-filter/src/worktree/encode_to_worktree.rs
+++ b/gix-filter/src/worktree/encode_to_worktree.rs
@@ -1,6 +1,6 @@
 /// The error returned by [`encode_to_worktree()][super::encode_to_worktree()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Cannot convert input of {input_len} UTF-8 bytes to target encoding without overflowing")]
     Overflow { input_len: usize },

--- a/gix-filter/src/worktree/encoding.rs
+++ b/gix-filter/src/worktree/encoding.rs
@@ -7,7 +7,7 @@ pub mod for_label {
 
     /// The error returned by [for_label()][super::for_label()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("An encoding named '{name}' is not known")]
         Unknown { name: BString },

--- a/gix-filter/tests/filter/eol/convert_to_git.rs
+++ b/gix-filter/tests/filter/eol/convert_to_git.rs
@@ -164,12 +164,10 @@ fn round_trip_check() -> crate::Result {
     Ok(())
 }
 
-#[allow(clippy::ptr_arg)]
 fn no_call(_buf: &mut Vec<u8>) -> Result<Option<()>, Box<dyn std::error::Error + Send + Sync>> {
     unreachable!("index function will not be called")
 }
 
-#[allow(clippy::ptr_arg)]
 fn no_object_in_index(_buf: &mut Vec<u8>) -> Result<Option<()>, Box<dyn std::error::Error + Send + Sync>> {
     Ok(None)
 }

--- a/gix-filter/tests/filter/pipeline/convert_to_git.rs
+++ b/gix-filter/tests/filter/pipeline/convert_to_git.rs
@@ -145,12 +145,10 @@ fn no_filter_means_reader_is_returned_unchanged() -> gix_testtools::Result {
     Ok(())
 }
 
-#[allow(clippy::ptr_arg)]
 fn no_call(_buf: &mut Vec<u8>) -> Result<Option<()>, Box<dyn std::error::Error + Send + Sync>> {
     unreachable!("index function will not be called")
 }
 
-#[allow(clippy::ptr_arg)]
 fn no_object_in_index(_buf: &mut Vec<u8>) -> Result<Option<()>, Box<dyn std::error::Error + Send + Sync>> {
     Ok(None)
 }

--- a/gix-fs/src/dir/create.rs
+++ b/gix-fs/src/dir/create.rs
@@ -31,7 +31,7 @@ mod error {
     use crate::dir::create::Retries;
 
     /// The error returned by [all()][super::all()].
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[derive(Debug)]
     pub enum Error<'a> {
         /// A failure we will probably recover from by trying again.

--- a/gix-fs/src/stack.rs
+++ b/gix-fs/src/stack.rs
@@ -13,7 +13,7 @@ pub mod to_normal_path_components {
 
     /// The error used in [`ToNormalPathComponents::to_normal_path_components()`](super::ToNormalPathComponents::to_normal_path_components()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Input path \"{path}\" contains relative or absolute components", path = .0.display())]
         NotANormalComponent(PathBuf),

--- a/gix-hash/src/hasher.rs
+++ b/gix-hash/src/hasher.rs
@@ -1,6 +1,6 @@
 /// The error returned by [`Hasher::try_finalize()`](crate::Hasher::try_finalize()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Detected SHA-1 collision attack with digest {digest}")]
     CollisionAttack { digest: crate::ObjectId },
@@ -75,7 +75,7 @@ pub(super) mod _impl {
                         //
                         // As of Rust 1.84.1, the compiler can’t figure out
                         // this function cannot panic without this.
-                        #[allow(unsafe_code)]
+                        #[expect(unsafe_code)]
                         unsafe {
                             std::hint::unreachable_unchecked()
                         }

--- a/gix-hash/src/io.rs
+++ b/gix-hash/src/io.rs
@@ -2,7 +2,7 @@ use crate::hasher;
 
 /// The error type for I/O operations that compute hashes.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/gix-hash/src/object_id.rs
+++ b/gix-hash/src/object_id.rs
@@ -31,14 +31,13 @@ pub enum ObjectId {
 // extremely unlikely to begin with so it doesn't matter.
 // This implementation matches the `Hash` implementation for `oid`
 // and allows the usage of custom Hashers that only copy a truncated ShaHash
-#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for ObjectId {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write(self.as_slice());
     }
 }
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod decode {
     use std::str::FromStr;
 
@@ -52,7 +51,7 @@ pub mod decode {
 
     /// An error returned by [`ObjectId::from_hex()`][crate::ObjectId::from_hex()]
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("A hash sized {0} hexadecimal characters is invalid")]
         InvalidHexEncodingLength(usize),

--- a/gix-hash/src/oid.rs
+++ b/gix-hash/src/oid.rs
@@ -22,7 +22,7 @@ use crate::{EMPTY_BLOB_SHA256, EMPTY_TREE_SHA256, SIZE_OF_SHA256_DIGEST};
 /// than 64 bytes.
 #[derive(PartialEq, Eq, Ord, PartialOrd)]
 #[repr(transparent)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types, reason = "the name mirrors 'str'")]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct oid {
     bytes: [u8],
@@ -33,7 +33,6 @@ pub struct oid {
 // it attempting to hash the length of the slice first. On 32 bit systems
 // this can lead to issues with the custom `gix_hashtable` `Hasher` implementation,
 // and it currently ends up being discarded there anyway.
-#[allow(clippy::derived_hash_with_manual_eq)]
 impl hash::Hash for oid {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         state.write(self.as_bytes());
@@ -73,7 +72,7 @@ impl std::fmt::Debug for oid {
 }
 
 /// The error returned when trying to convert a byte slice to an [`oid`] or [`ObjectId`]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Cannot instantiate git hash from a digest of length {0}")]
@@ -88,14 +87,14 @@ impl oid {
         match digest.len() {
             #[cfg(feature = "sha1")]
             SIZE_OF_SHA1_DIGEST => Ok(
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 unsafe {
                     &*(std::ptr::from_ref::<[u8]>(digest) as *const oid)
                 },
             ),
             #[cfg(feature = "sha256")]
             SIZE_OF_SHA256_DIGEST => Ok(
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 unsafe {
                     &*(std::ptr::from_ref::<[u8]>(digest) as *const oid)
                 },
@@ -112,7 +111,7 @@ impl oid {
 
     /// Only from code that statically assures correct sizes using array conversions.
     pub(crate) fn from_bytes(value: &[u8]) -> &Self {
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             &*(std::ptr::from_ref::<[u8]>(value) as *const oid)
         }

--- a/gix-hash/src/prefix.rs
+++ b/gix-hash/src/prefix.rs
@@ -4,7 +4,7 @@ use crate::{ObjectId, Prefix, oid};
 
 /// The error returned by [`Prefix::new()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(
         "The minimum hex length of a short object id is {}, got {hex_len}",
@@ -19,7 +19,7 @@ pub enum Error {
 pub mod from_hex {
     /// The error returned by [`Prefix::from_hex`][super::Prefix::from_hex()].
     #[derive(Debug, Eq, PartialEq, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(
             "The minimum hex length of a short object id is {}, got {hex_len}",

--- a/gix-hash/src/verify.rs
+++ b/gix-hash/src/verify.rs
@@ -2,7 +2,7 @@ use crate::{ObjectId, oid};
 
 /// The error returned by [`oid::verify()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[error("Hash was {actual}, but should have been {expected}")]
 pub struct Error {
     pub actual: ObjectId,

--- a/gix-imara-diff/src/histogram/list_pool.rs
+++ b/gix-imara-diff/src/histogram/list_pool.rs
@@ -198,7 +198,6 @@ impl ListPool {
 
 impl ListHandle {
     /// Get the number of elements in the list.
-    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self, pool: &ListPool) -> u32 {
         if self.generation == pool.generation {
             self.len

--- a/gix-index/src/access/mod.rs
+++ b/gix-index/src/access/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 // TODO: integrate this somehow, somewhere, depending on later usage.
-#[allow(dead_code)]
+#[expect(dead_code, reason = "to be used for when we handle checkouts/resets better")]
 mod sparse;
 
 /// General information and entries

--- a/gix-index/src/decode/header.rs
+++ b/gix-index/src/decode/header.rs
@@ -8,7 +8,7 @@ mod error {
 
     /// The error produced when failing to decode an index header.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("{0}")]
         Corrupt(&'static str),

--- a/gix-index/src/decode/mod.rs
+++ b/gix-index/src/decode/mod.rs
@@ -12,7 +12,7 @@ mod error {
 
     /// The error returned by [`State::from_bytes()`][crate::State::from_bytes()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Header(#[from] decode::header::Error),

--- a/gix-index/src/extension/decode.rs
+++ b/gix-index/src/extension/decode.rs
@@ -11,7 +11,7 @@ mod error {
 
     /// The error returned when decoding extensions.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(
             "Encountered mandatory extension '{}' which isn't implemented yet",

--- a/gix-index/src/extension/fs_monitor.rs
+++ b/gix-index/src/extension/fs_monitor.rs
@@ -6,7 +6,10 @@ use crate::{
 };
 
 #[derive(Clone)]
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "for the time when we actually support the git status daemon, this just models its data."
+)]
 pub enum Token {
     V1 { nanos_since_1970: u64 },
     V2 { token: BString },

--- a/gix-index/src/extension/link.rs
+++ b/gix-index/src/extension/link.rs
@@ -17,7 +17,7 @@ pub mod decode {
 
     /// The error returned when decoding link extensions.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("{0}")]
         Corrupt(&'static str),

--- a/gix-index/src/extension/mod.rs
+++ b/gix-index/src/extension/mod.rs
@@ -44,7 +44,6 @@ pub struct Link {
 }
 
 /// The extension for untracked files.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct UntrackedCache {
     /// Something identifying the location and machine that this cache is for.
@@ -63,7 +62,10 @@ pub struct UntrackedCache {
 }
 
 /// The extension for keeping state on recent information provided by the filesystem monitor.
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "for the time when we know what to do with it, for now we just ser-de it"
+)]
 #[derive(Clone)]
 pub struct FsMonitor {
     token: fs_monitor::Token,

--- a/gix-index/src/extension/resolve_undo.rs
+++ b/gix-index/src/extension/resolve_undo.rs
@@ -5,7 +5,10 @@ use crate::{extension::Signature, util::split_at_byte_exclusive};
 
 pub type Paths = Vec<ResolvePath>;
 
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "REUC is decoded but not yet exposed or written; retain its fields for planned round-trip support"
+)]
 #[derive(Clone)]
 pub struct ResolvePath {
     /// relative to the root of the repository, or what would be stored in the index
@@ -15,7 +18,10 @@ pub struct ResolvePath {
     stages: [Option<Stage>; 3],
 }
 
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "REUC is decoded but not yet exposed or written; retain its fields for planned round-trip support"
+)]
 #[derive(Clone, Copy)]
 pub struct Stage {
     mode: u32,

--- a/gix-index/src/extension/tree/verify.rs
+++ b/gix-index/src/extension/tree/verify.rs
@@ -7,7 +7,7 @@ use crate::extension::Tree;
 
 /// The error returned by [`Tree::verify()`][crate::extension::Tree::verify()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(
         "The entry {entry_id} at path '{name}' in parent tree {parent_id} wasn't found in the nodes children, making it incomplete"
@@ -100,7 +100,6 @@ impl Tree {
             }
             for child in children {
                 // This is actually needed here as it's a mut ref, which isn't copy. We do a re-borrow here.
-                #[allow(clippy::needless_option_as_deref)]
                 let actual_num_entries =
                     verify_recursive(child.id, &child.children, object_buf.as_deref_mut(), objects)?;
                 if let Some((actual, num_entries)) = actual_num_entries.zip(child.num_entries) {

--- a/gix-index/src/file/init.rs
+++ b/gix-index/src/file/init.rs
@@ -8,7 +8,7 @@ mod error {
 
     /// The error returned by [File::at()][super::File::at()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("An IO error occurred while opening the index")]
         Io(#[from] std::io::Error),
@@ -61,7 +61,7 @@ impl File {
         let (data, mtime) = {
             let mut file = std::fs::File::open(&path)?;
             // SAFETY: we have to take the risk of somebody changing the file underneath. Git never writes into the same file.
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             let data = unsafe { memmap2::MmapOptions::new().map_copy_read_only(&file)? };
 
             if !skip_hash {

--- a/gix-index/src/file/verify.rs
+++ b/gix-index/src/file/verify.rs
@@ -5,7 +5,7 @@ use crate::File;
 mod error {
     /// The error returned by [File::verify_integrity()][super::File::verify_integrity()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not read index file to generate hash")]
         Io(#[from] gix_hash::io::Error),

--- a/gix-index/src/file/write.rs
+++ b/gix-index/src/file/write.rs
@@ -2,7 +2,7 @@ use crate::{File, Version, write};
 
 /// The error produced by [`File::write()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Io(#[from] gix_hash::io::Error),

--- a/gix-index/src/fs.rs
+++ b/gix-index/src/fs.rs
@@ -38,7 +38,10 @@ impl Metadata {
 }
 
 /// Access
-#[allow(clippy::len_without_is_empty)]
+#[expect(
+    clippy::len_without_is_empty,
+    reason = "emptiness is either impossible or not meaningful for this type"
+)]
 impl Metadata {
     /// Return true if the metadata belongs to a directory
     pub fn is_dir(&self) -> bool {

--- a/gix-index/src/init.rs
+++ b/gix-index/src/init.rs
@@ -13,7 +13,7 @@ pub mod from_tree {
 
     /// The error returned by [State::from_tree()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The path \"{path}\" is invalid")]
         InvalidComponent {

--- a/gix-index/src/verify.rs
+++ b/gix-index/src/verify.rs
@@ -8,7 +8,7 @@ pub mod entries {
 
     /// The error returned by [`State::verify_entries()`][crate::State::verify_entries()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(
             "Entry '{current_path}' (stage = {current_stage}) at index {current_index} should order after prior entry '{previous_path}' (stage = {previous_stage})"
@@ -29,7 +29,7 @@ pub mod extensions {
 
     /// The error returned by [`State::verify_extensions()`][crate::State::verify_extensions()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Tree(#[from] extension::tree::verify::Error),

--- a/gix-lock/src/acquire.rs
+++ b/gix-lock/src/acquire.rs
@@ -42,7 +42,7 @@ impl From<Duration> for Fail {
 
 /// The error returned when acquiring a [`File`] or [`Marker`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Another IO error occurred while obtaining the lock")]
     Io(#[from] std::io::Error),

--- a/gix-macros/tests/momo/mod.rs
+++ b/gix-macros/tests/momo/mod.rs
@@ -4,13 +4,12 @@ use gix_macros::momo;
 
 struct Options;
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 fn test_open_opts_inner(_dir: impl Into<std::path::PathBuf>, _options: Options) -> Result<(), ()> {
     Ok(())
 }
 
 /// See if doc are kept
-#[allow(dead_code)]
 #[momo]
 fn test_open_opts(directory: impl Into<std::path::PathBuf>, options: Options) -> Result<(), ()> {
     test_open_opts_inner(directory, options)
@@ -81,7 +80,7 @@ impl TestStruct {
         Ok(s)
     }
 
-    #[allow(clippy::needless_arbitrary_self_type)]
+    #[expect(clippy::needless_arbitrary_self_type)]
     #[momo]
     fn test_method2<E>(
         self: Self,
@@ -150,7 +149,6 @@ impl TestStruct {
         Ok(s)
     }
 
-    #[allow(unused)]
     #[momo]
     fn test_fn_ret<E>(
         _this: Pin<&mut Self>,
@@ -181,7 +179,6 @@ impl TryInto<String> for S {
     }
 }
 
-#[allow(unused)]
 #[momo]
 fn test_fn_pat<E>(
     a: impl Into<String>,

--- a/gix-merge/src/blob/builtin_driver/text/function.rs
+++ b/gix-merge/src/blob/builtin_driver/text/function.rs
@@ -243,7 +243,6 @@ impl<'input, 'data> Merge<'input, 'data> {
 ///
 /// *The caller* is responsible for clearing `input`, otherwise tokens will accumulate.
 /// This idea is to save time if the input is known to be very similar.
-#[allow(clippy::too_many_arguments)]
 pub fn merge<'a>(
     out: &mut Vec<u8>,
     input: &mut imara_diff::InternedInput<&'a [u8]>,

--- a/gix-merge/src/blob/pipeline.rs
+++ b/gix-merge/src/blob/pipeline.rs
@@ -119,7 +119,7 @@ pub mod convert_to_mergeable {
 
     /// The error returned by [Pipeline::convert_to_mergeable()](super::Pipeline::convert_to_mergeable()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Entry at '{rela_path}' must be regular file or symlink, but was {actual:?}")]
         InvalidEntryKind { rela_path: BString, actual: EntryKind },
@@ -161,7 +161,7 @@ impl Pipeline {
     /// Only blobs are allowed.
     ///
     /// Use `convert` to control what kind of the resource will be produced.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn convert_to_mergeable(
         &mut self,
         id: &gix_hash::oid,

--- a/gix-merge/src/blob/platform/merge.rs
+++ b/gix-merge/src/blob/platform/merge.rs
@@ -17,7 +17,7 @@ pub struct Options {
 
 /// The error returned by [`PlatformRef::merge()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     PrepareExternalDriver(#[from] inner::prepare_external_driver::Error),
@@ -38,7 +38,10 @@ pub enum Error {
 /// but `stdin` closed.
 /// It's expected to leave its result in the file substituted at `current` which is then supposed to be read back from there.
 // TODO: remove dead-code annotation
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "the tempfile handles are retained for RAII cleanup while the external merge command runs"
+)]
 pub struct Command {
     /// The pre-configured command
     cmd: std::process::Command,
@@ -74,7 +77,7 @@ pub(super) mod inner {
 
         /// The error returned by [PlatformRef::prepare_external_driver()](PlatformRef::prepare_external_driver()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("The resource of kind {kind:?} was too large to be processed")]
             ResourceTooLarge { kind: ResourceKind },
@@ -342,11 +345,15 @@ pub(super) mod inner {
                         (Pick::Buffer, resolution)
                     }
                     BuiltinDriver::Binary => {
-                        // easier to reason about the 'split' compared to merging both conditions
-                        #[allow(clippy::if_same_then_else)]
-                        if !(self.current.id.is_null() || self.other.id.is_null()) && self.current.id == self.other.id {
-                            (Pick::Ours, Resolution::Complete)
-                        } else if (self.current.id.is_null() || self.other.id.is_null()) && ours == theirs {
+                        // Object IDs are authoritative when both resources have one. A null ID means the resource isn't
+                        // backed by an object, so compare its prepared data.
+                        let ours_matches_theirs = if self.current.id.is_null() || self.other.id.is_null() {
+                            ours == theirs
+                        } else {
+                            self.current.id == self.other.id
+                        };
+
+                        if ours_matches_theirs {
                             (Pick::Ours, Resolution::Complete)
                         } else {
                             let (pick, resolution) = builtin_driver::binary(self.options.resolve_binary_with);
@@ -438,7 +445,11 @@ impl<'parent> PlatformRef<'parent> {
     /// Using a `pick` obtained from [`merge()`](Self::merge), obtain the respective buffer suitable for reading or copying.
     /// Return `Ok(None)`  if the `pick` corresponds to a buffer (that was written separately).
     /// Return `Err(())` if the buffer is *too large*, so it was never read.
-    #[allow(clippy::result_unit_err)]
+    #[expect(
+        clippy::result_unit_err,
+        // TODO: make this nicer once we have nicer errors. OOM should be a standard error anyway.
+        reason = "Err(()) is needed to encode 'too large', without need for anything specific"
+    )]
     pub fn buffer_by_pick(&self, pick: inner::builtin_merge::Pick) -> Result<Option<&'parent [u8]>, ()> {
         match pick {
             inner::builtin_merge::Pick::Ancestor => self.ancestor.data.as_slice().map(Some).ok_or(()),

--- a/gix-merge/src/blob/platform/prepare_merge.rs
+++ b/gix-merge/src/blob/platform/prepare_merge.rs
@@ -11,7 +11,7 @@ use crate::blob::{
 
 /// The error returned by [Platform::prepare_merge_state()](Platform::prepare_merge()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("The 'current', 'ancestor' or 'other' resource for the merge operation were not set")]
     UnsetResource,

--- a/gix-merge/src/blob/platform/set_resource.rs
+++ b/gix-merge/src/blob/platform/set_resource.rs
@@ -4,7 +4,7 @@ use crate::blob::{Platform, ResourceKind, pipeline, platform::Resource};
 
 /// The error returned by [Platform::set_resource](Platform::set_resource).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Can only diff blobs, not {mode:?}")]
     InvalidMode { mode: gix_object::tree::EntryKind },

--- a/gix-merge/src/commit/function.rs
+++ b/gix-merge/src/commit/function.rs
@@ -41,7 +41,7 @@ use crate::{
 /// * It's known that certain conflicts around symbolic links can be auto-resolved. We don't have an option for this
 ///   at all, yet, primarily as Git seems to not implement the *ours*/*theirs* choice in other places even though it
 ///   reasonably could. So we leave it to the caller to continue processing the returned tree at will.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn commit<'objects>(
     our_commit: gix_hash::ObjectId,
     their_commit: gix_hash::ObjectId,

--- a/gix-merge/src/commit/mod.rs
+++ b/gix-merge/src/commit/mod.rs
@@ -1,6 +1,6 @@
 /// The error returned by [`commit()`](crate::commit()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Failed to obtain the merge base between the two commits to be merged")]
     MergeBase(#[from] gix_revision::merge_base::Error),

--- a/gix-merge/src/commit/virtual_merge_base.rs
+++ b/gix-merge/src/commit/virtual_merge_base.rs
@@ -13,7 +13,7 @@ pub struct Outcome {
 
 /// The error returned by [`commit::merge_base()`](crate::commit::virtual_merge_base()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     MergeTree(#[from] crate::tree::Error),
@@ -45,7 +45,7 @@ pub(super) mod function {
     /// The parameters `graph`, `diff_resource_cache`, `blob_merge`, `objects`, `abbreviate_hash` and `options` are passed
     /// directly to [`tree()`](crate::tree()) for merging the trees of two merge-bases at a time.
     /// Note that most of `options` are overwritten to match the requirements of a merge-base merge.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn virtual_merge_base<'objects>(
         first_commit: gix_hash::ObjectId,
         second_commit: gix_hash::ObjectId,

--- a/gix-merge/src/tree/function.rs
+++ b/gix-merge/src/tree/function.rs
@@ -54,7 +54,7 @@ use crate::tree::{
 /// ### Performance
 ///
 /// Note that `objects` *should* have an object cache to greatly accelerate tree-retrieval.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn tree<'objects, E>(
     base_tree: &gix_hash::oid,
     our_tree: &gix_hash::oid,

--- a/gix-merge/src/tree/mod.rs
+++ b/gix-merge/src/tree/mod.rs
@@ -3,7 +3,7 @@ use gix_diff::{Rewrites, tree_with_rewrites::Change};
 
 /// The error returned by [`tree()`](crate::tree()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not find ancestor, our or their tree to get started")]
     FindTree(#[from] gix_object::find::existing_object::Error),

--- a/gix-merge/src/tree/utils.rs
+++ b/gix-merge/src/tree/utils.rs
@@ -89,7 +89,7 @@ pub fn unique_path_in_tree(
 }
 
 /// Perform a merge between two blobs and return the result of its object id.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn perform_blob_merge<E>(
     mut labels: crate::blob::builtin_driver::text::Labels<'_>,
     objects: &impl gix_object::FindObjectOrHeader,

--- a/gix-merge/tests/merge/tree/baseline.rs
+++ b/gix-merge/tests/merge/tree/baseline.rs
@@ -48,7 +48,7 @@ pub enum ConflictKind {
 
 /// More loosely structured information about the `Conflict`.
 #[derive(Debug)]
-#[allow(dead_code)] // used only for debugging
+#[expect(dead_code, reason = "used only for debugging")]
 pub struct ConflictInfo {
     /// All the paths involved in the informational message
     pub paths: Vec<String>,

--- a/gix-object/src/commit/ref_iter.rs
+++ b/gix-object/src/commit/ref_iter.rs
@@ -312,7 +312,7 @@ struct RawToken<'a> {
 }
 
 /// A token returned by the [commit iterator][CommitRefIter].
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 pub enum Token<'a> {
     Tree {

--- a/gix-object/src/data.rs
+++ b/gix-object/src/data.rs
@@ -57,7 +57,7 @@ impl<'a> Data<'a> {
 pub mod verify {
     /// Returned by [`crate::Data::verify_checksum()`]
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Failed to hash object")]
         Hasher(#[from] gix_hash::hasher::Error),

--- a/gix-object/src/encode.rs
+++ b/gix-object/src/encode.rs
@@ -5,7 +5,7 @@ use bstr::{BString, ByteSlice};
 
 /// An error returned when object encoding fails.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Newlines are not allowed in header values: {value:?}")]
     NewlineInHeaderValue { value: BString },

--- a/gix-object/src/find.rs
+++ b/gix-object/src/find.rs
@@ -6,7 +6,7 @@ pub mod existing {
 
     /// The error returned by the [`find(…)`][crate::FindExt::find()] trait methods.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Find(crate::find::Error),
@@ -21,7 +21,7 @@ pub mod existing_object {
 
     /// The error returned by the various [`find_*()`][crate::FindExt::find_commit()] trait methods.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Find(crate::find::Error),
@@ -47,7 +47,7 @@ pub mod existing_iter {
 
     /// The error returned by the various [`find_*_iter()`][crate::FindExt::find_commit_iter()] trait methods.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Find(crate::find::Error),

--- a/gix-object/src/kind.rs
+++ b/gix-object/src/kind.rs
@@ -4,7 +4,7 @@ use crate::Kind;
 
 /// The Error used in [`Kind::from_bytes()`].
 #[derive(Debug, Clone, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Unknown object kind: {kind:?}")]
     InvalidObjectKind { kind: bstr::BString },

--- a/gix-object/src/lib.rs
+++ b/gix-object/src/lib.rs
@@ -79,7 +79,7 @@ pub mod kind;
 /// The four types of objects that git differentiates.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Kind {
     Tree,
     Blob,
@@ -225,7 +225,7 @@ pub struct Tag {
 /// An `ObjectRef` is representing [`Trees`](TreeRef), [`Blobs`](BlobRef), [`Commits`](CommitRef), or [`Tags`](TagRef).
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum ObjectRef<'a> {
     #[cfg_attr(feature = "serde", serde(borrow))]
     Tree(TreeRef<'a>),
@@ -244,7 +244,7 @@ pub enum ObjectRef<'a> {
 /// An `Object` is representing [`Trees`](Tree), [`Blobs`](Blob), [`Commits`](Commit), or [`Tags`](Tag).
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[allow(clippy::large_enum_variant, missing_docs)]
+#[expect(missing_docs)]
 pub enum Object {
     Tree(Tree),
     Blob(Blob),
@@ -332,7 +332,7 @@ pub mod decode {
 
     /// Returned by [`loose_header()`]
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum LooseHeaderDecodeError {
         #[error("{message}: {number:?}")]
         ParseIntegerError {

--- a/gix-object/src/object/mod.rs
+++ b/gix-object/src/object/mod.rs
@@ -95,7 +95,10 @@ impl Object {
         }
     }
     /// Turns this instance into a [`Blob`] if it is one.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     pub fn try_into_blob(self) -> Result<Blob, Self> {
         match self {
             Object::Blob(v) => Ok(v),
@@ -110,7 +113,10 @@ impl Object {
         }
     }
     /// Turns this instance into a [`Commit`] if it is one.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     pub fn try_into_commit(self) -> Result<Commit, Self> {
         match self {
             Object::Commit(v) => Ok(v),
@@ -118,7 +124,10 @@ impl Object {
         }
     }
     /// Turns this instance into a [`Tree`] if it is one.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     pub fn try_into_tree(self) -> Result<Tree, Self> {
         match self {
             Object::Tree(v) => Ok(v),
@@ -126,7 +135,10 @@ impl Object {
         }
     }
     /// Turns this instance into a [`Tag`] if it is one.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     pub fn try_into_tag(self) -> Result<Tag, Self> {
         match self {
             Object::Tag(v) => Ok(v),
@@ -179,7 +191,6 @@ use crate::{
 };
 
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
 pub enum LooseDecodeError {
     #[error(transparent)]
     InvalidHeader(#[from] LooseHeaderDecodeError),

--- a/gix-object/src/tag/ref_iter.rs
+++ b/gix-object/src/tag/ref_iter.rs
@@ -127,7 +127,7 @@ impl<'a> Iterator for TagRefIter<'a> {
 }
 
 /// A token returned by the [tag iterator][TagRefIter].
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 pub enum Token<'a> {
     Target {

--- a/gix-object/src/tag/write.rs
+++ b/gix-object/src/tag/write.rs
@@ -7,7 +7,7 @@ use crate::{Kind, Tag, TagRef, encode, encode::NL};
 
 /// An Error used in [`Tag::write_to()`][crate::WriteTo::write_to()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Tags must not start with a dash: '-'")]
     StartsWithDash,

--- a/gix-object/src/tree/editor.rs
+++ b/gix-object/src/tree/editor.rs
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Editor<'_> {
 
 /// The error returned by [Editor] or [Cursor] edit operation.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Empty path components are not allowed")]
     EmptyPathComponent,

--- a/gix-object/src/tree/write.rs
+++ b/gix-object/src/tree/write.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// The Error used in [`Tree::write_to()`][crate::WriteTo::write_to()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Nullbytes are invalid in file paths as they are separators: {name:?}")]
     NullbyteInFilename { name: BString },

--- a/gix-odb/src/alternate/mod.rs
+++ b/gix-odb/src/alternate/mod.rs
@@ -25,7 +25,7 @@ pub mod parse;
 
 /// Returned by [`resolve()`]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Io(#[from] io::Error),

--- a/gix-odb/src/alternate/parse.rs
+++ b/gix-odb/src/alternate/parse.rs
@@ -4,7 +4,7 @@ use gix_object::bstr::ByteSlice;
 
 /// Returned as part of [`crate::alternate::Error::Parse`]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not obtain an object path for the alternate directory '{}'", String::from_utf8_lossy(.0))]
     PathConversion(Vec<u8>),

--- a/gix-odb/src/store_impls/dynamic/find.rs
+++ b/gix-odb/src/store_impls/dynamic/find.rs
@@ -9,7 +9,7 @@ pub(crate) mod error {
 
     /// Returned by [`Handle::try_find()`][gix_pack::Find::try_find()]
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("An error occurred while obtaining an object from the loose object store")]
         Loose(#[from] loose::find::Error),

--- a/gix-odb/src/store_impls/dynamic/load_index.rs
+++ b/gix-odb/src/store_impls/dynamic/load_index.rs
@@ -28,7 +28,7 @@ mod error {
 
     /// Returned by [`crate::at_opts()`]
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The objects directory at '{0}' is not an accessible directory")]
         Inaccessible(PathBuf),
@@ -552,7 +552,6 @@ impl super::Store {
     }
 
     /// returns `Ok(dest_slot_was_empty)` if the copy could happen because dest-slot was actually free or disposable.
-    #[allow(clippy::too_many_arguments)]
     fn try_set_index_slot(
         lock: &parking_lot::MutexGuard<'_, ()>,
         dest_slot: &MutableIndexAndPack,
@@ -763,10 +762,9 @@ impl PartialEq<Self> for Either {
     }
 }
 
-#[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd<Self> for Either {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.path().cmp(other.path()))
+        Some(self.cmp(other))
     }
 }
 

--- a/gix-odb/src/store_impls/dynamic/prefix.rs
+++ b/gix-odb/src/store_impls/dynamic/prefix.rs
@@ -10,7 +10,7 @@ pub mod lookup {
 
     /// Returned by [`Handle::lookup_prefix()`][crate::store::Handle::lookup_prefix()]
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("An error occurred looking up a prefix which requires iteration")]
         LooseWalkDir(#[from] loose::iter::Error),
@@ -64,7 +64,7 @@ pub mod disambiguate {
 
     /// Returned by [`Handle::disambiguate_prefix()`][crate::store::Handle::disambiguate_prefix()]
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("An error occurred while trying to determine if a full hash contained in the object database")]
         Contains(#[from] crate::store::find::Error),
@@ -148,7 +148,7 @@ where
         loop {
             let snapshot = self.snapshot.borrow();
             for index in &snapshot.indices {
-                #[allow(clippy::needless_option_as_deref)] // needed as it's the equivalent of a reborrow.
+                // needed as it's the equivalent of a reborrow.
                 let lookup_result = index.lookup_prefix(prefix, candidates.as_deref_mut());
                 if candidates.is_none() && !check_candidate(lookup_result, &mut candidate) {
                     return Ok(Some(Err(())));
@@ -156,7 +156,7 @@ where
             }
 
             for lodb in snapshot.loose_dbs.iter() {
-                #[allow(clippy::needless_option_as_deref)] // needed as it's the equivalent of a reborrow.
+                // needed as it's the equivalent of a reborrow.
                 let lookup_result = lodb.lookup_prefix(prefix, candidates.as_deref_mut())?;
                 if candidates.is_none() && !check_candidate(lookup_result, &mut candidate) {
                     return Ok(Some(Err(())));

--- a/gix-odb/src/store_impls/dynamic/verify.rs
+++ b/gix-odb/src/store_impls/dynamic/verify.rs
@@ -23,7 +23,7 @@ pub mod integrity {
 
     /// Returned by [`Store::verify_integrity()`][crate::Store::verify_integrity()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         MultiIndexIntegrity(#[from] pack::index::traverse::Error<pack::multi_index::verify::integrity::Error>),
@@ -56,7 +56,7 @@ pub mod integrity {
     #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Clone)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     /// Traversal statistics of packs governed by single indices or multi-pack indices.
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum SingleOrMultiStatistics {
         Single(pack::index::traverse::Statistics),
         Multi(Vec<(PathBuf, pack::index::traverse::Statistics)>),

--- a/gix-odb/src/store_impls/dynamic/write.rs
+++ b/gix-odb/src/store_impls/dynamic/write.rs
@@ -10,7 +10,7 @@ mod error {
 
     /// The error returned by the [dynamic Store's][crate::Store] [`Write`](gix_object::Write) implementation.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         LoadIndex(#[from] store::load_index::Error),

--- a/gix-odb/src/store_impls/loose/find.rs
+++ b/gix-odb/src/store_impls/loose/find.rs
@@ -4,7 +4,7 @@ use crate::store_impls::loose::{HEADER_MAX_SIZE, Store, hash_path};
 
 /// Returned by [`Store::try_find()`]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("decompression of loose object at '{path}' failed")]
     DecompressFile {
@@ -257,7 +257,7 @@ mod mmap {
     pub fn read_only(path: &Path) -> std::io::Result<memmap2::Mmap> {
         let file = std::fs::File::open(path)?;
         // SAFETY: we have to take the risk of somebody changing the file underneath. Git never writes into the same file.
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             memmap2::MmapOptions::new().map_copy_read_only(&file)
         }

--- a/gix-odb/src/store_impls/loose/verify.rs
+++ b/gix-odb/src/store_impls/loose/verify.rs
@@ -11,7 +11,7 @@ use crate::loose::Store;
 pub mod integrity {
     /// The error returned by [`verify_integrity()`][super::Store::verify_integrity()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("{kind} object {id} could not be decoded")]
         ObjectDecode {

--- a/gix-odb/src/store_impls/loose/write.rs
+++ b/gix-odb/src/store_impls/loose/write.rs
@@ -9,7 +9,7 @@ use crate::store_impls::loose;
 
 /// Returned by the [`gix_object::Write`] trait implementation of [`Store`]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not {message} '{path}'")]
     Io {

--- a/gix-odb/tests/odb/store/dynamic.rs
+++ b/gix-odb/tests/odb/store/dynamic.rs
@@ -445,7 +445,6 @@ fn contains() {
 
     // pack, the smallest one
     // The new handle should make no difference.
-    #[allow(clippy::redundant_clone)]
     let mut new_handle = handle.clone();
     assert!(new_handle.exists(&hex_to_id("501b297447a8255d3533c6858bb692575cdefaa0")));
     assert_eq!(

--- a/gix-pack/src/bundle/init.rs
+++ b/gix-pack/src/bundle/init.rs
@@ -4,7 +4,7 @@ use crate::Bundle;
 
 /// Returned by [`Bundle::at()`]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("An 'idx' extension is expected of an index file: '{0}'")]
     InvalidPath(PathBuf),

--- a/gix-pack/src/bundle/write/error.rs
+++ b/gix-pack/src/bundle/write/error.rs
@@ -4,7 +4,7 @@ use gix_tempfile::handle::Writable;
 
 /// The error returned by [`Bundle::write_to_directory()`][crate::Bundle::write_to_directory()]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("An IO error occurred when reading the pack or creating a temporary file")]
     Io(#[from] io::Error),

--- a/gix-pack/src/bundle/write/mod.rs
+++ b/gix-pack/src/bundle/write/mod.rs
@@ -371,7 +371,7 @@ fn resolve_entry(range: data::EntryRange, mapped_file: &memmap2::Mmap) -> Option
     mapped_file.get(range.start as usize..range.end as usize)
 }
 
-#[allow(clippy::type_complexity)] // cannot typedef impl Fn
+#[expect(clippy::type_complexity)] // cannot typedef impl Fn
 fn new_pack_file_resolver(
     data_file: SharedTempFile,
 ) -> io::Result<(

--- a/gix-pack/src/cache/delta/from_offsets.rs
+++ b/gix-pack/src/cache/delta/from_offsets.rs
@@ -11,7 +11,6 @@ use crate::{cache::delta::Tree, data};
 
 /// Returned by [`Tree::from_offsets_in_pack()`]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
 pub enum Error {
     #[error("{message}")]
     Io { source: io::Error, message: &'static str },

--- a/gix-pack/src/cache/delta/mod.rs
+++ b/gix-pack/src/cache/delta/mod.rs
@@ -1,6 +1,5 @@
 /// Returned when using various methods on a [`Tree`]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
 pub enum Error {
     #[error(
         "Pack offsets must only increment. The previous pack offset was {last_pack_offset}, the current one is {pack_offset}"

--- a/gix-pack/src/cache/delta/traverse/mod.rs
+++ b/gix-pack/src/cache/delta/traverse/mod.rs
@@ -20,7 +20,6 @@ pub(crate) mod util;
 
 /// Returned by [`Tree::traverse()`]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
 pub enum Error {
     #[error("{message}")]
     ZlibInflate {
@@ -178,7 +177,7 @@ where
                     // SAFETY: This invariant is upheld since `child_items` and `node` come from the same Tree.
                     // This means we can rely on Tree's invariant that node.children will be the only `children` array in
                     // for nodes in this tree that will contain any of those children.
-                    #[allow(unsafe_code)]
+                    #[expect(unsafe_code)]
                     unsafe {
                         resolve::deltas(
                             object_counter.clone(),

--- a/gix-pack/src/cache/delta/traverse/resolve.rs
+++ b/gix-pack/src/cache/delta/traverse/resolve.rs
@@ -36,7 +36,7 @@ mod root {
         ///
         /// Note that this invariant is a bit more relaxed than that on `deltas()`, because this function can be called
         /// for traversal within a child item, which happens in into_child_iter()
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         pub(super) unsafe fn new(item: &'a mut Item<T>, child_items: &'a ItemSliceSync<'a, Item<T>>) -> Self {
             Node { item, child_items }
         }
@@ -68,7 +68,7 @@ mod root {
         /// Children are `Node`s referring to pack entries whose base object is this pack entry.
         pub fn into_child_iter(self) -> impl Iterator<Item = Node<'a, T>> + 'a {
             let children = self.child_items;
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             self.item.children().iter().map(move |&index| {
                 // SAFETY: Due to the invariant on new(), we can rely on these indices
                 // being unique.
@@ -96,7 +96,7 @@ pub(super) struct State<'items, F, MBFN, T: Send> {
 /// This safety invariant can be reliably upheld by making sure `item` comes from a Tree and `child_items`
 /// was constructed using that Tree's child_items. This works since Tree has this invariant as well: all
 /// child_items are referenced at most once (really, exactly once) by a node in the tree.
-#[allow(clippy::too_many_arguments, unsafe_code)]
+#[expect(clippy::too_many_arguments, unsafe_code)]
 #[deny(unsafe_op_in_unsafe_fn)] // this is a big function, require unsafe for the one small unsafe op we have
 pub(super) unsafe fn deltas<T, F, MBFN, E, R>(
     objects: gix_features::progress::StepShared,
@@ -140,7 +140,7 @@ where
     // These will be pushed onto our stack until all are processed
     let root_level = 0;
     // SAFETY: This invariant is required from the caller
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     let root_node = unsafe { root::Node::new(item, child_items) };
     let mut nodes: Vec<_> = vec![(root_level, root_node)];
     while let Some((level, mut base)) = nodes.pop() {
@@ -258,7 +258,7 @@ where
 /// * `initial_threads` is the threads we may spawn, not accounting for our own thread which is still considered used by the parent
 ///   system. Since this thread will take a controlling function, we may spawn one more than that. In threaded mode, we will finish
 ///   all remaining work.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn deltas_mt<T, F, MBFN, E, R>(
     mut threads_to_create: isize,
     decompressed_bytes_by_pack_offset: BTreeMap<u64, (data::Entry, u64, Vec<u8>)>,
@@ -435,8 +435,11 @@ where
             // Get out of threads are already starving or they would be starving soon as no work is left.
             //
             // Lint: ScopedJoinHandle is not the same depending on active features and is not exposed in some cases.
-            #[allow(clippy::redundant_closure_for_method_calls)]
-            if threads.iter().any(|t| t.is_finished()) {
+            #[allow(
+                clippy::redundant_closure_for_method_calls,
+                reason = "the closure supports both real and serial scoped thread handles"
+            )]
+            if threads.iter().any(|thread| thread.is_finished()) {
                 let mut running_threads = Vec::new();
                 for thread in threads.drain(..) {
                     if thread.is_finished() {

--- a/gix-pack/src/cache/delta/traverse/util.rs
+++ b/gix-pack/src/cache/delta/traverse/util.rs
@@ -40,7 +40,7 @@ where
     }
 
     // SAFETY: The index must point into the slice and must not be reused concurrently.
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     pub(super) unsafe fn get_mut(&self, index: usize) -> &'a mut T {
         #[cfg(debug_assertions)]
         if index >= self.len {
@@ -57,8 +57,8 @@ where
 
 // SAFETY: This is logically an &mut T, which is Send if T is Send
 // (note: this is different from &T, which also needs T: Sync)
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 unsafe impl<T> Send for ItemSliceSync<'_, T> where T: Send {}
 // SAFETY: This is logically an &mut T, which is Sync if T is Sync
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 unsafe impl<T> Sync for ItemSliceSync<'_, T> where T: Send {}

--- a/gix-pack/src/data/delta.rs
+++ b/gix-pack/src/data/delta.rs
@@ -2,7 +2,7 @@
 pub mod apply {
     /// Returned when failing to apply deltas.
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Corrupt delta data: {message}")]
         Corrupt { message: &'static str },

--- a/gix-pack/src/data/entry/decode.rs
+++ b/gix-pack/src/data/entry/decode.rs
@@ -7,7 +7,7 @@ use crate::data;
 
 /// The error returned by [data::Entry::from_bytes()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Object type {type_id} is unsupported")]
     UnsupportedType { type_id: u8 },
@@ -81,7 +81,6 @@ impl data::Entry {
                 let mut buf = gix_hash::Kind::buf();
                 let hash = &mut buf[..hash_len];
                 r.read_exact(hash)?;
-                #[allow(clippy::redundant_slicing)]
                 let delta = RefDelta {
                     base_id: gix_hash::ObjectId::from_bytes_or_panic(&hash[..]),
                 };

--- a/gix-pack/src/data/entry/header.rs
+++ b/gix-pack/src/data/entry/header.rs
@@ -6,7 +6,7 @@ use crate::data;
 /// The header portion of a pack data entry, identifying the kind of stored object.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Header {
     /// The object is a commit
     Commit,

--- a/gix-pack/src/data/file/decode/entry.rs
+++ b/gix-pack/src/data/file/decode/entry.rs
@@ -14,7 +14,7 @@ pub enum ResolvedBase {
     InPack(data::Entry),
     /// Indicates the object of `kind` was found outside of the pack, and its data was written into an output
     /// vector which now has a length of `end`.
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     OutOfPack { kind: gix_object::Kind, end: usize },
 }
 

--- a/gix-pack/src/data/file/decode/mod.rs
+++ b/gix-pack/src/data/file/decode/mod.rs
@@ -9,7 +9,7 @@ pub mod header;
 /// [`File::decode_entry()`][crate::data::File::decode_entry()] and .
 /// [`File::decompress_entry()`][crate::data::File::decompress_entry()]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Failed to decompress pack entry")]
     ZlibInflate(#[from] gix_zlib::inflate::Error),

--- a/gix-pack/src/data/header.rs
+++ b/gix-pack/src/data/header.rs
@@ -40,7 +40,7 @@ pub fn encode(version: data::Version, num_objects: u32) -> [u8; 12] {
 pub mod decode {
     /// Returned by [`decode()`][super::decode()].
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not open pack file at '{path}'")]
         Io {

--- a/gix-pack/src/data/input/types.rs
+++ b/gix-pack/src/data/input/types.rs
@@ -1,7 +1,7 @@
 /// Returned by [`BytesToEntriesIter::new_from_header()`][crate::data::input::BytesToEntriesIter::new_from_header()] and as part
 /// of `Item` of [`BytesToEntriesIter`][crate::data::input::BytesToEntriesIter].
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("An IO operation failed while streaming an entry")]
     Io(#[from] gix_hash::io::Error),

--- a/gix-pack/src/data/output/bytes.rs
+++ b/gix-pack/src/data/output/bytes.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use crate::{data::output, exact_vec};
 
 /// The error returned by `next()` in the [`FromEntriesIter`] iterator.
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error<E>
 where

--- a/gix-pack/src/data/output/count/objects/mod.rs
+++ b/gix-pack/src/data/output/count/objects/mod.rs
@@ -132,14 +132,14 @@ mod expand {
         data::{output, output::count::PackLocation},
     };
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn this(
         db: &dyn crate::Find,
         input_object_expansion: ObjectExpansion,
         seen_objs: &impl util::InsertImmutable,
         oids: &mut dyn Iterator<Item = Result<ObjectId, Box<dyn std::error::Error + Send + Sync + 'static>>>,
         buf1: &mut Vec<u8>,
-        #[allow(clippy::ptr_arg)] buf2: &mut Vec<u8>,
+        buf2: &mut Vec<u8>,
         objects: &gix_features::progress::AtomicStep,
         should_interrupt: &AtomicBool,
         allow_pack_lookups: bool,

--- a/gix-pack/src/data/output/count/objects/types.rs
+++ b/gix-pack/src/data/output/count/objects/types.rs
@@ -79,7 +79,7 @@ impl Default for Options {
 
 /// The error returned by the pack generation iterator [`bytes::FromEntriesIter`][crate::data::output::bytes::FromEntriesIter].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     CommitDecode(gix_object::decode::Error),

--- a/gix-pack/src/data/output/entry/iter_from_counts.rs
+++ b/gix-pack/src/data/output/entry/iter_from_counts.rs
@@ -410,7 +410,7 @@ mod types {
 
     /// The error returned by the pack generation function [`iter_from_counts()`][crate::data::output::entry::iter_from_counts()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Find(gix_object::find::Error),

--- a/gix-pack/src/data/output/entry/mod.rs
+++ b/gix-pack/src/data/output/entry/mod.rs
@@ -32,7 +32,7 @@ pub enum Kind {
 }
 
 /// The error returned by [`output::Entry::from_data()`].
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("{0}")]

--- a/gix-pack/src/find.rs
+++ b/gix-pack/src/find.rs
@@ -3,7 +3,6 @@
 /// Its commonly retrieved by reading from a pack index file followed by a read from a pack data file.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[allow(missing_docs)]
 pub struct Entry {
     /// The pack-data encoded bytes of the pack data entry as present in the pack file, including the header followed by compressed data.
     pub data: Vec<u8>,

--- a/gix-pack/src/index/init.rs
+++ b/gix-pack/src/index/init.rs
@@ -7,7 +7,7 @@ use crate::index::{self, FAN_LEN, V2_SIGNATURE, Version};
 
 /// Returned by [`index::File::at()`].
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not open pack index file at '{path}'")]
     Io {

--- a/gix-pack/src/index/mod.rs
+++ b/gix-pack/src/index/mod.rs
@@ -81,7 +81,7 @@ use crate::MMap;
 /// The version of an index file
 #[derive(Default, PartialEq, Eq, Ord, PartialOrd, Debug, Hash, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Version {
     V1 = 1,
     #[default]

--- a/gix-pack/src/index/traverse/error.rs
+++ b/gix-pack/src/index/traverse/error.rs
@@ -2,7 +2,7 @@ use crate::index;
 
 /// Returned by [`index::File::traverse_with_index()`] and [`index::File::traverse_with_lookup`]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error<E: std::error::Error + Send + Sync + 'static> {
     #[error("One of the traversal processors failed")]
     Processor(#[source] E),

--- a/gix-pack/src/index/traverse/mod.rs
+++ b/gix-pack/src/index/traverse/mod.rs
@@ -154,7 +154,7 @@ where
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn decode_and_process_entry<C, E, D>(
         &self,
         check: SafetyCheck,
@@ -208,7 +208,6 @@ where
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn process_entry<E>(
     check: SafetyCheck,
     object_kind: gix_object::Kind,

--- a/gix-pack/src/index/verify.rs
+++ b/gix-pack/src/index/verify.rs
@@ -13,7 +13,7 @@ pub mod integrity {
 
     /// Returned by [`index::File::verify_integrity()`][crate::index::File::verify_integrity()].
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Reserialization of an object failed")]
         Io(#[from] std::io::Error),
@@ -233,7 +233,6 @@ where
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn verify_entry(
         verify_mode: Mode,
         encode_buf: &mut Vec<u8>,

--- a/gix-pack/src/index/write/error.rs
+++ b/gix-pack/src/index/write/error.rs
@@ -1,6 +1,6 @@
 /// Returned by [`crate::index::write_data_iter_to_stream()`]
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("An error occurred when writing the pack index file")]
     Io(#[from] gix_hash::io::Error),

--- a/gix-pack/src/index/write/mod.rs
+++ b/gix-pack/src/index/write/mod.rs
@@ -85,7 +85,7 @@ pub(super) mod function {
     ///   provides all bytes belonging to a pack entry writing them to the given mutable output `Vec`.
     ///   It should return `None` if the entry cannot be resolved from the pack that produced the `entries` iterator, causing
     ///   the write operation to fail.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn write_data_iter_to_stream<F, F2, R>(
         version: crate::index::Version,
         make_resolver: F,

--- a/gix-pack/src/lib.rs
+++ b/gix-pack/src/lib.rs
@@ -63,7 +63,7 @@ mod mmap {
     pub fn read_only(path: &Path) -> std::io::Result<memmap2::Mmap> {
         let file = std::fs::File::open(path)?;
         // SAFETY: we have to take the risk of somebody changing the file underneath. Git never writes into the same file.
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             memmap2::MmapOptions::new().map_copy_read_only(&file)
         }

--- a/gix-pack/src/multi_index/chunk.rs
+++ b/gix-pack/src/multi_index/chunk.rs
@@ -15,7 +15,7 @@ pub mod index_names {
 
         /// The error returned by [`from_bytes()`][super::from_bytes()].
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("The pack names were not ordered alphabetically.")]
             NotOrderedAlphabetically,

--- a/gix-pack/src/multi_index/init.rs
+++ b/gix-pack/src/multi_index/init.rs
@@ -7,7 +7,7 @@ mod error {
 
     /// The error returned by [File::at()][super::File::at()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not open multi-index file at '{path}'")]
         Io {

--- a/gix-pack/src/multi_index/mod.rs
+++ b/gix-pack/src/multi_index/mod.rs
@@ -5,7 +5,7 @@ use crate::MMap;
 /// Known multi-index file versions
 #[derive(Default, PartialEq, Eq, Ord, PartialOrd, Debug, Hash, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Version {
     #[default]
     V1 = 1,

--- a/gix-pack/src/multi_index/verify.rs
+++ b/gix-pack/src/multi_index/verify.rs
@@ -10,7 +10,7 @@ pub mod integrity {
 
     /// Returned by [`multi_index::File::verify_integrity()`][crate::multi_index::File::verify_integrity()].
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Object {id} should be at pack-offset {expected_pack_offset} but was found at {actual_pack_offset}")]
         PackOffsetMismatch {

--- a/gix-pack/src/multi_index/write.rs
+++ b/gix-pack/src/multi_index/write.rs
@@ -5,7 +5,7 @@ use crate::multi_index;
 mod error {
     /// The error returned by [`crate::multi_index::write_from_index_paths()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Io(#[from] gix_hash::io::Error),

--- a/gix-pack/src/verify.rs
+++ b/gix-pack/src/verify.rs
@@ -6,7 +6,7 @@ use gix_features::progress::Progress;
 pub mod checksum {
     /// Returned by various methods to verify the checksum of a memory mapped file that might also exist on disk.
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Interrupted by user")]
         Interrupted,

--- a/gix-pack/tests/pack/data/file.rs
+++ b/gix-pack/tests/pack/data/file.rs
@@ -139,7 +139,6 @@ mod decode_entry {
     }
 
     fn decode_entry_at_offset(offset: u64) -> Vec<u8> {
-        #[allow(clippy::ptr_arg)]
         fn resolve_with_panic(_oid: &gix_hash::oid, _out: &mut Vec<u8>) -> Option<ResolvedBase> {
             panic!("should not want to resolve an id here")
         }

--- a/gix-packetline/src/async_io/read.rs
+++ b/gix-packetline/src/async_io/read.rs
@@ -82,7 +82,6 @@ where
                 Ok(Ok(line)) => {
                     if trace {
                         match line {
-                            #[allow(unused_variables)]
                             PacketLineRef::Data(d) => {
                                 gix_trace::trace!("<< {}", d.as_bstr().trim().as_bstr());
                             }
@@ -196,7 +195,7 @@ where
     /// Same as [`as_read_with_sidebands(…)`](StreamingPeekableIter::as_read_with_sidebands()), but for channels without side band support.
     ///
     /// Due to the preconfigured function type this method can be called without 'turbofish'.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn as_read(&mut self) -> WithSidebands<'_, T, fn(bool, &[u8]) -> ProgressAction> {
         WithSidebands::new(self)
     }

--- a/gix-packetline/src/async_io/sidebands.rs
+++ b/gix-packetline/src/async_io/sidebands.rs
@@ -69,7 +69,7 @@ enum State<'a, T> {
 /// However, it's only used when pinned and thus isn't actually sent anywhere, it's a secondary state of the future used after it was Send
 /// to a thread possibly.
 // TODO: Is it possible to declare it as it should be?
-#[allow(unsafe_code, clippy::non_send_fields_in_send_ty)]
+#[expect(unsafe_code)]
 unsafe impl<T> Send for State<'_, T> where T: Send {}
 
 impl<'a, T, F> WithSidebands<'a, T, F>
@@ -175,7 +175,10 @@ where
     }
 }
 
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "the manual future is implemented but no public operation currently constructs it, or… maybe it needs specific feature toggles?"
+)]
 pub struct ReadDataLineFuture<'a, 'b, T: AsyncRead, F> {
     parent: &'b mut WithSidebands<'a, T, F>,
     buf: &'b mut Vec<u8>,
@@ -267,7 +270,7 @@ where
                                 // Also: We keep a pointer around which is protected by borrowcheck since it's created
                                 // from a legal mutable reference which is moved into the read_line future - if it was manually
                                 // implemented we would be able to re-obtain it from there.
-                                #[allow(unsafe_code)]
+                                #[expect(unsafe_code)]
                                 let parent = unsafe { &mut *parent };
                                 State::Idle { parent: Some(parent) }
                             };

--- a/gix-packetline/src/blocking_io/read.rs
+++ b/gix-packetline/src/blocking_io/read.rs
@@ -77,7 +77,7 @@ where
                 Ok(Ok(line)) => {
                     if trace {
                         match line {
-                            #[allow(unused_variables)]
+                            #[allow(unused_variables, reason = "Used when tracing is enabled at compile time.")]
                             PacketLineRef::Data(d) => {
                                 gix_trace::trace!("<< {}", d.as_bstr().trim().as_bstr());
                             }
@@ -212,7 +212,7 @@ where
     /// Same as [`as_read_with_sidebands(…)`](StreamingPeekableIter::as_read_with_sidebands()), but for channels without side band support.
     ///
     /// Due to the preconfigured function type this method can be called without 'turbofish'.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn as_read(&mut self) -> WithSidebands<'_, T, fn(bool, &[u8]) -> ProgressAction> {
         WithSidebands::new(self)
     }

--- a/gix-packetline/src/decode.rs
+++ b/gix-packetline/src/decode.rs
@@ -4,7 +4,7 @@ use crate::{DELIMITER_LINE, FLUSH_LINE, MAX_DATA_LEN, MAX_LINE_LEN, PacketLineRe
 
 /// The error used in the [`decode`][mod@crate::decode] module
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Failed to decode the first four hex bytes indicating the line length: {err}")]
     HexDecode { err: String },
@@ -26,7 +26,7 @@ pub enum Error {
 pub mod band {
     /// The error used in [`PacketLineRef::decode_band()`][super::PacketLineRef::decode_band()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("attempt to decode a non-side channel line or input was malformed: {band_id}")]
         InvalidSideBand { band_id: u8 },

--- a/gix-packetline/src/encode.rs
+++ b/gix-packetline/src/encode.rs
@@ -2,7 +2,7 @@ use super::MAX_DATA_LEN;
 
 /// The error returned by most functions in the [`encode`](crate::encode) module
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Cannot encode more than {MAX_DATA_LEN} bytes, got {length_in_bytes}")]
     DataLengthLimitExceeded { length_in_bytes: usize },

--- a/gix-packetline/tests/packetline/write.rs
+++ b/gix-packetline/tests/packetline/write.rs
@@ -12,7 +12,7 @@ use gix_packetline::blocking_io::Writer;
 const MAX_DATA_LEN: usize = 65516;
 const MAX_LINE_LEN: usize = 4 + MAX_DATA_LEN;
 
-#[allow(clippy::unused_io_amount)] // under test
+#[expect(clippy::unused_io_amount)]
 #[maybe_async::test(feature = "blocking-io", async(feature = "async-io", async_std::test))]
 async fn each_write_results_in_one_line() -> crate::Result {
     let mut w = Writer::new(Vec::new());
@@ -23,7 +23,7 @@ async fn each_write_results_in_one_line() -> crate::Result {
     Ok(())
 }
 
-#[allow(clippy::unused_io_amount)] // under test
+#[expect(clippy::unused_io_amount)]
 #[maybe_async::test(feature = "blocking-io", async(feature = "async-io", async_std::test))]
 async fn write_text_and_write_binary() -> crate::Result {
     let buf = {
@@ -38,7 +38,7 @@ async fn write_text_and_write_binary() -> crate::Result {
     Ok(())
 }
 
-#[allow(clippy::unused_io_amount)] // under test
+#[expect(clippy::unused_io_amount)]
 #[maybe_async::test(feature = "blocking-io", async(feature = "async-io", async_std::test))]
 async fn huge_writes_are_split_into_lines() -> crate::Result {
     let buf = {

--- a/gix-path/src/realpath.rs
+++ b/gix-path/src/realpath.rs
@@ -1,6 +1,6 @@
 /// The error returned by [`realpath()`][super::realpath()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("The maximum allowed number {} of symlinks in path is exceeded", .max_symlinks)]
     MaxSymlinksExceeded { max_symlinks: u8 },

--- a/gix-path/src/relative_path.rs
+++ b/gix-path/src/relative_path.rs
@@ -29,7 +29,7 @@ use types::RelativePath;
 impl RelativePath {
     fn new_unchecked(value: &BStr) -> Result<&RelativePath, Error> {
         // SAFETY: `RelativePath` is transparent and equivalent to a `&BStr` if provided as reference.
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             Ok(std::mem::transmute::<&BStr, &RelativePath>(value))
         }
@@ -38,7 +38,7 @@ impl RelativePath {
 
 /// The error used in [`RelativePath`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("A RelativePath is not allowed to be absolute")]
     IsAbsolute,

--- a/gix-pathspec/src/defaults.rs
+++ b/gix-pathspec/src/defaults.rs
@@ -6,7 +6,7 @@ use crate::{Defaults, MagicSignature, SearchMode};
 pub mod from_environment {
     /// The error returned by [Defaults::from_environment()](super::Defaults::from_environment()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         ParseValue(#[from] gix_config_value::Error),

--- a/gix-pathspec/src/lib.rs
+++ b/gix-pathspec/src/lib.rs
@@ -52,7 +52,7 @@ pub mod normalize {
 
     /// The error returned by [Pattern::normalize()](super::Pattern::normalize()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The path '{}' is not inside of the worktree '{}'", path.display(), worktree_path.display())]
         AbsolutePathOutsideOfWorktree { path: PathBuf, worktree_path: PathBuf },

--- a/gix-pathspec/src/parse.rs
+++ b/gix-pathspec/src/parse.rs
@@ -6,7 +6,7 @@ use crate::{Defaults, MagicSignature, Pattern, SearchMode};
 
 /// The error returned by [parse()][crate::parse()].
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("An empty string is not a valid pathspec")]
     EmptyString,

--- a/gix-prompt/src/types.rs
+++ b/gix-prompt/src/types.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 /// The error returned by [ask()][crate::ask()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Terminal prompts are disabled")]
     Disabled,

--- a/gix-protocol/src/command.rs
+++ b/gix-protocol/src/command.rs
@@ -240,7 +240,7 @@ mod with_io {
 
         /// The error returned by [Command::validate_argument_prefixes()](super::Command::validate_argument_prefixes()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("{command}: argument {argument} is not known or allowed")]
             UnsupportedArgument { command: &'static str, argument: BString },

--- a/gix-protocol/src/fetch/error.rs
+++ b/gix-protocol/src/fetch/error.rs
@@ -1,6 +1,6 @@
 /// The error returned by [`fetch()`](crate::fetch()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not decode server reply")]
     FetchResponse(#[from] crate::fetch::response::Error),

--- a/gix-protocol/src/fetch/function.rs
+++ b/gix-protocol/src/fetch/function.rs
@@ -141,7 +141,6 @@ where
                 }
             };
             // This needs drop if tracing is compiled in. We just don't know it.
-            #[allow(clippy::drop_non_drop)]
             drop(negotiate_span);
 
             let mut previous_response = previous_response.expect("knowledge of a pack means a response was received");

--- a/gix-protocol/src/fetch/negotiate.rs
+++ b/gix-protocol/src/fetch/negotiate.rs
@@ -17,7 +17,7 @@ type Queue = gix_revwalk::PriorityQueue<SecondsSinceUnixEpoch, gix_hash::ObjectI
 
 /// The error returned during [`one_round()`] or [`mark_complete_and_common_ref()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("We were unable to figure out what objects the server should send after {rounds} round(s)")]
     NegotiationFailed { rounds: usize },
@@ -117,7 +117,7 @@ pub struct Round {
 /// * `mapping_is_ignored`
 ///     - `f(mapping) -> bool` returns `true` if the given mapping should not participate in change tracking.
 ///     - [`make_refmapping_ignore_predicate()`] is a typical implementation for this.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn mark_complete_and_common_ref<Out, F, E>(
     objects: &(impl gix_object::Find + gix_object::FindHeader + gix_object::Exists),
     refs: &gix_ref::file::Store,

--- a/gix-protocol/src/fetch/refmap/init.rs
+++ b/gix-protocol/src/fetch/refmap/init.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// The error returned by [`crate::Handshake::prepare_lsrefs_or_extract_refmap()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("The object format {format:?} as used by the remote is unsupported")]
     UnknownObjectFormat { format: BString },

--- a/gix-protocol/src/fetch/response/mod.rs
+++ b/gix-protocol/src/fetch/response/mod.rs
@@ -5,7 +5,7 @@ use crate::{command::Feature, fetch::Response};
 
 /// The error returned in the [response module][crate::fetch::response].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Failed to read from line reader")]
     Io(#[source] std::io::Error),

--- a/gix-protocol/src/handshake/function.rs
+++ b/gix-protocol/src/handshake/function.rs
@@ -15,7 +15,6 @@ use crate::{credentials, handshake::refs};
 /// each time it is performed in case authentication is required.
 /// `progress` is used to inform about what's currently happening.
 /// The `service` tells the server whether to be in 'send' or 'receive' mode.
-#[allow(clippy::result_large_err)]
 #[maybe_async]
 pub async fn handshake<AuthFn, T>(
     mut transport: T,

--- a/gix-protocol/src/handshake/mod.rs
+++ b/gix-protocol/src/handshake/mod.rs
@@ -89,7 +89,6 @@ pub(crate) mod hero {
         impl ObtainRefMap<'_> {
             /// Fetch the refmap, either by returning the existing one or invoking the `ls-refs` command.
             #[cfg(feature = "async-client")]
-            #[allow(clippy::result_large_err)]
             pub async fn fetch_async(
                 self,
                 mut progress: impl Progress,
@@ -109,7 +108,6 @@ pub(crate) mod hero {
 
             /// Fetch the refmap, either by returning the existing one or invoking the `ls-refs` command.
             #[cfg(feature = "blocking-client")]
-            #[allow(clippy::result_large_err)]
             pub fn fetch_blocking(
                 self,
                 mut progress: impl Progress,
@@ -130,7 +128,6 @@ pub(crate) mod hero {
 
         impl Handshake {
             /// Prepare fetching a [refmap](RefMap) if not present in the handshake.
-            #[allow(clippy::result_large_err)]
             pub fn prepare_lsrefs_or_extract_refmap(
                 &mut self,
                 user_agent: Feature,
@@ -167,7 +164,7 @@ mod error {
 
     /// The error returned by [`handshake()`][crate::handshake()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Failed to obtain credentials")]
         Credentials(#[from] credentials::protocol::Error),

--- a/gix-protocol/src/handshake/refs/mod.rs
+++ b/gix-protocol/src/handshake/refs/mod.rs
@@ -8,7 +8,7 @@ pub mod parse {
 
     /// The error returned when parsing References/refs from the server response.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Io(#[from] std::io::Error),

--- a/gix-protocol/src/ls_refs.rs
+++ b/gix-protocol/src/ls_refs.rs
@@ -4,7 +4,7 @@ mod error {
 
     /// The error returned by invoking a [`super::function::LsRefsCommand`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Io(#[from] std::io::Error),

--- a/gix-protocol/tests/protocol/fetch/_impl.rs
+++ b/gix-protocol/tests/protocol/fetch/_impl.rs
@@ -65,7 +65,6 @@ mod fetch_fn {
     /// # WARNING - Do not use!
     ///
     /// As it will hang when having multiple negotiation rounds.
-    #[allow(clippy::result_large_err)]
     #[maybe_async]
     // TODO: remove this without losing test coverage - we have the same but better in `gix` and it's
     //       not really worth it to maintain the delegates here.

--- a/gix-protocol/tests/protocol/fetch/mod.rs
+++ b/gix-protocol/tests/protocol/fetch/mod.rs
@@ -23,7 +23,7 @@ mod error {
 
     /// The error used in [`fetch()`][crate::fetch()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Handshake(#[from] handshake::Error),
@@ -46,7 +46,7 @@ type Cursor = std::io::Cursor<Vec<u8>>;
 #[cfg(feature = "async-client")]
 type Cursor = futures_lite::io::Cursor<Vec<u8>>;
 
-#[allow(clippy::result_large_err)]
+#[expect(clippy::result_large_err)]
 fn helper_unused(_action: gix_credentials::helper::Action) -> gix_credentials::protocol::Result {
     panic!("Call to credentials helper is unexpected")
 }

--- a/gix-protocol/tests/protocol/handshake.rs
+++ b/gix-protocol/tests/protocol/handshake.rs
@@ -232,7 +232,7 @@ impl gix_transport::client::blocking_io::ReadlineBufRead for Fixture<'_> {
 #[cfg(feature = "async-client")]
 impl<'a> Fixture<'a> {
     fn project_inner(self: std::pin::Pin<&mut Self>) -> std::pin::Pin<&mut &'a [u8]> {
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             std::pin::Pin::new(&mut self.get_unchecked_mut().0)
         }

--- a/gix-ref/src/lib.rs
+++ b/gix-ref/src/lib.rs
@@ -86,14 +86,20 @@ pub mod store {
 
     /// A thread-local handle for interacting with a [`Store`][crate::Store] to find and iterate references.
     #[derive(Clone)]
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "the general reference-store handle is scaffolding for planned ref-table support"
+    )]
     pub(crate) struct Handle {
         /// A way to access shared state with the requirement that interior mutability doesn't leak or is incorporated into error types
         /// if it could. The latter can't happen if references to said internal aren't ever returned.
         state: handle::State,
     }
 
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "the general reference-store state is scaffolding for planned ref-table support"
+    )]
     pub(crate) enum State {
         Loose { store: file::Store },
     }
@@ -110,7 +116,10 @@ pub mod store {
 
 /// The git reference store.
 /// TODO: Figure out if handles are needed at all, which depends on the ref-table implementation.
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "callers still use file::Store directly while this general store awaits ref-table support"
+)]
 pub(crate) struct Store {
     inner: store::State,
 }

--- a/gix-ref/src/name.rs
+++ b/gix-ref/src/name.rs
@@ -49,7 +49,7 @@ impl Category<'_> {
 impl FullNameRef {
     pub(crate) fn new_unchecked(v: &BStr) -> &Self {
         // SAFETY: FullNameRef is transparent and equivalent to a &BStr if provided as reference
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             std::mem::transmute(v)
         }
@@ -59,7 +59,7 @@ impl FullNameRef {
 impl PartialNameRef {
     pub(crate) fn new_unchecked(v: &BStr) -> &Self {
         // SAFETY: PartialNameRef is transparent and equivalent to a &BStr if provided as reference
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             std::mem::transmute(v)
         }
@@ -224,7 +224,10 @@ impl<'a> convert::TryFrom<&'a str> for PartialName {
     }
 }
 
-#[allow(clippy::infallible_try_from)]
+#[expect(
+    clippy::infallible_try_from,
+    reason = "it's here so that it can be done, even if infallible. Needed for parameters that use `TryFrom` generically."
+)]
 impl<'a> convert::TryFrom<&'a FullName> for &'a PartialNameRef {
     type Error = Infallible;
 

--- a/gix-ref/src/peel.rs
+++ b/gix-ref/src/peel.rs
@@ -4,7 +4,7 @@ pub mod to_id {
 
     /// The error returned by [`crate::file::ReferenceExt::peel_to_id()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         FollowToObject(#[from] super::to_object::Error),
@@ -23,7 +23,7 @@ pub mod to_object {
 
     /// The error returned by [`file::ReferenceExt::follow_to_object_packed()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not follow a single level of a symbolic reference")]
         Follow(#[from] file::find::existing::Error),

--- a/gix-ref/src/store/file/find.rs
+++ b/gix-ref/src/store/file/find.rs
@@ -425,7 +425,7 @@ pub mod existing {
 
         /// The error returned by [file::Store::find_existing()][crate::file::Store::find()].
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("An error occurred while trying to find a reference")]
             Find(#[from] find::Error),
@@ -442,7 +442,7 @@ mod error {
 
     /// The error returned by [file::Store::find()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The ref name or path is not a valid ref name")]
         RefnameValidation(#[from] crate::name::Error),

--- a/gix-ref/src/store/file/log/iter.rs
+++ b/gix-ref/src/store/file/log/iter.rs
@@ -147,7 +147,7 @@ pub mod reverse {
 
     /// The error returned by the [`Reverse`][super::Reverse] iterator
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The buffer could not be filled to make more lines available")]
         Io(#[from] std::io::Error),

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -18,7 +18,6 @@ mod write {
 
     /// The Error produced by [`Line::write_to()`] (but wrapped in an io error).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
     enum Error {
         #[error(r"Messages must not contain newlines (\n)")]
         IllegalCharacter,

--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -10,7 +10,7 @@ enum MaybeUnsafeState {
 
 /// The error returned by [`Reference::try_from_path()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("{content:?} could not be parsed")]
     Parse { content: BString },

--- a/gix-ref/src/store/file/loose/reflog.rs
+++ b/gix-ref/src/store/file/loose/reflog.rs
@@ -97,7 +97,6 @@ pub mod create_or_update {
     use crate::store_impl::{file, file::WriteReflog};
 
     impl file::Store {
-        #[allow(clippy::too_many_arguments)]
         pub(crate) fn reflog_create_or_append(
             &self,
             name: &FullNameRef,
@@ -207,7 +206,7 @@ pub mod create_or_update {
 
         /// The error returned when creating or appending to a reflog
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("Could create one or more directories in {reflog_directory:?} to contain reflog file")]
             CreateLeadingDirectories {
@@ -233,7 +232,7 @@ pub mod create_or_update {
 mod error {
     /// The error returned by [`crate::file::Store::reflog_iter()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The reflog name or path is not a valid ref name")]
         RefnameValidation(#[from] crate::name::Error),

--- a/gix-ref/src/store/file/overlay_iter.rs
+++ b/gix-ref/src/store/file/overlay_iter.rs
@@ -25,7 +25,6 @@ pub struct LooseThenPacked<'p, 's> {
     namespace: Option<&'s Namespace>,
     iter_packed: Option<Peekable<packed::Iter<'p>>>,
     iter_git_dir: Peekable<SortedLoosePaths>,
-    #[allow(dead_code)]
     iter_common_dir: Option<Peekable<SortedLoosePaths>>,
     buf: Vec<u8>,
 }
@@ -462,7 +461,7 @@ mod error {
 
     /// The error returned by the [`LooseThenPacked`][super::LooseThenPacked] iterator.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The file system could not be traversed")]
         Traversal(#[source] io::Error),

--- a/gix-ref/src/store/file/packed.rs
+++ b/gix-ref/src/store/file/packed.rs
@@ -67,7 +67,7 @@ pub mod transaction {
 
     /// The error returned by [`file::Transaction::prepare()`][crate::file::Transaction::prepare()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("An existing pack couldn't be opened or read when preparing a transaction")]
         BufferOpen(#[from] packed::buffer::open::Error),

--- a/gix-ref/src/store/file/transaction/commit.rs
+++ b/gix-ref/src/store/file/transaction/commit.rs
@@ -183,7 +183,7 @@ mod error {
 
     /// The error returned by various [`Transaction`][super::Transaction] methods.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The packed-ref transaction could not be committed")]
         PackedTransactionCommit(#[source] packed::transaction::commit::Error),

--- a/gix-ref/src/store/file/transaction/prepare.rs
+++ b/gix-ref/src/store/file/transaction/prepare.rs
@@ -475,7 +475,7 @@ mod error {
 
     /// The error returned by various [`Transaction`][super::Transaction] methods.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The packed ref buffer could not be loaded")]
         Packed(#[from] packed::buffer::open::Error),

--- a/gix-ref/src/store/general/handle/find.rs
+++ b/gix-ref/src/store/general/handle/find.rs
@@ -5,7 +5,7 @@ mod error {
 
     /// The error returned by [`crate::file::Store::find_loose()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("An error occurred while finding a reference in the loose file database")]
         Loose(#[from] crate::file::find::Error),
@@ -46,7 +46,6 @@ mod existing {
 
         /// The error returned by [file::Store::find_existing()][crate::file::Store::find_existing()].
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
         pub enum Error {
             #[error("An error occurred while finding a reference in the database")]
             Find(#[from] crate::store::find::Error),

--- a/gix-ref/src/store/general/init.rs
+++ b/gix-ref/src/store/general/init.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 mod error {
     /// The error returned by [`crate::Store::at()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
     pub enum Error {
         #[error("There was an error accessing the store's directory")]
         Io(#[from] std::io::Error),
@@ -14,7 +13,10 @@ pub use error::Error;
 
 use crate::file;
 
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "callers still initialize file::Store directly while the general store awaits ref-table support"
+)]
 impl crate::Store {
     /// Create a new store at the given location, typically the `.git/` directory.
     /// Use [`opts`](crate::store::init::Options) to adjust settings.

--- a/gix-ref/src/store/packed/buffer.rs
+++ b/gix-ref/src/store/packed/buffer.rs
@@ -85,7 +85,7 @@ pub mod open {
             } else {
                 packed::Backing::Mapped(
                     // SAFETY: we have to take the risk of somebody changing the file underneath. Git never writes into the same file.
-                    #[allow(unsafe_code)]
+                    #[expect(unsafe_code)]
                     unsafe {
                         memmap2::MmapOptions::new().map_copy_read_only(&std::fs::File::open(&path)?)?
                     },
@@ -110,7 +110,7 @@ pub mod open {
 
         /// The error returned by [`open()`][super::packed::Buffer::open()].
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("The packed-refs file did not have a header or wasn't sorted and could not be iterated")]
             Iter(#[from] packed::iter::Error),

--- a/gix-ref/src/store/packed/find.rs
+++ b/gix-ref/src/store/packed/find.rs
@@ -102,7 +102,7 @@ mod error {
 
     /// The error returned by [`find()`][super::packed::Buffer::find()]
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The ref name or path is not a valid ref name")]
         RefnameValidation(#[from] crate::name::Error),
@@ -123,7 +123,7 @@ pub mod existing {
 
     /// The error returned by [`find_existing()`][super::packed::Buffer::find()]
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The find operation failed")]
         Find(#[from] super::Error),

--- a/gix-ref/src/store/packed/iter.rs
+++ b/gix-ref/src/store/packed/iter.rs
@@ -116,7 +116,7 @@ mod error {
 
     /// The error returned by [`Iter`][super::packed::Iter],
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The header existed but could not be parsed: {invalid_first_line:?}")]
         Header { invalid_first_line: BString },

--- a/gix-ref/src/store/packed/mod.rs
+++ b/gix-ref/src/store/packed/mod.rs
@@ -38,7 +38,7 @@ pub(crate) struct Transaction {
     buffer: Option<file::packed::SharedBufferSnapshot>,
     edits: Option<Vec<Edit>>,
     lock: Option<gix_lock::File>,
-    #[allow(dead_code)] // It just has to be kept alive, hence no reads
+    // It just has to be kept alive, hence no reads
     closed_lock: Option<gix_lock::Marker>,
     precompose_unicode: bool,
     /// The namespace to use when preparing or writing refs

--- a/gix-ref/src/store/packed/transaction.rs
+++ b/gix-ref/src/store/packed/transaction.rs
@@ -280,7 +280,7 @@ pub(crate) fn buffer_into_transaction(
 pub mod prepare {
     /// The error used in [`Transaction::prepare(…)`][crate::file::Transaction::prepare()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not close a lock which won't ever be committed")]
         CloseLock(#[from] std::io::Error),
@@ -295,7 +295,7 @@ pub mod commit {
 
     /// The error used in [`Transaction::commit(…)`][crate::file::Transaction::commit()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Changes to the resource could not be committed")]
         Commit(#[from] gix_lock::commit::Error<gix_lock::File>),

--- a/gix-refspec/src/parse.rs
+++ b/gix-refspec/src/parse.rs
@@ -1,6 +1,6 @@
 /// The error returned by the [`parse()`][crate::parse()] function.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Empty refspecs are invalid")]
     Empty,

--- a/gix-refspec/src/spec.rs
+++ b/gix-refspec/src/spec.rs
@@ -69,10 +69,9 @@ mod impls {
         }
     }
 
-    #[allow(clippy::non_canonical_partial_ord_impl)]
     impl PartialOrd for RefSpec {
         fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-            Some(self.to_ref().cmp(&other.to_ref()))
+            Some(self.cmp(other))
         }
     }
 

--- a/gix-revision/src/lib.rs
+++ b/gix-revision/src/lib.rs
@@ -13,8 +13,7 @@
 pub mod describe;
 #[cfg(feature = "describe")]
 pub use describe::function::describe;
-///
-#[allow(clippy::empty_docs)]
+/// Find common ancestors of commits.
 #[cfg(feature = "merge_base")]
 pub mod merge_base;
 #[cfg(feature = "merge_base")]

--- a/gix-revision/src/spec/parse/function.rs
+++ b/gix-revision/src/spec/parse/function.rs
@@ -262,7 +262,7 @@ fn long_describe_prefix(name: &BStr) -> Option<(&BStr, delegate::PrefixHint<'_>)
                 let last_token_len = token.len();
                 let first_token_ptr = iter.next_back().map_or(token.as_ptr(), <[_]>::as_ptr);
                 // SAFETY: both pointers are definitely part of the same object
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 let prior_tokens_len: usize = unsafe { token.as_ptr().offset_from(first_token_ptr) }
                     .try_into()
                     .expect("positive value");
@@ -475,7 +475,10 @@ where
             })
             .or_else(|| {
                 name.is_empty().then_some(()).or_else(|| {
-                    #[allow(clippy::let_unit_value)]
+                    #[expect(
+                        clippy::let_unit_value,
+                        reason = "the binding keeps generated async and blocking code structurally consistent"
+                    )]
                     {
                         let res = delegate.find_ref(name).or_else_none(|err| {
                             errors.push(err);

--- a/gix-revwalk/src/graph/commit.rs
+++ b/gix-revwalk/src/graph/commit.rs
@@ -150,7 +150,7 @@ impl Iterator for Parents<'_, '_> {
 pub mod iter_parents {
     /// The error returned by the [`Parents`][super::Parents] iterator.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("An error occurred when parsing commit parents")]
         DecodeCommit(#[from] gix_object::decode::Error),
@@ -163,7 +163,7 @@ pub mod iter_parents {
 pub mod to_owned {
     /// The error returned by [`to_owned()`][crate::graph::LazyCommit::to_owned()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("A commit could not be decoded during traversal")]
         Decode(#[from] gix_object::decode::Error),

--- a/gix-revwalk/src/graph/mod.rs
+++ b/gix-revwalk/src/graph/mod.rs
@@ -18,7 +18,7 @@ mod errors {
 
         /// The error returned by [`insert_parents()`](crate::Graph::insert_parents()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             Lookup(#[from] gix_object::find::existing_iter::Error),
@@ -35,7 +35,7 @@ mod errors {
 
         /// The error returned by [`try_lookup_or_insert_default()`](crate::Graph::try_lookup_or_insert_default()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             Lookup(#[from] gix_object::find::existing_iter::Error),
@@ -166,7 +166,7 @@ impl<'cache, T> Graph<'_, 'cache, T> {
     /// provided the full parent commit information.
     /// It will be provided either existing data, along with complete information about the parent,
     /// and produces new data even though it's only used in case the parent isn't stored in the graph yet.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn insert_parents_with_lookup<E>(
         &mut self,
         id: &gix_hash::oid,
@@ -374,7 +374,6 @@ fn try_lookup<'graph, 'cache>(
             }));
         }
     }
-    #[allow(clippy::manual_map)]
     Ok(
         match objects
             .try_find(id, buf)

--- a/gix-sec/src/identity.rs
+++ b/gix-sec/src/identity.rs
@@ -40,7 +40,7 @@ mod impl_ {
 
         fn owner_of_current_process() -> std::io::Result<u32> {
             // SAFETY: there is no documented possibility for failure
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             let uid = unsafe { libc::geteuid() };
             Ok(uid)
         }
@@ -92,7 +92,7 @@ mod impl_ {
             Security::GetTokenInformation,
         };
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             let mut buffer_size = 36;
             let mut heap_buf = vec![0; 36];
@@ -133,7 +133,7 @@ mod impl_ {
     ) -> io::Result<T> {
         use windows_sys::Win32::Security::GetTokenInformation;
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             let mut info = MaybeUninit::<T>::uninit();
             let mut returned_size = 0;
@@ -180,7 +180,7 @@ mod impl_ {
             return Ok(true);
         }
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             let (folder_owner, descriptor) = {
                 let mut folder_owner = MaybeUninit::uninit();
@@ -216,7 +216,7 @@ mod impl_ {
 
             impl Drop for Descriptor {
                 fn drop(&mut self) {
-                    #[allow(unsafe_code)]
+                    #[expect(unsafe_code)]
                     // SAFETY: syscall only invoked if we have a valid descriptor
                     unsafe {
                         LocalFree(self.0 as _);

--- a/gix-shallow/src/lib.rs
+++ b/gix-shallow/src/lib.rs
@@ -111,7 +111,7 @@ pub mod write {
 
     /// The error returned by [`write()`](crate::write()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Commit(#[from] gix_lock::commit::Error<gix_lock::File>),
@@ -127,7 +127,7 @@ pub use write::function::write;
 pub mod read {
     /// The error returned by [`read`](crate::read()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not open shallow file for reading")]
         Io(#[from] std::io::Error),

--- a/gix-status/src/fscache.rs
+++ b/gix-status/src/fscache.rs
@@ -283,7 +283,7 @@ mod windows {
     /// # Safety
     ///
     /// `p` must point at `len` `u16`s of an in-bounds, initialized directory record.
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     unsafe fn name_from_maybe_unaligned<'a>(p: *const u16, len: usize) -> std::borrow::Cow<'a, [u16]> {
         if p.is_aligned() {
             std::borrow::Cow::Borrowed(unsafe { std::slice::from_raw_parts(p, len) })
@@ -319,7 +319,7 @@ mod windows {
             worktree.join(gix_path::from_bstr(rel_dir))
         };
         let dir_path = utf16_null_terminated(&dir);
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         let handle = unsafe {
             CreateFileW(
                 dir_path.as_ptr(),
@@ -344,7 +344,7 @@ mod windows {
         let buffer_bytes = (buffer.len() * 8) as u32;
 
         loop {
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             let success = unsafe {
                 GetFileInformationByHandleEx(
                     handle,
@@ -362,17 +362,20 @@ mod windows {
 
             let mut offset = 0usize;
             loop {
-                #[allow(clippy::cast_ptr_alignment)]
-                #[allow(unsafe_code)]
+                #[expect(
+                    clippy::cast_ptr_alignment,
+                    reason = "the caller guarantees the pointer alignment required by this cast"
+                )]
+                #[expect(unsafe_code)]
                 let info_ptr = unsafe { buffer.as_ptr().cast::<u8>().add(offset).cast::<FILE_ID_BOTH_DIR_INFO>() };
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 let info = unsafe { info_ptr.read_unaligned() };
                 let info = &info;
 
                 let name_len = (info.FileNameLength / 2) as usize;
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 let name_ptr = unsafe { (&raw const (*info_ptr).FileName).cast::<u16>() };
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 let name = unsafe { name_from_maybe_unaligned(name_ptr, name_len) };
                 let name_slice: &[u16] = &name;
 
@@ -402,7 +405,7 @@ mod windows {
             }
         }
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             CloseHandle(handle)
         };

--- a/gix-status/src/index_as_worktree/function.rs
+++ b/gix-status/src/index_as_worktree/function.rs
@@ -51,7 +51,7 @@ use crate::{
 ///
 /// Thus, some care has to be taken to do the right thing when letting the index match the worktree by evaluating the changes observed
 /// by the `collector`.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn index_as_worktree<'index, T, U, Find, E>(
     index: &'index gix_index::State,
     worktree: &Path,
@@ -259,7 +259,7 @@ struct State<'a, 'b> {
 type StatusResult<'index, T, U> = Result<(&'index gix_index::Entry, usize, &'index BStr, EntryStatus<T, U>), Error>;
 
 impl<'index> State<'_, 'index> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn process<T, U, Find, E>(
         &mut self,
         entries: &'index [gix_index::Entry],

--- a/gix-status/src/index_as_worktree/types.rs
+++ b/gix-status/src/index_as_worktree/types.rs
@@ -5,7 +5,7 @@ use gix_index::entry;
 
 /// The error returned by [index_as_worktree()`](crate::index_as_worktree()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not convert path to UTF8")]
     IllformedUtf8,

--- a/gix-status/src/index_as_worktree_with_renames/mod.rs
+++ b/gix-status/src/index_as_worktree_with_renames/mod.rs
@@ -44,7 +44,7 @@ pub(super) mod function {
     ///    -  Additional information that will be accessed during index modification checks and traversal.
     /// * `options`
     ///    - a way to configure both paths of the operation.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn index_as_worktree_with_renames<'index, T, U, Find, E>(
         index: &'index gix_index::State,
         worktree: &Path,
@@ -501,7 +501,7 @@ pub(super) mod function {
 
         /// Note that for non-files, we always return a null-sha and assume that the rename-tracking
         /// does nothing for these anyway.
-        #[allow(clippy::too_many_arguments)]
+        #[expect(clippy::too_many_arguments)]
         pub(super) fn calculate_worktree_id(
             object_hash: gix_hash::Kind,
             worktree_root: &Path,

--- a/gix-status/src/index_as_worktree_with_renames/types.rs
+++ b/gix-status/src/index_as_worktree_with_renames/types.rs
@@ -6,7 +6,7 @@ use crate::index_as_worktree::{Change, EntryStatus};
 
 /// The error returned by [index_as_worktree_with_renames()`](crate::index_as_worktree_with_renames()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     TrackedFileModifications(#[from] crate::index_as_worktree::Error),

--- a/gix-status/tests/status/index_as_worktree.rs
+++ b/gix-status/tests/status/index_as_worktree.rs
@@ -130,7 +130,7 @@ fn fixture_filtered(name: &str, pathspecs: &[&str], expected_status: &[Expectati
     )
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn fixture_filtered_detailed(
     name: &str,
     subdir: &str,

--- a/gix-submodule/src/config.rs
+++ b/gix-submodule/src/config.rs
@@ -139,7 +139,7 @@ impl TryFrom<&BStr> for Update {
 
 /// The error returned by [File::fetch_recurse()](crate::File::fetch_recurse) and [File::ignore()](crate::File::ignore).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[error("The '{field}' field of submodule '{submodule}' was invalid: '{actual}'")]
 pub struct Error {
     pub field: &'static str,
@@ -153,7 +153,7 @@ pub mod branch {
 
     /// The error returned by [File::branch()](crate::File::branch).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[error(
         "The value '{actual}' of the 'branch' field of submodule '{submodule}' couldn't be turned into a valid fetch refspec"
     )]
@@ -170,7 +170,7 @@ pub mod update {
 
     /// The error returned by [File::update()](crate::File::update).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The 'update' field of submodule '{submodule}' tried to set command '{actual}' to be shared")]
         CommandForbiddenInModulesConfiguration { submodule: BString, actual: BString },
@@ -185,7 +185,7 @@ pub mod url {
 
     /// The error returned by [File::url()](crate::File::url).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The url of submodule '{submodule}' could not be parsed")]
         Parse {
@@ -203,7 +203,7 @@ pub mod path {
 
     /// The error returned by [File::path()](crate::File::path).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The path '{actual}' of submodule '{submodule}' needs to be relative")]
         Absolute { actual: BString, submodule: BString },

--- a/gix-submodule/src/is_active_platform.rs
+++ b/gix-submodule/src/is_active_platform.rs
@@ -4,7 +4,7 @@ use crate::IsActivePlatform;
 
 /// The error returned by [File::names_and_active_state](crate::File::names_and_active_state()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     NormalizePattern(#[from] gix_pathspec::normalize::Error),

--- a/gix-tempfile/src/lib.rs
+++ b/gix-tempfile/src/lib.rs
@@ -136,7 +136,7 @@ static REGISTRY: LazyLock<HashMap<usize, Option<ForksafeTempfile>>> = LazyLock::
     if signal::handler::MODE.load(std::sync::atomic::Ordering::SeqCst) != signal::handler::Mode::None as usize {
         for sig in signal_hook::consts::TERM_SIGNALS {
             // SAFETY: handlers are considered unsafe because a lot can go wrong. See `cleanup_tempfiles()` for details on safety.
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             unsafe {
                 #[cfg(not(windows))]
                 {

--- a/gix-trace/tests/trace.rs
+++ b/gix-trace/tests/trace.rs
@@ -17,12 +17,10 @@ fn coarse() {
         event!(gix_trace::event::Level::WARN, "an info: {}", 42);
         event!(gix_trace::event::Level::INFO, answer = 42, field = "some");
         #[derive(Debug)]
-        #[allow(dead_code)]
         struct User {
             name: &'static str,
             email: &'static str,
         }
-        #[allow(unused_variables)]
         let user = User {
             name: "ferris",
             email: "ferris@example.com",

--- a/gix-transport/src/client/async_io/request.rs
+++ b/gix-transport/src/client/async_io/request.rs
@@ -86,7 +86,6 @@ impl<'a> RequestWriter<'a> {
                 encode::write_packet_line(&gix_packetline::PacketLineRef::ResponseEnd, self.writer.inner_mut()).await
             }
             MessageKind::Text(t) => {
-                #[allow(unused_variables, unused_imports)]
                 if self.trace {
                     use bstr::ByteSlice;
                     gix_features::trace::trace!(">> {}", t.as_bstr());

--- a/gix-transport/src/client/blocking_io/http/curl/mod.rs
+++ b/gix-transport/src/client/blocking_io/http/curl/mod.rs
@@ -26,7 +26,7 @@ pub struct Options {
 ///
 /// It can be used for downcasting errors, which are boxed to hide the actual implementation.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Curl(#[from] curl::Error),
@@ -139,7 +139,6 @@ impl Default for Curl {
     }
 }
 
-#[allow(clippy::type_complexity)]
 impl http::Http for Curl {
     type Headers = io::pipe::Reader;
     type ResponseBody = io::pipe::Reader;

--- a/gix-transport/src/client/blocking_io/http/mod.rs
+++ b/gix-transport/src/client/blocking_io/http/mod.rs
@@ -73,7 +73,7 @@ pub mod options {
 
     /// Available SSL version numbers.
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum SslVersion {
         /// The implementation default, which is unknown to this layer of abstraction.
         Default,
@@ -88,7 +88,6 @@ pub mod options {
 
     /// Available HTTP version numbers.
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd)]
-    #[allow(missing_docs)]
     pub enum HttpVersion {
         /// Equivalent to HTTP/1.1
         V1_1,
@@ -304,7 +303,6 @@ impl<H: Http> Transport<H> {
         Ok(())
     }
 
-    #[allow(clippy::unnecessary_wraps, unknown_lints)]
     fn add_basic_auth_if_present(&self, headers: &mut Vec<Cow<'_, str>>) -> Result<(), client::Error> {
         if let Some(gix_sec::identity::Account {
             username,

--- a/gix-transport/src/client/blocking_io/http/reqwest/remote.rs
+++ b/gix-transport/src/client/blocking_io/http/reqwest/remote.rs
@@ -18,7 +18,7 @@ use crate::client::blocking_io::http::{
 
 /// The error returned by the 'remote' helper, a purely internal construct to perform http requests.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),

--- a/gix-transport/src/client/blocking_io/http/traits.rs
+++ b/gix-transport/src/client/blocking_io/http/traits.rs
@@ -2,7 +2,7 @@ use crate::client::WriteMode;
 
 /// The error used by the [Http] trait.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not initialize the http client")]
     InitHttpClient {
@@ -86,7 +86,7 @@ impl<A, B, C> From<PostResponse<A, B, C>> for GetResponse<A, B> {
 /// A trait to abstract the HTTP operations needed to power all git interactions: read via GET and write via POST.
 /// Note that 401 must be turned into `std::io::Error(PermissionDenied)`, and other non-success http statuses must be transformed
 /// into `std::io::Error(Other)`
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub trait Http {
     /// A type providing headers line by line.
     type Headers: std::io::BufRead + Unpin;

--- a/gix-transport/src/client/blocking_io/request.rs
+++ b/gix-transport/src/client/blocking_io/request.rs
@@ -17,7 +17,6 @@ pub struct RequestWriter<'a> {
 
 impl io::Write for RequestWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        #[allow(unused_imports)]
         if self.trace {
             use bstr::ByteSlice;
             gix_features::trace::trace!(">> {}", buf.as_bstr());
@@ -78,7 +77,6 @@ impl<'a> RequestWriter<'a> {
                 encode::write_packet_line(&gix_packetline::PacketLineRef::ResponseEnd, self.writer.inner_mut())
             }
             MessageKind::Text(t) => {
-                #[allow(unused_variables, unused_imports)]
                 if self.trace {
                     use bstr::ByteSlice;
                     gix_features::trace::trace!(">> {}", t.as_bstr());

--- a/gix-transport/src/client/blocking_io/ssh/mod.rs
+++ b/gix-transport/src/client/blocking_io/ssh/mod.rs
@@ -9,7 +9,7 @@ use crate::{Protocol, client::blocking_io::file::SpawnProcessOnDemand};
 
 /// The error used in [`connect()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("The scheme in \"{}\" is not usable for an ssh connection", .0.to_bstring())]
     UnsupportedScheme(gix_url::Url),
@@ -44,7 +44,7 @@ pub mod invocation {
 
     /// The error returned when producing ssh invocation arguments based on a selected invocation kind.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Username '{user}' could be mistaken for a command-line argument")]
         AmbiguousUserName { user: String },
@@ -101,7 +101,10 @@ pub mod connect {
 /// The `desired_version` is the preferred protocol version when establishing the connection, but note that it can be
 /// downgraded by servers not supporting it.
 /// If `trace` is `true`, all packetlines received or sent will be passed to the facilities of the `gix-trace` crate.
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 pub fn connect(
     url: Url,
     desired_version: Protocol,
@@ -125,7 +128,10 @@ pub fn connect(
     ))
 }
 
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 fn determine_client_kind(
     known_kind: Option<ProgramKind>,
     ssh_cmd: &OsStr,
@@ -145,7 +151,10 @@ fn determine_client_kind(
     Ok(kind)
 }
 
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 fn build_client_feature_check_command(ssh_cmd: &OsStr, url: &Url, disallow_shell: bool) -> Result<Command, Error> {
     let mut prepare = gix_command::prepare(ssh_cmd)
         .stderr(Stdio::null())

--- a/gix-transport/src/client/capabilities.rs
+++ b/gix-transport/src/client/capabilities.rs
@@ -6,7 +6,7 @@ use crate::client;
 
 /// The error used in [`Capabilities::from_bytes()`] and [`Capabilities::from_lines()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Capabilities were missing entirely as there was no 0 byte")]
     MissingDelimitingNullByte,
@@ -255,7 +255,6 @@ pub mod blocking_recv {
 
 ///
 #[cfg(feature = "async-client")]
-#[allow(missing_docs)]
 pub mod async_recv {
     use bstr::ByteVec;
     use futures_io::AsyncRead;

--- a/gix-transport/src/client/git/blocking_io.rs
+++ b/gix-transport/src/client/git/blocking_io.rs
@@ -180,7 +180,7 @@ pub mod connect {
 
     /// The error used in [`connect()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("An IO error occurred when connecting to the server")]
         Io(#[from] std::io::Error),

--- a/gix-transport/src/client/non_io_types.rs
+++ b/gix-transport/src/client/non_io_types.rs
@@ -49,7 +49,7 @@ pub(crate) mod connect {
     ///
     /// (Both blocking and async I/O use the same error type.)
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Url(#[from] gix_url::parse::Error),
@@ -111,7 +111,7 @@ mod error {
 
     /// The error used in most methods of the [`client`][crate::client] module
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("A request was performed without performing the handshake first")]
         MissingHandshake,

--- a/gix-transport/tests/client/git.rs
+++ b/gix-transport/tests/client/git.rs
@@ -77,11 +77,11 @@ async fn handshake_v1_and_request() -> crate::Result {
     );
     let mut lines = res.refs.as_mut().expect("v1 protocol provides refs").lines();
     let mut refs = Vec::new();
-    #[allow(clippy::while_let_on_iterator)] // needed in async version of test
+    // needed in async version of test
     while let Some(line) = lines.next().await {
         refs.push(line?);
     }
-    #[allow(clippy::drop_non_drop)] // needed for non-async version
+    // needed for non-async version
     drop(lines);
 
     assert_eq!(
@@ -186,7 +186,7 @@ async fn push_v1_simulated() -> crate::Result {
         })));
         let mut lines = read.lines();
         let mut info = Vec::new();
-        #[allow(clippy::while_let_on_iterator)] // needed in async version of test
+        // needed in async version of test
         while let Some(line) = lines.next().await {
             info.push(line?);
         }
@@ -269,7 +269,7 @@ async fn handshake_v2_downgrade_to_v1() -> crate::Result {
     Ok(())
 }
 
-#[allow(clippy::unit_arg)] // side-effect of maybe-async
+#[expect(clippy::unit_arg)] // side-effect of maybe-async
 #[maybe_async::test(feature = "blocking-client", async(feature = "async-client", async_std::test))]
 async fn handshake_v2_and_request() -> crate::Result {
     #[cfg(feature = "blocking-client")]
@@ -351,7 +351,7 @@ async fn handshake_v2_and_request_inner() -> crate::Result {
 
     let mut lines = reader.lines();
     let mut refs = Vec::new();
-    #[allow(clippy::while_let_on_iterator)] // needed in async version of test
+    // needed in async version of test
     while let Some(line) = lines.next().await {
         refs.push(line?);
     }

--- a/gix-traverse/src/commit/simple.rs
+++ b/gix-traverse/src/commit/simple.rs
@@ -70,7 +70,7 @@ pub enum Sorting {
 
 /// The error is part of the item returned by the [Ancestors](super::Simple) iterator.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Find(#[from] gix_object::find::existing_iter::Error),
@@ -671,7 +671,7 @@ mod init {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn insert_into_seen_and_queue(
         seen: &mut gix_hashtable::HashSet<ObjectId>,
         hidden: &gix_revwalk::graph::IdMap<()>,

--- a/gix-traverse/src/commit/topo/mod.rs
+++ b/gix-traverse/src/commit/topo/mod.rs
@@ -4,7 +4,7 @@ use bitflags::bitflags;
 
 /// The errors that can occur during creation and iteration.
 #[derive(thiserror::Error, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Indegree information is missing")]
     MissingIndegreeUnexpected,

--- a/gix-traverse/src/tree/breadthfirst.rs
+++ b/gix-traverse/src/tree/breadthfirst.rs
@@ -5,7 +5,7 @@ use gix_hash::ObjectId;
 /// The error is part of the item returned by the [`breadthfirst()`](crate::tree::breadthfirst())  and
 ///[`depthfirst()`](crate::tree::depthfirst()) functions.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Find(#[from] gix_object::find::existing_iter::Error),

--- a/gix-url/src/expand_path.rs
+++ b/gix-url/src/expand_path.rs
@@ -24,7 +24,7 @@ impl From<ForUser> for Option<BString> {
 
 /// The error used by [`parse()`], [`with()`] and [`expand_path()`](crate::expand_path()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("UTF8 conversion on non-unix system failed for path: {path:?}")]
     IllformedUtf8 { path: BString },

--- a/gix-url/src/parse.rs
+++ b/gix-url/src/parse.rs
@@ -6,7 +6,7 @@ use crate::Scheme;
 
 /// The error returned by [parse()](crate::parse()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("{} \"{url}\" is not valid UTF-8", kind.as_str())]
     Utf8 {

--- a/gix-url/src/scheme.rs
+++ b/gix-url/src/scheme.rs
@@ -3,7 +3,6 @@
 /// It defines how to talk to a given repository.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[allow(missing_docs)]
 pub enum Scheme {
     /// A local resource that is accessible on the current host.
     File,

--- a/gix-url/src/simple_url.rs
+++ b/gix-url/src/simple_url.rs
@@ -14,7 +14,6 @@ pub(crate) struct ParsedUrl {
 
 /// Minimal parse error type to replace url::ParseError
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[allow(missing_docs)]
 pub enum UrlParseError {
     #[error("relative URL without a base")]
     RelativeUrlWithoutBase,

--- a/gix-url/tests/url/baseline.rs
+++ b/gix-url/tests/url/baseline.rs
@@ -103,7 +103,7 @@ fn assert_urls_equal(expected: &baseline::GitDiagUrl<'_>, actual: &gix_url::Url)
     assert_eq!(actual.path, expected.path.unwrap_or_default());
 }
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 mod baseline {
     use bstr::{BStr, BString, ByteSlice};
     use std::sync::LazyLock;

--- a/gix-validate/src/path.rs
+++ b/gix-validate/src/path.rs
@@ -4,7 +4,7 @@ use bstr::{BStr, ByteSlice};
 pub mod component {
     /// The error returned by [`component()`](super::component()).
     #[derive(Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[non_exhaustive]
     pub enum Error {
         Empty,

--- a/gix-validate/src/reference.rs
+++ b/gix-validate/src/reference.rs
@@ -7,7 +7,7 @@ pub mod name {
 
     /// The error used in [name()][super::name()] and [`name_partial()`][super::name_partial()]
     #[derive(Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[non_exhaustive]
     pub enum Error {
         InvalidByte { byte: BString },

--- a/gix-validate/src/submodule.rs
+++ b/gix-validate/src/submodule.rs
@@ -4,7 +4,7 @@ use bstr::{BStr, ByteSlice};
 pub mod name {
     /// The error used in [name()](super::name()).
     #[derive(Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[non_exhaustive]
     pub enum Error {
         Empty,

--- a/gix-validate/src/tag.rs
+++ b/gix-validate/src/tag.rs
@@ -6,7 +6,7 @@ pub mod name {
 
     /// The error returned by [`name()`][super::name()].
     #[derive(Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[non_exhaustive]
     pub enum Error {
         InvalidByte { byte: BString },

--- a/gix-worktree-state/src/checkout/function.rs
+++ b/gix-worktree-state/src/checkout/function.rs
@@ -15,7 +15,6 @@ use crate::checkout::chunk;
 ///
 /// Note that interruption still produce an `Ok(…)` value, so the caller should look at `should_interrupt` to communicate the outcome.
 ///
-#[allow(clippy::too_many_arguments)]
 pub fn checkout<Find>(
     index: &mut gix_index::State,
     dir: impl Into<std::path::PathBuf>,
@@ -34,7 +33,7 @@ where
     res
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn checkout_inner<Find>(
     index: &mut gix_index::State,
     paths: &gix_index::PathStorage,

--- a/gix-worktree-state/src/checkout/mod.rs
+++ b/gix-worktree-state/src/checkout/mod.rs
@@ -76,7 +76,7 @@ pub struct Options {
 
 /// The error returned by the [checkout()][crate::checkout()] function.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not convert path to UTF8: {}", .path)]
     IllformedUtf8 { path: BString },

--- a/gix-worktree-stream/src/from_tree/mod.rs
+++ b/gix-worktree-stream/src/from_tree/mod.rs
@@ -130,7 +130,6 @@ where
         )
         .or_raise(|| message("Could not write entry header"))?;
         // pipe writer always writes all in one go.
-        #[allow(clippy::unused_io_amount)]
         match entry.source {
             entry::Source::Memory(buf) => out.write(&buf).map(|_| ()),
             entry::Source::Null => out.write(&[]).map(|_| ()),

--- a/gix-worktree-stream/src/from_tree/traverse.rs
+++ b/gix-worktree-stream/src/from_tree/traverse.rs
@@ -86,7 +86,6 @@ where
             .or_raise(|| message("Could not convert to worktree representation"))?;
 
         // Our pipe writer always writes the whole amount.
-        #[allow(clippy::unused_io_amount)]
         match converted {
             ToWorktreeOutcome::Unchanged(buf) | ToWorktreeOutcome::Buffer(buf) => {
                 protocol::write_entry_header_and_path(

--- a/gix-worktree-stream/src/protocol.rs
+++ b/gix-worktree-stream/src/protocol.rs
@@ -48,8 +48,10 @@ pub(crate) fn write_entry_header_and_path(
     bytes[1] = hash_to_byte(oid.kind());
     bytes[2..][..oid.kind().len_in_bytes()].copy_from_slice(oid.as_bytes());
 
-    // We know how `out` works in a pipe writer, it's always writing everything.
-    #[allow(clippy::unused_io_amount)]
+    #[expect(
+        clippy::unused_io_amount,
+        reason = "We know how `out` works in a pipe writer, it's always writing everything."
+    )]
     {
         out.write(&buf[..HEADER_LEN + oid.kind().len_in_bytes()])?;
         out.write(path)?;
@@ -67,8 +69,10 @@ pub(crate) fn write_stream(
     const BUF_LEN: usize = u16::MAX as usize;
     clear_and_set_len(buf, BUF_LEN)?;
 
-    // We know how `out` works in a pipe writer, it's always writing everything.
-    #[allow(clippy::unused_io_amount)]
+    #[expect(
+        clippy::unused_io_amount,
+        reason = "We know how `out` works in a pipe writer, it's always writing everything."
+    )]
     loop {
         match input.read(buf) {
             Ok(0) => {

--- a/gix-worktree/src/stack/state/attributes.rs
+++ b/gix-worktree/src/stack/state/attributes.rs
@@ -83,7 +83,7 @@ impl Attributes {
         self.stack.pop_pattern_list().expect("something to pop");
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn push_directory(
         &mut self,
         root: &Path,

--- a/gix-worktree/src/stack/state/ignore.rs
+++ b/gix-worktree/src/stack/state/ignore.rs
@@ -160,7 +160,7 @@ impl Ignore {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn push_directory(
         &mut self,
         root: &Path,

--- a/gix-worktree/src/stack/state/mod.rs
+++ b/gix-worktree/src/stack/state/mod.rs
@@ -30,7 +30,6 @@ pub struct Attributes {
 /// State related to the exclusion of files, supporting static overrides and globals, along with a stack of dynamically read
 /// ignore files from disk or from the index each time the directory changes.
 #[derive(Default, Clone)]
-#[allow(unused)]
 pub struct Ignore {
     /// Ignore patterns passed as overrides to everything else, typically passed on the command-line and the first patterns to
     /// be consulted.

--- a/gix-zlib/src/decompress.rs
+++ b/gix-zlib/src/decompress.rs
@@ -6,7 +6,7 @@ use crate::{Decompress, FlushDecompress, Status};
 ///
 /// The error produced by [`Decompress::decompress()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum DecompressError {
     #[error("stream error")]
     StreamError,

--- a/gix-zlib/src/inflate.rs
+++ b/gix-zlib/src/inflate.rs
@@ -2,7 +2,7 @@ use crate::{FlushDecompress, Inflate, Status};
 
 /// The error returned by various [Inflate methods][super::Inflate]
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not write all bytes when decompressing content")]
     WriteInflated(#[from] std::io::Error),

--- a/gix-zlib/src/lib.rs
+++ b/gix-zlib/src/lib.rs
@@ -60,7 +60,6 @@ pub enum Status {
 /// decompressing in-memory data.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[non_exhaustive]
-#[allow(clippy::unnecessary_cast)]
 pub enum FlushDecompress {
     /// A typical parameter for passing to compression/decompression functions,
     /// this indicates that the underlying stream to decide how much data to

--- a/gix-zlib/src/stream/deflate.rs
+++ b/gix-zlib/src/stream/deflate.rs
@@ -76,7 +76,7 @@ impl Compress {
 
 /// The error produced by [`Compress::compress()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum CompressError {
     #[error("stream error")]
     StreamError,
@@ -100,7 +100,6 @@ impl From<zlib_rs::DeflateError> for CompressError {
 /// in-memory data.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[non_exhaustive]
-#[allow(clippy::unnecessary_cast)]
 pub enum FlushCompress {
     /// A typical parameter for passing to compression/decompression functions,
     /// this indicates that the underlying stream to decide how much data to

--- a/gix-zlib/tests/zlib/stream/deflate.rs
+++ b/gix-zlib/tests/zlib/stream/deflate.rs
@@ -53,7 +53,7 @@ fn small_file_decompress() -> Result<(), Box<dyn std::error::Error>> {
     let r = InflateReader::from_read(io::BufReader::new(std::fs::File::open(fixture_path(
         "objects/37/d4e6c5c48ba0d245164c4e10d5f41140cab980",
     ))?));
-    #[allow(clippy::unbuffered_bytes)]
+    #[expect(clippy::unbuffered_bytes)]
     let mut bytes = r.bytes();
     let content = bytes.by_ref().take(16).collect::<Result<Vec<_>, _>>()?;
     assert_eq!(content.as_slice().as_bstr(), b"blob 9\0hi there\n".as_bstr());

--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -8,7 +8,7 @@ pub mod main_worktree {
 
     /// The error returned by [`PrepareCheckout::main_worktree()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Repository at \"{}\" is a bare repository and cannot have a main worktree checkout", git_dir.display())]
         BareRepository { git_dir: PathBuf },

--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -6,7 +6,7 @@ use gix_ref::Category;
 
 /// The error returned by [`PrepareFetch::fetch_only()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Connect(#[from] crate::remote::connect::Error),

--- a/gix/src/clone/fetch/util.rs
+++ b/gix/src/clone/fetch/util.rs
@@ -16,7 +16,10 @@ enum WriteMode {
     Append,
 }
 
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 pub fn append_remote_to_local_config_file(
     remote: &mut crate::Remote<'_>,
     remote_name: BString,

--- a/gix/src/clone/mod.rs
+++ b/gix/src/clone/mod.rs
@@ -48,7 +48,7 @@ pub struct PrepareFetch {
 
 /// The error returned by [`PrepareFetch::new()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Init(#[from] crate::init::Error),
@@ -75,7 +75,10 @@ impl PrepareFetch {
     ///
     /// Similar to `git`, a missing user name and email configuration is not terminal and we will fill it in with dummy values. However,
     /// instead of deriving values from the system, ours are hardcoded to indicate what happened.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     pub fn new<Url, E>(
         url: Url,
         path: impl AsRef<std::path::Path>,
@@ -96,7 +99,10 @@ impl PrepareFetch {
         )
     }
 
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     fn new_inner(
         mut url: gix_url::Url,
         path: &std::path::Path,

--- a/gix/src/commit.rs
+++ b/gix/src/commit.rs
@@ -8,7 +8,7 @@ pub const NO_PARENT_IDS: [gix_hash::ObjectId; 0] = [];
 
 /// The error returned by [`commit(…)`](crate::Repository::commit()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     ParseTime(#[from] crate::config::time::Error),
@@ -79,7 +79,7 @@ pub mod describe {
 
     /// The error returned by [`try_format()`][Platform::try_format()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         OpenCache(#[from] crate::repository::commit_graph_if_enabled::Error),

--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -18,7 +18,7 @@ use crate::{
 
 /// Initialization
 impl Cache {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn from_stage_one(
         StageOne {
             git_dir_config,

--- a/gix/src/config/mod.rs
+++ b/gix/src/config/mod.rs
@@ -57,7 +57,7 @@ pub mod section {
 pub mod set_value {
     /// The error produced when calling [`SnapshotMut::set(_subsection)?_value()`][crate::config::SnapshotMut::set_value()]
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         SetRaw(#[from] gix_config::file::set_raw_value::Error),
@@ -74,7 +74,7 @@ pub mod set_value {
 ///
 /// This configuration is on the critical path when opening a repository.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     ConfigBoolean(#[from] boolean::Error),
@@ -129,7 +129,7 @@ pub mod merge {
     pub mod pipeline_options {
         /// The error produced when obtaining options needed to fill in [gix_merge::blob::pipeline::Options].
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             BigFileThreshold(#[from] crate::config::unsigned_integer::Error),
@@ -140,7 +140,7 @@ pub mod merge {
     pub mod drivers {
         /// The error produced when obtaining a list of [Drivers](gix_merge::blob::Driver).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             ConfigBoolean(#[from] crate::config::boolean::Error),
@@ -156,7 +156,7 @@ pub mod diff {
 
         /// The error produced when obtaining `diff.algorithm`.
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("Unknown diff algorithm named '{name}'")]
             Unknown { name: BString },
@@ -169,7 +169,7 @@ pub mod diff {
     pub mod pipeline_options {
         /// The error produced when obtaining options needed to fill in [gix_diff::blob::pipeline::Options].
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             FilesystemCapabilities(#[from] crate::config::boolean::Error),
@@ -200,7 +200,7 @@ pub mod diff {
 pub mod stat_options {
     /// The error produced when collecting stat information, and returned by [Repository::stat_options()](crate::Repository::stat_options()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         ConfigCheckStat(#[from] super::key::GenericErrorWithValue),
@@ -214,7 +214,7 @@ pub mod stat_options {
 pub mod checkout_options {
     /// The error produced when collecting all information needed for checking out files into a worktree.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         ConfigCheckStat(#[from] super::key::GenericErrorWithValue),
@@ -239,7 +239,7 @@ pub mod command_context {
     /// The error produced when collecting all information relevant to spawned commands,
     /// obtained via [Repository::command_context()](crate::Repository::command_context()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Boolean(#[from] config::boolean::Error),
@@ -255,7 +255,7 @@ pub mod exclude_stack {
 
     /// The error produced when setting up a stack to query `gitignore` information.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not read repository exclude")]
         Io(#[from] std::io::Error),
@@ -272,7 +272,7 @@ pub mod exclude_stack {
 pub mod attribute_stack {
     /// The error produced when setting up the attribute stack to query `gitattributes`.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("An attribute file could not be read")]
         Io(#[from] std::io::Error),
@@ -289,7 +289,7 @@ pub mod protocol {
 
         /// The error returned when obtaining the permission for a particular scheme.
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         #[error("The value {value:?} must be allow|deny|user in configuration key protocol{0}.allow", scheme.as_ref().map(|s| format!(".{s}")).unwrap_or_default())]
         pub struct Error {
             pub scheme: Option<String>,
@@ -302,7 +302,6 @@ pub mod protocol {
 pub mod ssh_connect_options {
     /// The error produced when obtaining ssh connection configuration.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
     #[error(transparent)]
     pub struct Error(#[from] super::key::GenericErrorWithValue);
 }
@@ -538,7 +537,7 @@ pub mod transport {
 
     /// The error produced when configuring a transport for a particular protocol.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(
             "Could not interpret configuration key {key:?} as {kind} integer of desired range with value: {actual}"
@@ -575,7 +574,7 @@ pub mod transport {
 
         /// The error produced when configuring a HTTP transport.
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             Boolean(#[from] crate::config::boolean::Error),

--- a/gix/src/config/overrides.rs
+++ b/gix/src/config/overrides.rs
@@ -4,7 +4,7 @@ use crate::bstr::{BStr, BString, ByteSlice};
 
 /// The error returned by [`SnapshotMut::apply_cli_overrides()`][crate::config::SnapshotMut::append_config()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("{input:?} is not a valid configuration key. Examples are 'core.abbrev' or 'remote.origin.url'")]
     InvalidKey { input: BString },

--- a/gix/src/config/snapshot/credential_helpers.rs
+++ b/gix/src/config/snapshot/credential_helpers.rs
@@ -7,7 +7,7 @@ mod error {
 
     /// The error returned by [`Snapshot::credential_helpers()`][super::Snapshot::credential_helpers()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not parse 'useHttpPath' key in section {section}")]
         InvalidUseHttpPath {

--- a/gix/src/config/tree/keys.rs
+++ b/gix/src/config/tree/keys.rs
@@ -529,7 +529,10 @@ mod remote_name {
         }
 
         /// Try to validate `name` as symbolic remote name and return it.
-        #[allow(clippy::result_large_err)]
+        #[expect(
+            clippy::result_large_err,
+            reason = "will be removed once `gix-error` is used consistently"
+        )]
         pub fn try_into_symbolic_name(
             &'static self,
             name: impl gix_utils::AsBStr,

--- a/gix/src/config/tree/mod.rs
+++ b/gix/src/config/tree/mod.rs
@@ -125,7 +125,6 @@ pub mod key {
         /// The error returned by [`Key::validate()`][crate::config::tree::Key::validate()].
         #[derive(Debug, thiserror::Error)]
         #[error(transparent)]
-        #[allow(missing_docs)]
         pub struct Error {
             #[from]
             source: Box<dyn std::error::Error + Send + Sync + 'static>,
@@ -135,7 +134,7 @@ pub mod key {
     pub mod validate_assignment {
         /// The error returned by [`Key::validated_assignment`*()][crate::config::tree::Key::validated_assignment_fmt()].
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("Failed to validate the value to be assigned to this key")]
             Validate(#[from] super::validate::Error),

--- a/gix/src/create.rs
+++ b/gix/src/create.rs
@@ -9,7 +9,7 @@ use gix_discover::DOT_GIT_DIR;
 
 /// The error used in [`into()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not obtain the current directory")]
     CurrentDir(#[from] std::io::Error),

--- a/gix/src/diff.rs
+++ b/gix/src/diff.rs
@@ -7,7 +7,7 @@ pub mod options {
     pub mod init {
         /// The error returned when instantiating [diff options](crate::diff::Options).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[cfg(feature = "blob-diff")]
             #[error(transparent)]
@@ -142,7 +142,7 @@ pub(crate) mod utils {
     pub mod new_rewrites {
         /// The error returned by [`new_rewrites()`](super::new_rewrites()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             ConfigDiffRenames(#[from] crate::config::key::GenericError),
@@ -155,7 +155,7 @@ pub(crate) mod utils {
     pub mod resource_cache {
         /// The error returned by [`resource_cache()`](super::resource_cache()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             DiffAlgorithm(#[from] crate::config::diff::algorithm::Error),
@@ -174,7 +174,6 @@ pub(crate) mod utils {
     /// Returns `Ok((None, false))` if nothing is configured, or `Ok((None, true))` if it's configured and disabled.
     ///
     /// Note that missing values will be defaulted similar to what git does.
-    #[allow(clippy::result_large_err)]
     pub fn new_rewrites(
         config: &gix_config::File,
         lenient: bool,

--- a/gix/src/dirwalk/iter.rs
+++ b/gix/src/dirwalk/iter.rs
@@ -43,7 +43,7 @@ pub struct Outcome {
 
 /// The error returned by [Repository::dirwalk_iter()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Failed to spawn producer thread")]
     #[cfg(feature = "parallel")]

--- a/gix/src/dirwalk/mod.rs
+++ b/gix/src/dirwalk/mod.rs
@@ -24,7 +24,7 @@ pub mod iter;
 /// to interrupt unless the interrupt flag is set from another thread.
 pub struct Iter {
     #[cfg(feature = "parallel")]
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     rx_and_join: Option<(
         std::sync::mpsc::Receiver<iter::Item>,
         std::thread::JoinHandle<Result<iter::Outcome, Error>>,
@@ -40,7 +40,7 @@ pub struct Iter {
 
 /// The error returned by [dirwalk()](crate::Repository::dirwalk()).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Walk(#[from] gix_dir::walk::Error),

--- a/gix/src/discover.rs
+++ b/gix/src/discover.rs
@@ -7,7 +7,7 @@ use crate::{ThreadSafeRepository, bstr::BString};
 
 /// The error returned by [`crate::discover()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Discover(#[from] upwards::Error),

--- a/gix/src/env.rs
+++ b/gix/src/env.rs
@@ -56,7 +56,7 @@ pub mod collate {
         /// It can be used to detect if the repository is likely be corrupted in some way, or if the fetch failed spuriously
         /// and thus can be retried.
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error<E: std::error::Error + Send + Sync + 'static = std::convert::Infallible> {
             #[error(transparent)]
             Open(#[from] crate::open::Error),

--- a/gix/src/filter.rs
+++ b/gix/src/filter.rs
@@ -20,7 +20,7 @@ pub mod pipeline {
 
         /// The error returned by [Pipeline::options()](crate::filter::Pipeline::options()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             CheckRoundTripEncodings(#[from] config::encoding::Error),
@@ -40,7 +40,7 @@ pub mod pipeline {
     pub mod convert_to_git {
         /// The error returned by [Pipeline::convert_to_git()](crate::filter::Pipeline::convert_to_git()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("Failed to prime attributes to the path at which the data resides")]
             WorktreeCacheAtPath(#[from] std::io::Error),
@@ -53,7 +53,7 @@ pub mod pipeline {
     pub mod convert_to_worktree {
         /// The error returned by [Pipeline::convert_to_worktree()](crate::filter::Pipeline::convert_to_worktree()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("Failed to prime attributes to the path at which the data resides")]
             WorktreeCacheAtPath(#[from] std::io::Error),
@@ -68,7 +68,7 @@ pub mod pipeline {
 
         /// The error returned by [Pipeline::worktree_file_to_object()](crate::filter::Pipeline::worktree_file_to_object()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("Cannot add worktree files in bare repositories")]
             MissingWorktree,

--- a/gix/src/head/peel.rs
+++ b/gix/src/head/peel.rs
@@ -10,7 +10,7 @@ mod error {
     /// The error returned by [`Head::peel_to_id()`](super::Head::try_peel_to_id()) and
     /// [`Head::into_fully_peeled_id()`](super::Head::try_into_peeled_id()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         FindExistingObject(#[from] object::find::existing::Error),
@@ -27,7 +27,7 @@ pub mod into_id {
 
     /// The error returned by [`Head::into_peeled_id()`](super::Head::into_peeled_id()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Peel(#[from] super::Error),
@@ -44,7 +44,7 @@ pub mod to_commit {
 
     /// The error returned by [`Head::peel_to_commit()`](super::Head::peel_to_commit()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         PeelToObject(#[from] super::to_object::Error),
@@ -57,7 +57,7 @@ pub mod to_commit {
 pub mod to_object {
     /// The error returned by [`Head::peel_to_object()`](super::Head::peel_to_object()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Peel(#[from] super::Error),

--- a/gix/src/id.rs
+++ b/gix/src/id.rs
@@ -72,7 +72,7 @@ fn calculate_auto_hex_len(num_packed_objects: u64) -> usize {
 pub mod shorten {
     /// Returned by [`Id::prefix()`][super::Id::shorten()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         PackedObjectsCount(#[from] gix_odb::store::load_index::Error),

--- a/gix/src/init.rs
+++ b/gix/src/init.rs
@@ -22,7 +22,7 @@ pub const DEFAULT_BRANCH_NAME: &str = "main";
 
 /// The error returned by [`crate::init()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Could not obtain the current directory")]
     CurrentDir(#[from] std::io::Error),

--- a/gix/src/interrupt.rs
+++ b/gix/src/interrupt.rs
@@ -48,7 +48,7 @@ mod init {
             for (sig, _) in hooks {
                 // # SAFETY
                 // * we only register a handler that is specifically designed to run in this environment.
-                #[allow(unsafe_code)]
+                #[expect(unsafe_code)]
                 unsafe {
                     default_hooks.push(signal_hook::low_level::register(sig, move || {
                         signal_hook::low_level::emulate_default_handler(sig).ok();
@@ -91,7 +91,7 @@ mod init {
     /// deadlocking even when trying to write to stderr directly.
     ///
     /// SAFETY: `interrupt()` will be called from a signal handler. See [`signal_hook::low_level::register()`] for details about.
-    #[allow(unsafe_code, clippy::missing_safety_doc)]
+    #[expect(unsafe_code, clippy::missing_safety_doc)]
     pub unsafe fn init_handler(
         grace_count: usize,
         interrupt: impl Fn() + Send + Sync + Clone + 'static,
@@ -126,7 +126,7 @@ mod init {
                 interrupt();
                 super::trigger();
             };
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             unsafe {
                 let hook_id = signal_hook::low_level::register(*sig, action)?;
                 hooks.push((*sig, hook_id));

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -254,7 +254,10 @@ pub mod merge;
 /// assert!(repo.workdir_path("this").expect("non-bare").is_file());
 /// # Ok(()) }
 /// ```
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 pub fn discover(directory: impl AsRef<std::path::Path>) -> Result<Repository, discover::Error> {
     ThreadSafeRepository::discover(directory).map(Into::into)
 }
@@ -262,7 +265,10 @@ pub fn discover(directory: impl AsRef<std::path::Path>) -> Result<Repository, di
 /// Try to discover a git repository directly from the environment.
 ///
 /// For details, see [`ThreadSafeRepository::discover_with_environment_overrides_opts()`].
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 pub fn discover_with_environment_overrides(
     directory: impl AsRef<std::path::Path>,
 ) -> Result<Repository, discover::Error> {
@@ -272,7 +278,10 @@ pub fn discover_with_environment_overrides(
 /// Try to open a git repository directly from the environment.
 ///
 /// See [`ThreadSafeRepository::open_with_environment_overrides()`].
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 pub fn open_with_environment_overrides(directory: impl Into<std::path::PathBuf>) -> Result<Repository, open::Error> {
     ThreadSafeRepository::open_with_environment_overrides(directory, Default::default()).map(Into::into)
 }
@@ -292,13 +301,19 @@ pub fn open_with_environment_overrides(directory: impl Into<std::path::PathBuf>)
 /// assert!(repo.head()?.is_unborn());
 /// # Ok(()) }
 /// ```
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 pub fn init(directory: impl AsRef<std::path::Path>) -> Result<Repository, init::Error> {
     ThreadSafeRepository::init(directory, create::Kind::WithWorktree, create::Options::default()).map(Into::into)
 }
 
 /// See [`ThreadSafeRepository::init()`], but returns a [`Repository`] instead.
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 pub fn init_bare(directory: impl AsRef<std::path::Path>) -> Result<Repository, init::Error> {
     ThreadSafeRepository::init(directory, create::Kind::Bare, create::Options::default()).map(Into::into)
 }
@@ -307,7 +322,10 @@ pub fn init_bare(directory: impl AsRef<std::path::Path>) -> Result<Repository, i
 /// amended with using configuration from the git installation to ensure all authentication options are honored).
 ///
 /// See [`clone::PrepareFetch::new()`] for a function to take full control over all options.
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 pub fn prepare_clone_bare<Url, E>(
     url: Url,
     path: impl AsRef<std::path::Path>,
@@ -329,7 +347,10 @@ where
 /// (but amended with using configuration from the git installation to ensure all authentication options are honored).
 ///
 /// See [`clone::PrepareFetch::new()`] for a function to take full control over all options.
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 pub fn prepare_clone<Url, E>(url: Url, path: impl AsRef<std::path::Path>) -> Result<clone::PrepareFetch, clone::Error>
 where
     Url: std::convert::TryInto<gix_url::Url, Error = E>,
@@ -365,14 +386,20 @@ fn open_opts_with_git_binary_config() -> open::Options {
 /// assert_eq!(repo.head_commit()?.decode()?.message, "c2\n");
 /// # Ok(()) }
 /// ```
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 #[doc(alias = "git2")]
 pub fn open(directory: impl Into<std::path::PathBuf>) -> Result<Repository, open::Error> {
     ThreadSafeRepository::open(directory).map(Into::into)
 }
 
 /// See [`ThreadSafeRepository::open_opts()`], but returns a [`Repository`] instead.
-#[allow(clippy::result_large_err)]
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 #[doc(alias = "open_ext", alias = "git2")]
 pub fn open_opts(directory: impl Into<std::path::PathBuf>, options: open::Options) -> Result<Repository, open::Error> {
     ThreadSafeRepository::open_opts(directory, options).map(Into::into)

--- a/gix/src/mailmap.rs
+++ b/gix/src/mailmap.rs
@@ -4,7 +4,7 @@ pub use gix_mailmap::*;
 pub mod load {
     /// The error returned by [`crate::Repository::open_mailmap_into()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The mailmap file declared in `mailmap.file` could not be read")]
         Io(#[from] std::io::Error),

--- a/gix/src/object/blob.rs
+++ b/gix/src/object/blob.rs
@@ -26,7 +26,7 @@ pub mod diff {
 
         /// The error returned by [Platform::lines()](super::Platform::lines()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error<E>
         where
             E: std::error::Error + Send + Sync + 'static,

--- a/gix/src/object/commit.rs
+++ b/gix/src/object/commit.rs
@@ -4,7 +4,7 @@ mod error {
     use crate::object;
 
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         FindExistingObject(#[from] object::find::existing::Error),

--- a/gix/src/object/errors.rs
+++ b/gix/src/object/errors.rs
@@ -3,7 +3,7 @@ pub mod conversion {
 
     /// The error returned by [`crate::object::try_to_()`][crate::Object::try_to_commit_ref()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Decode(#[from] gix_object::decode::Error),
@@ -30,7 +30,7 @@ pub mod find {
         pub mod with_conversion {
             /// The error returned by [Repository::find_commit()](crate::Repository::find_commit).
             #[derive(Debug, thiserror::Error)]
-            #[allow(missing_docs)]
+            #[expect(missing_docs)]
             pub enum Error {
                 #[error(transparent)]
                 Find(#[from] crate::object::find::existing::Error),

--- a/gix/src/object/mod.rs
+++ b/gix/src/object/mod.rs
@@ -23,7 +23,7 @@ pub mod tree;
 ///
 pub mod try_into {
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     #[error("Object named {id} was supposed to be of kind {expected}, but was kind {actual}.")]
     pub struct Error {
         pub actual: gix_object::Kind,

--- a/gix/src/object/peel.rs
+++ b/gix/src/object/peel.rs
@@ -13,7 +13,7 @@ pub mod to_kind {
 
         /// The error returned by [`Object::peel_to_kind()`][crate::Object::peel_to_kind()].
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             FindExistingObject(#[from] object::find::existing::Error),

--- a/gix/src/object/tree/diff/for_each.rs
+++ b/gix/src/object/tree/diff/for_each.rs
@@ -5,7 +5,7 @@ use crate::{Tree, diff::rewrites::tracker};
 
 /// The error return by methods on the [diff platform][Platform].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Diff(#[from] gix_diff::tree_with_rewrites::Error),

--- a/gix/src/object/tree/diff/mod.rs
+++ b/gix/src/object/tree/diff/mod.rs
@@ -124,7 +124,10 @@ impl<'repo> Tree<'repo> {
     /// Note that if a clone with `--filter=blob=none` was created, rename tracking may fail as it might
     /// try to access blobs to compute a similarity metric. Thus, it's more compatible to turn rewrite tracking off
     /// using [`Options::track_rewrites()`](crate::diff::Options::track_rewrites()).
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     #[doc(alias = "diff_tree_to_tree", alias = "git2")]
     pub fn changes<'a>(&'a self) -> Result<Platform<'a, 'repo>, crate::diff::options::init::Error> {
         Ok(Platform {
@@ -169,7 +172,7 @@ pub struct Stats {
 pub mod stats {
     /// The error returned by [`stats()`](super::Platform::stats()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         CreateResourceCache(#[from] crate::repository::diff_resource_cache::Error),

--- a/gix/src/object/tree/editor.rs
+++ b/gix/src/object/tree/editor.rs
@@ -11,7 +11,7 @@ use crate::{
 pub mod init {
     /// The error returned by [`Editor::new()](crate::object::tree::Editor::new()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         DecodeTree(#[from] gix_object::decode::Error),
@@ -26,7 +26,7 @@ pub mod write {
 
     /// The error returned by [`Editor::write()](crate::object::tree::Editor::write()) and [`Cursor::write()](super::Cursor::write).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         WriteTree(#[from] crate::object::write::Error),

--- a/gix/src/open/mod.rs
+++ b/gix/src/open/mod.rs
@@ -42,7 +42,7 @@ pub struct Options {
 
 /// The error returned by [`crate::open()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("Failed to load the git configuration")]
     Config(#[from] config::Error),

--- a/gix/src/open/options.rs
+++ b/gix/src/open/options.rs
@@ -143,7 +143,10 @@ impl Options {
     }
 
     /// Open a repository at `path` with the options set so far.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     pub fn open(self, path: impl Into<PathBuf>) -> Result<ThreadSafeRepository, Error> {
         ThreadSafeRepository::open_opts(path, self)
     }

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -303,7 +303,7 @@ impl ThreadSafeRepository {
                     _ => worktree_dir_from_repository_config(&git_dir, wt_path, current_dir),
                 };
                 worktree_dir = gix_path::normalize(wt_path.into(), current_dir).map(Cow::into_owned);
-                #[allow(unused_variables)]
+                #[allow(unused_variables, reason = "Used when tracing is enabled at compile time.")]
                 if let Some(worktree_path) = worktree_dir.as_deref().filter(|wtd| !wtd.is_dir()) {
                     gix_trace::warn!(
                         "The configured worktree path '{}' is not a directory or doesn't exist - `core.worktree` may be misleading",

--- a/gix/src/pathspec.rs
+++ b/gix/src/pathspec.rs
@@ -7,7 +7,7 @@ use crate::{AttributeStack, Pathspec, PathspecDetached, Repository, bstr::BStr};
 pub mod init {
     /// The error returned by [`Pathspec::new()`](super::Pathspec::new()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         MakeAttributes(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),

--- a/gix/src/reference/edits.rs
+++ b/gix/src/reference/edits.rs
@@ -9,7 +9,7 @@ pub mod set_target_id {
 
         /// The error returned by [`Reference::set_target_id()`][super::Reference::set_target_id()].
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error("Cannot change symbolic reference {name:?} into a direct one by setting it to an id")]
             SymbolicReference { name: FullName },
@@ -27,7 +27,6 @@ pub mod set_target_id {
         /// Furthermore, refrain from using this method for more than a one-off change as it creates a transaction for each invocation.
         /// If multiple reference should be changed, use [`Repository::edit_references()`][crate::Repository::edit_references()]
         /// or the lower level reference database instead.
-        #[allow(clippy::result_large_err)]
         pub fn set_target_id(
             &mut self,
             id: impl Into<gix_hash::ObjectId>,

--- a/gix/src/reference/errors.rs
+++ b/gix/src/reference/errors.rs
@@ -5,7 +5,7 @@ pub mod edit {
     /// The error returned by [`edit_references(…)`][crate::Repository::edit_references()], and others
     /// which ultimately create a reference.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         FileTransactionPrepare(#[from] gix_ref::file::transaction::prepare::Error),
@@ -27,7 +27,7 @@ pub mod peel {
     /// The error returned by [`Reference::peel_to_id()`](crate::Reference::peel_to_id()) and
     /// [`Reference::into_fully_peeled_id()`](crate::Reference::into_fully_peeled_id()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         ToId(#[from] gix_ref::peel::to_id::Error),
@@ -39,7 +39,7 @@ pub mod peel {
     pub mod to_kind {
         /// The error returned by [`Reference::peel_to_kind(…)`](crate::Reference::peel_to_kind()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             FollowToObject(#[from] gix_ref::peel::to_object::Error),
@@ -59,7 +59,7 @@ pub mod follow {
     pub mod to_object {
         /// The error returned by [`Reference::follow_to_object(…)`](crate::Reference::follow_to_object()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             FollowToObject(#[from] gix_ref::peel::to_object::Error),
@@ -73,7 +73,7 @@ pub mod follow {
 pub mod head_id {
     /// The error returned by [`Repository::head_id(…)`](crate::Repository::head_id()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Head(#[from] crate::reference::find::existing::Error),
@@ -86,7 +86,7 @@ pub mod head_id {
 pub mod head_commit {
     /// The error returned by [`Repository::head_commit`(…)](crate::Repository::head_commit()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Head(#[from] crate::reference::find::existing::Error),
@@ -99,7 +99,7 @@ pub mod head_commit {
 pub mod head_tree_id {
     /// The error returned by [`Repository::head_tree_id`(…)](crate::Repository::head_tree_id()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         HeadCommit(#[from] crate::reference::head_commit::Error),
@@ -112,7 +112,7 @@ pub mod head_tree_id {
 pub mod head_tree {
     /// The error returned by [`Repository::head_tree`(…)](crate::Repository::head_tree()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         HeadCommit(#[from] crate::reference::head_commit::Error),
@@ -129,7 +129,7 @@ pub mod find {
 
         /// The error returned by [`find_reference(…)`][crate::Repository::find_reference()], and others.
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             Find(#[from] crate::reference::find::Error),
@@ -140,7 +140,7 @@ pub mod find {
 
     /// The error returned by [`try_find_reference(…)`][crate::Repository::try_find_reference()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Find(#[from] gix_ref::file::find::Error),

--- a/gix/src/reference/iter.rs
+++ b/gix/src/reference/iter.rs
@@ -128,7 +128,7 @@ impl<'r> Iterator for Iter<'_, 'r> {
 pub mod init {
     /// The error returned by [`Platform::all()`](super::Platform::all()) or [`Platform::prefixed()`](super::Platform::prefixed()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Io(#[from] std::io::Error),

--- a/gix/src/remote/connect.rs
+++ b/gix/src/remote/connect.rs
@@ -15,7 +15,7 @@ mod error {
 
     /// The error returned by [connect()][crate::Remote::connect()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not obtain options for connecting via ssh")]
         SshOptions(#[from] config::ssh_connect_options::Error),

--- a/gix/src/remote/connection/fetch/error.rs
+++ b/gix/src/remote/connection/fetch/error.rs
@@ -3,7 +3,7 @@ use crate::config;
 /// The error returned by [`receive()`](super::Prepare::receive()).
 // TODO: remove unused variants
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     Fetch(#[from] gix_protocol::fetch::Error),

--- a/gix/src/remote/connection/fetch/mod.rs
+++ b/gix/src/remote/connection/fetch/mod.rs
@@ -103,7 +103,7 @@ pub use gix_protocol::fetch::ProgressId;
 pub mod prepare {
     /// The error returned by [`prepare_fetch()`][super::Connection::prepare_fetch()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Cannot perform a meaningful fetch operation without any configured ref-specs")]
         MissingRefSpecs,
@@ -137,7 +137,6 @@ where
     /// should the fetch not be performed. Furthermore, there the code doing the fetch is inherently blocking and it's not offloaded to a thread,
     /// making this call block the executor.
     /// It's best to unblock it by placing it into its own thread or offload it should usage in an async context be truly required.
-    #[allow(clippy::result_large_err)]
     #[gix_protocol::maybe_async::maybe_async]
     pub async fn prepare_fetch(
         self,
@@ -154,7 +153,6 @@ impl<'remote, T> ConnectionDetached<'remote, T>
 where
     T: Transport,
 {
-    #[allow(clippy::result_large_err)]
     #[gix_protocol::maybe_async::maybe_async]
     pub(crate) async fn prepare_fetch(
         mut self,
@@ -187,7 +185,6 @@ where
     }
 }
 
-#[allow(dead_code)]
 impl<T> PrepareDetached<'_, T>
 where
     T: Transport,
@@ -265,7 +262,6 @@ where
 }
 
 /// Builder
-#[allow(dead_code)]
 impl<T> PrepareDetached<'_, T>
 where
     T: Transport,

--- a/gix/src/remote/connection/fetch/update_refs/mod.rs
+++ b/gix/src/remote/connection/fetch/update_refs/mod.rs
@@ -60,7 +60,7 @@ impl From<Mode> for Update {
 /// * …existing refs would not become 'unborn', i.e. point to a reference that doesn't exist and won't be created due to ref-specs
 ///
 /// With these safeguards in place, one can handle each naturally and implement mirrors or bare repos easily.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn update(
     repo: &Repository,
     message: RefLogMessage,

--- a/gix/src/remote/connection/fetch/update_refs/update.rs
+++ b/gix/src/remote/connection/fetch/update_refs/update.rs
@@ -5,7 +5,7 @@ use crate::remote::fetch;
 mod error {
     /// The error returned when updating references.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         FindReference(#[from] crate::reference::find::Error),

--- a/gix/src/remote/connection/ref_map.rs
+++ b/gix/src/remote/connection/ref_map.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// The error returned by [`Connection::ref_map()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     InitRefMap(#[from] gix_protocol::fetch::refmap::init::Error),
@@ -86,7 +86,6 @@ where
     /// ### Configuration
     ///
     /// - `gitoxide.userAgent` is read to obtain the application user agent for git servers and for HTTP servers as well.
-    #[allow(clippy::result_large_err)]
     #[gix_protocol::maybe_async::maybe_async]
     pub async fn ref_map(
         self,
@@ -102,7 +101,6 @@ impl<T> ConnectionDetached<'_, T>
 where
     T: Transport,
 {
-    #[allow(clippy::result_large_err)]
     #[gix_protocol::maybe_async::maybe_async]
     pub(crate) async fn ref_map(
         mut self,
@@ -117,7 +115,6 @@ where
         Ok((refmap, handshake))
     }
 
-    #[allow(clippy::result_large_err)]
     #[gix_protocol::maybe_async::maybe_async]
     pub(crate) async fn ref_map_by_ref(
         &mut self,

--- a/gix/src/remote/errors.rs
+++ b/gix/src/remote/errors.rs
@@ -4,7 +4,7 @@ pub mod find {
 
     /// The error returned by [`Repository::find_remote(…)`](crate::Repository::find_remote()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The value for 'remote.<name>.tagOpt` is invalid and must either be '--tags' or '--no-tags'")]
         TagOpt(#[from] config::key::GenericErrorWithValue),
@@ -30,7 +30,7 @@ pub mod find {
 
         /// The error returned by [`Repository::find_remote(…)`](crate::Repository::find_remote()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             Find(#[from] super::Error),
@@ -45,7 +45,7 @@ pub mod find {
     pub mod for_fetch {
         /// The error returned by [`Repository::find_fetch_remote(…)`](crate::Repository::find_fetch_remote()).
         #[derive(Debug, thiserror::Error)]
-        #[allow(missing_docs)]
+        #[expect(missing_docs)]
         pub enum Error {
             #[error(transparent)]
             FindExisting(#[from] super::existing::Error),

--- a/gix/src/remote/init.rs
+++ b/gix/src/remote/init.rs
@@ -7,7 +7,7 @@ mod error {
 
     /// The error returned by [`Repository::remote_at(…)`][crate::Repository::remote_at()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Url(#[from] gix_url::parse::Error),
@@ -28,7 +28,7 @@ type UrlRewriteAliases = (UrlAliases, UrlAliases, UrlAliases);
 
 /// Initialization
 impl<'repo> Remote<'repo> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn from_preparsed_config(
         name_or_url: Option<BString>,
         urls: Vec<gix_url::Url>,

--- a/gix/src/remote/name.rs
+++ b/gix/src/remote/name.rs
@@ -6,7 +6,7 @@ use crate::bstr::{BStr, BString, ByteSlice, ByteVec};
 /// The error returned by [validated()].
 #[derive(Debug, thiserror::Error)]
 #[error("remote names must be valid within refspecs for fetching: {name:?}")]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub struct Error {
     pub source: gix_refspec::parse::Error,
     pub name: BString,

--- a/gix/src/remote/save.rs
+++ b/gix/src/remote/save.rs
@@ -3,7 +3,7 @@ use gix_utils::AsBStr;
 
 /// The error returned by [`Remote::save_to()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("The remote pointing to {} is anonymous and can't be saved.", url.to_bstring())]
     NameMissing { url: gix_url::Url },
@@ -15,7 +15,7 @@ pub enum Error {
 ///
 /// Note that this type should rather be in the `as` module, but cannot be as it's part of the Rust syntax.
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum AsError {
     #[error(transparent)]
     Save(#[from] Error),
@@ -30,7 +30,10 @@ impl Remote<'_> {
     /// Note that all sections named `remote "<name>"` will be cleared of all values we are about to write,
     /// and the last `remote "<name>"` section will be containing all relevant values so that reloading the remote
     /// from `config` would yield the same in-memory state.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     pub fn save_to(&self, config: &mut gix_config::File) -> Result<(), Error> {
         fn as_key(name: &str) -> gix_config::parse::section::ValueName {
             name.try_into().expect("valid")
@@ -140,7 +143,10 @@ impl Remote<'_> {
     /// Note that this sets a name for anonymous remotes, but overwrites the name for those who were named before.
     /// If this name is different from the current one, the git configuration will still contain the previous name,
     /// and the caller should account for that.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     pub fn save_as_to(&mut self, name: impl AsBStr, config: &mut gix_config::File) -> Result<(), AsError> {
         let name = crate::remote::name::validated(name.as_bstr().to_owned())?;
         let prev_name = self.name.take();

--- a/gix/src/repository/attributes.rs
+++ b/gix/src/repository/attributes.rs
@@ -3,7 +3,7 @@ use crate::{AttributeStack, Repository, config};
 
 /// The error returned by [`Repository::attributes()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     ConfigureAttributes(#[from] config::attribute_stack::Error),

--- a/gix/src/repository/filter.rs
+++ b/gix/src/repository/filter.rs
@@ -4,7 +4,7 @@ use crate::{Id, Repository, filter, worktree::IndexPersistedOrInMemory};
 pub mod pipeline {
     /// The error returned by [Repository::filter_pipeline()](super::Repository::filter_pipeline()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not obtain head commit of bare repository")]
         HeadCommit(#[from] crate::reference::head_commit::Error),

--- a/gix/src/repository/init.rs
+++ b/gix/src/repository/init.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 
 impl crate::Repository {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn from_refs_and_objects(
         refs: crate::RefStore,
         mut objects: crate::OdbHandle,

--- a/gix/src/repository/mod.rs
+++ b/gix/src/repository/mod.rs
@@ -64,7 +64,6 @@ mod worktree;
 mod new_commit {
     /// The error returned by [`new_commit(…)`](crate::Repository::new_commit()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         ParseTime(#[from] crate::config::time::Error),
@@ -81,7 +80,6 @@ mod new_commit {
 mod new_commit_as {
     /// The error returned by [`new_commit_as(…)`](crate::Repository::new_commit_as()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         WriteObject(#[from] crate::object::write::Error),
@@ -108,7 +106,7 @@ pub mod blame_file {
 
     /// The error returned by [Repository::blame_file()](crate::Repository::blame_file()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         CommitGraphIfEnabled(#[from] super::commit_graph_if_enabled::Error),
@@ -126,7 +124,7 @@ pub mod blame_file {
 pub mod diff_tree_to_tree {
     /// The error returned by [Repository::diff_tree_to_tree()](crate::Repository::diff_tree_to_tree()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         DiffOptions(#[from] crate::diff::options::init::Error),
@@ -142,7 +140,7 @@ pub mod diff_tree_to_tree {
 pub mod blob_merge_options {
     /// The error returned by [Repository::blob_merge_options()](crate::Repository::blob_merge_options()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         DiffAlgorithm(#[from] crate::config::diff::algorithm::Error),
@@ -156,7 +154,7 @@ pub mod blob_merge_options {
 pub mod merge_resource_cache {
     /// The error returned by [Repository::merge_resource_cache()](crate::Repository::merge_resource_cache()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         RenormalizeConfig(#[from] crate::config::boolean::Error),
@@ -180,7 +178,7 @@ pub mod merge_resource_cache {
 pub mod merge_trees {
     /// The error returned by [Repository::merge_trees()](crate::Repository::merge_trees()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         MergeResourceCache(#[from] super::merge_resource_cache::Error),
@@ -198,7 +196,7 @@ pub mod merge_trees {
 pub mod merge_commits {
     /// The error returned by [Repository::merge_commits()](crate::Repository::merge_commits()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         OpenCommitGraph(#[from] super::commit_graph_if_enabled::Error),
@@ -218,7 +216,7 @@ pub mod merge_commits {
 pub mod virtual_merge_base {
     /// The error returned by [Repository::virtual_merge_base()](crate::Repository::virtual_merge_base()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         OpenCommitGraph(#[from] super::commit_graph_if_enabled::Error),
@@ -232,7 +230,7 @@ pub mod virtual_merge_base {
 pub mod virtual_merge_base_with_graph {
     /// The error returned by [Repository::virtual_merge_base_with_graph()](crate::Repository::virtual_merge_base_with_graph()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("No commit was provided as merge-base")]
         MissingCommit,
@@ -254,7 +252,7 @@ pub mod virtual_merge_base_with_graph {
 pub mod merge_base_octopus_with_graph {
     /// The error returned by [Repository::merge_base_octopus_with_graph()](crate::Repository::merge_base_octopus_with_graph()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("No commit was provided")]
         MissingCommit,
@@ -270,7 +268,7 @@ pub mod merge_base_octopus_with_graph {
 pub mod merge_base_octopus {
     /// The error returned by [Repository::merge_base_octopus()](crate::Repository::merge_base_octopus()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         OpenCache(#[from] crate::repository::commit_graph_if_enabled::Error),
@@ -284,7 +282,7 @@ pub mod merge_base_octopus {
 pub mod merge_bases_many {
     /// The error returned by [Repository::merge_bases_many()](crate::Repository::merge_bases_many()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         OpenCache(#[from] crate::repository::commit_graph_if_enabled::Error),
@@ -298,7 +296,7 @@ pub mod merge_bases_many {
 pub mod tree_merge_options {
     /// The error returned by [Repository::tree_merge_options()](crate::Repository::tree_merge_options()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         BlobMergeOptions(#[from] super::blob_merge_options::Error),
@@ -314,7 +312,7 @@ pub mod tree_merge_options {
 pub mod diff_resource_cache {
     /// The error returned by [Repository::diff_resource_cache()](crate::Repository::diff_resource_cache()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not obtain resource cache for diffing")]
         ResourceCache(#[from] crate::diff::resource_cache::Error),
@@ -330,7 +328,7 @@ pub mod diff_resource_cache {
 pub mod edit_tree {
     /// The error returned by [Repository::edit_tree()](crate::Repository::edit_tree).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         FindTree(#[from] crate::object::find::existing::with_conversion::Error),
@@ -344,7 +342,7 @@ pub mod edit_tree {
 pub mod merge_base {
     /// The error returned by [Repository::merge_base()](crate::Repository::merge_base()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         OpenCache(#[from] crate::repository::commit_graph_if_enabled::Error),
@@ -363,7 +361,7 @@ pub mod merge_base {
 pub mod merge_base_with_graph {
     /// The error returned by [Repository::merge_base_with_cache()](crate::Repository::merge_base_with_graph()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         FindMergeBase(#[from] gix_revision::merge_base::Error),
@@ -379,7 +377,7 @@ pub mod merge_base_with_graph {
 pub mod commit_graph_if_enabled {
     /// The error returned by [Repository::commit_graph_if_enabled()](crate::Repository::commit_graph_if_enabled()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         ConfigBoolean(#[from] crate::config::boolean::Error),
@@ -393,7 +391,7 @@ pub mod commit_graph_if_enabled {
 pub mod index_from_tree {
     /// The error returned by [Repository::index_from_tree()](crate::Repository::index_from_tree).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Could not create index from tree at {id}")]
         IndexFromTree {
@@ -409,7 +407,7 @@ pub mod index_from_tree {
 pub mod branch_remote_ref_name {
     /// The error returned by [Repository::branch_remote_ref_name()](crate::Repository::branch_remote_ref_name()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The configured name of the remote ref to merge wasn't valid")]
         ValidateFetchRemoteRefName(#[from] gix_validate::reference::name::Error),
@@ -424,7 +422,7 @@ pub mod branch_remote_ref_name {
 pub mod branch_remote_tracking_ref_name {
     /// The error returned by [Repository::branch_remote_tracking_ref_name()](crate::Repository::branch_remote_tracking_ref_name()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The name of the tracking reference was invalid")]
         ValidateTrackingRef(#[from] gix_validate::reference::name::Error),
@@ -439,7 +437,7 @@ pub mod branch_remote_tracking_ref_name {
 pub mod upstream_branch_and_remote_name_for_tracking_branch {
     /// The error returned by [Repository::upstream_branch_and_remote_name_for_tracking_branch()](crate::Repository::upstream_branch_and_remote_for_tracking_branch()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("The input branch '{}' needs to be a remote tracking branch", full_name.as_bstr())]
         BranchCategory { full_name: gix_ref::FullName },
@@ -459,7 +457,7 @@ pub mod upstream_branch_and_remote_name_for_tracking_branch {
 pub mod pathspec_defaults_ignore_case {
     /// The error returned by [Repository::pathspec_defaults_ignore_case()](crate::Repository::pathspec_defaults_inherit_ignore_case()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error("Filesystem configuration could not be obtained to learn about case sensitivity")]
         FilesystemConfig(#[from] crate::config::boolean::Error),
@@ -473,7 +471,7 @@ pub mod pathspec_defaults_ignore_case {
 pub mod index_or_load_from_head {
     /// The error returned by [`Repository::index_or_load_from_head()`](crate::Repository::index_or_load_from_head()).
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         HeadCommit(#[from] crate::reference::head_commit::Error),
@@ -491,7 +489,7 @@ pub mod index_or_load_from_head {
 pub mod index_or_load_from_head_or_empty {
     /// The error returned by [`Repository::index_or_load_from_head_or_empty()`](crate::Repository::index_or_load_from_head_or_empty()).
     #[derive(thiserror::Error, Debug)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         ReadHead(#[from] crate::reference::find::existing::Error),
@@ -513,7 +511,7 @@ pub mod index_or_load_from_head_or_empty {
 pub mod worktree_stream {
     /// The error returned by [`Repository::worktree_stream()`](crate::Repository::worktree_stream()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         FindTree(#[from] crate::object::find::existing::Error),

--- a/gix/src/repository/worktree.rs
+++ b/gix/src/repository/worktree.rs
@@ -43,7 +43,10 @@ impl crate::Repository {
     ///
     /// Note that it might be the one that is currently open if this repository doesn't point to a linked worktree.
     /// Also note that the main repo might be bare.
-    #[allow(clippy::result_large_err)]
+    #[expect(
+        clippy::result_large_err,
+        reason = "will be removed once `gix-error` is used consistently"
+    )]
     pub fn main_repo(&self) -> Result<crate::Repository, crate::open::Error> {
         crate::ThreadSafeRepository::open_opts(self.common_dir(), self.options.clone()).map(Into::into)
     }

--- a/gix/src/revision/spec/parse/mod.rs
+++ b/gix/src/revision/spec/parse/mod.rs
@@ -13,7 +13,7 @@ pub mod single {
 
     /// The error returned by [`crate::Repository::rev_parse_single()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Parse(#[from] gix_error::Error),

--- a/gix/src/revision/walk.rs
+++ b/gix/src/revision/walk.rs
@@ -6,7 +6,7 @@ use crate::{Repository, ext::ObjectIdExt, revision};
 
 /// The error returned by [`Platform::all()`] and [`Platform::selected()`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     SimpleTraversal(#[from] gix_traverse::commit::simple::Error),
@@ -344,7 +344,7 @@ impl<'repo> Platform<'repo> {
 pub mod iter {
     /// The error returned by the [Walk](crate::revision::Walk) iterator.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         SimpleTraversal(#[from] gix_traverse::commit::simple::Error),

--- a/gix/src/status/index_worktree.rs
+++ b/gix/src/status/index_worktree.rs
@@ -10,7 +10,7 @@ use gix_status::index_as_worktree::traits::{CompareBlobs, SubmoduleStatus};
 
 /// The error returned by [Repository::index_worktree_status()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error("A working tree is required to perform a directory walk")]
     MissingWorkDir,
@@ -86,7 +86,7 @@ impl Repository {
     /// ### Note
     ///
     /// This is a lower-level method, prefer the [`status`](Repository::status()) method for greater ease of use.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn index_worktree_status<'index, T, U, E>(
         &self,
         index: &'index gix_index::State,
@@ -249,7 +249,6 @@ mod submodule_status {
 
     /// The error returned submodule status checks.
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         SubmoduleStatus(#[from] crate::submodule::status::Error),

--- a/gix/src/status/iter/mod.rs
+++ b/gix/src/status/iter/mod.rs
@@ -221,7 +221,7 @@ where
 
 /// The error returned for each item returned by [`Iter`].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     IndexWorktree(#[from] index_worktree::Error),

--- a/gix/src/status/iter/types.rs
+++ b/gix/src/status/iter/types.rs
@@ -32,7 +32,7 @@ use crate::{
 /// configured.
 pub struct Iter {
     #[cfg(feature = "parallel")]
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub(super) rx_and_join: Option<(
         std::sync::mpsc::Receiver<Item>,
         std::thread::JoinHandle<Result<Outcome, index_worktree::Error>>,

--- a/gix/src/status/mod.rs
+++ b/gix/src/status/mod.rs
@@ -65,7 +65,7 @@ impl Default for Submodule {
 
 /// The error returned by [status()](Repository::status).
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     DirwalkOptions(#[from] config::boolean::Error),
@@ -139,7 +139,7 @@ pub mod is_dirty {
 
     /// The error returned by [Repository::is_dirty()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         StatusPlatform(#[from] crate::status::Error),
@@ -205,7 +205,7 @@ pub mod is_dirty {
 pub mod into_iter {
     /// The error returned by [status::Platform::into_iter()](crate::status::Platform::into_iter()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Index(#[from] crate::worktree::open_index::Error),

--- a/gix/src/status/tree_index.rs
+++ b/gix/src/status/tree_index.rs
@@ -2,7 +2,7 @@ use crate::{Repository, config::tree};
 
 /// The error returned by [Repository::tree_index_status()].
 #[derive(Debug, thiserror::Error)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
     IndexFromMTree(#[from] crate::repository::index_from_tree::Error),

--- a/gix/src/submodule/errors.rs
+++ b/gix/src/submodule/errors.rs
@@ -2,7 +2,7 @@
 pub mod open_modules_file {
     /// The error returned by [Repository::open_modules_file()](crate::Repository::open_modules_file()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Configuration(#[from] gix_submodule::init::Error),
@@ -15,7 +15,7 @@ pub mod open_modules_file {
 pub mod modules {
     /// The error returned by [Repository::modules()](crate::Repository::modules()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         OpenModulesFile(#[from] crate::submodule::open_modules_file::Error),
@@ -38,7 +38,7 @@ pub mod modules {
 pub mod is_active {
     /// The error returned by [Submodule::is_active()](crate::Submodule::is_active()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         InitIsActivePlatform(#[from] gix_submodule::is_active_platform::Error),
@@ -57,7 +57,7 @@ pub mod is_active {
 pub mod fetch_recurse {
     /// The error returned by [Submodule::fetch_recurse()](crate::Submodule::fetch_recurse()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         ModuleBoolean(#[from] gix_submodule::config::Error),
@@ -70,7 +70,7 @@ pub mod fetch_recurse {
 pub mod open {
     /// The error returned by [Submodule::open()](crate::Submodule::open()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         OpenRepository(#[from] crate::open::Error),
@@ -87,7 +87,7 @@ pub mod open {
 pub mod git_dir_try_old_form {
     /// The error returned by [Submodule::git_dir_try_old_form()](crate::Submodule::git_dir_try_old_form()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         PathConfiguration(#[from] gix_submodule::config::path::Error),
@@ -107,7 +107,7 @@ pub mod git_dir_try_old_form {
 pub mod state {
     /// The error returned by [Submodule::state()](crate::Submodule::state()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         GitDirTryOldForm(#[from] crate::submodule::git_dir_try_old_form::Error),
@@ -122,7 +122,7 @@ pub mod state {
 pub mod index_id {
     /// The error returned by [Submodule::index_id()](crate::Submodule::index_id()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         PathConfiguration(#[from] gix_submodule::config::path::Error),
@@ -135,7 +135,7 @@ pub mod index_id {
 pub mod head_id {
     /// The error returned by [Submodule::head_id()](crate::Submodule::head_id()).
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         HeadCommit(#[from] crate::reference::head_commit::Error),

--- a/gix/src/submodule/mod.rs
+++ b/gix/src/submodule/mod.rs
@@ -389,7 +389,7 @@ pub mod status {
 
     /// The error returned by [Submodule::status()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         State(#[from] state::Error),

--- a/gix/src/tag.rs
+++ b/gix/src/tag.rs
@@ -4,7 +4,7 @@ mod error {
 
     /// The error returned by [`tag(…)`][crate::Repository::tag()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         ReferenceNameValidation(#[from] gix_ref::name::Error),

--- a/gix/src/util.rs
+++ b/gix/src/util.rs
@@ -54,7 +54,7 @@ impl From<Arc<AtomicBool>> for OwnedOrStaticAtomicBool {
     }
 }
 #[cfg(feature = "parallel")]
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub fn parallel_iter_drop<T, U, V>(
     mut rx_and_join: Option<(
         std::sync::mpsc::Receiver<T>,

--- a/gix/src/worktree/mod.rs
+++ b/gix/src/worktree/mod.rs
@@ -22,7 +22,10 @@ pub type Index = gix_fs::SharedFileSnapshot<gix_index::File>;
 
 /// A type to represent an index which either was loaded from disk as it was persisted there, or created on the fly in memory.
 #[cfg(feature = "index")]
-#[allow(clippy::large_enum_variant)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
 #[derive(Clone)]
 pub enum IndexPersistedOrInMemory {
     /// The index as loaded from disk, and shared across clones of the owning `Repository`.
@@ -117,7 +120,7 @@ pub mod proxy;
 pub mod open_index {
     /// The error returned by [`Worktree::open_index()`][crate::Worktree::open_index()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         ConfigIndexThreads(#[from] crate::config::key::GenericErrorWithValue),
@@ -149,7 +152,7 @@ pub mod excludes {
 
     /// The error returned by [`Worktree::excludes()`][crate::Worktree::excludes()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         OpenIndex(#[from] crate::worktree::open_index::Error),
@@ -185,7 +188,7 @@ pub mod attributes {
 
     /// The error returned by [`Worktree::attributes()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         OpenIndex(#[from] crate::worktree::open_index::Error),
@@ -234,7 +237,7 @@ pub mod pathspec {
 
     /// The error returned by [`Worktree::pathspec()`].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Init(#[from] crate::pathspec::init::Error),

--- a/gix/src/worktree/proxy.rs
+++ b/gix/src/worktree/proxy.rs
@@ -7,13 +7,13 @@ use crate::{
     worktree::Proxy,
 };
 
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub mod into_repo {
     use std::path::PathBuf;
 
     /// The error returned by [`Proxy::into_repo()`][super::Proxy::into_repo()].
     #[derive(Debug, thiserror::Error)]
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub enum Error {
         #[error(transparent)]
         Open(#[from] crate::open::Error),

--- a/gix/tests/gix/remote/fetch.rs
+++ b/gix/tests/gix/remote/fetch.rs
@@ -45,7 +45,7 @@ mod blocking_and_async_io {
         dir.join(name)
     }
 
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub(crate) fn try_repo_rw(
         name: &str,
     ) -> Result<(gix::Repository, gix_testtools::tempfile::TempDir), gix::open::Error> {
@@ -57,7 +57,7 @@ mod blocking_and_async_io {
         CloneWithShallowSupport,
     }
 
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub(crate) fn try_repo_rw_args<S: Into<String>>(
         name: &str,
         args: impl IntoIterator<Item = S>,
@@ -224,7 +224,7 @@ mod blocking_and_async_io {
 
     #[test]
     #[cfg(feature = "blocking-network-client")]
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     fn collate_fetch_error() -> Result<(), gix::env::collate::fetch::Error<std::io::Error>> {
         let (repo, _tmp) = try_repo_rw("two-origins")?;
         let remote = repo

--- a/gix/tests/gix/repository/object.rs
+++ b/gix/tests/gix/repository/object.rs
@@ -40,7 +40,7 @@ mod edit_tree {
 
     #[test]
     // Some part of the test validation the implementation for this exists, but it's needless nonetheless.
-    #[allow(clippy::needless_borrows_for_generic_args)]
+    #[expect(clippy::needless_borrows_for_generic_args)]
     fn from_head_tree() -> crate::Result {
         let (repo, _tmp) = crate::repo_rw("make_packed_and_loose.sh")?;
         let head_tree_id = repo.head_tree_id()?;

--- a/gix/tests/gix/repository/open.rs
+++ b/gix/tests/gix/repository/open.rs
@@ -274,7 +274,7 @@ fn none_bare_repo_without_index() -> crate::Result {
         repo.workdir_path(BString::from("this")).map(|p| p.is_file()),
         Some(true)
     );
-    #[allow(clippy::needless_borrows_for_generic_args)]
+    #[expect(clippy::needless_borrows_for_generic_args)]
     let actual = repo.workdir_path(&BString::from("this")).map(|p| p.is_file());
     assert_eq!(actual, Some(true));
     assert!(

--- a/gix/tests/gix/repository/worktree.rs
+++ b/gix/tests/gix/repository/worktree.rs
@@ -214,7 +214,6 @@ mod baseline {
     pub type Reason = BString;
 
     #[derive(Debug)]
-    #[allow(dead_code)]
     pub struct Worktree {
         pub root: PathBuf,
         pub bare: bool,

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -147,7 +147,7 @@ pub fn main() -> Result<()> {
     let auto_verbose = !progress && !args.no_verbose;
 
     let should_interrupt = Arc::new(AtomicBool::new(false));
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     unsafe {
         // SAFETY: The closure doesn't use mutexes or memory allocation, so it should be safe to call from a signal handler.
         gix::interrupt::init_handler(1, {

--- a/src/porcelain/main.rs
+++ b/src/porcelain/main.rs
@@ -15,7 +15,7 @@ use crate::{
 pub fn main() -> Result<()> {
     let args: Args = Args::parse_from(gix::env::args_os());
     let should_interrupt = Arc::new(AtomicBool::new(false));
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     unsafe {
         // SAFETY: The closure doesn't use mutexes or memory allocation, so it should be safe to call from a signal handler.
         gix::interrupt::init_handler(1, {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,14 +1,11 @@
 #[cfg(any(feature = "prodash-render-line", feature = "prodash-render-tui"))]
 pub const DEFAULT_FRAME_RATE: f32 = 6.0;
 
-#[allow(unused)]
 pub type ProgressRange = std::ops::RangeInclusive<prodash::progress::key::Level>;
-#[allow(unused)]
 pub const STANDARD_RANGE: ProgressRange = 2..=2;
 
 /// If verbose is true, the env logger will be forcibly set to 'info' logging level. Otherwise env logging facilities
 /// will just be initialized.
-#[allow(unused)] // Squelch warning because it's used in porcelain as well and we can't know that at compile time
 pub fn init_env_logger() {
     if cfg!(feature = "small") {
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
@@ -248,7 +245,6 @@ pub mod pretty {
     }
 }
 
-#[allow(unused)]
 #[cfg(feature = "prodash-render-line")]
 pub fn setup_line_renderer_range(
     progress: &std::sync::Arc<prodash::tree::Root>,


### PR DESCRIPTION
## Tasks

- [x] refackiew

----
Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Replace applicable item-level Rust lint allowances with expectations so obsolete suppressions become visible through `unfulfilled_lint_expectations`. Remove stale suppressions, preserve crate-level allowances, and retain ordinary allowances only where feature or compiler-version differences make expectations unreliable.

## Context

This is a workspace-wide lint-policy migration. Crate-level `#![allow(...)]` directives remain unchanged. Expectations for large errors and enum variants explain that they will be removed once `gix-error` is used consistently; other reasons are limited to non-obvious production constraints. Obvious expectations, `clippy::too_many_arguments`, and expectations in tests intentionally omit reasons.

The standard Clippy matrix was used to distinguish live expectations from stale or configuration-dependent suppressions. Compatibility guards involving `unknown_lints` and feature-dependent unused/unreachable cases remain allowances with explanatory comments.

## Validation

- `just clippy`
- `cargo fmt --all -- --check`
- `git diff --check`

## User Prompts

> Find all occurrences of `#[allow` or `#![allow` and turn them into `#[expect *where approriate*. Further, make sure that each non-crate-level `#[expect` comes with a `reason = <insert-here>`. Think to find reasons that make sense. Explain "large-struct" like errors with something like "will be removed once `gix-error` is used consistently".
>
> Do not replace crate-level allow directives.
>
> Let's remove the reasons in all cases that are obvious enough.
>
> Also remove reasons from clippy::too_many_arguments, and from tests.
