### PR TITLE
fix: retry cleared object database pack slots

### DIFF
--- a/gix-odb/src/store_impls/dynamic/load_one.rs
+++ b/gix-odb/src/store_impls/dynamic/load_one.rs
@@ -67,11 +67,7 @@ impl super::Store {
                                         // something changed between us getting the lock, trigger a complete index refresh.
                                         None
                                     }
-                                    None => {
-                                        unreachable!(
-                                            "BUG: must set this handle to be stable to avoid slots to be cleared/changed"
-                                        )
-                                    }
+                                    None => None,
                                 };
                                 slot.files.store(files);
                                 Ok(pack)
@@ -81,9 +77,7 @@ impl super::Store {
                     // This can also happen if they use an old index into our new and refreshed data which might have a multi-index
                     // here.
                     Some(types::IndexAndPacks::MultiIndex(_)) => Ok(None),
-                    None => {
-                        unreachable!("BUG: must set this handle to be stable to avoid slots to be cleared/changed")
-                    }
+                    None => Ok(None),
                 }
             }
             Some(pack_index) => {
@@ -109,11 +103,7 @@ impl super::Store {
                                             .load_with_recovery(|path| {
                                                 load_pack(path, id, self.object_hash, self.alloc_limit_bytes)
                                             })?,
-                                        None => {
-                                            unreachable!(
-                                                "BUG: must set this handle to be stable to avoid slots to be cleared/changed"
-                                            )
-                                        }
+                                        None => None,
                                     };
                                     slot.files.store(files);
                                     Ok(pack)
@@ -124,9 +114,7 @@ impl super::Store {
                     // This can also happen if they use an old index into our new and refreshed data which might have a multi-index
                     // here.
                     Some(types::IndexAndPacks::Index(_)) => Ok(None),
-                    None => {
-                        unreachable!("BUG: must set this handle to be stable to avoid slots to be cleared/changed")
-                    }
+                    None => Ok(None),
                 }
             }
         }

--- a/gix-odb/tests/odb/store/dynamic.rs
+++ b/gix-odb/tests/odb/store/dynamic.rs
@@ -278,6 +278,61 @@ fn multi_index_keep_open() -> crate::Result {
 }
 
 #[test]
+fn an_object_in_a_pack_moved_by_an_external_process_can_be_found_from_a_stale_handle() -> crate::Result {
+    let tmp = gix_testtools::tempfile::tempdir()?;
+    let pack_dir = tmp.path().join("objects/pack");
+    std::fs::create_dir_all(&pack_dir)?;
+    gix_testtools::copy_recursively_into_existing_dir(fixture_path("objects/pack"), &pack_dir)?;
+
+    // Keep only the biggest pack visible so the first lookup captures exactly the index that will be moved,
+    // without opening its pack. Renaming the pair then models an external repack replacing an index in-place.
+    for name in [
+        "pack-11fdfa9e156ab73caae3b6da867192221f2089c2",
+        "pack-a2bf8e71d8c18879e499335762dd95119d93d9f1",
+    ] {
+        let stem = pack_dir.join(name);
+        std::fs::rename(
+            stem.with_extension("idx"),
+            stem.with_extension("idx.permanently-hidden"),
+        )?;
+        std::fs::rename(
+            stem.with_extension("pack"),
+            stem.with_extension("pack.permanently-hidden"),
+        )?;
+    }
+
+    let stale_handle = gix_odb::at(tmp.path().join("objects"))?;
+    let id = hex_to_id("dd25c539efbb0ab018caa4cda2d133285634e9b5");
+    assert!(
+        stale_handle.exists(&id),
+        "the soon-to-be-stale handle records the original index without loading its pack"
+    );
+    assert_eq!(
+        stale_handle.store_ref().metrics().open_reachable_packs,
+        0,
+        "the pack must stay unloaded for load_pack() to exercise the cleared slot"
+    );
+    let refresh_handle = stale_handle.clone();
+
+    let original = pack_dir.join("pack-c0438c19fb16422b6bbcce24387b3264416d485b");
+    let moved = pack_dir.join("pack-moved-by-external-process");
+    std::fs::rename(original.with_extension("idx"), moved.with_extension("idx"))?;
+    std::fs::rename(original.with_extension("pack"), moved.with_extension("pack"))?;
+    assert!(
+        !refresh_handle.exists(&missing_id(&refresh_handle)),
+        "a miss refreshes the shared store after the pack pair moved"
+    );
+
+    let mut buf = Vec::new();
+    assert_eq!(
+        stale_handle.find(&id, &mut buf)?.kind,
+        gix_object::Kind::Blob,
+        "a stale pack id should trigger an index refresh and find the moved pack"
+    );
+    Ok(())
+}
+
+#[test]
 fn write() -> crate::Result {
     let dir = gix_testtools::tempfile::tempdir()?;
     let mut handle = gix_odb::at(dir.path())?;


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #2723

## Summary

- Treat cleared single-index and multi-pack-index slots as stale lookup misses instead of panicking.
- Let the existing index refresh and object lookup retry recover transparently.
- Add a deterministic public-API regression that reproduces the single-index panic without invoking fetch.

## Reproduction

The test loads an index while leaving its pack unopened, renames the index/pack pair to model an external repack, refreshes the shared store through a second handle, and reads the same object through the stale first handle. Before the fix this panicked at the single-index cleared-slot assertion; afterward it reloads the moved index and finds the object.

## Git baseline

Current git.git at a23bace963d508bd96983cc637131392d3face18 uses packfile_store_reprepare() in packfile.c to clear initialization and rescan the pack directory.

## Validation

- cargo test -p gix-odb --test odb an_object_in_a_pack_moved_by_an_external_process_can_be_found_from_a_stale_handle -- --nocapture
- GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix-odb
- cargo clippy -p gix-odb --all-targets -- -D warnings
- cargo fmt --all -- --check
- codex review --commit 6ae9eb12d431f2ecfd2839b871d7d910210d807a (no findings)