### PR TITLE
Align documentation on agent impersonation policy

### DIFF
--- a/COLLABORATING.md
+++ b/COLLABORATING.md
@@ -16,15 +16,7 @@
     - …and you _do know_ the cause, please fix it immediately. If necessary by reverting the offending commit until a more durable fix is possible.
     - …and you _do not know_ the cause, please open a PR to invite collaborators for their input. This is to avoid multiple collaborators
       trying to fix the issue independently, causing merge-conflicts and confusion. We use this PR as synchronization primitive.
-- **please disclose AI assistance when collaborating**
-   - if AI edits files for you, disclose it in the PR description and commit metadata, preferably with an AI author
-     such as `$agent $version <ai-agent@example.invalid>` or a `Co-authored-by: <agent-identity>` trailer.
-   - agents operating through a person's GitHub account must identify themselves in comments, for example with phrases
-     like `AI agent on behalf of <person>: ...`.
-   - fully AI-generated PR or issue comments must be disclosed. Undisclosed AI-generated comments may lead to the PR or
-     issue being closed.
-   - AI-assisted proofreading or wording polish does not need disclosure, but it is still courteous to mention it when
-     the AI materially influenced the final text.
+- **please follow the [agent impersonation policy] when collaborating**
 - **for crates _you own_**
     - feel free to make any kind of changes to it, including major ones.
     - please use `cargo smart-release` for publishing to crates.io as it will handle dependencies properly.
@@ -39,5 +31,6 @@ The workflow can be changed after public discussion - to get started, open a PR.
 Please see the [development guide] for more detailed information on how code and cargo manifests are structured.
 
 [development guide]: https://github.com/GitoxideLabs/gitoxide/blob/main/DEVELOPMENT.md
+[agent impersonation policy]: https://github.com/GitoxideLabs/gitoxide/blob/main/CONTRIBUTING.md#prevent-agent-impersonation
 [project-board]: https://github.com/GitoxideLabs/gitoxide/projects
 [discussions]: https://github.com/GitoxideLabs/gitoxide/discussions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-### Please disclose fully AI-written public text
+### Prevent agent impersonation
 
-Public text posted under a user's name, such as issue or PR descriptions and comments, must disclose
-when it was fully written by AI. This makes it clear whether maintainers are talking to a person or
-an AI agent. AI-assisted proofreading or wording polish does not need disclosure.
+AI agents communicating through a person's account must identify themselves, for example in issue or
+PR descriptions and comments. AI assistance that does not replace the person as the speaker, such as
+proofreading or wording polish, does not require identification.
 
-Attributing AI in commit metadata, for example with a `Co-authored-by` trailer, is welcome but not
+Attributing AI assistance in commit metadata, for example with a `Co-authored-by` trailer, is welcome but not
 required. Code is reviewed the same way regardless of its origin.
 
 For everything else, please have a look at the respective section in the [README] file.

--- a/README.md
+++ b/README.md
@@ -356,10 +356,10 @@ We recommend running `just test` during the development process to assure CI is 
 A backlog for work ready to be picked up is [available in the Project's Kanban board][project-board], which contains instructions on how
 to pick a task. If it's empty or you have other questions, feel free to [start a discussion][discussions] or reach out to @Byron [privately][keybase].
 
-For additional details, also take a look at the [collaboration guide]. If public text is fully written by AI, please
-follow the [AI disclosure requirement].
+For additional details, also take a look at the [collaboration guide]. If an AI agent communicates through your account,
+please follow the [agent impersonation policy].
 
-[AI disclosure requirement]: https://github.com/GitoxideLabs/gitoxide/blob/main/CONTRIBUTING.md#please-disclose-fully-ai-written-public-text
+[agent impersonation policy]: https://github.com/GitoxideLabs/gitoxide/blob/main/CONTRIBUTING.md#prevent-agent-impersonation
 [collaboration guide]: https://github.com/GitoxideLabs/gitoxide/blob/main/COLLABORATING.md
 [project-board]: https://github.com/GitoxideLabs/gitoxide/projects
 [discussions]: https://github.com/GitoxideLabs/gitoxide/discussions


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [ ] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

Align AI disclosure docs before relaxing metadata**

This now says AI attribution in commit metadata is welcome but not required, but the README still directs contributors to the collaboration guide, where `COLLABORATING.md` lines 19-21 still require AI-edited files to be disclosed in the PR description and commit metadata. Contributors following the linked docs get contradictory requirements for the same AI-assisted contribution, so the stale collaboration-guide section should be updated or unlinked along with this policy change.

## Changes

- Frame the policy as preventing agent impersonation whenever agent-written text is posted under an account holder's name.
- Remove the unexplained public/private distinction.
- Keep agent attribution in commit metadata welcome but optional.
- Make `CONTRIBUTING.md` canonical and point both the README and collaboration guide to it.

## Validation

- Focused assertions for stale terminology, mandatory metadata language, public-text qualification, and heading-anchor consistency
- `typos CONTRIBUTING.md COLLABORATING.md`
- `git diff --check`
- Codex review of `377c51cf99`: no findings
- Full README checks retain unrelated existing failures for `flate2`, GitHub Projects links, and unreachable YouTube links