### PR TITLE
fix: avoid treating symbolic remote names as URLs

### DIFF
--- a/gitoxide-core/src/repository/remote.rs
+++ b/gitoxide-core/src/repository/remote.rs
@@ -19,11 +19,18 @@ pub fn url(
             .ok_or_else(|| anyhow::anyhow!("Could not determine a remote for pushing"))?,
     };
     if all {
-        for url in remote.urls(direction) {
+        let mut urls = remote.urls(direction).peekable();
+        if urls.peek().is_none() {
+            anyhow::bail!("The remote has no {} URL", direction.as_str());
+        }
+        for url in urls {
             out.write_all(&url.to_bstring())?;
             out.write_all(b"\n")?;
         }
-    } else if let Some(url) = remote.url(direction) {
+    } else {
+        let url = remote
+            .url(direction)
+            .ok_or_else(|| anyhow::anyhow!("The remote has no {} URL", direction.as_str()))?;
         out.write_all(&url.to_bstring())?;
         out.write_all(b"\n")?;
     }

--- a/gix/src/remote/access.rs
+++ b/gix/src/remote/access.rs
@@ -33,7 +33,8 @@ impl<'repo> Remote<'repo> {
     /// was created with one of the `_without_url_rewrite()` methods.
     /// See [`urls()`](Self::urls()) for how rewrite rules differ between fetch URLs, explicit push URLs, and push fallbacks.
     /// For pushing, this is the first `remote.<name>.pushUrl` or the first `remote.<name>.url` used for fetching, and for
-    /// fetching it's the first `remote.<name>.url`, matching the default behaviour of `git remote get-url`.
+    /// fetching it's the first `remote.<name>.url`. Unlike `git remote get-url`, a missing fetch URL doesn't fall back to a
+    /// symbolic remote name, but a URL-shaped remote name may itself be used as the fallback URL.
     /// Note that it's possible to only have the push url set, in which case there will be no way to fetch from the remote as
     /// the push-url isn't used for that.
     pub fn url(&self, direction: remote::Direction) -> Option<&gix_url::Url> {

--- a/gix/src/remote/init.rs
+++ b/gix/src/remote/init.rs
@@ -39,10 +39,6 @@ impl<'repo> Remote<'repo> {
         fetch_tags: remote::fetch::Tags,
         repo: &'repo Repository,
     ) -> Result<Self, Error> {
-        debug_assert!(
-            !urls.is_empty() || !push_urls.is_empty(),
-            "BUG: fetch or push url must be set at least"
-        );
         let (url_aliases, url_push_aliases, push_url_aliases) = if should_rewrite_urls {
             rewrite_urls(&repo.config, &urls, &push_urls)
         } else {

--- a/gix/src/repository/remote.rs
+++ b/gix/src/repository/remote.rs
@@ -103,8 +103,9 @@ impl crate::Repository {
     ///
     /// There are various error kinds related to partial information or incorrectly formatted URLs or ref-specs.
     /// Also note that the created `Remote` may have neither fetch nor push ref-specs set at all.
-    /// A configured remote without an effective fetch URL uses its requested name as the fetch URL, matching Git. This
-    /// includes remotes whose URL list was cleared by an empty value and remotes configured only with a push URL.
+    /// Unlike Git, a configured remote with a symbolic name and no effective fetch URL remains without a fetch URL. If the
+    /// requested remote name is itself a URL, it is used as the fetch URL instead. This applies equally to remotes whose URL
+    /// list was cleared by an empty value and remotes configured only with a push URL.
     ///
     /// URL rewrite rules are applied while constructing the remote. A malformed `pushInsteadOf` result is ignored when a fetch
     /// URL is used as the push fallback, keeping the original URL usable. Malformed `insteadOf` results for fetch URLs or explicit
@@ -301,19 +302,22 @@ impl crate::Repository {
                     None => Vec::new(),
                 };
                 if urls.is_empty() {
-                    // Git makes an explicitly requested remote usable by treating its name as the missing fetch URL.
-                    let fallback = match config::tree::Remote::URL.try_into_url(std::borrow::Cow::Borrowed(name_or_url))
-                    {
-                        Ok(url) => url,
-                        Err(source) => {
+                    let name_is_url = matches!(
+                        remote::Name::try_from(std::borrow::Cow::Borrowed(name_or_url)),
+                        Ok(remote::Name::Url(_))
+                    ) || gix_path::is_absolute(gix_path::from_bstr(name_or_url));
+                    match config::tree::Remote::URL.try_into_url(std::borrow::Cow::Borrowed(name_or_url)) {
+                        Ok(url) if name_is_url || url.scheme != gix_url::Scheme::File => urls.push(url),
+                        Ok(_) => {}
+                        Err(source) if name_is_url => {
                             return Some(Err(find::Error::Url {
                                 kind: "fetch",
                                 remote_name: name_or_url.into(),
                                 source,
                             }));
                         }
-                    };
-                    urls.push(fallback);
+                        Err(_) => {}
+                    }
                 }
 
                 Some(

--- a/gix/tests/fixtures/make_remote_repos.sh
+++ b/gix/tests/fixtures/make_remote_repos.sh
@@ -254,9 +254,8 @@ git init --bare multiple-urls-with-empty-reset
   } > baseline.git
 )
 
-# A named remote remains usable when it has no effective fetch URL: Git treats the
-# requested remote name itself as the fetch URL. Cover an absent URL, URLs cleared
-# by an empty reset value, and a push-only remote whose explicit push URL still wins.
+# Cover remotes without an effective fetch URL: an absent URL, URLs cleared by an
+# empty reset value, a push-only remote, and URL-shaped remote names.
 git init --bare missing-urls
 (cd missing-urls
   git config remote.no-url.prune true
@@ -264,20 +263,9 @@ git init --bare missing-urls
   git config --add remote.reset-url.url ""
   git config remote.push-only.pushUrl ssh://push.example/repo
   git config remote.https://fallback.example/repo.prune true
+  git config remote.relative/path.prune true
+  git config remote.example.com:repo.prune true
 
-  {
-    git remote get-url no-url
-    git remote get-url --push no-url
-    # Git 2.50.1 treats the empty value as a reset and falls back to the name;
-    # spell that out so older fixture generators produce the same baseline.
-    echo reset-url
-    echo reset-url
-    for remote in push-only https://fallback.example/repo
-    do
-      git remote get-url "$remote"
-      git remote get-url --push "$remote"
-    done
-  } > baseline.git
 )
 
 git init --bare bad-push-fallback-url-rewriting

--- a/gix/tests/gix/repository/remote.rs
+++ b/gix/tests/gix/repository/remote.rs
@@ -232,27 +232,43 @@ mod find_remote {
     }
 
     #[test]
-    fn missing_fetch_urls_fall_back_to_the_remote_name_like_git() -> crate::Result {
+    fn missing_fetch_urls_only_fall_back_to_url_shaped_remote_names() -> crate::Result {
         let repo = remote::repo("missing-urls");
-        let baseline = std::fs::read(repo.git_dir().join("baseline.git"))?;
-        let mut baseline = baseline.lines().map_while(Result::ok);
-
-        for name in ["no-url", "reset-url", "push-only", "https://fallback.example/repo"] {
+        for name in ["no-url", "reset-url"] {
             let remote = repo.find_remote(name)?;
-            let expected_fetch_url = baseline.next().expect("Git fetch URL");
-            let expected_push_url = baseline.next().expect("Git push URL");
             assert_eq!(
-                remote.url(Direction::Fetch).expect("fallback URL").to_bstring(),
-                expected_fetch_url,
-                "a missing effective fetch URL falls back to the requested remote name"
+                remote.url(Direction::Fetch),
+                None,
+                "a symbolic remote name must not become a fetch URL"
             );
             assert_eq!(
-                remote.url(Direction::Push).expect("push URL").to_bstring(),
-                expected_push_url,
-                "pushing uses an explicit pushUrl when present and otherwise falls back to the fetch URL"
+                remote.url(Direction::Push),
+                None,
+                "without an explicit push URL there is no fetch URL to fall back to"
             );
         }
-        assert!(baseline.next().is_none(), "all Git baseline URLs were consumed");
+
+        let remote = repo.find_remote("push-only")?;
+        assert_eq!(remote.url(Direction::Fetch), None, "there is no fetch URL");
+        assert_eq!(
+            remote.url(Direction::Push).expect("explicit push URL").to_bstring(),
+            "ssh://push.example/repo",
+            "an explicit push URL remains available"
+        );
+
+        for name in ["https://fallback.example/repo", "relative/path", "example.com:repo"] {
+            let remote = repo.find_remote(name)?;
+            assert_eq!(
+                remote.url(Direction::Fetch).expect("fallback URL").to_bstring(),
+                name,
+                "a URL-shaped remote name becomes the missing fetch URL"
+            );
+            assert_eq!(
+                remote.url(Direction::Push).expect("fallback URL").to_bstring(),
+                name,
+                "the fetch URL is also the push fallback"
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

```
"    remote
        .url(gix::remote::Direction::Fetch)" should not fallback to the remote name unless it's a URL. Document this as deviation from Git in the method docs. `gix remote url` can just show an error, no need to match Git - nothing special to do here.
```

## Summary

- Leave configured symbolic remotes without an effective fetch URL URL-less instead of interpreting their name as a local path.
- Preserve fallback for URL-shaped names, including relative and absolute paths, standard schemes, and scp-style URLs.
- Document the intentional deviation from Git and make `gix remote url` report a missing URL.

## Git reference

Git's `remote.c:remotes_remote_get_1()` adds an explicitly supplied remote name as a URL when the remote has no configured URL. This change intentionally diverges for symbolic names; `t/t5505-remote.sh` covers Git's `remote get-url` behavior.

## Validation

- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix --test gix repository::remote::`
- `cargo test -p gitoxide-core --lib`
- `cargo clippy -p gix --test gix -- -D warnings`
- `cargo clippy -p gitoxide-core --lib --features blocking-client,gix/sha1` (completed with pre-existing warnings outside the change)
- `cargo test -p gix --doc remote::access`
- `cargo fmt --all --check`
- `git diff --check`
- `codex review --commit 8d48fa62c47ebb54a4429eb5218d7edab1ef3557`
