### PR TITLE
fix executable-bit handling during checkout

### DIFF
--- a/gix-worktree-state/src/checkout/chunk.rs
+++ b/gix-worktree-state/src/checkout/chunk.rs
@@ -204,11 +204,11 @@ where
                         gix_filter::driver::Operation::Smudge,
                     )?,
                 );
-                let (file, set_executable_after_creation) = match entry::open_file(
+                let (file, executable_bit_change) = match entry::open_file(
                     &std::mem::take(&mut delayed.validated_file_path), // mark it as seen, relevant for `unprocessed_paths`
                     destination_is_initially_empty,
                     overwrite_existing,
-                    delayed.needs_executable_bit,
+                    delayed.fs_supports_executable_bit,
                     delayed.entry.mode,
                 ) {
                     Ok(res) => res,
@@ -230,7 +230,7 @@ where
                     delayed.entry,
                     write.inner.into_inner().map_err(std::io::IntoInnerError::into_error)?,
                     actual_bytes,
-                    set_executable_after_creation,
+                    executable_bit_change,
                 )?;
                 delayed_files += 1;
                 files.fetch_add(1, Ordering::Relaxed);

--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -100,7 +100,7 @@ where
                 },
                 filter_process_delay,
             )?;
-            let (num_bytes, file, set_executable_after_creation) = match filtered {
+            let (num_bytes, file, executable_bit_change) = match filtered {
                 ToWorktreeOutcome::Unchanged(buf) | ToWorktreeOutcome::Buffer(buf) => {
                     let (mut file, flag) = open_file(
                         dest,
@@ -135,7 +135,7 @@ where
             };
 
             // For possibly existing, overwritten files, we must change the file mode explicitly.
-            finalize_entry(entry, file, num_bytes as u64, set_executable_after_creation)?;
+            finalize_entry(entry, file, num_bytes as u64, executable_bit_change)?;
             num_bytes
         }
         gix_index::entry::Mode::SYMLINK => {
@@ -255,39 +255,45 @@ pub(crate) fn open_file(
     overwrite_existing: bool,
     fs_supports_executable_bit: bool,
     entry_mode: gix_index::entry::Mode,
-) -> std::io::Result<(std::fs::File, bool)> {
+) -> std::io::Result<(std::fs::File, ExecutableBitChange)> {
     #[cfg_attr(windows, allow(unused_mut))]
     let mut options = open_options(path, destination_is_initially_empty, overwrite_existing);
     let needs_executable_bit = fs_supports_executable_bit && entry_mode == gix_index::entry::Mode::FILE_EXECUTABLE;
     #[cfg(unix)]
-    let set_executable_after_creation = if needs_executable_bit && destination_is_initially_empty {
+    let executable_bit_change = if needs_executable_bit && destination_is_initially_empty {
         use std::os::unix::fs::OpenOptionsExt;
         // Note that these only work if the file was newly created, but won't if it's already
         // existing, possibly without the executable bit set. Thus we do this only if the file is new.
         options.mode(0o777);
-        false
+        ExecutableBitChange::NoChange
+    } else if !fs_supports_executable_bit || destination_is_initially_empty {
+        ExecutableBitChange::NoChange
+    } else if needs_executable_bit {
+        ExecutableBitChange::Set
     } else {
-        needs_executable_bit
+        ExecutableBitChange::Remove
     };
     //  not supported on windows
     #[cfg(windows)]
-    let set_executable_after_creation = needs_executable_bit;
-    try_op_or_unlink(path, overwrite_existing, |p| options.open(p)).map(|f| (f, set_executable_after_creation))
+    let executable_bit_change = ExecutableBitChange::NoChange;
+    try_op_or_unlink(path, overwrite_existing, |p| options.open(p)).map(|f| (f, executable_bit_change))
 }
 
-/// Close `file` and store its stats in `entry`, possibly setting `file` executable.
+/// Close `file` and store its stats in `entry`, possibly adjusting whether `file` is executable.
 ///
 /// `desired_bytes` is the amount of bytes Git thinks the file should have after writing.
 pub(crate) fn finalize_entry(
     entry: &mut gix_index::Entry,
     file: std::fs::File,
     desired_bytes: u64,
-    #[cfg_attr(windows, allow(unused_variables))] set_executable_after_creation: bool,
+    #[cfg_attr(windows, allow(unused_variables))] executable_bit_change: ExecutableBitChange,
 ) -> Result<(), crate::checkout::Error> {
-    // For possibly existing, overwritten files, we must change the file mode explicitly.
+    // For possibly existing, overwritten files, we must change the file mode explicitly to match the index.
     #[cfg(unix)]
-    if set_executable_after_creation {
-        set_executable(&file)?;
+    match executable_bit_change {
+        ExecutableBitChange::NoChange => {}
+        ExecutableBitChange::Set => adjust_executable_bits(&file, true)?,
+        ExecutableBitChange::Remove => adjust_executable_bits(&file, false)?,
     }
 
     let md = &gix_index::fs::Metadata::from_file(&file)?;
@@ -305,30 +311,44 @@ pub(crate) fn finalize_entry(
     Ok(())
 }
 
-/// Use `fstat` and `fchmod` on a file descriptor to make a regular file executable.
+/// Use `fstat` and, if needed, `fchmod` on a file descriptor to adjust whether a regular file is executable.
 ///
-/// See `let_readers_execute` for the exact details of how the mode is transformed.
+/// See `adjust_mode_executable_bits` for the exact details of how the mode is transformed.
 #[cfg(unix)]
-fn set_executable(file: &std::fs::File) -> Result<(), std::io::Error> {
+fn adjust_executable_bits(file: &std::fs::File, executable: bool) -> Result<(), std::io::Error> {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
     let old_mode = file.metadata()?.mode();
-    let new_mode = let_readers_execute(old_mode);
-    file.set_permissions(std::fs::Permissions::from_mode(new_mode))?;
+    let new_mode = adjust_mode_executable_bits(old_mode, executable);
+    if old_mode & 0o7777 != new_mode {
+        file.set_permissions(std::fs::Permissions::from_mode(new_mode))?;
+    }
     Ok(())
 }
 
-/// Given the st_mode of a regular file, compute the mode with executable bits safely added.
+/// Given the st_mode of a regular file, compute the mode with executable bits safely adjusted.
 ///
-/// Currently this adds executable bits for whoever has read bits already. It doesn't use the umask.
-/// Set-user-ID and set-group-ID bits are unset for safety. The sticky bit is also unset.
+/// When making a file executable, this adds executable bits for whoever has read bits already. When making a file
+/// non-executable, it removes all executable bits. It doesn't use the umask. Set-user-ID and set-group-ID bits are
+/// unset for safety. The sticky bit is also unset.
 ///
 /// This returns only mode bits, not file type. The return value can be used in chmod or fchmod.
 #[cfg(any(unix, test))]
-fn let_readers_execute(mut mode: u32) -> u32 {
+fn adjust_mode_executable_bits(mut mode: u32, executable: bool) -> u32 {
     assert_eq!(mode & 0o170000, 0o100000, "bug in caller if not from a regular file");
     mode &= 0o777; // Clear type, non-rwx mode bits (setuid, setgid, sticky).
-    mode |= (mode & 0o444) >> 2; // Let readers also execute.
+    if executable {
+        mode |= (mode & 0o444) >> 2; // Let readers also execute.
+    } else {
+        mode &= !0o111;
+    }
     mode
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum ExecutableBitChange {
+    NoChange,
+    Set,
+    Remove,
 }
 
 #[cfg(test)]
@@ -382,7 +402,26 @@ mod tests {
             (0o102462, 0o572),
         ];
         for (st_mode, expected) in cases {
-            let actual = super::let_readers_execute(st_mode);
+            let actual = super::adjust_mode_executable_bits(st_mode, true);
+            assert_eq!(
+                actual, expected,
+                "{st_mode:06o} should become {expected:04o}, became {actual:04o}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_one_executes() {
+        let cases = [
+            (0o100755, 0o644),
+            (0o100750, 0o640),
+            (0o100700, 0o600),
+            (0o100111, 0o000),
+            (0o100571, 0o460),
+            (0o107755, 0o644),
+        ];
+        for (st_mode, expected) in cases {
+            let actual = super::adjust_mode_executable_bits(st_mode, false);
             assert_eq!(
                 actual, expected,
                 "{st_mode:06o} should become {expected:04o}, became {actual:04o}"
@@ -393,12 +432,12 @@ mod tests {
     #[test]
     #[should_panic]
     fn let_readers_execute_panics_on_directory() {
-        super::let_readers_execute(0o040644);
+        super::adjust_mode_executable_bits(0o040644, true);
     }
 
     #[test]
     #[should_panic]
     fn let_readers_execute_should_panic_on_symlink() {
-        super::let_readers_execute(0o120644);
+        super::adjust_mode_executable_bits(0o120644, true);
     }
 }

--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -22,8 +22,8 @@ pub struct Context<'a, Find> {
 pub struct DelayedFilteredStream<'a> {
     /// The key identifying the driver program
     pub key: gix_filter::driver::Key,
-    /// If the file is going to be an executable.
-    pub needs_executable_bit: bool,
+    /// Whether the filesystem supports executable bits.
+    pub fs_supports_executable_bit: bool,
     /// The validated path on disk at which the file should be placed.
     pub validated_file_path: PathBuf,
     /// The entry to adjust with the file we will write.
@@ -126,7 +126,7 @@ where
                 ToWorktreeOutcome::Process(MaybeDelayed::Delayed(key)) => {
                     return Ok(Outcome::Delayed(DelayedFilteredStream {
                         key,
-                        needs_executable_bit: false,
+                        fs_supports_executable_bit: executable_bit,
                         validated_file_path: dest.to_owned(),
                         entry,
                         entry_path,

--- a/gix-worktree-state/tests/fixtures/make_mixed_without_submodules_and_symlinks.sh
+++ b/gix-worktree-state/tests/fixtures/make_mixed_without_submodules_and_symlinks.sh
@@ -6,6 +6,8 @@ git init -q
 touch empty
 echo -n "content" > executable
 chmod +x executable
+echo -n "filtered content" > filtered-executable
+chmod +x filtered-executable
 
 mkdir dir
 echo "other content" > dir/content
@@ -17,5 +19,5 @@ mkdir dir/sub-dir
 echo "even other content" > dir/sub-dir/file
 
 git add -A
-git update-index --chmod=+x executable  # For Windows.
+git update-index --chmod=+x executable filtered-executable  # For Windows.
 git commit -m "Commit"

--- a/gix-worktree-state/tests/worktree-state/checkout.rs
+++ b/gix-worktree-state/tests/worktree-state/checkout.rs
@@ -124,10 +124,9 @@ fn writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed() {
 #[test]
 fn delayed_driver_process() -> crate::Result {
     let mut opts = opts_from_probe();
-    opts.overwrite_existing = true;
     opts.filter_process_delay = gix_filter::driver::apply::Delay::Allow;
-    opts.destination_is_initially_empty = false;
     setup_filter_pipeline(opts.filters.options_mut());
+    let fs_supports_executable_bit = opts.fs.executable_bit;
     let (_source, destination, _index, outcome) = checkout_index_in_tmp_dir_opts(
         opts,
         "make_mixed_without_submodules_and_symlinks",
@@ -137,7 +136,7 @@ fn delayed_driver_process() -> crate::Result {
     )?;
     assert_eq!(outcome.collisions.len(), 0);
     assert_eq!(outcome.errors.len(), 0);
-    assert_eq!(outcome.files_updated, 5);
+    assert_eq!(outcome.files_updated, 6);
 
     let dest = destination.path();
     assert_eq!(
@@ -146,12 +145,55 @@ fn delayed_driver_process() -> crate::Result {
         "unfiltered"
     );
     assert_eq!(
+        std::fs::read(dest.join("filtered-executable"))?.as_bstr(),
+        "➡filtered content",
+        "filtered executable"
+    );
+    #[cfg(unix)]
+    if fs_supports_executable_bit {
+        assert_ne!(
+            std::fs::metadata(dest.join("filtered-executable"))?.mode() & 0o111,
+            0,
+            "a delayed filter must not prevent executable bits from being applied"
+        );
+    }
+    assert_eq!(
         std::fs::read(dest.join("dir").join("content"))?.as_bstr(),
         "➡other content\r\n"
     );
     assert_eq!(
         std::fs::read(dest.join("dir").join("sub-dir").join("file"))?.as_bstr(),
         "➡even other content\r\n"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn delayed_driver_process_removes_obsolete_executable_bits() -> crate::Result {
+    let mut opts = opts_from_probe();
+    opts.destination_is_initially_empty = false;
+    opts.filter_process_delay = gix_filter::driver::apply::Delay::Allow;
+    setup_filter_pipeline(opts.filters.options_mut());
+    let (_source, destination, _index, outcome) = checkout_index_in_tmp_dir_opts(
+        opts,
+        "make_mixed_without_submodules_and_symlinks",
+        None,
+        |_| true,
+        |destination| {
+            let filtered_non_executable = destination.join("empty");
+            std::fs::write(&filtered_non_executable, [])?;
+            std::fs::set_permissions(&filtered_non_executable, std::fs::Permissions::from_mode(0o755))?;
+            Ok(())
+        },
+    )?;
+
+    assert!(outcome.collisions.is_empty(), "regular files should not collide");
+    assert!(outcome.errors.is_empty(), "checkout should succeed");
+    assert_eq!(
+        std::fs::metadata(destination.path().join("empty"))?.mode() & 0o111,
+        0,
+        "a delayed filter must not prevent obsolete executable bits from being removed"
     );
     Ok(())
 }

--- a/gix-worktree-state/tests/worktree-state/checkout.rs
+++ b/gix-worktree-state/tests/worktree-state/checkout.rs
@@ -1,5 +1,5 @@
 #[cfg(unix)]
-use std::os::unix::prelude::MetadataExt;
+use std::os::unix::prelude::{MetadataExt, PermissionsExt};
 use std::{
     fs,
     io::{ErrorKind, ErrorKind::AlreadyExists},
@@ -153,6 +153,50 @@ fn delayed_driver_process() -> crate::Result {
         std::fs::read(dest.join("dir").join("sub-dir").join("file"))?.as_bstr(),
         "➡even other content\r\n"
     );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn nonexclusive_checkout_adjusts_executable_bits_in_both_directions() -> crate::Result {
+    for overwrite_existing in [false, true] {
+        let mut opts = opts_from_probe();
+        opts.destination_is_initially_empty = false;
+        opts.overwrite_existing = overwrite_existing;
+        let (_source, destination, _index, outcome) = checkout_index_in_tmp_dir_opts(
+            opts,
+            "make_mixed_without_submodules_and_symlinks",
+            None,
+            |_| true,
+            |destination| {
+                let soon_non_executable = destination.join("empty");
+                std::fs::write(&soon_non_executable, [])?;
+                std::fs::set_permissions(&soon_non_executable, std::fs::Permissions::from_mode(0o755))?;
+
+                let soon_executable = destination.join("executable");
+                std::fs::write(&soon_executable, b"old content")?;
+                std::fs::set_permissions(&soon_executable, std::fs::Permissions::from_mode(0o644))?;
+                Ok(())
+            },
+        )?;
+
+        assert!(outcome.collisions.is_empty(), "regular files should not collide");
+        assert!(outcome.errors.is_empty(), "checkout should succeed");
+
+        let non_executable_mode = std::fs::metadata(destination.path().join("empty"))?.mode();
+        assert_eq!(
+            non_executable_mode & 0o111,
+            0,
+            "checkout must remove obsolete executable bits with overwrite_existing={overwrite_existing}"
+        );
+
+        let executable_mode = std::fs::metadata(destination.path().join("executable"))?.mode();
+        assert_ne!(
+            executable_mode & 0o111,
+            0,
+            "checkout must add tracked executable bits with overwrite_existing={overwrite_existing}"
+        );
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- remove obsolete executable bits when nonexclusive checkout reuses a tracked non-executable file
- preserve executable-bit handling when a process filter delays checkout output
- keep mode changes tied to the open file descriptor and cover delayed +x and -x paths

Fixes #1783
Fixes #1784

## Git baseline

Git creates regular checkout files according to the cache-entry mode in `entry.c`. Its delayed checkout path retries `checkout_entry()` with that cache entry, and `git checkout --force` does not retain obsolete executable permissions.

## Tests

- `cargo test -p gix-worktree-state --all-features`
- `cargo clippy -p gix-worktree-state --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`