### PR TITLE
fix: escape unsafe paths in gix index entries

### DIFF
--- a/gitoxide-core/src/lib.rs
+++ b/gitoxide-core/src/lib.rs
@@ -82,6 +82,8 @@ pub mod query;
 pub mod remote;
 pub mod repository;
 
+mod output;
+
 mod discover;
 pub use discover::discover;
 

--- a/gitoxide-core/src/output.rs
+++ b/gitoxide-core/src/output.rs
@@ -1,0 +1,56 @@
+use std::io::Write;
+
+use gix::{bstr::BStr, utils::AsBStr};
+
+/// Write arbitrary bytes losslessly, quoting the entire value with its debug representation if it contains
+/// control characters, quotes, backslashes, or invalid UTF-8 that must be escaped.
+pub(crate) fn write_bstr(mut out: impl Write, input: &BStr, scratch: &mut Vec<u8>) -> std::io::Result<()> {
+    scratch.clear();
+    write!(scratch, "{input:?}").expect("writing to a byte buffer cannot fail");
+    let debug_matches_input = scratch
+        .strip_prefix(b"\"")
+        .and_then(|debug| debug.strip_suffix(b"\""))
+        .is_some_and(|debug| debug == input);
+    let input = if debug_matches_input { input } else { scratch.as_bstr() };
+    out.write_all(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use gix::bstr::ByteSlice;
+
+    use super::write_bstr;
+
+    fn render(input: &[u8], scratch: &mut Vec<u8>) -> Vec<u8> {
+        let mut out = Vec::new();
+        write_bstr(&mut out, input.as_bstr(), scratch).expect("in-memory writes succeed");
+        out
+    }
+
+    #[test]
+    fn safe_ascii_and_unicode_remain_unchanged() {
+        let mut scratch = Vec::new();
+        for input in [b"hello world".as_slice(), "hello 💡".as_bytes()] {
+            assert_eq!(
+                render(input, &mut scratch),
+                input,
+                "safe text should remain easy to read"
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_controls_and_ambiguous_bytes_are_quoted_losslessly() {
+        let mut scratch = Vec::new();
+        assert_eq!(
+            render(b"control-\0\x08\t\n\r\x1b\x7f\"\\end", &mut scratch),
+            br#""control-\0\x08\t\n\r\x1b\x7f\"\\end""#,
+            "terminal-active and syntax bytes must be escaped"
+        );
+        assert_eq!(
+            render(b"invalid-\xff", &mut scratch),
+            br#""invalid-\xff""#,
+            "invalid UTF-8 must remain recoverable"
+        );
+    }
+}

--- a/gitoxide-core/src/repository/index/entries.rs
+++ b/gitoxide-core/src/repository/index/entries.rs
@@ -25,7 +25,7 @@ pub(crate) mod function {
 
     use gix::{
         Repository,
-        bstr::{BStr, BString},
+        bstr::{BStr, BString, ByteSlice},
         index::entry::Stage,
         worktree::IndexPersistedOrInMemory,
     };
@@ -126,6 +126,9 @@ pub(crate) mod function {
         if let Some(entries) = index.prefixed_entries(pathspec.common_prefix()) {
             stats.entries_after_prune = entries.len();
             let mut entries = entries.iter().peekable();
+            let mut path = prefix.to_owned();
+            let prefix_len = path.len();
+            let mut buf = Vec::new();
             while let Some(entry) = entries.next() {
                 let mut last_match = None;
                 let attrs = cache
@@ -220,12 +223,20 @@ pub(crate) mod function {
                     )?;
                     stats.submodule.push((sm_path.into_owned(), sm_stats));
                 } else {
+                    let entry_path = entry.path(&index);
+                    let path = if prefix.is_empty() {
+                        entry_path
+                    } else {
+                        path.truncate(prefix_len);
+                        path.extend_from_slice(entry_path);
+                        path.as_bstr()
+                    };
                     match format {
                         OutputFormat::Human => {
                             if simple {
-                                to_human_simple(out, &index, entry, attrs, prefix)
+                                to_human_simple(out, entry, attrs, path, &mut buf)
                             } else {
-                                to_human(out, &index, entry, attrs, prefix)
+                                to_human(out, entry, attrs, path, &mut buf)
                             }?;
                         }
                         #[cfg(feature = "serde")]
@@ -364,34 +375,29 @@ pub(crate) mod function {
 
     fn to_human_simple(
         out: &mut impl std::io::Write,
-        file: &gix::index::File,
         entry: &gix::index::Entry,
         attrs: Option<Attrs>,
-        prefix: &BStr,
+        path: &BStr,
+        buf: &mut Vec<u8>,
     ) -> std::io::Result<()> {
-        if !prefix.is_empty() {
-            out.write_all(prefix)?;
-        }
+        crate::output::write_bstr(&mut *out, path, buf)?;
         match attrs {
-            Some(attrs) => {
-                out.write_all(entry.path(file))?;
-                out.write_all(print_attrs(Some(attrs), entry.mode).as_bytes())
-            }
-            None => out.write_all(entry.path(file)),
+            Some(attrs) => out.write_all(print_attrs(Some(attrs), entry.mode).as_bytes()),
+            None => Ok(()),
         }?;
         out.write_all(b"\n")
     }
 
     fn to_human(
         out: &mut impl std::io::Write,
-        file: &gix::index::File,
         entry: &gix::index::Entry,
         attrs: Option<Attrs>,
-        prefix: &BStr,
+        path: &BStr,
+        buf: &mut Vec<u8>,
     ) -> std::io::Result<()> {
-        writeln!(
+        write!(
             out,
-            "{} {}{:?} {} {}{}{}",
+            "{} {}{:?} {} ",
             match entry.flags.stage() {
                 Stage::Unconflicted => "       ",
                 Stage::Base => "BASE   ",
@@ -405,10 +411,10 @@ pub(crate) mod function {
             },
             entry.mode,
             entry.id,
-            prefix,
-            entry.path(file),
-            print_attrs(attrs, entry.mode)
-        )
+        )?;
+        crate::output::write_bstr(&mut *out, path, buf)?;
+        out.write_all(print_attrs(attrs, entry.mode).as_bytes())?;
+        out.write_all(b"\n")
     }
 
     fn print_attrs(attrs: Option<Attrs>, mode: gix::index::entry::Mode) -> Cow<'static, str> {

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -53,6 +53,32 @@ title '`gix` crate'
 title "gix (with repository)"
 (with "a git repository"
   snapshot="$snapshot/repository"
+
+  title "gix index"
+  (with "the 'entries' sub-command"
+    snapshot="$snapshot/index/entries"
+    (sandbox
+      git init -q
+
+      # Keep the hostile names in the index only so this regression also works on
+      # filesystems that reject terminal control characters in paths.
+      empty_blob="$(git hash-object -w --stdin </dev/null)"
+      ansi_path="$(printf 'ansi-\033[31mred\033[0m')"
+      newline_path="$(printf 'line\nbreak')"
+      git update-index --add --cacheinfo "100644,$empty_blob,$ansi_path"
+      git update-index --add --cacheinfo "100644,$empty_blob,$newline_path"
+
+      it "escapes repository-controlled paths in simple output" && {
+        WITH_SNAPSHOT="$snapshot/control-characters-simple" \
+        expect_run $SUCCESSFULLY "$exe_plumbing" --no-verbose index entries --no-attributes
+      }
+      it "escapes repository-controlled paths in rich output" && {
+        WITH_SNAPSHOT="$snapshot/control-characters-rich" \
+        expect_run $SUCCESSFULLY "$exe_plumbing" --no-verbose index entries --no-attributes --format rich
+      }
+    )
+  )
+
   (small-repo-in-sandbox
     (with "the 'verify' sub-command"
       snapshot="$snapshot/verify"

--- a/tests/snapshots/plumbing/repository/index/entries/control-characters-rich
+++ b/tests/snapshots/plumbing/repository/index/entries/control-characters-rich
@@ -1,0 +1,2 @@
+        Mode(FILE) e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 "ansi-\x1b[31mred\x1b[0m"
+        Mode(FILE) e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 "line\nbreak"

--- a/tests/snapshots/plumbing/repository/index/entries/control-characters-simple
+++ b/tests/snapshots/plumbing/repository/index/entries/control-characters-simple
@@ -1,0 +1,2 @@
+"ansi-\x1b[31mred\x1b[0m"
+"line\nbreak"


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Refs #1534

## Summary

- add a reusable, allocation-reusing writer for lossless display of arbitrary repository bytes
- preserve ordinary UTF-8 paths as-is while quoting paths containing terminal controls, ambiguous bytes, or invalid UTF-8
- apply safe path output to both simple and rich `gix index entries` formats, including submodule-prefixed paths
- add command-level regressions for ANSI escape and newline-containing index paths

## Git baseline

Git's `builtin/ls-files.c` routes line-oriented paths through `write_name_quoted_relative()`, backed by the C-style quoting in `quote.c`. This change follows the same behavioral principle: ordinary paths stay readable, while terminal-active bytes are never emitted literally.

## Validation

- `cargo test -p gitoxide-core --lib`
- `just journey-tests-small`
- `cargo clippy -p gitoxide-core --lib --features gix/sha1,serde -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `codex review --commit 409702c90b4e66748ddc094c58d1de0b814fff4a` — no actionable findings

## Scope

This is the maintainer-recommended first increment for #1534. It secures `gix index entries`; the advisory's `gix tree entries` proof of concept and the broader repository-metadata output audit remain follow-up work.
