### PR TITLE
fix: let archived fixtures bypass Git version gates (#1622)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,7 @@ jobs:
 
     runs-on: ${{ matrix.runner-os }}
 
-    container: ${{ matrix.container-architecture }}/debian:bookworm-slim
+    container: ${{ matrix.container-architecture }}/debian:stable-slim
 
     steps:
       - name: Prerequisites

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,7 +1601,6 @@ dependencies = [
  "smallvec",
  "termtree",
  "thiserror 2.0.18",
- "walkdir",
 ]
 
 [[package]]

--- a/gix-discover/tests/discover/is_git.rs
+++ b/gix-discover/tests/discover/is_git.rs
@@ -145,14 +145,13 @@ fn split_worktree_using_configuration() -> crate::Result {
 
 #[test]
 fn reftable() -> crate::Result {
-    let repo_path = match gix_testtools::scripted_fixture_read_only("make_reftable_repo.sh") {
-        Ok(root) => root.join("reftable-clone/.git"),
-        Err(_) if *gix_testtools::GIT_VERSION < (2, 44, 0) => {
-            eprintln!("Fixture script failure ignored as it looks like Git isn't recent enough.");
-            return Ok(());
-        }
-        Err(err) => panic!("{err}"),
+    let Some(root) = gix_testtools::scripted_fixture_read_only_with_git_version("make_reftable_repo.sh", |version| {
+        version >= (2, 44, 0)
+    })?
+    else {
+        return Ok(());
     };
+    let repo_path = root.join("reftable-clone/.git");
     let kind = gix_discover::is_git(&repo_path)?;
     assert_eq!(kind, gix_discover::repository::Kind::WorkTree { linked_git_dir: None });
     Ok(())

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -428,7 +428,6 @@ pretty_assertions = "1.4.0"
 gix-testtools = { path = "../tests/tools" }
 is_ci = "1.1.1"
 anyhow = "1"
-walkdir = "2.3.2"
 serial_test = { version = "3.4.0", default-features = false }
 async-std = { version = "1.12.0", features = ["attributes"] }
 termtree = "1.0.0"

--- a/gix/tests/gix/repository/open.rs
+++ b/gix/tests/gix/repository/open.rs
@@ -87,18 +87,13 @@ fn on_root_with_decomposed_unicode() -> crate::Result {
 
 #[test]
 fn non_bare_reftable() -> crate::Result {
-    let repo = match named_subrepo_opts(
-        "make_reftable_repo.sh",
-        "reftable-clone",
-        gix::open::Options::isolated(),
-    ) {
-        Ok(r) => r,
-        Err(_) if *gix_testtools::GIT_VERSION < (2, 44, 0) => {
-            eprintln!("Fixture script failure ignored as it looks like Git isn't recent enough.");
-            return Ok(());
-        }
-        Err(err) => panic!("{err}"),
+    let Some(root) = gix_testtools::scripted_fixture_read_only_with_git_version("make_reftable_repo.sh", |version| {
+        version >= (2, 44, 0)
+    })?
+    else {
+        return Ok(());
     };
+    let repo = gix::open_opts(root.join("reftable-clone"), gix::open::Options::isolated())?;
     assert!(
         repo.head_id().is_err(),
         "Trying to do anything with head will fail as we don't support reftables yet"

--- a/gix/tests/gix/repository/worktree.rs
+++ b/gix/tests/gix/repository/worktree.rs
@@ -271,10 +271,14 @@ mod baseline {
 
 #[test]
 fn from_bare_parent_repo() {
-    if gix_testtools::should_skip_as_git_version_is_smaller_than(2, 31, 0) {
+    let Some(dir) = gix_testtools::scripted_fixture_read_only_with_args_with_git_version(
+        "make_worktree_repo.sh",
+        ["bare"],
+        |version| version >= (2, 31, 0),
+    )
+    .unwrap() else {
         return;
-    }
-    let dir = gix_testtools::scripted_fixture_read_only_with_args("make_worktree_repo.sh", ["bare"]).unwrap();
+    };
     let repo = gix::open(dir.join("repo.git")).unwrap();
 
     run_assertions(repo, true /* bare */);
@@ -282,10 +286,12 @@ fn from_bare_parent_repo() {
 
 #[test]
 fn from_nonbare_parent_repo() {
-    if gix_testtools::should_skip_as_git_version_is_smaller_than(2, 31, 0) {
+    let Some(dir) = gix_testtools::scripted_fixture_read_only_with_git_version("make_worktree_repo.sh", |version| {
+        version >= (2, 31, 0)
+    })
+    .unwrap() else {
         return;
-    }
-    let dir = gix_testtools::scripted_fixture_read_only("make_worktree_repo.sh").unwrap();
+    };
     let repo = gix::open(dir.join("repo")).unwrap();
 
     run_assertions(repo, false /* bare */);
@@ -345,11 +351,12 @@ fn linked_worktree_proxy_base_with_symlinked_main_repo() -> crate::Result {
 
 #[test]
 fn from_nonbare_parent_repo_set_workdir() -> gix_testtools::Result {
-    if gix_testtools::should_skip_as_git_version_is_smaller_than(2, 31, 0) {
+    let Some(dir) = gix_testtools::scripted_fixture_read_only_with_git_version("make_worktree_repo.sh", |version| {
+        version >= (2, 31, 0)
+    })?
+    else {
         return Ok(());
-    }
-
-    let dir = gix_testtools::scripted_fixture_read_only("make_worktree_repo.sh").unwrap();
+    };
     let mut repo = gix::open(dir.join("repo")).unwrap();
 
     assert!(repo.worktree().is_some_and(|wt| wt.is_main()), "we have main worktree");

--- a/gix/tests/gix/revision/spec/from_bytes/regex.rs
+++ b/gix/tests/gix/revision/spec/from_bytes/regex.rs
@@ -72,12 +72,14 @@ mod find_youngest_matching_commit {
     use gix::revision::Spec;
 
     use super::*;
-    use crate::revision::spec::from_bytes::parse_spec;
+    use crate::revision::spec::from_bytes::{parse_spec, repo_with_correct_pattern_revision_order};
 
     #[test]
     #[cfg(not(feature = "revparse-regex"))]
     fn contained_string_matches() {
-        let repo = repo("complex_graph").unwrap();
+        let Some(repo) = repo_with_correct_pattern_revision_order("complex_graph").unwrap() else {
+            return;
+        };
 
         assert_eq!(
             parse_spec(":/message", &repo).unwrap(),
@@ -111,7 +113,9 @@ mod find_youngest_matching_commit {
     #[test]
     #[cfg(feature = "revparse-regex")]
     fn regex_matches() {
-        let repo = repo("complex_graph").unwrap();
+        let Some(repo) = repo_with_correct_pattern_revision_order("complex_graph").unwrap() else {
+            return;
+        };
 
         assert_eq!(
             parse_spec(":/mes.age", &repo).unwrap(),

--- a/gix/tests/gix/revision/spec/from_bytes/util.rs
+++ b/gix/tests/gix/revision/spec/from_bytes/util.rs
@@ -1,116 +1,117 @@
 #![allow(clippy::result_large_err)]
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, path::Path, str::FromStr};
 
 use gix_object::{bstr, bstr::BStr};
 use gix_ref::bstr::{BString, ByteSlice};
 use gix_revision::spec::Kind;
-use std::sync::LazyLock;
 
 const FIXTURE_NAME: &str = "make_rev_spec_parse_repos.sh";
-static BASELINE: LazyLock<HashMap<PathBuf, HashMap<BString, Option<gix_revision::Spec>>>> = LazyLock::new(|| {
-    fn kind_of(spec: &BStr) -> gix_revision::spec::Kind {
-        if spec.starts_with(b"^") {
-            gix_revision::spec::Kind::IncludeReachable
-        } else if spec.contains_str(b"...") {
-            gix_revision::spec::Kind::ReachableToMergeBase
-        } else if spec.contains_str(b"..") {
-            gix_revision::spec::Kind::RangeBetween
-        } else if spec.ends_with(b"^!") {
-            gix_revision::spec::Kind::ExcludeReachableFromParents
-        } else if spec.ends_with(b"^@") {
-            unreachable!("BUG: cannot use rev^@ as it won't list the actual commit")
-        } else {
-            gix_revision::spec::Kind::IncludeReachable
-        }
+
+fn git_has_correct_pattern_revision_order(version: (u8, u8, u8)) -> bool {
+    // Git 57fb139b5e accidentally reversed `:/<text>` traversal order in 2.47.x.
+    // Git 0ff919e87a restored youngest-first traversal starting with 2.48.0.
+    !((2, 47, 0)..(2, 48, 0)).contains(&version)
+}
+
+fn kind_of(spec: &BStr) -> gix_revision::spec::Kind {
+    if spec.starts_with(b"^") {
+        gix_revision::spec::Kind::IncludeReachable
+    } else if spec.contains_str(b"...") {
+        gix_revision::spec::Kind::ReachableToMergeBase
+    } else if spec.contains_str(b"..") {
+        gix_revision::spec::Kind::RangeBetween
+    } else if spec.ends_with(b"^!") {
+        gix_revision::spec::Kind::ExcludeReachableFromParents
+    } else if spec.ends_with(b"^@") {
+        unreachable!("BUG: cannot use rev^@ as it won't list the actual commit")
+    } else {
+        gix_revision::spec::Kind::IncludeReachable
     }
-    fn lines_of(kind: gix_revision::spec::Kind) -> Option<usize> {
-        Some(match kind {
-            Kind::ExcludeReachable | Kind::IncludeReachable => 1,
-            Kind::RangeBetween => 2,
-            Kind::ReachableToMergeBase => 3,
-            Kind::IncludeReachableFromParents | Kind::ExcludeReachableFromParents => return None,
-        })
-    }
-    fn object_id_of_next(lines: &mut std::iter::Peekable<bstr::Lines<'_>>) -> gix_hash::ObjectId {
-        let hex_hash = lines.next().expect("valid respect yields enough lines");
-        object_id_of(hex_hash).expect("git yields full objects ids")
-    }
-    fn object_id_of(input: &[u8]) -> Option<gix_hash::ObjectId> {
-        let hex_hash = input.strip_prefix(b"^").unwrap_or(input);
-        gix_hash::ObjectId::from_str(hex_hash.to_str().expect("hex is ascii")).ok()
-    }
-    let mut baseline_map = HashMap::new();
-    let base = gix_testtools::scripted_fixture_read_only(FIXTURE_NAME).unwrap();
-    for baseline_entry in walkdir::WalkDir::new(base)
-        .max_depth(2)
-        .follow_links(false)
-        .into_iter()
-        .filter_map(|e| e.ok().and_then(|e| (e.file_name() == "baseline.git").then_some(e)))
-    {
-        let map = baseline_map
-            .entry(baseline_entry.path().parent().expect("file in directory").into())
-            .or_insert_with(HashMap::default);
-        let baseline = std::fs::read(baseline_entry.path()).unwrap();
-        let mut lines = baseline.lines().peekable();
-        while let Some(spec) = lines.next() {
-            let exit_code_or_hash = lines.next().expect("exit code or single hash").to_str().unwrap();
-            let kind = kind_of(spec.as_bstr());
-            let first_hash = match u8::from_str(exit_code_or_hash) {
-                Ok(_exit_code) => {
-                    let is_duplicate = map.insert(spec.into(), None).is_some();
-                    assert!(!is_duplicate, "Duplicate spec '{}' cannot be handled", spec.as_bstr());
-                    continue;
-                }
-                Err(_) => match gix::ObjectId::from_str(exit_code_or_hash) {
-                    Ok(hash) => hash,
-                    Err(_) => break, // for now bail out, we can't parse multi-line results yet
-                },
-            };
-            let num_lines = lines_of(kind);
-            let rev_spec = match num_lines {
-                Some(line_count) => match line_count {
-                    1 if kind == gix_revision::spec::Kind::IncludeReachable => gix_revision::Spec::Include(first_hash),
-                    1 if kind == gix_revision::spec::Kind::ExcludeReachable => gix_revision::Spec::Exclude(first_hash),
-                    2 | 3 => {
-                        let second_hash = object_id_of_next(&mut lines);
-                        if line_count == 2 {
-                            gix_revision::Spec::Range {
-                                from: second_hash,
-                                to: first_hash,
-                            }
-                        } else {
-                            lines.next().expect("merge-base to consume");
-                            gix_revision::Spec::Merge {
-                                theirs: first_hash,
-                                ours: second_hash,
-                            }
+}
+
+fn lines_of(kind: gix_revision::spec::Kind) -> Option<usize> {
+    Some(match kind {
+        Kind::ExcludeReachable | Kind::IncludeReachable => 1,
+        Kind::RangeBetween => 2,
+        Kind::ReachableToMergeBase => 3,
+        Kind::IncludeReachableFromParents | Kind::ExcludeReachableFromParents => return None,
+    })
+}
+
+fn object_id_of_next(lines: &mut std::iter::Peekable<bstr::Lines<'_>>) -> gix_hash::ObjectId {
+    let hex_hash = lines.next().expect("valid result yields enough lines");
+    object_id_of(hex_hash).expect("git yields full object ids")
+}
+
+fn object_id_of(input: &[u8]) -> Option<gix_hash::ObjectId> {
+    let hex_hash = input.strip_prefix(b"^").unwrap_or(input);
+    gix_hash::ObjectId::from_str(hex_hash.to_str().expect("hex is ascii")).ok()
+}
+
+fn baseline_at(repo_dir: &Path) -> HashMap<BString, Option<gix_revision::Spec>> {
+    let mut map = HashMap::new();
+    let baseline_path = repo_dir.join("baseline.git");
+    let baseline = std::fs::read(&baseline_path)
+        .unwrap_or_else(|err| panic!("baseline at '{}' can be read: {err}", baseline_path.display()));
+    let mut lines = baseline.lines().peekable();
+    while let Some(spec) = lines.next() {
+        let exit_code_or_hash = lines.next().expect("exit code or single hash").to_str().unwrap();
+        let kind = kind_of(spec.as_bstr());
+        let first_hash = match u8::from_str(exit_code_or_hash) {
+            Ok(_exit_code) => {
+                let is_duplicate = map.insert(spec.into(), None).is_some();
+                assert!(!is_duplicate, "Duplicate spec '{}' cannot be handled", spec.as_bstr());
+                continue;
+            }
+            Err(_) => match gix::ObjectId::from_str(exit_code_or_hash) {
+                Ok(hash) => hash,
+                Err(_) => break, // for now bail out, we can't parse multi-line results yet
+            },
+        };
+        let num_lines = lines_of(kind);
+        let rev_spec = match num_lines {
+            Some(line_count) => match line_count {
+                1 if kind == gix_revision::spec::Kind::IncludeReachable => gix_revision::Spec::Include(first_hash),
+                1 if kind == gix_revision::spec::Kind::ExcludeReachable => gix_revision::Spec::Exclude(first_hash),
+                2 | 3 => {
+                    let second_hash = object_id_of_next(&mut lines);
+                    if line_count == 2 {
+                        gix_revision::Spec::Range {
+                            from: second_hash,
+                            to: first_hash,
                         }
+                    } else {
+                        lines.next().expect("merge-base to consume");
+                        gix_revision::Spec::Merge {
+                            theirs: first_hash,
+                            ours: second_hash,
+                        }
+                    }
+                }
+                _ => unreachable!(),
+            },
+            None => {
+                let rev_spec = match kind {
+                    gix_revision::spec::Kind::ExcludeReachableFromParents => {
+                        gix_revision::Spec::ExcludeParents(first_hash)
                     }
                     _ => unreachable!(),
-                },
-                None => {
-                    let rev_spec = match kind {
-                        gix_revision::spec::Kind::ExcludeReachableFromParents => {
-                            gix_revision::Spec::ExcludeParents(first_hash)
-                        }
-                        _ => unreachable!(),
-                    };
-                    while let Some(_oid) = lines.peek().map(|hex| object_id_of(hex)) {
-                        lines.next();
-                    }
-                    rev_spec
+                };
+                while let Some(_oid) = lines.peek().map(|hex| object_id_of(hex)) {
+                    lines.next();
                 }
-            };
-            let is_duplicate = map.insert(spec.into(), Some(rev_spec)).is_some();
-            assert!(!is_duplicate, "Duplicate spec '{}' cannot be handled", spec.as_bstr());
-            if num_lines.filter(|count| *count > 1).is_some() {
-                // git always considers these errors for some reason, so skip it.
-                lines.next();
+                rev_spec
             }
+        };
+        let is_duplicate = map.insert(spec.into(), Some(rev_spec)).is_some();
+        assert!(!is_duplicate, "Duplicate spec '{}' cannot be handled", spec.as_bstr());
+        if num_lines.filter(|count| *count > 1).is_some() {
+            // git always considers these errors for some reason, so skip it.
+            lines.next();
         }
     }
-    baseline_map
-});
+    map
+}
 
 pub fn parse_spec_no_baseline<'a>(
     spec: &str,
@@ -168,9 +169,8 @@ fn compare_with_baseline(
 ) {
     let actual = res.as_deref().ok().copied();
     let spec: BString = spec.into();
-    let expected = *BASELINE
-        .get(repo.workdir().unwrap_or_else(|| repo.git_dir()))
-        .unwrap_or_else(|| panic!("No baseline for {repo:?}"))
+    let baseline = baseline_at(repo.workdir().unwrap_or_else(|| repo.git_dir()));
+    let expected = *baseline
         .get(&spec)
         .unwrap_or_else(|| panic!("'{spec}' revspec not found in git baseline"));
     match expectation {
@@ -193,4 +193,10 @@ pub fn parse_spec(spec: impl AsRef<str>, repo: &gix::Repository) -> Result<gix::
 pub fn repo(name: &str) -> crate::Result<gix::Repository> {
     let base = gix_testtools::scripted_fixture_read_only(FIXTURE_NAME)?;
     Ok(gix::open(base.join(name))?)
+}
+
+pub fn repo_with_correct_pattern_revision_order(name: &str) -> crate::Result<Option<gix::Repository>> {
+    gix_testtools::scripted_fixture_read_only_with_git_version(FIXTURE_NAME, git_has_correct_pattern_revision_order)?
+        .map(|base| gix::open(base.join(name)).map_err(Into::into))
+        .transpose()
 }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -1927,12 +1927,10 @@ fn populate_meta_dir(destination_dir: &Path, script_identity: u32) -> std::io::R
         meta_dir.join(META_IDENTITY),
         format!("{}-{}", script_identity, family_name()).as_bytes(),
     )?;
+    let (major, minor, patch) = *GIT_VERSION;
     std::fs::write(
         meta_dir.join(META_GIT_VERSION),
-        std::process::Command::new(GIT_PROGRAM)
-            .arg("--version")
-            .output()?
-            .stdout,
+        format!("git version {major}.{minor}.{patch}\n"),
     )?;
     Ok(meta_dir)
 }

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -636,6 +636,47 @@ enum ArgsInHash {
     No,
 }
 
+/// Controls whether a scripted fixture may use or must use its archive.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum ArchivePolicy {
+    /// Honor `GIX_TEST_IGNORE_ARCHIVES` and generate the fixture if no archive is used.
+    Normal,
+    /// Ignore `GIX_TEST_IGNORE_ARCHIVES`, preferring the archive but falling back to generation.
+    Prefer,
+    /// Ignore `GIX_TEST_IGNORE_ARCHIVES` and return no fixture if the archive is unavailable.
+    Require,
+}
+
+impl ArchivePolicy {
+    /// Return the subdirectory used to keep this policy's extracted fixture separate.
+    /// This way fixtures extracted from a test that has a stricter policy will not accidentally
+    /// be reused by a test that has a weaker policy.
+    fn cache_variant(self) -> Option<&'static str> {
+        match self {
+            ArchivePolicy::Normal => None,
+            ArchivePolicy::Prefer => Some("archive"),
+            ArchivePolicy::Require => Some("required-archive"),
+        }
+    }
+
+    /// Return whether `GIX_TEST_IGNORE_ARCHIVES` must be ignored when extracting the fixture.
+    ///
+    /// Preferred archives freeze otherwise unstable generated contents, while required archives
+    /// are the only valid source when the installed Git is incompatible. Allowing the environment
+    /// override in either case would defeat that guarantee.
+    fn ignores_archive_override(self) -> bool {
+        !matches!(self, ArchivePolicy::Normal)
+    }
+
+    /// Return whether the fixture script may run when no usable archive is available.
+    ///
+    /// Generation is forbidden for [`ArchivePolicy::Require`] because that policy is selected when
+    /// the installed Git is incompatible; running the script would produce an unsupported fixture.
+    fn allows_generation(self) -> bool {
+        !matches!(self, ArchivePolicy::Require)
+    }
+}
+
 /// Return the path to the `<crate-root>/tests/fixtures/<path>` directory.
 pub fn fixture_path(path: impl AsRef<Path>) -> PathBuf {
     fixture_base().join(path.as_ref())
@@ -699,9 +740,23 @@ pub fn scripted_fixture_read_only_needs_archive(script_name: impl AsRef<Path>) -
         ArgsInHash::Yes,
         default_excludes(),
         None::<(u32, _)>,
-        true,
+        ArchivePolicy::Prefer,
     )
-    .map(|(dir, _)| dir)
+    .map(|fixture| fixture.expect("preferred archives fall back to generation").0)
+}
+
+/// Produce a read-only scripted fixture when the installed Git version is compatible, or extract it from a matching
+/// archive otherwise.
+///
+/// `is_git_version_compatible` receives [`GIT_VERSION`]. If it returns `true`, this behaves like
+/// [`scripted_fixture_read_only()`]. Otherwise, `GIX_TEST_IGNORE_ARCHIVES` is ignored and the fixture is only made
+/// available by extracting an archive whose identity matches the fixture script. The script is never run with an
+/// incompatible Git version, and `None` is returned if no matching archive is available.
+pub fn scripted_fixture_read_only_with_git_version(
+    script_name: impl AsRef<Path>,
+    is_git_version_compatible: impl FnOnce((u8, u8, u8)) -> bool,
+) -> Result<Option<PathBuf>> {
+    scripted_fixture_read_only_with_args_with_git_version(script_name, None::<String>, is_git_version_compatible)
 }
 
 /// Run the executable at `script_name`, like `make_repo.sh` to produce a writable directory to which
@@ -772,8 +827,9 @@ where
                 args_in_hash,
                 excludes,
                 post_process.as_mut().map(|(v, f)| (*v, f)),
-                false,
-            )?;
+                ArchivePolicy::Normal,
+            )?
+            .expect("normal fixtures fall back to generation");
             copy_recursively_into_existing_dir(ro_dir, dst.path())?;
             (dst, _res_ignored)
         }
@@ -786,8 +842,9 @@ where
                 args_in_hash,
                 excludes,
                 post_process.as_mut().map(|(v, f)| (*v, f)),
-                false,
-            )?;
+                ArchivePolicy::Normal,
+            )?
+            .expect("normal fixtures fall back to generation");
             (dst, post_result)
         }
     })
@@ -824,9 +881,32 @@ pub fn scripted_fixture_read_only_with_args(
         ArgsInHash::Yes,
         default_excludes(),
         None::<(u32, _)>,
-        false,
+        ArchivePolicy::Normal,
     )
-    .map(|(dir, _)| dir)
+    .map(|fixture| fixture.expect("normal fixtures fall back to generation").0)
+}
+
+/// Like [`scripted_fixture_read_only_with_git_version()`], but passes `args` to `script_name`.
+pub fn scripted_fixture_read_only_with_args_with_git_version(
+    script_name: impl AsRef<Path>,
+    args: impl IntoIterator<Item = impl Into<String>>,
+    is_git_version_compatible: impl FnOnce((u8, u8, u8)) -> bool,
+) -> Result<Option<PathBuf>> {
+    let archive_policy = if is_git_version_compatible(*GIT_VERSION) {
+        ArchivePolicy::Normal
+    } else {
+        ArchivePolicy::Require
+    };
+    scripted_fixture_read_only_with_args_inner::<fn(FixtureState<'_>) -> PostResult, ()>(
+        script_name,
+        args,
+        None,
+        ArgsInHash::Yes,
+        default_excludes(),
+        None::<(u32, _)>,
+        archive_policy,
+    )
+    .map(|fixture| fixture.map(|(dir, _)| dir))
 }
 
 /// Like `scripted_fixture_read_only()`], but passes `args` to `script_name`.
@@ -851,9 +931,9 @@ pub fn scripted_fixture_read_only_with_args_single_archive(
         ArgsInHash::No,
         default_excludes(),
         None::<(u32, _)>,
-        false,
+        ArchivePolicy::Normal,
     )
-    .map(|(dir, _)| dir)
+    .map(|fixture| fixture.expect("normal fixtures fall back to generation").0)
 }
 
 /// Like [`scripted_fixture_read_only`], but runs a Rust closure after the script completes.
@@ -876,9 +956,12 @@ pub fn scripted_fixture_read_only_with_post<T>(
         ArgsInHash::Yes,
         default_excludes(),
         Some((version, post_process)),
-        false,
+        ArchivePolicy::Normal,
     )
-    .map(|(path, opt)| (path, opt.expect("post_process was provided")))
+    .map(|fixture| {
+        let (path, opt) = fixture.expect("normal fixtures fall back to generation");
+        (path, opt.expect("post_process was provided"))
+    })
 }
 
 /// Like [`scripted_fixture_read_only_with_args`], but runs a Rust closure after the script completes.
@@ -897,9 +980,12 @@ pub fn scripted_fixture_read_only_with_args_with_post<T>(
         ArgsInHash::Yes,
         default_excludes(),
         Some((version, post_process)),
-        false,
+        ArchivePolicy::Normal,
     )
-    .map(|(path, opt)| (path, opt.expect("post_process was provided")))
+    .map(|fixture| {
+        let (path, opt) = fixture.expect("normal fixtures fall back to generation");
+        (path, opt.expect("post_process was provided"))
+    })
 }
 
 /// Like [`scripted_fixture_read_only_with_args_single_archive`], but runs a Rust closure after the script completes.
@@ -918,9 +1004,12 @@ pub fn scripted_fixture_read_only_with_args_single_archive_with_post<T>(
         ArgsInHash::No,
         default_excludes(),
         Some((version, post_process)),
-        false,
+        ArchivePolicy::Normal,
     )
-    .map(|(path, opt)| (path, opt.expect("post_process was provided")))
+    .map(|fixture| {
+        let (path, opt) = fixture.expect("normal fixtures fall back to generation");
+        (path, opt.expect("post_process was provided"))
+    })
 }
 
 /// Like [`scripted_fixture_writable`], but runs a Rust closure after the script completes.
@@ -1142,12 +1231,17 @@ where
         &script_result_directory,
         script_identity,
         force_run,
-        false,
+        ArchivePolicy::Normal,
         excludes,
         &format!("using Rust closure '{name}'"),
         make_fixture,
     )
-    .map(|res| (script_result_directory, res))
+    .map(|res| {
+        (
+            script_result_directory,
+            res.expect("normal fixtures fall back to generation"),
+        )
+    })
 }
 
 // We may assume that destination_dir is already unique (i.e. temp-dir) if present - thus there is no need for a lock,
@@ -1199,11 +1293,11 @@ fn run_fixture_generator_with_marker_handling<T, F>(
     script_result_directory: &Path,
     script_identity: u32,
     force_run: bool,
-    needs_archive: bool,
+    archive_policy: ArchivePolicy,
     excludes: &dyn IsExcluded,
     description: &str,
     make_fixture: F,
-) -> Result<T>
+) -> Result<Option<T>>
 where
     F: FnOnce(FixtureState<'_>) -> PostResult<T>,
 {
@@ -1222,7 +1316,7 @@ where
             archive_file_path,
             script_result_directory,
             script_identity,
-            needs_archive,
+            archive_policy.ignores_archive_override(),
         ) {
             Ok((archive_id, platform)) => {
                 eprintln!(
@@ -1231,17 +1325,29 @@ where
                     archive_id,
                     platform
                 );
-                make_fixture(FixtureState::Fresh(script_result_directory))
+                make_fixture(FixtureState::Fresh(script_result_directory)).map(Some)
             }
             Err(err) => {
-                if err.kind() != std::io::ErrorKind::NotFound {
-                    eprintln!("failed to extract '{}': {}", archive_file_path.display(), err);
-                    std::fs::remove_dir_all(script_result_directory).map_err(|err| {
+                let archive_missing = err.kind() == std::io::ErrorKind::NotFound;
+                let generation_allowed = archive_policy.allows_generation();
+                if !generation_allowed || !archive_missing {
+                    // Remove incomplete output, or an empty required-fixture directory that a later call could
+                    // mistake for a valid cached fixture.
+                    std::fs::remove_dir_all(script_result_directory).map_err(|cleanup_err| {
                         format!(
-                            "Failed to remove '{script_result_directory}', please try to do that by hand. Original error: {err}",
-                            script_result_directory = script_result_directory.display()
+                            "Failed to remove incomplete fixture at '{}': {cleanup_err}",
+                            script_result_directory.display()
                         )
                     })?;
+                }
+                if !generation_allowed {
+                    if archive_missing {
+                        return Ok(None);
+                    }
+                    return Err(err.into());
+                }
+                if !archive_missing {
+                    eprintln!("failed to extract '{}': {}", archive_file_path.display(), err);
                     std::fs::create_dir_all(script_result_directory)?;
                 } else if !excludes.is_excluded(archive_file_path) {
                     eprintln!(
@@ -1261,11 +1367,11 @@ where
                     .inspect_err(|_err| {
                         write_failure_marker(&failure_marker);
                     })?;
-                Ok(res)
+                Ok(Some(res))
             }
         }
     } else {
-        make_fixture(FixtureState::Fresh(script_result_directory))
+        make_fixture(FixtureState::Fresh(script_result_directory)).map(Some)
     }
 }
 
@@ -1276,8 +1382,8 @@ fn scripted_fixture_read_only_with_args_inner<F, T>(
     args_in_hash: ArgsInHash,
     excludes: &dyn IsExcluded,
     post_process: Option<(u32, F)>,
-    needs_archive: bool,
-) -> Result<(PathBuf, Option<T>)>
+    archive_policy: ArchivePolicy,
+) -> Result<Option<(PathBuf, Option<T>)>>
 where
     F: FnMut(FixtureState<'_>) -> PostResult<T>,
 {
@@ -1361,7 +1467,7 @@ where
         script_basename,
         Some(object_hash),
         &script_identity,
-        needs_archive.then_some("archive"),
+        archive_policy.cache_variant(),
     );
     let _marker = marker_if_needed(destination_dir, script_basename)?;
 
@@ -1377,7 +1483,7 @@ where
         &script_result_directory,
         script_identity_for_archive,
         force_run,
-        needs_archive,
+        archive_policy,
         excludes,
         &format!("using script '{}'", script_location.display()),
         |fixture_state| {
@@ -1408,7 +1514,7 @@ where
         },
     )?;
 
-    Ok((script_result_directory, res))
+    Ok(res.map(|res| (script_result_directory, res)))
 }
 
 /// Returns the hash function that is used when creating or loading test fixtures.
@@ -1837,13 +1943,13 @@ fn extract_archive(
     archive: &Path,
     destination_dir: &Path,
     required_script_identity: u32,
-    needs_archive: bool,
+    ignore_archive_override: bool,
 ) -> std::io::Result<(u32, Option<String>)> {
     let archive_buf: Vec<u8> = {
         let mut buf = Vec::new();
         #[cfg_attr(feature = "xz", allow(unused_mut))]
         let mut input_archive = std::fs::File::open(archive)?;
-        if !needs_archive && env::var_os("GIX_TEST_IGNORE_ARCHIVES").is_some() {
+        if !ignore_archive_override && env::var_os("GIX_TEST_IGNORE_ARCHIVES").is_some() {
             return Err(std::io::Error::other(format!(
                 "Ignoring archive at '{}' as GIX_TEST_IGNORE_ARCHIVES is set.",
                 archive.display()

--- a/tests/tools/src/tests.rs
+++ b/tests/tools/src/tests.rs
@@ -384,3 +384,160 @@ fn archive_required_fixtures_use_a_separate_cache_directory() {
             .any(|component| component.as_os_str() == "archive")
     );
 }
+
+struct Included;
+
+impl IsExcluded for Included {
+    fn is_excluded(&self, _archive: &Path) -> bool {
+        false
+    }
+}
+
+fn write_test_archive(source: &Path, archive: &Path, identity: u32) {
+    let meta_dir = populate_meta_dir(source, identity).expect("archive metadata can be created");
+    let mut archive_buf = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut archive_buf);
+        builder.append_dir_all(".", source).expect("fixture can be archived");
+        builder.finish().expect("archive can be finished");
+    }
+
+    #[cfg(feature = "xz")]
+    {
+        use std::io::Write;
+
+        let mut encoder = xz2::write::XzEncoder::new(Vec::new(), 3);
+        encoder.write_all(&archive_buf).expect("archive can be compressed");
+        std::fs::write(archive, encoder.finish().expect("compression can finish"))
+            .expect("compressed archive can be written");
+    }
+    #[cfg(not(feature = "xz"))]
+    std::fs::write(archive, archive_buf).expect("archive can be written");
+
+    std::fs::remove_dir_all(meta_dir).expect("temporary metadata can be removed");
+}
+
+#[test]
+fn required_archives_never_fall_back_to_fixture_generation() {
+    let temp = tempfile::TempDir::new().expect("temporary directory can be created");
+    let archive = temp.path().join("missing.tar");
+    let destination = temp.path().join("fixture");
+    let mut generator_was_called = false;
+
+    let result = run_fixture_generator_with_marker_handling(
+        &archive,
+        &destination,
+        42,
+        false,
+        ArchivePolicy::Require,
+        &Included,
+        "from a test generator",
+        |_| {
+            generator_was_called = true;
+            Ok(())
+        },
+    )
+    .expect("a missing required archive is not an error");
+
+    assert!(result.is_none(), "the unavailable fixture is reported to the caller");
+    assert!(
+        !generator_was_called,
+        "an incompatible Git must never generate the fixture"
+    );
+    assert!(
+        !destination.exists(),
+        "an unavailable archive leaves no reusable cache directory"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn required_archives_are_extracted_even_when_archives_are_ignored() {
+    let temp = tempfile::TempDir::new().expect("temporary directory can be created");
+    let source = temp.path().join("source");
+    std::fs::create_dir(&source).expect("source directory can be created");
+    std::fs::write(source.join("payload"), "from archive").expect("payload can be written");
+    let archive = temp.path().join(tar_extension());
+    write_test_archive(&source, &archive, 42);
+    let destination = temp.path().join("fixture");
+    let _env = Env::new().set("GIX_TEST_IGNORE_ARCHIVES", "1");
+
+    let result = run_fixture_generator_with_marker_handling(
+        &archive,
+        &destination,
+        42,
+        false,
+        ArchivePolicy::Require,
+        &Included,
+        "from a test generator",
+        |state| {
+            assert!(matches!(state, FixtureState::Fresh(_)), "the generator is not invoked");
+            std::fs::read_to_string(state.path().join("payload")).map_err(Into::into)
+        },
+    )
+    .expect("the required archive can be extracted");
+
+    assert_eq!(result.as_deref(), Some("from archive"));
+}
+
+#[test]
+fn stale_required_archives_are_unavailable_instead_of_generated() {
+    let temp = tempfile::TempDir::new().expect("temporary directory can be created");
+    let source = temp.path().join("source");
+    std::fs::create_dir(&source).expect("source directory can be created");
+    let archive = temp.path().join(tar_extension());
+    write_test_archive(&source, &archive, 41);
+    let destination = temp.path().join("fixture");
+    let mut generator_was_called = false;
+
+    let result = run_fixture_generator_with_marker_handling(
+        &archive,
+        &destination,
+        42,
+        false,
+        ArchivePolicy::Require,
+        &Included,
+        "from a test generator",
+        |_| {
+            generator_was_called = true;
+            Ok(())
+        },
+    )
+    .expect("a stale required archive is not an error");
+
+    assert!(result.is_none(), "the stale fixture is reported to the caller");
+    assert!(
+        !generator_was_called,
+        "a stale archive must not fall back to generation"
+    );
+}
+
+#[test]
+fn required_archives_use_a_dedicated_cache_directory() {
+    let fixture_base = Path::new("tests").join("fixtures");
+    let (_, generated_dir) = force_and_dir(None, &fixture_base, "scripted", Some(gix_hash::Kind::Sha1), &1234, None);
+    let (_, preferred_archive_dir) = force_and_dir(
+        None,
+        &fixture_base,
+        "scripted",
+        Some(gix_hash::Kind::Sha1),
+        &1234,
+        Some("archive"),
+    );
+    let (_, required_archive_dir) = force_and_dir(
+        None,
+        &fixture_base,
+        "scripted",
+        Some(gix_hash::Kind::Sha1),
+        &1234,
+        Some("required-archive"),
+    );
+
+    assert_ne!(required_archive_dir, generated_dir);
+    assert_ne!(required_archive_dir, preferred_archive_dir);
+    assert!(
+        required_archive_dir
+            .components()
+            .any(|component| component.as_os_str() == "required-archive")
+    );
+}


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

Fixes #1622 .

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- add Git-version-aware scripted fixture loaders that require an identity-matching archive when the installed Git is incompatible
- keep required fixtures in a dedicated cache, honor archives even with GIX_TEST_IGNORE_ARCHIVES, and never generate them with incompatible Git
- run the affected rev-spec tests against the Git 2.50.1 archive on Git 2.47.x, while skipping only when the matching SHA-1/SHA-256 archive is unavailable
- migrate Git >= 2.31 worktree tests and restore 32-bit CI to Debian stable

Git 57fb139b5e introduced reversed :/<text> traversal in 2.47.x; Git 0ff919e87a restored youngest-first ordering in 2.48.0.

Refs #1622

## Validation

- cargo test -p gix-testtools --all-features --lib
- cargo test -p gix-testtools --no-default-features --lib
- cargo nextest run -p gix revision::spec::from_bytes --no-default-features --features max-performance-safe,comfort,basic
- GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix revision::spec::from_bytes::regex::find_youngest_matching_commit --no-default-features --features max-performance-safe,comfort,basic
- focused worktree tests
- cargo clippy -p gix-testtools --all-targets --all-features -- -D warnings
- cargo clippy -p gix --tests -- -D warnings
- cargo doc -p gix-testtools --no-deps
- cargo fmt --all -- --check
- git diff --check
- Codex commit review, including a simulated Git 2.47 archive-path test