### PR TITLE
fix: handle tracked paths in exclude queries

### DIFF
--- a/gitoxide-core/src/query/engine/command.rs
+++ b/gitoxide-core/src/query/engine/command.rs
@@ -19,23 +19,15 @@ impl query::Engine {
         match cmd {
             Command::TracePath { spec } => {
                 let is_excluded = spec.is_excluded();
-                // Just to get the normalized version of the path with everything auto-configured.
-                let relpath = self
-                    .repo
-                    .pathspec(
-                        true,
-                        Some(spec.to_bstring()),
-                        false,
-                        &gix::index::State::new(self.repo.object_hash()),
-                        gix::worktree::stack::state::attributes::Source::WorktreeThenIdMapping
-                            .adjust_for_bare(self.repo.is_bare()),
-                    )?
-                    .search()
-                    .patterns()
-                    .next()
-                    .expect("exactly one")
-                    .path()
-                    .to_owned();
+                let relpath = if spec.signature.contains(gix::pathspec::MagicSignature::TOP) {
+                    let root = self.repo.workdir().unwrap_or_else(|| self.repo.git_dir());
+                    let path = root.join(gix::path::from_bstr(spec.path()).as_ref());
+                    self.repo
+                        .normalize_path(gix::path::into_bstr(path).as_ref())?
+                        .into_owned()
+                } else {
+                    self.repo.normalize_path(spec.path())?.into_owned()
+                };
                 if relpath.is_empty() || is_excluded {
                     bail!(
                         "Invalid pathspec {spec} - path must not be empty, not be excluded, and wildcards are taken literally"

--- a/gitoxide-core/src/repository/blame.rs
+++ b/gitoxide-core/src/repository/blame.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 
-use gix::{bstr::ByteSlice, config::tree};
+use gix::{bstr::BStr, config::tree};
 
 pub fn blame_file(
     mut repo: gix::Repository,
@@ -19,21 +19,7 @@ pub fn blame_file(
     repo.object_cache_size_if_unset(repo.compute_object_cache_size_for_tree_diffs(&index));
 
     let file = gix::path::os_str_into_bstr(file)?;
-    let specs = repo.pathspec(
-        false,
-        [file],
-        true,
-        &index,
-        gix::worktree::stack::state::attributes::Source::WorktreeThenIdMapping.adjust_for_bare(repo.is_bare()),
-    )?;
-    // TODO: there should be a way to normalize paths without going through patterns, at least in this case maybe?
-    //       `Search` actually sorts patterns by excluding or not, all that can lead to strange results.
-    let file = specs
-        .search()
-        .patterns()
-        .map(|p| p.path().to_owned())
-        .next()
-        .expect("exactly one pattern");
+    let file = repo.normalize_path(file)?;
 
     let suspect: gix::ObjectId = repo.head()?.into_peeled_id()?.into();
     let cache: Option<gix::commitgraph::Graph> = repo.commit_graph_if_enabled()?;
@@ -43,11 +29,11 @@ pub fn blame_file(
         suspect,
         cache,
         &mut resource_cache,
-        file.as_bstr(),
+        file.as_ref(),
         options,
     )?;
     let statistics = outcome.statistics;
-    show_blame_entries(out, outcome, file)?;
+    show_blame_entries(out, outcome, file.as_ref())?;
 
     if let Some(err) = err {
         writeln!(err, "{statistics:#?}")?;
@@ -58,7 +44,7 @@ pub fn blame_file(
 fn show_blame_entries(
     mut out: impl std::io::Write,
     outcome: gix::blame::Outcome,
-    source_file_name: gix::bstr::BString,
+    source_file_name: &BStr,
 ) -> Result<(), std::io::Error> {
     for (entry, lines_in_hunk) in outcome.entries_with_lines() {
         for ((actual_lno, source_lno), line) in entry
@@ -73,7 +59,7 @@ fn show_blame_entries(
                 line_no = actual_lno + 1,
             )?;
 
-            let source_file_name = entry.source_file_name.as_ref().unwrap_or(&source_file_name);
+            let source_file_name = entry.source_file_name.as_ref().map_or(source_file_name, BStr::new);
             write!(out, "{source_file_name} ")?;
 
             write!(out, "{src_line_no} {line}", src_line_no = source_lno + 1)?;

--- a/gitoxide-core/src/repository/exclude.rs
+++ b/gitoxide-core/src/repository/exclude.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, io};
 
 use anyhow::bail;
-use gix::bstr::BStr;
+use gix::bstr::{BStr, ByteSlice};
 
 use crate::{OutputFormat, is_dir_to_mode, repository::PathsOrPatterns};
 
@@ -44,69 +44,22 @@ pub fn query(
         Default::default(),
     )?;
 
-    match input {
-        PathsOrPatterns::Paths(paths) => {
-            for path in paths {
-                let mode = gix::path::from_bstr(Cow::Borrowed(path.as_ref()))
-                    .metadata()
-                    .ok()
-                    .map(|m| is_dir_to_mode(m.is_dir()));
-                let entry = cache.at_entry(&path, mode)?;
-                let match_ = entry
-                    .matching_exclude_pattern()
-                    .and_then(|m| (show_ignore_patterns || !m.pattern.is_negative()).then_some(m));
-                print_match(match_, path.as_ref(), &mut out)?;
-            }
-        }
-        PathsOrPatterns::Patterns(patterns) => {
-            let mut pathspec_matched_something = false;
-            let mut pathspec = repo.pathspec(
-                true,
-                patterns.iter(),
-                repo.workdir().is_some(),
-                &index,
-                gix::worktree::stack::state::attributes::Source::WorktreeThenIdMapping.adjust_for_bare(repo.is_bare()),
-            )?;
-
-            if let Some(it) = pathspec.index_entries_with_paths(&index) {
-                for (path, entry) in it {
-                    pathspec_matched_something = true;
-                    let entry = cache.at_entry(path, entry.mode.into())?;
-                    let match_ = entry
-                        .matching_exclude_pattern()
-                        .and_then(|m| (show_ignore_patterns || !m.pattern.is_negative()).then_some(m));
-                    print_match(match_, path, &mut out)?;
-                }
-            }
-
-            if !pathspec_matched_something {
-                // TODO(borrowchk): this shouldn't be necessary at all, but `pathspec` stays borrowed mutably for some reason.
-                //                  It's probably due to the strange lifetimes of `index_entries_with_paths()`.
-                let pathspec = repo.pathspec(
-                    true,
-                    patterns.iter(),
-                    repo.workdir().is_some(),
-                    &index,
-                    gix::worktree::stack::state::attributes::Source::WorktreeThenIdMapping
-                        .adjust_for_bare(repo.is_bare()),
-                )?;
-                let workdir = repo.workdir();
-                for pattern in pathspec.search().patterns() {
-                    let path = pattern.path();
-                    let entry = cache.at_entry(
-                        path,
-                        Some(is_dir_to_mode(
-                            workdir.is_some_and(|wd| wd.join(gix::path::from_bstr(path)).is_dir())
-                                || pattern.signature.contains(gix::pathspec::MagicSignature::MUST_BE_DIR),
-                        )),
-                    )?;
-                    let match_ = entry
-                        .matching_exclude_pattern()
-                        .and_then(|m| (show_ignore_patterns || !m.pattern.is_negative()).then_some(m));
-                    print_match(match_, path, &mut out)?;
-                }
-            }
-        }
+    let paths: Box<dyn Iterator<Item = gix::bstr::BString>> = match input {
+        PathsOrPatterns::Paths(paths) => paths,
+        PathsOrPatterns::Patterns(paths) => Box::new(paths.into_iter()),
+    };
+    for path in paths {
+        let mode = gix::path::from_bstr(Cow::Borrowed(path.as_ref()))
+            .metadata()
+            .ok()
+            .map(|m| is_dir_to_mode(m.is_dir()))
+            .or_else(|| path.ends_with(b"/").then_some(gix::index::entry::Mode::DIR));
+        let query_path = repo.normalize_path(&path)?;
+        let entry = cache.at_entry(query_path.as_bstr(), mode)?;
+        let match_ = entry
+            .matching_exclude_pattern()
+            .filter(|m| show_ignore_patterns || !m.pattern.is_negative());
+        print_match_unless_tracked(match_, &index, query_path.as_bstr(), path.as_ref(), &mut out)?;
     }
 
     if let Some(stats) = statistics.then(|| cache.take_statistics()) {
@@ -114,6 +67,21 @@ pub fn query(
         writeln!(err, "{stats:#?}").ok();
     }
     Ok(())
+}
+
+fn print_match_unless_tracked(
+    match_: Option<gix::ignore::search::Match<'_>>,
+    index: &gix::index::State,
+    query_path: &BStr,
+    display_path: &BStr,
+    out: impl std::io::Write,
+) -> std::io::Result<()> {
+    print_match(match_.filter(|_| !is_tracked(index, query_path)), display_path, out)
+}
+
+fn is_tracked(index: &gix::index::State, path: &BStr) -> bool {
+    let path = path.trim_end_with(|b| b == '/').as_bstr();
+    index.entry_by_path(path).is_some() || index.path_is_directory(path)
 }
 
 fn print_match(

--- a/gitoxide-core/src/repository/merge/file.rs
+++ b/gitoxide-core/src/repository/merge/file.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::{Context, anyhow, bail};
 use gix::{
     Id,
-    bstr::{BString, ByteSlice},
+    bstr::BString,
     merge::blob::{
         Resolution, ResourceKind,
         builtin_driver::{binary, text::Conflict},
@@ -26,24 +26,13 @@ pub fn file(
     if format != OutputFormat::Human {
         bail!("JSON output isn't implemented yet");
     }
-    let index = &repo.index_or_load_from_head()?;
-    let specs = repo.pathspec(
-        false,
-        [base, ours, theirs],
-        true,
-        index,
-        gix::worktree::stack::state::attributes::Source::WorktreeThenIdMapping.adjust_for_bare(repo.is_bare()),
-    )?;
-    // TODO: there should be a way to normalize paths without going through patterns, at least in this case maybe?
-    //       `Search` actually sorts patterns by excluding or not, all that can lead to strange results.
-    let mut patterns = specs.search().patterns().map(|p| p.path().to_owned());
-    let base = patterns.next().unwrap();
-    let ours = patterns.next().unwrap();
-    let theirs = patterns.next().unwrap();
+    let base = repo.normalize_path(&base)?;
+    let ours = repo.normalize_path(&ours)?;
+    let theirs = repo.normalize_path(&theirs)?;
 
-    let base_id = repo.rev_parse_single(base.as_bstr()).ok();
-    let ours_id = repo.rev_parse_single(ours.as_bstr()).ok();
-    let theirs_id = repo.rev_parse_single(theirs.as_bstr()).ok();
+    let base_id = repo.rev_parse_single(base.as_ref()).ok();
+    let ours_id = repo.rev_parse_single(ours.as_ref()).ok();
+    let theirs_id = repo.rev_parse_single(theirs.as_ref()).ok();
     let roots = worktree_roots(base_id, ours_id, theirs_id, repo.workdir())?;
 
     let mut cache = repo.merge_resource_cache(roots)?;
@@ -51,21 +40,21 @@ pub fn file(
     cache.set_resource(
         base_id.map_or(null, Id::detach),
         EntryKind::Blob,
-        base.as_bstr(),
+        base.as_ref(),
         ResourceKind::CommonAncestorOrBase,
         &repo.objects,
     )?;
     cache.set_resource(
         ours_id.map_or(null, Id::detach),
         EntryKind::Blob,
-        ours.as_bstr(),
+        ours.as_ref(),
         ResourceKind::CurrentOrOurs,
         &repo.objects,
     )?;
     cache.set_resource(
         theirs_id.map_or(null, Id::detach),
         EntryKind::Blob,
-        theirs.as_bstr(),
+        theirs.as_ref(),
         ResourceKind::OtherOrTheirs,
         &repo.objects,
     )?;
@@ -82,9 +71,9 @@ pub fn file(
     }
     let platform = cache.prepare_merge(&repo.objects, options)?;
     let labels = gix::merge::blob::builtin_driver::text::Labels {
-        ancestor: Some(base.as_bstr()),
-        current: Some(ours.as_bstr()),
-        other: Some(theirs.as_bstr()),
+        ancestor: Some(base.as_ref()),
+        current: Some(ours.as_ref()),
+        other: Some(theirs.as_ref()),
     };
     let mut buf = repo.empty_reusable_buffer();
     let (pick, resolution) = platform.merge(&mut buf, labels, &repo.command_context()?)?;

--- a/gix-path/src/convert.rs
+++ b/gix-path/src/convert.rs
@@ -291,6 +291,44 @@ pub fn normalize<'a>(path: Cow<'a, Path>, current_dir: &Path) -> Option<Cow<'a, 
     .into()
 }
 
+/// Like [`normalize()`], but also removes `.` components and duplicate or trailing separators.
+///
+/// If cleaning leaves no components, `current_dir` is returned. Already-clean borrowed paths remain borrowed.
+pub fn normalize_and_clean<'a>(path: Cow<'a, Path>, current_dir: &Path) -> Option<Cow<'a, Path>> {
+    fn needs_cleaning(path: &Path) -> bool {
+        use std::path::Component::CurDir;
+
+        if path.as_os_str().is_empty() || path.components().any(|component| matches!(component, CurDir)) {
+            return true;
+        }
+
+        let mut components = path
+            .as_os_str()
+            .as_encoded_bytes()
+            .split(|byte| std::path::is_separator(*byte as char));
+        let Some(first) = components.next() else { return true };
+        first == b"." || components.any(|component| component.is_empty() || component == b".")
+    }
+
+    let path = normalize(path, current_dir)?;
+    if !needs_cleaning(path.as_ref()) {
+        return Some(path);
+    }
+
+    let mut cleaned: PathBuf = path
+        .components()
+        .filter(|component| !matches!(component, Component::CurDir))
+        .collect();
+    if cleaned.as_os_str().is_empty() {
+        cleaned.push(current_dir);
+    }
+    if cleaned.as_os_str() == path.as_os_str() {
+        Some(path)
+    } else {
+        Some(Cow::Owned(cleaned))
+    }
+}
+
 /// Rebuild the worktree-relative `relative_path` to be relative to `prefix`, which is the
 /// worktree-relative path equivalent to the position of the user, or current working directory.
 ///

--- a/gix-path/tests/path/convert/normalize.rs
+++ b/gix-path/tests/path/convert/normalize.rs
@@ -1,9 +1,46 @@
 use std::{borrow::Cow, path::Path};
 
-use gix_path::normalize;
+use gix_path::{normalize, normalize_and_clean};
 
 fn p(input: &str) -> &Path {
     Path::new(input)
+}
+
+#[test]
+fn clean_paths_and_use_the_cwd_for_empty_results() {
+    let cwd = p("/cwd");
+    for (input, expected) in [
+        ("", "/cwd"),
+        (".", "/cwd"),
+        ("./a", "a"),
+        ("a/./b", "a/b"),
+        ("a//b/", "a/b"),
+        ("a/..", "/cwd"),
+    ] {
+        assert_eq!(
+            normalize_and_clean(p(input).into(), cwd).expect("path can be normalized"),
+            p(expected),
+            "'{input}' cleans to '{expected}'"
+        );
+    }
+    assert_eq!(
+        normalize_and_clean(p(".").into(), p(""))
+            .expect("path can be normalized")
+            .as_ref(),
+        p(""),
+        "an empty CWD allows an empty normalized path"
+    );
+    assert_eq!(
+        normalize_and_clean(p(".").into(), cwd)
+            .expect("path can be normalized")
+            .as_ref(),
+        cwd,
+        "an empty input path is the CWD"
+    );
+    assert!(
+        matches!(normalize_and_clean(p("a/b").into(), cwd), Some(Cow::Borrowed(path)) if path == p("a/b")),
+        "already-clean borrowed paths stay borrowed"
+    );
 }
 
 #[test]

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -262,6 +262,29 @@ pub fn discover(directory: impl AsRef<std::path::Path>) -> Result<Repository, di
     ThreadSafeRepository::discover(directory).map(Into::into)
 }
 
+/// Try to open a git repository in `directory` and search upwards through its parents until one is found,
+/// using `open_options` regardless of the trust level of the discovered repository.
+/// The detected trust level is retained, so repositories with reduced trust still restrict their behavior accordingly.
+#[expect(
+    clippy::result_large_err,
+    reason = "will be removed once `gix-error` is used consistently"
+)]
+pub fn discover_opts(
+    directory: impl AsRef<std::path::Path>,
+    options: discover::upwards::Options<'_>,
+    open_options: open::Options,
+) -> Result<Repository, discover::Error> {
+    ThreadSafeRepository::discover_opts(
+        directory,
+        options,
+        sec::trust::Mapping {
+            full: open_options.clone(),
+            reduced: open_options,
+        },
+    )
+    .map(Into::into)
+}
+
 /// Try to discover a git repository directly from the environment.
 ///
 /// For details, see [`ThreadSafeRepository::discover_with_environment_overrides_opts()`].

--- a/gix/src/repository/location.rs
+++ b/gix/src/repository/location.rs
@@ -1,7 +1,10 @@
 use gix_path::realpath::MAX_SYMLINKS;
-use std::path::{Path, PathBuf};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 
-use crate::bstr::{BStr, ByteSlice};
+use crate::bstr::BStr;
 
 impl crate::Repository {
     /// Return the path to the repository itself, containing objects, references, configuration, and more.
@@ -91,14 +94,75 @@ impl crate::Repository {
         self.work_tree.as_deref()
     }
 
-    /// Turn `rela_path` into a path qualified with the [`workdir()`](Self::workdir()) of this instance,
-    /// if one is available.
+    /// Turn the repository-relative Git path `rela_path` into a filesystem path qualified with the
+    /// [`workdir()`](Self::workdir()) of this instance, if one is available.
+    ///
+    /// This is useful for accessing a path obtained from repository data, such as an index or tree entry, in the
+    /// worktree. It performs no normalization or containment checks. Use [`normalize_path()`](Self::normalize_path)
+    /// first for paths supplied relative to the current working directory, absolute paths, or paths with `.` or `..`
+    /// components.
     pub fn workdir_path(&self, rela_path: impl AsRef<BStr>) -> Option<PathBuf> {
         self.workdir().and_then(|wd| {
             gix_path::try_from_bstr(rela_path.as_ref())
                 .ok()
                 .map(|rela| wd.join(rela))
         })
+    }
+
+    /// Normalize `path` into a repository-relative Git path with slash separators.
+    ///
+    /// This is useful for turning user-supplied filesystem paths into paths suitable for querying repository data.
+    /// To access the corresponding file in a non-bare repository, pass the result to
+    /// [`workdir_path()`](Self::workdir_path).
+    ///
+    /// Relative paths are interpreted from [`current_dir()`](Self::current_dir), as captured when this repository was
+    /// instantiated, if it is inside the worktree. Otherwise they are considered repository-relative.
+    /// An empty path or `.` refers to that directory, and the result is empty if that directory is the repository root.
+    ///
+    /// Absolute paths must be within the worktree, or within the Git directory for bare repositories.
+    /// Paths which traverse outside of the repository are rejected. Note that passing absolute paths is expensive
+    /// as their realpath has to be determined.
+    pub fn normalize_path<'a>(
+        &self,
+        path: &'a (impl gix_utils::AsBStr + ?Sized),
+    ) -> Result<Cow<'a, BStr>, crate::repository::normalize_path::Error> {
+        use crate::repository::normalize_path::Error;
+
+        let path = gix_path::from_bstr(Cow::Borrowed(path.as_bstr()));
+        let path = if gix_path::is_absolute(path.as_ref()) {
+            let root = gix_path::realpath_opts(
+                self.workdir().unwrap_or_else(|| self.git_dir()),
+                self.current_dir(),
+                MAX_SYMLINKS,
+            )?;
+            let absolute = path.into_owned();
+            let relative = if let Ok(relative) = absolute.strip_prefix(&root) {
+                relative.to_owned()
+            } else {
+                gix_path::realpath_opts(&absolute, self.current_dir(), MAX_SYMLINKS)?
+                    .strip_prefix(&root)
+                    .map_err(|_| Error::AbsolutePathOutsideOfRepository { path: absolute, root })?
+                    .to_owned()
+            };
+            Cow::Owned(relative)
+        } else if let Some(prefix) = self.prefix()?.filter(|prefix| !prefix.as_os_str().is_empty()) {
+            Cow::Owned(prefix.join(path.as_ref()))
+        } else {
+            path
+        };
+
+        let path = match path {
+            Cow::Borrowed(path) => gix_path::normalize_and_clean(Cow::Borrowed(path), Path::new(""))
+                .ok_or_else(|| Error::OutsideOfRepository { path: path.to_owned() })?,
+            Cow::Owned(path) => {
+                if gix_path::normalize_and_clean(Cow::Borrowed(path.as_path()), Path::new("")).is_none() {
+                    return Err(Error::OutsideOfRepository { path });
+                }
+                gix_path::normalize_and_clean(Cow::Owned(path), Path::new(""))
+                    .expect("path was just validated as normalizable")
+            }
+        };
+        Ok(gix_path::to_unix_separators_on_windows(gix_path::into_bstr(path)))
     }
 
     // TODO: tests, respect precomposeUnicode
@@ -142,6 +206,7 @@ impl crate::Repository {
     /// Return `None` if a defect in the database makes the answer uncertain.
     #[doc(alias = "is_empty", alias = "git2")]
     pub fn is_pristine(&self) -> Option<bool> {
+        use gix_utils::AsBStr;
         let name = self
             .config
             .resolved

--- a/gix/src/repository/mod.rs
+++ b/gix/src/repository/mod.rs
@@ -453,6 +453,28 @@ pub mod upstream_branch_and_remote_name_for_tracking_branch {
 }
 
 ///
+pub mod normalize_path {
+    /// The error returned by [Repository::normalize_path()](crate::Repository::normalize_path()).
+    #[derive(Debug, thiserror::Error)]
+    #[expect(missing_docs)]
+    pub enum Error {
+        #[error(transparent)]
+        Realpath(#[from] gix_path::realpath::Error),
+        #[error("The path '{}' leaves the repository", path.display())]
+        OutsideOfRepository { path: std::path::PathBuf },
+        #[error(
+            "The absolute path '{}' is not inside the repository at '{}'",
+            path.display(),
+            root.display()
+        )]
+        AbsolutePathOutsideOfRepository {
+            path: std::path::PathBuf,
+            root: std::path::PathBuf,
+        },
+    }
+}
+
+///
 #[cfg(feature = "attributes")]
 pub mod pathspec_defaults_ignore_case {
     /// The error returned by [Repository::pathspec_defaults_ignore_case()](crate::Repository::pathspec_defaults_inherit_ignore_case()).

--- a/gix/tests/repository.rs
+++ b/gix/tests/repository.rs
@@ -1,0 +1,109 @@
+use gix::bstr::ByteSlice;
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn relative_paths_use_the_cwd_captured_when_opening() -> gix_testtools::Result {
+    let root = gix::path::realpath(gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?)?;
+    let nested = root.join("some/very");
+
+    let _cwd = gix_testtools::set_current_dir(&nested)?;
+    let repo = gix::discover_opts(".", Default::default(), gix::open::Options::isolated())?;
+    assert_eq!(
+        repo.normalize_path("file")?.as_bstr(),
+        "some/very/file",
+        "relative paths start at the captured CWD"
+    );
+    assert_eq!(
+        repo.normalize_path("../file")?.as_bstr(),
+        "some/file",
+        "parent components consume the captured CWD prefix"
+    );
+    assert_eq!(
+        repo.normalize_path("../../file")?.as_bstr(),
+        "file",
+        "all CWD components can be consumed"
+    );
+    assert_eq!(
+        repo.normalize_path("./file")?.as_bstr(),
+        "some/very/file",
+        "current-directory components are removed"
+    );
+
+    std::env::set_current_dir(&root)?;
+    assert_eq!(
+        repo.normalize_path("file")?.as_bstr(),
+        "some/very/file",
+        "Repository keeps the CWD captured when it was opened"
+    );
+    let repo = gix::discover_opts(".", Default::default(), gix::open::Options::isolated())?;
+    assert!(
+        matches!(repo.normalize_path("file")?, std::borrow::Cow::Borrowed(path) if path == "file"),
+        "unchanged paths are returned without allocation"
+    );
+    assert_eq!(
+        repo.normalize_path("")?.as_bstr(),
+        "",
+        "an empty path at the repository root remains empty"
+    );
+    assert_eq!(
+        repo.normalize_path(".")?.as_bstr(),
+        "",
+        "the repository root expressed as a current-directory component normalizes to an empty path"
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn paths_cannot_leave_the_repository() -> gix_testtools::Result {
+    let root = gix::path::realpath(gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?)?;
+    let nested = root.join("some");
+
+    let _cwd = gix_testtools::set_current_dir(&nested)?;
+    let repo = gix::discover_opts(".", Default::default(), gix::open::Options::isolated())?;
+    let absolute = gix::path::into_bstr(root.join("some-with-file/very/deeply/nested/subdir/empty-file"));
+    assert_eq!(
+        repo.normalize_path(&absolute)?.as_bstr(),
+        "some-with-file/very/deeply/nested/subdir/empty-file",
+        "absolute paths inside the worktree become repository-relative"
+    );
+    assert!(
+        matches!(
+            repo.normalize_path("../../outside"),
+            Err(gix::repository::normalize_path::Error::OutsideOfRepository { .. })
+        ),
+        "relative paths cannot traverse above the worktree"
+    );
+
+    assert_eq!(
+        repo.normalize_path("")?.as_bstr(),
+        "some",
+        "an empty path refers to the captured current directory"
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn absolute_paths_outside_the_repository_are_rejected() -> gix_testtools::Result {
+    let root = gix::path::realpath(gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?)?;
+    let repo = gix::discover_opts(&root, Default::default(), gix::open::Options::isolated())?;
+    let outside = root.parent().expect("fixture has a parent").to_owned();
+    let outside_as_bstr = gix::path::into_bstr(outside.clone());
+
+    match repo
+        .normalize_path(&outside_as_bstr)
+        .expect_err("an absolute path outside the repository must fail")
+    {
+        gix::repository::normalize_path::Error::AbsolutePathOutsideOfRepository {
+            path,
+            root: actual_root,
+        } => {
+            assert_eq!(path, outside, "the rejected path is retained");
+            assert_eq!(actual_root, root, "the repository root is retained");
+        }
+        err => panic!("expected an absolute-path-outside error, got {err:?}"),
+    }
+    Ok(())
+}

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -1653,7 +1653,7 @@ pub fn main() -> Result<()> {
             exclude::Subcommands::Query {
                 statistics,
                 patterns,
-                pathspec,
+                paths,
                 show_ignore_patterns,
             } => prepare_and_run(
                 "exclude-query",
@@ -1664,16 +1664,16 @@ pub fn main() -> Result<()> {
                 None,
                 move |_progress, out, err| {
                     let repo = repository(Mode::Strict)?;
-                    let pathspecs = if pathspec.is_empty() {
+                    let paths = if paths.is_empty() {
                         PathsOrPatterns::Paths(Box::new(
                             stdin_or_bail()?.byte_lines().filter_map(Result::ok).map(BString::from),
                         ))
                     } else {
-                        PathsOrPatterns::Patterns(pathspec)
+                        PathsOrPatterns::Patterns(paths)
                     };
                     core::repository::exclude::query(
                         repo,
-                        pathspecs,
+                        paths,
                         out,
                         err,
                         core::repository::exclude::query::Options {

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -1209,11 +1209,11 @@ pub mod exclude {
 
     use gix::bstr::BString;
 
-    use crate::shared::CheckPathSpec;
+    use crate::shared::AsBString;
 
     #[derive(Debug, clap::Subcommand)]
     pub enum Subcommands {
-        /// Check if path-specs are excluded and print the result similar to `git check-ignore`.
+        /// Check if paths are excluded and print the result similar to `git check-ignore`.
         Query {
             /// Print various statistics to stderr.
             #[clap(long, short = 's')]
@@ -1228,9 +1228,9 @@ pub mod exclude {
             /// Useful for undoing previous patterns using the '!' prefix.
             #[clap(long, short = 'p')]
             patterns: Vec<OsString>,
-            /// The git path specifications to check for exclusion, or unset to read from stdin one per line.
-            #[clap(value_parser = CheckPathSpec)]
-            pathspec: Vec<BString>,
+            /// The paths to check for exclusion, or unset to read from stdin one per line.
+            #[clap(value_parser = AsBString)]
+            paths: Vec<BString>,
         },
     }
 }

--- a/tests/journey/gix.sh
+++ b/tests/journey/gix.sh
@@ -79,6 +79,59 @@ title "gix (with repository)"
     )
   )
 
+  title "gix exclude"
+  (with "the 'query' sub-command"
+    snapshot="$snapshot/exclude/query"
+    (sandbox
+      git init -q
+
+      # An ignored directory with an indexed file must still expose untracked ignored children.
+      mkdir -p src/bin other/bin
+      printf 'bin/\nbuild/\n' >.gitignore
+      printf 'fn main() {}\n' >src/bin/stub_gen.rs
+      git add -f .gitignore src/bin/stub_gen.rs
+      printf 'extra\n' >src/bin/extra.txt
+      printf 'other\n' >other/bin/file.txt
+      printf '%s\n' \
+        src/bin \
+        src/bin/ \
+        src/bin/stub_gen.rs \
+        src/bin/extra.txt \
+        other/bin \
+        other/bin/file.txt >paths
+
+      it "handles tracked paths below ignored directories" && {
+        WITH_SNAPSHOT="$snapshot/tracked-paths-below-ignored-directories" \
+        expect_run $SUCCESSFULLY "$exe_plumbing" --no-verbose exclude query \
+          src/bin src/bin/ src/bin/stub_gen.rs src/bin/extra.txt other/bin other/bin/file.txt
+      }
+      it "produces the same output for paths read from stdin" && {
+        WITH_SNAPSHOT="$snapshot/same-paths-from-stdin" \
+        expect_run $SUCCESSFULLY "$exe_plumbing" --no-verbose exclude query <paths
+      }
+      it "resolves stdin paths relative to the current directory" && {
+        (
+          cd src &&
+          WITH_SNAPSHOT="$snapshot/stdin-paths-relative-to-cwd" \
+          expect_run $SUCCESSFULLY "$exe_plumbing" --no-verbose exclude query \
+            < <(printf 'bin/stub_gen.rs\nbin/extra.txt\n')
+        )
+      }
+      it "doesn't show ignore patterns for tracked paths" && {
+        WITH_SNAPSHOT="$snapshot/tracked-path-with-ignore-patterns" \
+        expect_run $SUCCESSFULLY "$exe_plumbing" --no-verbose exclude query --show-ignore-patterns src/bin/stub_gen.rs
+      }
+      it "keeps positional output in input order" && {
+        WITH_SNAPSHOT="$snapshot/positional-output-order" \
+        expect_run $SUCCESSFULLY "$exe_plumbing" --no-verbose exclude query src/bin/stub_gen.rs other/bin/file.txt
+      }
+      it "preserves directory intent for missing paths" && {
+        WITH_SNAPSHOT="$snapshot/missing-directory" \
+        expect_run $SUCCESSFULLY "$exe_plumbing" --no-verbose exclude query build/
+      }
+    )
+  )
+
   (small-repo-in-sandbox
     (with "the 'verify' sub-command"
       snapshot="$snapshot/verify"

--- a/tests/snapshots/plumbing/repository/exclude/query/missing-directory
+++ b/tests/snapshots/plumbing/repository/exclude/query/missing-directory
@@ -1,0 +1,1 @@
+./.gitignore:2:build/	build/

--- a/tests/snapshots/plumbing/repository/exclude/query/positional-output-order
+++ b/tests/snapshots/plumbing/repository/exclude/query/positional-output-order
@@ -1,0 +1,2 @@
+::	src/bin/stub_gen.rs
+./.gitignore:1:bin/	other/bin/file.txt

--- a/tests/snapshots/plumbing/repository/exclude/query/same-paths-from-stdin
+++ b/tests/snapshots/plumbing/repository/exclude/query/same-paths-from-stdin
@@ -1,0 +1,6 @@
+::	src/bin
+::	src/bin/
+::	src/bin/stub_gen.rs
+./.gitignore:1:bin/	src/bin/extra.txt
+./.gitignore:1:bin/	other/bin
+./.gitignore:1:bin/	other/bin/file.txt

--- a/tests/snapshots/plumbing/repository/exclude/query/stdin-paths-relative-to-cwd
+++ b/tests/snapshots/plumbing/repository/exclude/query/stdin-paths-relative-to-cwd
@@ -1,0 +1,2 @@
+::	bin/stub_gen.rs
+../.gitignore:1:bin/	bin/extra.txt

--- a/tests/snapshots/plumbing/repository/exclude/query/tracked-path-with-ignore-patterns
+++ b/tests/snapshots/plumbing/repository/exclude/query/tracked-path-with-ignore-patterns
@@ -1,0 +1,1 @@
+::	src/bin/stub_gen.rs

--- a/tests/snapshots/plumbing/repository/exclude/query/tracked-paths-below-ignored-directories
+++ b/tests/snapshots/plumbing/repository/exclude/query/tracked-paths-below-ignored-directories
@@ -1,0 +1,6 @@
+::	src/bin
+::	src/bin/
+::	src/bin/stub_gen.rs
+./.gitignore:1:bin/	src/bin/extra.txt
+./.gitignore:1:bin/	other/bin
+./.gitignore:1:bin/	other/bin/file.txt


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #2562

## Summary

- Suppress ignore matches for tracked files and directories represented in the index.
- Keep reporting untracked ignored descendants and preserve gix pathspec expansion semantics.
- Normalize stdin paths from repository subdirectories before index lookup.

## Git baseline

Compared with git check-ignore and Git sources builtin/check-ignore.c and dir.c at a23bace963d508bd96983cc637131392d3face18.

## Validation

- cargo fmt --all --check
- cargo test -p gitoxide-core --lib --quiet
- just journey-tests-small
- Codex commit review: clear

This is the smaller command-scoped replacement for draft #2564; that draft is left untouched.