### PR TITLE
feat: add the tix MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
+ "base64",
  "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
@@ -2528,8 +2529,10 @@ name = "gix-tix"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "crossterm",
  "gix",
  "gix-testtools",
+ "ratatui",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2526,6 +2526,11 @@ dependencies = [
 [[package]]
 name = "gix-tix"
 version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "gix",
+ "gix-testtools",
+]
 
 [[package]]
 name = "gix-trace"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,6 +1480,7 @@ dependencies = [
  "gitoxide-core",
  "gix",
  "gix-features",
+ "gix-tix",
  "is-terminal",
  "prodash",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,12 +57,12 @@ max-pure = ["hashes", "max-control", "http-client-reqwest", "gitoxide-core-block
 
 ## Like `max`, but with more control for configuration. See the *Package Maintainers* headline for more information.
 ## Needs to chose its own hash(es).
-max-control = ["tracing", "fast", "pretty-cli", "gitoxide-core-tools", "prodash-render-line", "prodash-render-tui", "prodash/render-line-autoconfigure", "gix/revparse-regex"]
+max-control = ["tracing", "fast", "pretty-cli", "tix", "gitoxide-core-tools", "prodash-render-line", "prodash-render-tui", "prodash/render-line-autoconfigure", "gix/revparse-regex"]
 
 ## All the good stuff, with less fanciness for smaller binaries.
 ##
 ## As fast as possible, progress line rendering, all transports based on their most mature implementation (HTTP), all `ein` tools, CLI colors and local-time support, JSON output.
-lean = ["hashes", "fast", "tracing", "pretty-cli", "http-client-curl-openssl", "gitoxide-core-tools-query", "gitoxide-core-tools-corpus", "gitoxide-core-tools", "gitoxide-core-blocking-client", "prodash-render-line"]
+lean = ["hashes", "fast", "tracing", "pretty-cli", "tix", "http-client-curl-openssl", "gitoxide-core-tools-query", "gitoxide-core-tools-corpus", "gitoxide-core-tools", "gitoxide-core-blocking-client", "prodash-render-line"]
 
 ## The smallest possible build, best suitable for small single-core machines.
 ##
@@ -80,7 +80,7 @@ small = ["hashes", "pretty-cli", "prodash-render-line", "is-terminal"]
 ##
 ## Due to async client-networking not being implemented for most transports, this one supports only the 'git+tcp' and HTTP transport.
 ## It uses, however, a fully asynchronous networking implementation which can serve a real-world example on how to implement custom async transports.
-lean-async = ["hashes", "fast", "tracing", "pretty-cli", "gitoxide-core-tools", "gitoxide-core-tools-query", "gitoxide-core-tools-corpus", "gitoxide-core-async-client", "prodash-render-line"]
+lean-async = ["hashes", "fast", "tracing", "pretty-cli", "tix", "gitoxide-core-tools", "gitoxide-core-tools-query", "gitoxide-core-tools-corpus", "gitoxide-core-async-client", "prodash-render-line"]
 
 #! ### Package Maintainers
 #! `*-control` features leave it to you to configure C libraries, involving choices for HTTP transport implementation.
@@ -94,9 +94,12 @@ lean-async = ["hashes", "fast", "tracing", "pretty-cli", "gitoxide-core-tools", 
 ## Provide support for all known hashes. If this isn't enabled, select an individual hash algorithms.
 hashes = ["sha1", "sha256"]
 ## Enable support for the SHA-1 hash throughout the `gix` crate.
-sha1 = ["gix/sha1"]
+sha1 = ["gix/sha1", "gix-tix?/sha1"]
 ## Enable support for the SHA-256 hash throughout the `gix` crate.
-sha256 = ["gix/sha256"]
+sha256 = ["gix/sha256", "gix-tix?/sha256"]
+
+## Enable the interactive commit graph. This requires Rust 1.88 or newer.
+tix = ["dep:gix-tix"]
 
 ## Makes the crate execute as fast as possible by supporting parallel computation of otherwise long-running functions.
 ## If disabled, the binary will be visibly smaller.
@@ -171,6 +174,7 @@ anyhow = "1.0.98"
 gitoxide-core = { version = "^0.59.0", path = "gitoxide-core" }
 gix-features = { version = "^0.48.1", path = "gix-features" }
 gix = { version = "^0.85.0", path = "gix", default-features = false }
+gix-tix = { version = "^0.0.0", path = "gix-tix", default-features = false, optional = true }
 
 clap = { version = "4.5.42", features = ["derive", "cargo"] }
 clap_complete = "4.5.55"

--- a/gix-tix/Cargo.toml
+++ b/gix-tix/Cargo.toml
@@ -14,10 +14,12 @@ include = ["/src/**/*", "/LICENSE-*"]
 [[bin]]
 name = "tix"
 path = "src/main.rs"
+required-features = ["sha1"]
 
 [features]
-default = ["sha1"]
+## Enable support for the SHA-1 hash by forwarding the feature to dependencies.
 sha1 = ["gix/sha1"]
+## Enable support for the SHA-256 hash by forwarding the feature to dependencies.
 sha256 = ["gix/sha256"]
 
 [dependencies]
@@ -28,3 +30,6 @@ ratatui = { version = "0.30.2", default-features = false, features = ["crossterm
 
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }
+
+[package.metadata.docs.rs]
+features = ["sha1"]

--- a/gix-tix/Cargo.toml
+++ b/gix-tix/Cargo.toml
@@ -11,6 +11,10 @@ edition = "2024"
 rust-version = "1.88"
 include = ["/src/**/*", "/LICENSE-*"]
 
+[[bin]]
+name = "tix"
+path = "src/main.rs"
+
 [features]
 default = ["sha1"]
 sha1 = ["gix/sha1"]

--- a/gix-tix/Cargo.toml
+++ b/gix-tix/Cargo.toml
@@ -11,12 +11,15 @@ edition = "2024"
 rust-version = "1.97"
 include = ["/src/**/*", "/LICENSE-*"]
 
-[lib]
-doctest = false
+[[bin]]
+name = "tix"
+path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.98"
+crossterm = { version = "0.29.0", features = ["osc52"] }
 gix = { version = "^0.85.0", path = "../gix" }
+ratatui = { version = "0.30.2", default-features = false, features = ["crossterm"] }
 
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }

--- a/gix-tix/Cargo.toml
+++ b/gix-tix/Cargo.toml
@@ -8,10 +8,15 @@ license = "MIT OR Apache-2.0"
 description = "A tool like `tig`, but minimal, fast and efficient"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.97"
 include = ["/src/**/*", "/LICENSE-*"]
 
 [lib]
 doctest = false
 
 [dependencies]
+anyhow = "1.0.98"
+gix = { version = "^0.85.0", path = "../gix" }
+
+[dev-dependencies]
+gix-testtools = { path = "../tests/tools" }

--- a/gix-tix/Cargo.toml
+++ b/gix-tix/Cargo.toml
@@ -8,17 +8,18 @@ license = "MIT OR Apache-2.0"
 description = "A tool like `tig`, but minimal, fast and efficient"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 edition = "2024"
-rust-version = "1.97"
+rust-version = "1.88"
 include = ["/src/**/*", "/LICENSE-*"]
 
-[[bin]]
-name = "tix"
-path = "src/main.rs"
+[features]
+default = ["sha1"]
+sha1 = ["gix/sha1"]
+sha256 = ["gix/sha256"]
 
 [dependencies]
 anyhow = "1.0.98"
 crossterm = { version = "0.29.0", features = ["osc52"] }
-gix = { version = "^0.85.0", path = "../gix" }
+gix = { version = "^0.85.0", path = "../gix", default-features = false, features = ["parallel", "revision"] }
 ratatui = { version = "0.30.2", default-features = false, features = ["crossterm"] }
 
 [dev-dependencies]

--- a/gix-tix/README.md
+++ b/gix-tix/README.md
@@ -1,0 +1,13 @@
+This is a `tig` inspired completely generated program to do what I used `tig` for, namely:
+
+- show project histories, but allow to trim them to hide given branches
+- copy selected hashes
+- but be faster and less memory hungry than `tig` when looking at big repositories.
+
+The commits that created it are clearly identified as authored by GPT, without myself as co-author.
+After all, I intentionally didn't look at the code.
+
+And from what I can tell, it does what I want it to, and seems to be worth maintaining.
+
+
+It's also an experiment to see how long, or if at all, this is maintainable.

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -1,19 +1,27 @@
 use std::{
     collections::HashMap,
+    ops::Range,
     time::{Duration, Instant},
 };
 
-use gix::{ObjectId, bstr::BString, traverse::commit::ParentIds};
+use gix::{
+    ObjectId,
+    bstr::{BStr, BString, ByteSlice},
+    traverse::commit::ParentIds,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct CommitRow {
+pub(crate) struct Commit<T> {
     pub id: ObjectId,
     pub parent_ids: ParentIds,
     pub lane: String,
     pub committer_time: gix::date::Time,
     pub author_name: BString,
-    pub subject: BString,
+    pub title: T,
 }
+
+pub(crate) type LoadedCommit = Commit<BString>;
+pub(crate) type CommitRow = Commit<Range<usize>>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum State {
@@ -57,6 +65,7 @@ pub(crate) enum Effect {
 #[derive(Debug)]
 pub(crate) struct App {
     pub rows: Vec<CommitRow>,
+    titles: Vec<u8>,
     pub selected: Option<usize>,
     pub offset: usize,
     pub state: State,
@@ -76,6 +85,7 @@ impl App {
     pub fn new(viewport_rows: usize) -> Self {
         App {
             rows: Vec::new(),
+            titles: Vec::new(),
             selected: None,
             offset: 0,
             state: State::Loading,
@@ -92,12 +102,33 @@ impl App {
         }
     }
 
-    pub(crate) fn extend_commits(&mut self, rows: Vec<CommitRow>) {
+    pub(crate) fn extend_commits(&mut self, rows: Vec<LoadedCommit>) {
         if self.state != State::Loading || rows.is_empty() {
             return;
         }
         let was_empty = self.rows.is_empty();
-        self.rows.extend(rows);
+        self.titles.reserve(rows.iter().map(|row| row.title.len()).sum());
+        self.rows.reserve(rows.len());
+        for row in rows {
+            let Commit {
+                id,
+                parent_ids,
+                lane,
+                committer_time,
+                author_name,
+                title,
+            } = row;
+            let start = self.titles.len();
+            self.titles.extend_from_slice(&title);
+            self.rows.push(Commit {
+                id,
+                parent_ids,
+                lane,
+                committer_time,
+                author_name,
+                title: start..self.titles.len(),
+            });
+        }
         if was_empty {
             self.selected = Some(0);
             self.ensure_visible();
@@ -105,6 +136,10 @@ impl App {
             self.selected = Some(self.rows.len() - 1);
             self.ensure_visible();
         }
+    }
+
+    pub(crate) fn title(&self, row: &CommitRow) -> &BStr {
+        self.titles[row.title.clone()].as_bstr()
     }
 
     pub fn update(&mut self, action: Action) -> Vec<Effect> {
@@ -364,20 +399,20 @@ fn transition(before: usize, after: usize, current: usize, edges: &[(usize, usiz
 mod tests {
     use super::*;
 
-    fn row(n: u8) -> CommitRow {
+    fn row(n: u8) -> LoadedCommit {
         let mut bytes = [0; 20];
         bytes[19] = n;
-        CommitRow {
+        Commit {
             id: ObjectId::Sha1(bytes),
             parent_ids: ParentIds::new(),
             lane: String::new(),
             committer_time: gix::date::Time::default(),
             author_name: "author".into(),
-            subject: format!("commit {n}").into(),
+            title: format!("commit {n}").into(),
         }
     }
 
-    fn row_with_parents(n: u8, parents: &[u8]) -> CommitRow {
+    fn row_with_parents(n: u8, parents: &[u8]) -> LoadedCommit {
         let mut commit = row(n);
         commit.parent_ids = parents.iter().map(|n| row(*n).id).collect();
         commit
@@ -550,5 +585,29 @@ mod tests {
         assert_eq!(app.state, State::Complete);
         assert_eq!(app.rows.len(), 1, "the loaded row count is the completed total");
         assert_eq!(app.update(Action::Quit), vec![Effect::Quit]);
+    }
+
+    #[test]
+    fn packs_titles_as_raw_bytes() {
+        let mut first = row(1);
+        first.title = vec![b'a', 0xff].into();
+        let mut second = row(2);
+        second.title = "second".into();
+        let mut app = App::new(2);
+
+        app.extend_commits(vec![first]);
+        app.extend_commits(vec![second]);
+
+        assert_eq!(app.titles, b"a\xffsecond", "title bytes share one allocation");
+        assert_eq!(
+            app.title(&app.rows[0]),
+            b"a\xff".as_bstr(),
+            "the first span preserves arbitrary bytes"
+        );
+        assert_eq!(
+            app.title(&app.rows[1]),
+            b"second".as_bstr(),
+            "the second span starts at the right offset"
+        );
     }
 }

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -11,6 +11,8 @@ pub(crate) struct CommitRow {
     pub id: ObjectId,
     pub parent_ids: ParentIds,
     pub lane: String,
+    pub committer_time: gix::date::Time,
+    pub author_name: BString,
     pub subject: BString,
 }
 
@@ -34,6 +36,8 @@ pub(crate) enum Action {
     PageDown,
     First,
     Last,
+    ToggleDate,
+    ToggleName,
     Cancel,
     Copy,
     Quit,
@@ -54,6 +58,8 @@ pub(crate) struct App {
     pub state: State,
     pub viewport_rows: usize,
     pub lane_time: Option<Duration>,
+    pub show_committer_date: bool,
+    pub show_author_name: bool,
     follow_tail: bool,
 }
 
@@ -66,6 +72,8 @@ impl App {
             state: State::Loading,
             viewport_rows,
             lane_time: None,
+            show_committer_date: true,
+            show_author_name: true,
             follow_tail: false,
         }
     }
@@ -108,6 +116,8 @@ impl App {
                 self.follow_tail = self.state == State::Loading;
                 self.ensure_visible();
             }
+            Action::ToggleDate => self.show_committer_date = !self.show_committer_date,
+            Action::ToggleName => self.show_author_name = !self.show_author_name,
             Action::Cancel if self.state == State::Loading => {
                 self.state = State::Cancelling;
                 return vec![Effect::Cancel];
@@ -329,6 +339,8 @@ mod tests {
             id: ObjectId::Sha1(bytes),
             parent_ids: ParentIds::new(),
             lane: String::new(),
+            committer_time: gix::date::Time::default(),
+            author_name: "author".into(),
             subject: format!("commit {n}").into(),
         }
     }
@@ -421,6 +433,17 @@ mod tests {
         assert_eq!(app.selected, Some(2));
         app.update(Action::HalfPageUp);
         assert_eq!(app.selected, Some(0));
+    }
+
+    #[test]
+    fn toggles_metadata_columns() {
+        let mut app = App::new(1);
+
+        app.update(Action::ToggleDate);
+        app.update(Action::ToggleName);
+
+        assert!(!app.show_committer_date);
+        assert!(!app.show_author_name);
     }
 
     #[test]

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -272,10 +272,9 @@ fn render_lanes(rows: &mut [CommitRow], known: &HashMap<ObjectId, usize>) {
                 _ => {
                     let destination = next.len();
                     next.push(*parent);
-                    if let Some(position) = old_position
-                        && *position != current
-                    {
-                        edges.push((*position, destination));
+                    match old_position {
+                        Some(position) if *position != current => edges.push((*position, destination)),
+                        _ => {}
                     }
                     destination
                 }

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -140,7 +140,7 @@ impl App {
         }
     }
 
-    fn ensure_visible(&mut self) {
+    pub(crate) fn ensure_visible(&mut self) {
         let Some(selected) = self.selected else { return };
         let height = self.viewport_rows.max(1);
         if selected < self.offset {

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::Reverse,
-    collections::{BinaryHeap, HashMap, HashSet},
+    collections::{BinaryHeap, HashMap},
+    time::{Duration, Instant},
 };
 
 use gix::{ObjectId, bstr::BString, traverse::commit::ParentIds};
@@ -23,7 +24,6 @@ pub(crate) enum State {
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum Action {
-    Commit(CommitRow),
     Complete,
     Cancelled,
     MoveUp,
@@ -53,6 +53,7 @@ pub(crate) struct App {
     pub offset: usize,
     pub state: State,
     pub viewport_rows: usize,
+    pub lane_time: Option<Duration>,
     follow_tail: bool,
 }
 
@@ -64,24 +65,31 @@ impl App {
             offset: 0,
             state: State::Loading,
             viewport_rows,
+            lane_time: None,
             follow_tail: false,
+        }
+    }
+
+    pub(crate) fn extend_commits(&mut self, rows: Vec<CommitRow>) {
+        if self.state != State::Loading || rows.is_empty() {
+            return;
+        }
+        let was_empty = self.rows.is_empty();
+        self.rows.extend(rows);
+        if was_empty {
+            self.selected = Some(0);
+            self.ensure_visible();
+        } else if self.follow_tail {
+            self.selected = Some(self.rows.len() - 1);
+            self.ensure_visible();
         }
     }
 
     pub fn update(&mut self, action: Action) -> Vec<Effect> {
         match action {
-            Action::Commit(row) if self.state == State::Loading => {
-                self.rows.push(row);
-                if self.selected.is_none() {
-                    self.selected = Some(0);
-                } else if self.follow_tail {
-                    self.selected = Some(self.rows.len() - 1);
-                }
-                self.ensure_visible();
-            }
             Action::Complete if self.state == State::Loading => {
                 let selected = self.selected.map(|index| self.rows[index].id);
-                finish_rows(&mut self.rows);
+                self.lane_time = Some(finish_rows(&mut self.rows));
                 self.selected = selected.and_then(|id| self.rows.iter().position(|row| row.id == id));
                 self.state = State::Complete;
                 self.follow_tail = false;
@@ -151,7 +159,7 @@ impl App {
     }
 }
 
-fn finish_rows(rows: &mut Vec<CommitRow>) {
+fn finish_rows(rows: &mut Vec<CommitRow>) -> Duration {
     let positions: HashMap<_, _> = rows.iter().enumerate().map(|(index, row)| (row.id, index)).collect();
     let mut children = vec![0usize; rows.len()];
     for row in rows.iter() {
@@ -186,45 +194,63 @@ fn finish_rows(rows: &mut Vec<CommitRow>) {
             .map(|index| old[index].take().expect("each row is moved exactly once"))
             .collect();
     }
-    render_lanes(rows);
+    let start = Instant::now();
+    render_lanes(rows, &positions);
+    start.elapsed()
 }
 
-fn render_lanes(rows: &mut [CommitRow]) {
-    let known: HashSet<_> = rows.iter().map(|row| row.id).collect();
+fn render_lanes(rows: &mut [CommitRow], known: &HashMap<ObjectId, usize>) {
     let mut columns = Vec::new();
+    let mut next = Vec::new();
+    let mut parents = Vec::new();
+    let mut edges = Vec::new();
     for row in rows {
         let current = columns.iter().position(|id| *id == row.id).unwrap_or_else(|| {
             columns.push(row.id);
             columns.len() - 1
         });
-        let mut next = Vec::new();
-        for (index, id) in columns.iter().copied().enumerate() {
-            if index == current {
-                for parent in row.parent_ids.iter().copied().filter(|id| known.contains(id)) {
-                    if !next.contains(&parent) {
-                        next.push(parent);
-                    }
-                }
-            } else if !next.contains(&id) {
-                next.push(id);
-            }
-        }
 
-        let mut edges = Vec::new();
-        for (index, id) in columns.iter().enumerate() {
-            if index != current
-                && let Some(next_index) = next.iter().position(|next_id| next_id == id)
-            {
-                edges.push((index, next_index));
+        parents.clear();
+        for parent in row.parent_ids.iter().copied().filter(|id| known.contains_key(id)) {
+            if !parents.iter().any(|(id, _, _)| *id == parent) {
+                parents.push((parent, columns.iter().position(|id| *id == parent), 0));
             }
         }
-        for parent in row.parent_ids.iter().copied().filter(|id| known.contains(id)) {
-            if let Some(next_index) = next.iter().position(|id| *id == parent) {
-                edges.push((current, next_index));
+        next.clear();
+        edges.clear();
+        for (index, id) in columns[..current].iter().copied().enumerate() {
+            let destination = next.len();
+            next.push(id);
+            edges.push((index, destination));
+        }
+        for (parent, old_position, destination) in &mut parents {
+            *destination = match old_position {
+                Some(position) if *position < current => *position,
+                _ => {
+                    let destination = next.len();
+                    next.push(*parent);
+                    if let Some(position) = old_position
+                        && *position != current
+                    {
+                        edges.push((*position, destination));
+                    }
+                    destination
+                }
+            };
+        }
+        for (index, id) in columns.iter().copied().enumerate().skip(current + 1) {
+            if parents.iter().any(|(_, position, _)| *position == Some(index)) {
+                continue;
             }
+            let destination = next.len();
+            next.push(id);
+            edges.push((index, destination));
+        }
+        for (_, _, destination) in &parents {
+            edges.push((current, *destination));
         }
         row.lane = transition(columns.len(), next.len(), current, &edges);
-        columns = next;
+        std::mem::swap(&mut columns, &mut next);
     }
 }
 
@@ -322,7 +348,7 @@ mod tests {
             row(1),
             row_with_parents(2, &[1]),
         ] {
-            app.update(Action::Commit(row));
+            app.extend_commits(vec![row]);
         }
 
         app.update(Action::Complete);
@@ -338,31 +364,42 @@ mod tests {
     }
 
     #[test]
+    fn lane_reuses_a_parent_that_is_already_to_the_right() {
+        let mut app = App::new(10);
+        for row in [row_with_parents(4, &[2, 3]), row_with_parents(2, &[3]), row(3)] {
+            app.extend_commits(vec![row]);
+        }
+
+        app.update(Action::Complete);
+
+        assert_eq!(
+            app.rows.iter().map(|row| row.lane.as_str()).collect::<Vec<_>>(),
+            ["●─┐ ", "●─┘ ", "● "]
+        );
+    }
+
+    #[test]
     fn selection_follows_the_oldest_commit_until_the_user_moves() {
         let mut app = App::new(2);
-        app.update(Action::Commit(row(1)));
-        app.update(Action::Commit(row(2)));
-        app.update(Action::Commit(row(3)));
+        app.extend_commits(vec![row(1), row(2), row(3)]);
 
         app.update(Action::Last);
         assert_eq!(app.selected, Some(2), "Last selects the oldest loaded commit");
         assert_eq!(app.offset, 1, "the selection remains visible");
 
-        app.update(Action::Commit(row(4)));
+        app.extend_commits(vec![row(4)]);
         assert_eq!(app.selected, Some(3), "new commits extend the followed tail");
         assert_eq!(app.offset, 2, "the viewport follows the tail");
 
         app.update(Action::MoveUp);
-        app.update(Action::Commit(row(5)));
+        app.extend_commits(vec![row(5)]);
         assert_eq!(app.selected, Some(2), "manual navigation stops following the tail");
     }
 
     #[test]
     fn navigation_is_clamped_and_uses_the_viewport_for_pages() {
         let mut app = App::new(2);
-        for n in 1..=5 {
-            app.update(Action::Commit(row(n)));
-        }
+        app.extend_commits((1..=5).map(row).collect());
 
         app.update(Action::PageDown);
         assert_eq!(app.selected, Some(2), "page-down advances by the viewport height");
@@ -378,9 +415,7 @@ mod tests {
     #[test]
     fn half_pages_use_half_the_viewport() {
         let mut app = App::new(4);
-        for n in 1..=5 {
-            app.update(Action::Commit(row(n)));
-        }
+        app.extend_commits((1..=5).map(row).collect());
 
         app.update(Action::HalfPageDown);
         assert_eq!(app.selected, Some(2));
@@ -391,11 +426,11 @@ mod tests {
     #[test]
     fn cancellation_preserves_rows_and_ignores_late_worker_events() {
         let mut app = App::new(10);
-        app.update(Action::Commit(row(1)));
+        app.extend_commits(vec![row(1)]);
 
         assert_eq!(app.update(Action::Cancel), vec![Effect::Cancel]);
         assert_eq!(app.state, State::Cancelling);
-        app.update(Action::Commit(row(2)));
+        app.extend_commits(vec![row(2)]);
         assert_eq!(app.rows.len(), 1, "commits arriving after cancellation are ignored");
 
         app.update(Action::Cancelled);
@@ -410,7 +445,7 @@ mod tests {
             app.update(Action::Copy).is_empty(),
             "there is nothing to copy without a selection"
         );
-        app.update(Action::Commit(row(7)));
+        app.extend_commits(vec![row(7)]);
 
         assert_eq!(app.update(Action::Copy), vec![Effect::Copy(row(7).id)]);
         app.update(Action::Complete);

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -29,6 +29,8 @@ pub(crate) enum Action {
     Cancelled,
     MoveUp,
     MoveDown,
+    ScrollLeft,
+    ScrollRight,
     HalfPageUp,
     HalfPageDown,
     PageUp,
@@ -64,6 +66,9 @@ pub(crate) struct App {
     pub show_author_name: bool,
     pub show_special_refs: bool,
     pub pin_metadata: Option<bool>,
+    pub horizontal_offset: usize,
+    horizontal_page: usize,
+    horizontal_max: usize,
     follow_tail: bool,
 }
 
@@ -80,6 +85,9 @@ impl App {
             show_author_name: true,
             show_special_refs: false,
             pin_metadata: None,
+            horizontal_offset: 0,
+            horizontal_page: 1,
+            horizontal_max: 0,
             follow_tail: false,
         }
     }
@@ -112,6 +120,15 @@ impl App {
             Action::Cancelled if self.state == State::Cancelling => self.state = State::Cancelled,
             Action::MoveUp => self.move_selection(1, false),
             Action::MoveDown => self.move_selection(1, true),
+            Action::ScrollLeft => {
+                self.horizontal_offset = self.horizontal_offset.saturating_sub(self.horizontal_page);
+            }
+            Action::ScrollRight => {
+                self.horizontal_offset = self
+                    .horizontal_offset
+                    .saturating_add(self.horizontal_page)
+                    .min(self.horizontal_max);
+            }
             Action::HalfPageUp => self.move_selection((self.viewport_rows / 2).max(1), false),
             Action::HalfPageDown => self.move_selection((self.viewport_rows / 2).max(1), true),
             Action::PageUp => self.move_selection(self.viewport_rows.max(1), false),
@@ -175,6 +192,12 @@ impl App {
         } else if selected >= self.offset.saturating_add(height) {
             self.offset = selected + 1 - height;
         }
+    }
+
+    pub(crate) fn set_horizontal_bounds(&mut self, page: usize, max: usize) {
+        self.horizontal_page = page.max(1);
+        self.horizontal_max = max;
+        self.horizontal_offset = self.horizontal_offset.min(max);
     }
 }
 
@@ -463,6 +486,23 @@ mod tests {
         assert_eq!(app.selected, Some(2));
         app.update(Action::HalfPageUp);
         assert_eq!(app.selected, Some(0));
+    }
+
+    #[test]
+    fn horizontal_pages_are_clamped_to_available_content() {
+        let mut app = App::new(1);
+        app.set_horizontal_bounds(10, 25);
+
+        app.update(Action::ScrollRight);
+        app.update(Action::ScrollRight);
+        app.update(Action::ScrollRight);
+        assert_eq!(app.horizontal_offset, 25);
+        app.update(Action::ScrollLeft);
+        assert_eq!(app.horizontal_offset, 15);
+
+        app.set_horizontal_bounds(10, 0);
+        app.update(Action::ScrollRight);
+        assert_eq!(app.horizontal_offset, 0, "scrolling is disabled when content fits");
     }
 
     #[test]

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -152,6 +152,10 @@ impl App {
                 self.follow_tail = false;
                 self.ensure_visible();
             }
+            Action::Complete if self.state == State::Cancelling => {
+                self.state = State::Cancelled;
+                self.follow_tail = false;
+            }
             Action::Cancelled if self.state == State::Cancelling => self.state = State::Cancelled,
             Action::MoveUp => self.move_selection(1, false),
             Action::MoveDown => self.move_selection(1, true),
@@ -566,9 +570,13 @@ mod tests {
         app.extend_commits(vec![row(2)]);
         assert_eq!(app.rows.len(), 1, "commits arriving after cancellation are ignored");
 
-        app.update(Action::Cancelled);
+        app.update(Action::Complete);
         assert_eq!(app.state, State::Cancelled);
-        assert_eq!(app.rows.len(), 1, "cancellation keeps already displayed commits");
+        assert_eq!(
+            app.rows.len(),
+            1,
+            "completion racing cancellation keeps already displayed commits"
+        );
     }
 
     #[test]

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -1,8 +1,15 @@
-use gix::{ObjectId, bstr::BString};
+use std::{
+    cmp::Reverse,
+    collections::{BinaryHeap, HashMap, HashSet},
+};
+
+use gix::{ObjectId, bstr::BString, traverse::commit::ParentIds};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct CommitRow {
     pub id: ObjectId,
+    pub parent_ids: ParentIds,
+    pub lane: String,
     pub subject: BString,
 }
 
@@ -73,8 +80,12 @@ impl App {
                 self.ensure_visible();
             }
             Action::Complete if self.state == State::Loading => {
+                let selected = self.selected.map(|index| self.rows[index].id);
+                finish_rows(&mut self.rows);
+                self.selected = selected.and_then(|id| self.rows.iter().position(|row| row.id == id));
                 self.state = State::Complete;
                 self.follow_tail = false;
+                self.ensure_visible();
             }
             Action::Cancelled if self.state == State::Cancelling => self.state = State::Cancelled,
             Action::MoveUp => self.move_selection(1, false),
@@ -140,6 +151,147 @@ impl App {
     }
 }
 
+fn finish_rows(rows: &mut Vec<CommitRow>) {
+    let positions: HashMap<_, _> = rows.iter().enumerate().map(|(index, row)| (row.id, index)).collect();
+    let mut children = vec![0usize; rows.len()];
+    for row in rows.iter() {
+        for parent in &row.parent_ids {
+            if let Some(index) = positions.get(parent) {
+                children[*index] += 1;
+            }
+        }
+    }
+
+    let mut ready: BinaryHeap<_> = children
+        .iter()
+        .enumerate()
+        .filter_map(|(index, count)| (*count == 0).then_some(Reverse(index)))
+        .collect();
+    let mut order = Vec::with_capacity(rows.len());
+    while let Some(Reverse(index)) = ready.pop() {
+        order.push(index);
+        for parent in &rows[index].parent_ids {
+            if let Some(parent_index) = positions.get(parent) {
+                children[*parent_index] -= 1;
+                if children[*parent_index] == 0 {
+                    ready.push(Reverse(*parent_index));
+                }
+            }
+        }
+    }
+    if order.len() == rows.len() {
+        let mut old: Vec<_> = std::mem::take(rows).into_iter().map(Some).collect();
+        *rows = order
+            .into_iter()
+            .map(|index| old[index].take().expect("each row is moved exactly once"))
+            .collect();
+    }
+    render_lanes(rows);
+}
+
+fn render_lanes(rows: &mut [CommitRow]) {
+    let known: HashSet<_> = rows.iter().map(|row| row.id).collect();
+    let mut columns = Vec::new();
+    for row in rows {
+        let current = columns.iter().position(|id| *id == row.id).unwrap_or_else(|| {
+            columns.push(row.id);
+            columns.len() - 1
+        });
+        let mut next = Vec::new();
+        for (index, id) in columns.iter().copied().enumerate() {
+            if index == current {
+                for parent in row.parent_ids.iter().copied().filter(|id| known.contains(id)) {
+                    if !next.contains(&parent) {
+                        next.push(parent);
+                    }
+                }
+            } else if !next.contains(&id) {
+                next.push(id);
+            }
+        }
+
+        let mut edges = Vec::new();
+        for (index, id) in columns.iter().enumerate() {
+            if index != current
+                && let Some(next_index) = next.iter().position(|next_id| next_id == id)
+            {
+                edges.push((index, next_index));
+            }
+        }
+        for parent in row.parent_ids.iter().copied().filter(|id| known.contains(id)) {
+            if let Some(next_index) = next.iter().position(|id| *id == parent) {
+                edges.push((current, next_index));
+            }
+        }
+        row.lane = transition(columns.len(), next.len(), current, &edges);
+        columns = next;
+    }
+}
+
+fn transition(before: usize, after: usize, current: usize, edges: &[(usize, usize)]) -> String {
+    const UP: u8 = 1;
+    const DOWN: u8 = 2;
+    const LEFT: u8 = 4;
+    const RIGHT: u8 = 8;
+    const VERTICAL: u8 = UP | DOWN;
+    const HORIZONTAL: u8 = LEFT | RIGHT;
+    const CROSS: u8 = VERTICAL | HORIZONTAL;
+    const VERTICAL_RIGHT: u8 = VERTICAL | RIGHT;
+    const VERTICAL_LEFT: u8 = VERTICAL | LEFT;
+    const DOWN_HORIZONTAL: u8 = DOWN | HORIZONTAL;
+    const UP_HORIZONTAL: u8 = UP | HORIZONTAL;
+    const DOWN_RIGHT: u8 = DOWN | RIGHT;
+    const DOWN_LEFT: u8 = DOWN | LEFT;
+    const UP_RIGHT: u8 = UP | RIGHT;
+    const UP_LEFT: u8 = UP | LEFT;
+
+    let width = before.max(after).max(current + 1) * 2 - 1;
+    let mut cells = vec![0u8; width];
+    for &(from, to) in edges {
+        let from = from * 2;
+        let to = to * 2;
+        cells[from] |= UP;
+        cells[to] |= DOWN;
+        if from < to {
+            cells[from] |= RIGHT;
+            cells[to] |= LEFT;
+            for cell in &mut cells[from + 1..to] {
+                *cell |= LEFT | RIGHT;
+            }
+        } else if to < from {
+            cells[from] |= LEFT;
+            cells[to] |= RIGHT;
+            for cell in &mut cells[to + 1..from] {
+                *cell |= LEFT | RIGHT;
+            }
+        }
+    }
+
+    let mut out = String::with_capacity(width + 1);
+    for (index, cell) in cells.into_iter().enumerate() {
+        out.push(if index == current * 2 {
+            '●'
+        } else {
+            match cell {
+                0 => ' ',
+                CROSS => '┼',
+                VERTICAL_RIGHT => '├',
+                VERTICAL_LEFT => '┤',
+                DOWN_HORIZONTAL => '┬',
+                UP_HORIZONTAL => '┴',
+                DOWN_RIGHT => '┌',
+                DOWN_LEFT => '┐',
+                UP_RIGHT => '└',
+                UP_LEFT => '┘',
+                HORIZONTAL => '─',
+                _ => '│',
+            }
+        });
+    }
+    out.push(' ');
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -149,8 +301,40 @@ mod tests {
         bytes[19] = n;
         CommitRow {
             id: ObjectId::Sha1(bytes),
+            parent_ids: ParentIds::new(),
+            lane: String::new(),
             subject: format!("commit {n}").into(),
         }
+    }
+
+    fn row_with_parents(n: u8, parents: &[u8]) -> CommitRow {
+        let mut commit = row(n);
+        commit.parent_ids = parents.iter().map(|n| row(*n).id).collect();
+        commit
+    }
+
+    #[test]
+    fn completion_orders_and_draws_merge_lanes() {
+        let mut app = App::new(10);
+        for row in [
+            row_with_parents(4, &[3, 2]),
+            row_with_parents(3, &[1]),
+            row(1),
+            row_with_parents(2, &[1]),
+        ] {
+            app.update(Action::Commit(row));
+        }
+
+        app.update(Action::Complete);
+
+        assert_eq!(
+            app.rows.iter().map(|row| row.id).collect::<Vec<_>>(),
+            [row(4).id, row(3).id, row(2).id, row(1).id]
+        );
+        assert_eq!(
+            app.rows.iter().map(|row| row.lane.as_str()).collect::<Vec<_>>(),
+            ["●─┐ ", "● │ ", "├─● ", "● "]
+        );
     }
 
     #[test]

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -16,7 +16,7 @@ pub(crate) struct Commit<T> {
     pub parent_ids: ParentIds,
     pub lane: String,
     pub committer_time: gix::date::Time,
-    pub author_name: BString,
+    pub author_name: &'static BStr,
     pub title: T,
 }
 
@@ -407,7 +407,7 @@ mod tests {
             parent_ids: ParentIds::new(),
             lane: String::new(),
             committer_time: gix::date::Time::default(),
-            author_name: "author".into(),
+            author_name: b"author".as_bstr(),
             title: format!("commit {n}").into(),
         }
     }

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -37,6 +37,7 @@ pub(crate) enum Action {
     Last,
     ToggleDate,
     ToggleName,
+    ToggleSpecialRefs,
     PinMetadata,
     UnpinMetadata,
     Cancel,
@@ -61,6 +62,7 @@ pub(crate) struct App {
     pub lane_time: Option<Duration>,
     pub show_committer_date: bool,
     pub show_author_name: bool,
+    pub show_special_refs: bool,
     pub pin_metadata: Option<bool>,
     follow_tail: bool,
 }
@@ -76,6 +78,7 @@ impl App {
             lane_time: None,
             show_committer_date: true,
             show_author_name: true,
+            show_special_refs: false,
             pin_metadata: None,
             follow_tail: false,
         }
@@ -121,6 +124,7 @@ impl App {
             }
             Action::ToggleDate => self.show_committer_date = !self.show_committer_date,
             Action::ToggleName => self.show_author_name = !self.show_author_name,
+            Action::ToggleSpecialRefs => self.show_special_refs = !self.show_special_refs,
             Action::PinMetadata => self.pin_metadata = Some(true),
             Action::UnpinMetadata => self.pin_metadata = Some(false),
             Action::Cancel if self.state == State::Loading => {
@@ -467,10 +471,12 @@ mod tests {
 
         app.update(Action::ToggleDate);
         app.update(Action::ToggleName);
+        app.update(Action::ToggleSpecialRefs);
         app.update(Action::PinMetadata);
 
         assert!(!app.show_committer_date);
         assert!(!app.show_author_name);
+        assert!(app.show_special_refs);
         assert_eq!(app.pin_metadata, Some(true));
         app.update(Action::UnpinMetadata);
         assert_eq!(app.pin_metadata, Some(false));

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -1,4 +1,4 @@
-use gix::{bstr::BString, ObjectId};
+use gix::{ObjectId, bstr::BString};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct CommitRow {
@@ -205,7 +205,10 @@ mod tests {
     #[test]
     fn completion_and_copy_effects_use_the_current_selection() {
         let mut app = App::new(10);
-        assert!(app.update(Action::Copy).is_empty(), "there is nothing to copy without a selection");
+        assert!(
+            app.update(Action::Copy).is_empty(),
+            "there is nothing to copy without a selection"
+        );
         app.update(Action::Commit(row(7)));
 
         assert_eq!(app.update(Action::Copy), vec![Effect::Copy(row(7).id)]);

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -1,6 +1,5 @@
 use std::{
-    cmp::Reverse,
-    collections::{BinaryHeap, HashMap},
+    collections::HashMap,
     time::{Duration, Instant},
 };
 
@@ -38,6 +37,8 @@ pub(crate) enum Action {
     Last,
     ToggleDate,
     ToggleName,
+    PinMetadata,
+    UnpinMetadata,
     Cancel,
     Copy,
     Quit,
@@ -60,6 +61,7 @@ pub(crate) struct App {
     pub lane_time: Option<Duration>,
     pub show_committer_date: bool,
     pub show_author_name: bool,
+    pub pin_metadata: Option<bool>,
     follow_tail: bool,
 }
 
@@ -74,6 +76,7 @@ impl App {
             lane_time: None,
             show_committer_date: true,
             show_author_name: true,
+            pin_metadata: None,
             follow_tail: false,
         }
     }
@@ -118,6 +121,8 @@ impl App {
             }
             Action::ToggleDate => self.show_committer_date = !self.show_committer_date,
             Action::ToggleName => self.show_author_name = !self.show_author_name,
+            Action::PinMetadata => self.pin_metadata = Some(true),
+            Action::UnpinMetadata => self.pin_metadata = Some(false),
             Action::Cancel if self.state == State::Loading => {
                 self.state = State::Cancelling;
                 return vec![Effect::Cancel];
@@ -180,19 +185,20 @@ fn finish_rows(rows: &mut Vec<CommitRow>) -> Duration {
         }
     }
 
-    let mut ready: BinaryHeap<_> = children
+    let mut ready: Vec<_> = children
         .iter()
         .enumerate()
-        .filter_map(|(index, count)| (*count == 0).then_some(Reverse(index)))
+        .rev()
+        .filter_map(|(index, count)| (*count == 0).then_some(index))
         .collect();
     let mut order = Vec::with_capacity(rows.len());
-    while let Some(Reverse(index)) = ready.pop() {
+    while let Some(index) = ready.pop() {
         order.push(index);
-        for parent in &rows[index].parent_ids {
+        for parent in rows[index].parent_ids.iter().rev() {
             if let Some(parent_index) = positions.get(parent) {
                 children[*parent_index] -= 1;
                 if children[*parent_index] == 0 {
-                    ready.push(Reverse(*parent_index));
+                    ready.push(*parent_index);
                 }
             }
         }
@@ -391,6 +397,26 @@ mod tests {
     }
 
     #[test]
+    fn completion_keeps_independent_lines_of_history_together() {
+        let mut app = App::new(10);
+        app.extend_commits(vec![
+            row_with_parents(5, &[3]),
+            row_with_parents(4, &[2]),
+            row_with_parents(3, &[1]),
+            row_with_parents(2, &[1]),
+            row(1),
+        ]);
+
+        app.update(Action::Complete);
+
+        assert_eq!(
+            app.rows.iter().map(|row| row.id).collect::<Vec<_>>(),
+            [row(5).id, row(3).id, row(4).id, row(2).id, row(1).id],
+            "topological order finishes one line before showing another"
+        );
+    }
+
+    #[test]
     fn selection_follows_the_oldest_commit_until_the_user_moves() {
         let mut app = App::new(2);
         app.extend_commits(vec![row(1), row(2), row(3)]);
@@ -441,9 +467,13 @@ mod tests {
 
         app.update(Action::ToggleDate);
         app.update(Action::ToggleName);
+        app.update(Action::PinMetadata);
 
         assert!(!app.show_committer_date);
         assert!(!app.show_author_name);
+        assert_eq!(app.pin_metadata, Some(true));
+        app.update(Action::UnpinMetadata);
+        assert_eq!(app.pin_metadata, Some(false));
     }
 
     #[test]

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -48,6 +48,7 @@ pub(crate) enum Action {
     ToggleDate,
     ToggleName,
     ToggleSpecialRefs,
+    ToggleHidden,
     PinMetadata,
     UnpinMetadata,
     Cancel,
@@ -59,6 +60,7 @@ pub(crate) enum Action {
 pub(crate) enum Effect {
     Cancel,
     Copy(ObjectId),
+    Reload(bool),
     Quit,
 }
 
@@ -74,6 +76,8 @@ pub(crate) struct App {
     pub show_committer_date: bool,
     pub show_author_name: bool,
     pub show_special_refs: bool,
+    pub has_hidden_filter: bool,
+    pub show_hidden: bool,
     pub pin_metadata: Option<bool>,
     pub horizontal_offset: usize,
     horizontal_page: usize,
@@ -94,6 +98,8 @@ impl App {
             show_committer_date: true,
             show_author_name: true,
             show_special_refs: false,
+            has_hidden_filter: false,
+            show_hidden: false,
             pin_metadata: None,
             horizontal_offset: 0,
             horizontal_page: 1,
@@ -181,6 +187,11 @@ impl App {
             Action::ToggleDate => self.show_committer_date = !self.show_committer_date,
             Action::ToggleName => self.show_author_name = !self.show_author_name,
             Action::ToggleSpecialRefs => self.show_special_refs = !self.show_special_refs,
+            Action::ToggleHidden
+                if self.has_hidden_filter && matches!(self.state, State::Complete | State::Cancelled) =>
+            {
+                return vec![Effect::Reload(!self.show_hidden)];
+            }
             Action::PinMetadata => self.pin_metadata = Some(true),
             Action::UnpinMetadata => self.pin_metadata = Some(false),
             Action::Cancel if self.state == State::Loading => {
@@ -202,6 +213,18 @@ impl App {
             _ => {}
         }
         Vec::new()
+    }
+
+    pub(crate) fn reload(&mut self, show_hidden: bool) {
+        self.rows = Vec::new();
+        self.titles = Vec::new();
+        self.selected = None;
+        self.offset = 0;
+        self.state = State::Loading;
+        self.lane_time = None;
+        self.show_hidden = show_hidden;
+        self.horizontal_offset = 0;
+        self.follow_tail = false;
     }
 
     fn move_selection(&mut self, distance: usize, down: bool) {
@@ -558,6 +581,34 @@ mod tests {
         assert_eq!(app.pin_metadata, Some(true));
         app.update(Action::UnpinMetadata);
         assert_eq!(app.pin_metadata, Some(false));
+    }
+
+    #[test]
+    fn hidden_history_is_reloaded_only_when_configured() {
+        let mut app = App::new(1);
+        assert!(
+            app.update(Action::ToggleHidden).is_empty(),
+            "the key is inert without hidden revisions"
+        );
+
+        app.has_hidden_filter = true;
+        app.extend_commits(vec![row(1)]);
+        assert!(
+            app.update(Action::ToggleHidden).is_empty(),
+            "a running walk cannot be replaced by another detached worker"
+        );
+        app.update(Action::Complete);
+        assert_eq!(app.update(Action::ToggleHidden), vec![Effect::Reload(true)]);
+        app.reload(true);
+        assert!(app.rows.is_empty(), "reloading drops rows from the previous view");
+        assert!(app.show_hidden);
+        assert_eq!(app.state, State::Loading);
+        assert!(
+            app.update(Action::ToggleHidden).is_empty(),
+            "the replacement walk must finish before it can be toggled again"
+        );
+        app.update(Action::Complete);
+        assert_eq!(app.update(Action::ToggleHidden), vec![Effect::Reload(false)]);
     }
 
     #[test]

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -1,0 +1,217 @@
+use gix::{bstr::BString, ObjectId};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CommitRow {
+    pub id: ObjectId,
+    pub subject: BString,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum State {
+    Loading,
+    Cancelling,
+    Complete,
+    Cancelled,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum Action {
+    Commit(CommitRow),
+    Complete,
+    Cancelled,
+    MoveUp,
+    MoveDown,
+    PageUp,
+    PageDown,
+    First,
+    Last,
+    Cancel,
+    Copy,
+    Quit,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Effect {
+    Cancel,
+    Copy(ObjectId),
+    Quit,
+}
+
+#[derive(Debug)]
+pub(crate) struct App {
+    pub rows: Vec<CommitRow>,
+    pub selected: Option<usize>,
+    pub offset: usize,
+    pub state: State,
+    pub viewport_rows: usize,
+    follow_tail: bool,
+}
+
+impl App {
+    pub fn new(viewport_rows: usize) -> Self {
+        App {
+            rows: Vec::new(),
+            selected: None,
+            offset: 0,
+            state: State::Loading,
+            viewport_rows,
+            follow_tail: false,
+        }
+    }
+
+    pub fn update(&mut self, action: Action) -> Vec<Effect> {
+        match action {
+            Action::Commit(row) if self.state == State::Loading => {
+                self.rows.push(row);
+                if self.selected.is_none() {
+                    self.selected = Some(0);
+                } else if self.follow_tail {
+                    self.selected = Some(self.rows.len() - 1);
+                }
+                self.ensure_visible();
+            }
+            Action::Complete if self.state == State::Loading => {
+                self.state = State::Complete;
+                self.follow_tail = false;
+            }
+            Action::Cancelled if self.state == State::Cancelling => self.state = State::Cancelled,
+            Action::MoveUp => self.move_selection(1, false),
+            Action::MoveDown => self.move_selection(1, true),
+            Action::PageUp => self.move_selection(self.viewport_rows.max(1), false),
+            Action::PageDown => self.move_selection(self.viewport_rows.max(1), true),
+            Action::First => self.select(0),
+            Action::Last if !self.rows.is_empty() => {
+                self.selected = Some(self.rows.len() - 1);
+                self.follow_tail = self.state == State::Loading;
+                self.ensure_visible();
+            }
+            Action::Cancel if self.state == State::Loading => {
+                self.state = State::Cancelling;
+                return vec![Effect::Cancel];
+            }
+            Action::Copy => {
+                if let Some(row) = self.selected.and_then(|index| self.rows.get(index)) {
+                    return vec![Effect::Copy(row.id)];
+                }
+            }
+            Action::Quit => {
+                return if matches!(self.state, State::Loading | State::Cancelling) {
+                    vec![Effect::Cancel, Effect::Quit]
+                } else {
+                    vec![Effect::Quit]
+                };
+            }
+            _ => {}
+        }
+        Vec::new()
+    }
+
+    fn move_selection(&mut self, distance: usize, down: bool) {
+        let Some(selected) = self.selected else { return };
+        self.selected = Some(if down {
+            selected.saturating_add(distance).min(self.rows.len() - 1)
+        } else {
+            selected.saturating_sub(distance)
+        });
+        self.follow_tail = false;
+        self.ensure_visible();
+    }
+
+    fn select(&mut self, selected: usize) {
+        if !self.rows.is_empty() {
+            self.selected = Some(selected.min(self.rows.len() - 1));
+            self.follow_tail = false;
+            self.ensure_visible();
+        }
+    }
+
+    fn ensure_visible(&mut self) {
+        let Some(selected) = self.selected else { return };
+        let height = self.viewport_rows.max(1);
+        if selected < self.offset {
+            self.offset = selected;
+        } else if selected >= self.offset.saturating_add(height) {
+            self.offset = selected + 1 - height;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(n: u8) -> CommitRow {
+        let mut bytes = [0; 20];
+        bytes[19] = n;
+        CommitRow {
+            id: ObjectId::Sha1(bytes),
+            subject: format!("commit {n}").into(),
+        }
+    }
+
+    #[test]
+    fn selection_follows_the_oldest_commit_until_the_user_moves() {
+        let mut app = App::new(2);
+        app.update(Action::Commit(row(1)));
+        app.update(Action::Commit(row(2)));
+        app.update(Action::Commit(row(3)));
+
+        app.update(Action::Last);
+        assert_eq!(app.selected, Some(2), "Last selects the oldest loaded commit");
+        assert_eq!(app.offset, 1, "the selection remains visible");
+
+        app.update(Action::Commit(row(4)));
+        assert_eq!(app.selected, Some(3), "new commits extend the followed tail");
+        assert_eq!(app.offset, 2, "the viewport follows the tail");
+
+        app.update(Action::MoveUp);
+        app.update(Action::Commit(row(5)));
+        assert_eq!(app.selected, Some(2), "manual navigation stops following the tail");
+    }
+
+    #[test]
+    fn navigation_is_clamped_and_uses_the_viewport_for_pages() {
+        let mut app = App::new(2);
+        for n in 1..=5 {
+            app.update(Action::Commit(row(n)));
+        }
+
+        app.update(Action::PageDown);
+        assert_eq!(app.selected, Some(2), "page-down advances by the viewport height");
+        app.update(Action::PageDown);
+        assert_eq!(app.selected, Some(4), "page-down clamps at the last row");
+        app.update(Action::MoveDown);
+        assert_eq!(app.selected, Some(4), "moving past the last row is a no-op");
+        app.update(Action::First);
+        assert_eq!(app.selected, Some(0), "First selects the newest commit");
+        assert_eq!(app.offset, 0, "the newest commit is visible");
+    }
+
+    #[test]
+    fn cancellation_preserves_rows_and_ignores_late_worker_events() {
+        let mut app = App::new(10);
+        app.update(Action::Commit(row(1)));
+
+        assert_eq!(app.update(Action::Cancel), vec![Effect::Cancel]);
+        assert_eq!(app.state, State::Cancelling);
+        app.update(Action::Commit(row(2)));
+        assert_eq!(app.rows.len(), 1, "commits arriving after cancellation are ignored");
+
+        app.update(Action::Cancelled);
+        assert_eq!(app.state, State::Cancelled);
+        assert_eq!(app.rows.len(), 1, "cancellation keeps already displayed commits");
+    }
+
+    #[test]
+    fn completion_and_copy_effects_use_the_current_selection() {
+        let mut app = App::new(10);
+        assert!(app.update(Action::Copy).is_empty(), "there is nothing to copy without a selection");
+        app.update(Action::Commit(row(7)));
+
+        assert_eq!(app.update(Action::Copy), vec![Effect::Copy(row(7).id)]);
+        app.update(Action::Complete);
+        assert_eq!(app.state, State::Complete);
+        assert_eq!(app.rows.len(), 1, "the loaded row count is the completed total");
+        assert_eq!(app.update(Action::Quit), vec![Effect::Quit]);
+    }
+}

--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -21,6 +21,8 @@ pub(crate) enum Action {
     Cancelled,
     MoveUp,
     MoveDown,
+    HalfPageUp,
+    HalfPageDown,
     PageUp,
     PageDown,
     First,
@@ -77,6 +79,8 @@ impl App {
             Action::Cancelled if self.state == State::Cancelling => self.state = State::Cancelled,
             Action::MoveUp => self.move_selection(1, false),
             Action::MoveDown => self.move_selection(1, true),
+            Action::HalfPageUp => self.move_selection((self.viewport_rows / 2).max(1), false),
+            Action::HalfPageDown => self.move_selection((self.viewport_rows / 2).max(1), true),
             Action::PageUp => self.move_selection(self.viewport_rows.max(1), false),
             Action::PageDown => self.move_selection(self.viewport_rows.max(1), true),
             Action::First => self.select(0),
@@ -185,6 +189,19 @@ mod tests {
         app.update(Action::First);
         assert_eq!(app.selected, Some(0), "First selects the newest commit");
         assert_eq!(app.offset, 0, "the newest commit is visible");
+    }
+
+    #[test]
+    fn half_pages_use_half_the_viewport() {
+        let mut app = App::new(4);
+        for n in 1..=5 {
+            app.update(Action::Commit(row(n)));
+        }
+
+        app.update(Action::HalfPageDown);
+        assert_eq!(app.selected, Some(2));
+        app.update(Action::HalfPageUp);
+        assert_eq!(app.selected, Some(0));
     }
 
     #[test]

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -14,11 +14,12 @@ use gix::{
 use crate::app::CommitRow;
 
 pub(crate) type Decorations = HashMap<ObjectId, Vec<BString>>;
+const COMMIT_BATCH_SIZE: usize = 1024;
 
 #[derive(Debug)]
 pub(crate) enum Event {
     Decorations(Decorations),
-    Commit(CommitRow),
+    Commits(Vec<CommitRow>),
     Complete,
     Cancelled,
 }
@@ -70,6 +71,7 @@ pub(crate) fn load(
         .sorting(gix::revision::walk::Sorting::ByCommitTime(Default::default()))
         .all()
         .context("could not start revision walk")?;
+    let mut rows = Vec::with_capacity(COMMIT_BATCH_SIZE);
     for info in walk {
         if cancelled.load(Ordering::Relaxed) {
             emit(Event::Cancelled);
@@ -83,14 +85,23 @@ pub(crate) fn load(
             .context("could not decode commit message")?
             .summary()
             .into_owned();
-        if !emit(Event::Commit(CommitRow {
+        rows.push(CommitRow {
             id: info.id,
             parent_ids: info.parent_ids,
             lane: String::new(),
             subject,
-        })) {
+        });
+        if rows.len() == COMMIT_BATCH_SIZE
+            && !emit(Event::Commits(std::mem::replace(
+                &mut rows,
+                Vec::with_capacity(COMMIT_BATCH_SIZE),
+            )))
+        {
             return Ok(());
         }
+    }
+    if !rows.is_empty() && !emit(Event::Commits(rows)) {
+        return Ok(());
     }
     emit(Event::Complete);
     Ok(())
@@ -153,9 +164,9 @@ mod tests {
         let events = loaded(&fixture, &["main", "topic"])?;
         let actual: HashSet<_> = events
             .iter()
-            .filter_map(|event| match event {
-                Event::Commit(row) => Some(row.id.to_hex().to_string()),
-                _ => None,
+            .flat_map(|event| match event {
+                Event::Commits(rows) => rows.iter().map(|row| row.id.to_hex().to_string()).collect(),
+                _ => Vec::new(),
             })
             .collect();
         let output = Command::new("git")

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -1,0 +1,150 @@
+use std::{
+    collections::HashMap,
+    ffi::OsString,
+    path::Path,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use anyhow::{Context, Result};
+use gix::{
+    bstr::{BString, ByteSlice, ByteVec},
+    ObjectId,
+};
+
+use crate::app::CommitRow;
+
+pub(crate) type Decorations = HashMap<ObjectId, Vec<BString>>;
+
+#[derive(Debug)]
+pub(crate) enum Event {
+    Decorations(Decorations),
+    Commit(CommitRow),
+    Complete,
+    Cancelled,
+}
+
+pub(crate) fn load(
+    repository: &Path,
+    revisions: &[OsString],
+    cancelled: &AtomicBool,
+    mut emit: impl FnMut(Event) -> bool,
+) -> Result<()> {
+    let repo = gix::open(repository).with_context(|| format!("could not open repository at {}", repository.display()))?;
+    let tips = if revisions.is_empty() {
+        match repo.head().context("could not read HEAD")?.try_peel_to_id().context("could not resolve HEAD")? {
+            Some(id) => vec![id.detach()],
+            None => {
+                emit(Event::Decorations(decorations(&repo)?));
+                emit(Event::Complete);
+                return Ok(());
+            }
+        }
+    } else {
+        revisions
+            .iter()
+            .map(|revision| {
+                let revision = gix::path::os_str_into_bstr(revision)
+                    .with_context(|| format!("revision {revision:?} is not valid UTF-8"))?;
+                repo.rev_parse_single(revision)
+                    .with_context(|| format!("could not resolve revision {revision:?}"))?
+                    .object()
+                    .context("could not read revision")?
+                    .peel_to_kind(gix::object::Kind::Commit)
+                    .context("revision does not resolve to a commit")
+                    .map(|object| object.id)
+            })
+            .collect::<Result<Vec<_>>>()?
+    };
+
+    if !emit(Event::Decorations(decorations(&repo)?)) {
+        return Ok(());
+    }
+    let walk = repo
+        .rev_walk(tips)
+        .sorting(gix::revision::walk::Sorting::ByCommitTime(Default::default()))
+        .all()
+        .context("could not start revision walk")?;
+    for info in walk {
+        if cancelled.load(Ordering::Relaxed) {
+            emit(Event::Cancelled);
+            return Ok(());
+        }
+        let info = info.context("could not traverse revision history")?;
+        let subject = info.object().context("could not read commit")?.message().context("could not decode commit message")?.summary().into_owned();
+        if !emit(Event::Commit(CommitRow { id: info.id, subject })) {
+            return Ok(());
+        }
+    }
+    emit(Event::Complete);
+    Ok(())
+}
+
+fn decorations(repo: &gix::Repository) -> Result<Decorations> {
+    let mut out = Decorations::new();
+    for reference in repo.references().context("could not open references")?.all().context("could not iterate references")? {
+        let mut reference = reference.map_err(|err| anyhow::anyhow!("could not read reference: {err}"))?;
+        let id = reference.peel_to_id().context("could not peel reference")?.detach();
+        let mut name = reference.name().shorten().to_owned();
+        if reference.name().as_bstr().starts_with_str("refs/tags/") {
+            name.insert_str(0, "tag: ");
+        }
+        out.entry(id).or_default().push(name);
+    }
+    if let Some(id) = repo.head().context("could not read HEAD")?.try_peel_to_id().context("could not peel HEAD")? {
+        out.entry(id.detach()).or_default().push("HEAD".into());
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashSet, process::Command};
+
+    use super::*;
+
+    fn fixture() -> gix_testtools::Result<std::path::PathBuf> {
+        gix_testtools::scripted_fixture_read_only("history.sh")
+    }
+
+    fn loaded(path: &Path, revisions: &[&str]) -> Result<Vec<Event>> {
+        let mut events = Vec::new();
+        load(path, &revisions.iter().map(OsString::from).collect::<Vec<_>>(), &AtomicBool::new(false), |event| {
+            events.push(event);
+            true
+        })?;
+        Ok(events)
+    }
+
+    #[test]
+    fn walks_the_same_reachable_set_as_git_for_multiple_tips() -> gix_testtools::Result {
+        let fixture = fixture()?;
+        let events = loaded(&fixture, &["main", "topic"])?;
+        let actual: HashSet<_> = events.iter().filter_map(|event| match event {
+            Event::Commit(row) => Some(row.id.to_hex().to_string()),
+            _ => None,
+        }).collect();
+        let output = Command::new("git").current_dir(&fixture).args(["rev-list", "main", "topic", "--"]).output()?;
+        assert!(
+            output.status.success(),
+            "git rev-list provides the reference result: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let expected = String::from_utf8(output.stdout)?.lines().map(str::to_owned).collect();
+        assert_eq!(actual, expected, "all commits reachable from either tip are shown once");
+        assert!(matches!(events.last(), Some(Event::Complete)), "the walk completes");
+        Ok(())
+    }
+
+    #[test]
+    fn reports_decorations_and_honours_cancellation() -> gix_testtools::Result {
+        let fixture = fixture()?;
+        let events = loaded(&fixture, &["main"])?;
+        let Event::Decorations(decorations) = &events[0] else { panic!("decorations are sent first") };
+        assert!(decorations.values().flatten().any(|name| name == "tag: v1"), "annotated tags decorate their commit");
+
+        let mut cancelled = Vec::new();
+        load(&fixture, &[], &AtomicBool::new(true), |event| { cancelled.push(event); true })?;
+        assert!(matches!(cancelled.as_slice(), [Event::Decorations(_), Event::Cancelled]), "cancellation preserves decorations and stops before commits");
+        Ok(())
+    }
+}

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -7,8 +7,8 @@ use std::{
 
 use anyhow::{Context, Result};
 use gix::{
-    bstr::{BString, ByteSlice, ByteVec},
     ObjectId,
+    bstr::{BString, ByteSlice, ByteVec},
 };
 
 use crate::app::CommitRow;
@@ -29,9 +29,15 @@ pub(crate) fn load(
     cancelled: &AtomicBool,
     mut emit: impl FnMut(Event) -> bool,
 ) -> Result<()> {
-    let repo = gix::open(repository).with_context(|| format!("could not open repository at {}", repository.display()))?;
+    let repo =
+        gix::open(repository).with_context(|| format!("could not open repository at {}", repository.display()))?;
     let tips = if revisions.is_empty() {
-        match repo.head().context("could not read HEAD")?.try_peel_to_id().context("could not resolve HEAD")? {
+        match repo
+            .head()
+            .context("could not read HEAD")?
+            .try_peel_to_id()
+            .context("could not resolve HEAD")?
+        {
             Some(id) => vec![id.detach()],
             None => {
                 emit(Event::Decorations(decorations(&repo)?));
@@ -70,7 +76,13 @@ pub(crate) fn load(
             return Ok(());
         }
         let info = info.context("could not traverse revision history")?;
-        let subject = info.object().context("could not read commit")?.message().context("could not decode commit message")?.summary().into_owned();
+        let subject = info
+            .object()
+            .context("could not read commit")?
+            .message()
+            .context("could not decode commit message")?
+            .summary()
+            .into_owned();
         if !emit(Event::Commit(CommitRow { id: info.id, subject })) {
             return Ok(());
         }
@@ -81,7 +93,12 @@ pub(crate) fn load(
 
 fn decorations(repo: &gix::Repository) -> Result<Decorations> {
     let mut out = Decorations::new();
-    for reference in repo.references().context("could not open references")?.all().context("could not iterate references")? {
+    for reference in repo
+        .references()
+        .context("could not open references")?
+        .all()
+        .context("could not iterate references")?
+    {
         let mut reference = reference.map_err(|err| anyhow::anyhow!("could not read reference: {err}"))?;
         let id = reference.peel_to_id().context("could not peel reference")?.detach();
         let mut name = reference.name().shorten().to_owned();
@@ -90,7 +107,12 @@ fn decorations(repo: &gix::Repository) -> Result<Decorations> {
         }
         out.entry(id).or_default().push(name);
     }
-    if let Some(id) = repo.head().context("could not read HEAD")?.try_peel_to_id().context("could not peel HEAD")? {
+    if let Some(id) = repo
+        .head()
+        .context("could not read HEAD")?
+        .try_peel_to_id()
+        .context("could not peel HEAD")?
+    {
         out.entry(id.detach()).or_default().push("HEAD".into());
     }
     Ok(out)
@@ -108,10 +130,15 @@ mod tests {
 
     fn loaded(path: &Path, revisions: &[&str]) -> Result<Vec<Event>> {
         let mut events = Vec::new();
-        load(path, &revisions.iter().map(OsString::from).collect::<Vec<_>>(), &AtomicBool::new(false), |event| {
-            events.push(event);
-            true
-        })?;
+        load(
+            path,
+            &revisions.iter().map(OsString::from).collect::<Vec<_>>(),
+            &AtomicBool::new(false),
+            |event| {
+                events.push(event);
+                true
+            },
+        )?;
         Ok(events)
     }
 
@@ -119,11 +146,17 @@ mod tests {
     fn walks_the_same_reachable_set_as_git_for_multiple_tips() -> gix_testtools::Result {
         let fixture = fixture()?;
         let events = loaded(&fixture, &["main", "topic"])?;
-        let actual: HashSet<_> = events.iter().filter_map(|event| match event {
-            Event::Commit(row) => Some(row.id.to_hex().to_string()),
-            _ => None,
-        }).collect();
-        let output = Command::new("git").current_dir(&fixture).args(["rev-list", "main", "topic", "--"]).output()?;
+        let actual: HashSet<_> = events
+            .iter()
+            .filter_map(|event| match event {
+                Event::Commit(row) => Some(row.id.to_hex().to_string()),
+                _ => None,
+            })
+            .collect();
+        let output = Command::new("git")
+            .current_dir(&fixture)
+            .args(["rev-list", "main", "topic", "--"])
+            .output()?;
         assert!(
             output.status.success(),
             "git rev-list provides the reference result: {}",
@@ -139,13 +172,23 @@ mod tests {
     fn reports_decorations_and_honours_cancellation() -> gix_testtools::Result {
         let fixture = fixture()?;
         let events = loaded(&fixture, &["main"])?;
-        let Event::Decorations(decorations) = &events[0] else { panic!("decorations are sent first") };
-        assert!(decorations.values().flatten().any(|name| name == "tag: v1"), "annotated tags decorate their commit");
+        let Event::Decorations(decorations) = &events[0] else {
+            panic!("decorations are sent first")
+        };
+        assert!(
+            decorations.values().flatten().any(|name| name == "tag: v1"),
+            "annotated tags decorate their commit"
+        );
 
         let mut cancelled = Vec::new();
-        load(&fixture, &[], &AtomicBool::new(true), |event| { cancelled.push(event); true })?;
-        assert!(matches!(cancelled.as_slice(), [Event::Decorations(_), Event::Cancelled]), "cancellation preserves decorations and stops before commits");
+        load(&fixture, &[], &AtomicBool::new(true), |event| {
+            cancelled.push(event);
+            true
+        })?;
+        assert!(
+            matches!(cancelled.as_slice(), [Event::Decorations(_), Event::Cancelled]),
+            "cancellation preserves decorations and stops before commits"
+        );
         Ok(())
     }
-
 }

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{Context, Result};
 use gix::{
     ObjectId,
-    bstr::{BString, ByteSlice, ByteVec},
+    bstr::{BString, ByteVec},
     objs::commit::ref_iter::Token,
 };
 
@@ -17,7 +17,17 @@ use crate::app::CommitRow;
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Decoration {
     pub name: BString,
-    pub special: bool,
+    pub kind: DecorationKind,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DecorationKind {
+    Head,
+    Local,
+    Remote,
+    Tag,
+    AnnotatedTag,
+    Special,
 }
 
 pub(crate) type Decorations = HashMap<ObjectId, Vec<Decoration>>;
@@ -140,13 +150,19 @@ fn decorations(repo: &gix::Repository) -> Result<Decorations> {
         .context("could not iterate references")?
     {
         let mut reference = reference.map_err(|err| anyhow::anyhow!("could not read reference: {err}"))?;
+        let mut kind = decoration_kind(reference.name().as_bstr());
+        if kind == DecorationKind::Tag
+            && let Some(id) = reference.try_id()
+            && id.header().context("could not inspect tag")?.kind() == gix::objs::Kind::Tag
+        {
+            kind = DecorationKind::AnnotatedTag;
+        }
         let id = reference.peel_to_id().context("could not peel reference")?.detach();
-        let special = is_special_ref(reference.name().as_bstr());
         let mut name = reference.name().shorten().to_owned();
-        if reference.name().as_bstr().starts_with_str("refs/tags/") {
+        if matches!(kind, DecorationKind::Tag | DecorationKind::AnnotatedTag) {
             name.insert_str(0, "tag: ");
         }
-        out.entry(id).or_default().push(Decoration { name, special });
+        out.entry(id).or_default().push(Decoration { name, kind });
     }
     if let Some(id) = repo
         .head()
@@ -156,14 +172,22 @@ fn decorations(repo: &gix::Repository) -> Result<Decorations> {
     {
         out.entry(id.detach()).or_default().push(Decoration {
             name: "HEAD".into(),
-            special: false,
+            kind: DecorationKind::Head,
         });
     }
     Ok(out)
 }
 
-fn is_special_ref(name: &[u8]) -> bool {
-    !name.starts_with(b"refs/heads/") && !name.starts_with(b"refs/tags/") && !name.starts_with(b"refs/remotes/")
+fn decoration_kind(name: &[u8]) -> DecorationKind {
+    if name.starts_with(b"refs/heads/") {
+        DecorationKind::Local
+    } else if name.starts_with(b"refs/tags/") {
+        DecorationKind::Tag
+    } else if name.starts_with(b"refs/remotes/") {
+        DecorationKind::Remote
+    } else {
+        DecorationKind::Special
+    }
 }
 
 #[cfg(test)]
@@ -241,7 +265,7 @@ mod tests {
             decorations
                 .values()
                 .flatten()
-                .any(|decoration| decoration.name == "tag: v1"),
+                .any(|decoration| { decoration.name == "tag: v1" && decoration.kind == DecorationKind::AnnotatedTag }),
             "annotated tags decorate their commit"
         );
 
@@ -258,11 +282,11 @@ mod tests {
     }
 
     #[test]
-    fn classifies_refs_outside_standard_namespaces_as_special() {
-        assert!(!is_special_ref(b"refs/heads/main"));
-        assert!(!is_special_ref(b"refs/tags/v1"));
-        assert!(!is_special_ref(b"refs/remotes/origin/main"));
-        assert!(is_special_ref(b"refs/patches/main/patch"));
-        assert!(is_special_ref(b"refs/stash"));
+    fn classifies_reference_kinds() {
+        assert_eq!(decoration_kind(b"refs/heads/main"), DecorationKind::Local);
+        assert_eq!(decoration_kind(b"refs/tags/v1"), DecorationKind::Tag);
+        assert_eq!(decoration_kind(b"refs/remotes/origin/main"), DecorationKind::Remote);
+        assert_eq!(decoration_kind(b"refs/patches/main/patch"), DecorationKind::Special);
+        assert_eq!(decoration_kind(b"refs/stash"), DecorationKind::Special);
     }
 }

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -83,7 +83,12 @@ pub(crate) fn load(
             .context("could not decode commit message")?
             .summary()
             .into_owned();
-        if !emit(Event::Commit(CommitRow { id: info.id, subject })) {
+        if !emit(Event::Commit(CommitRow {
+            id: info.id,
+            parent_ids: info.parent_ids,
+            lane: String::new(),
+            subject,
+        })) {
             return Ok(());
         }
     }

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     ffi::OsString,
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -7,7 +7,7 @@ use std::{
 use anyhow::{Context, Result};
 use gix::{
     ObjectId,
-    bstr::{BString, ByteVec},
+    bstr::{BStr, BString, ByteSlice, ByteVec},
     objs::commit::ref_iter::Token,
 };
 
@@ -85,6 +85,7 @@ pub(crate) fn load(
         .sorting(gix::revision::walk::Sorting::ByCommitTime(Default::default()))
         .all()
         .context("could not start revision walk")?;
+    let mut author_names = HashSet::new();
     let mut rows = Vec::with_capacity(COMMIT_BATCH_SIZE);
     for info in walk {
         if cancelled.load(Ordering::Relaxed) {
@@ -99,7 +100,7 @@ pub(crate) fn load(
         for token in object.iter() {
             match token.context("could not decode commit")? {
                 Token::Author { signature } => {
-                    author_name = Some(signature.trim().name.to_owned());
+                    author_name = Some(intern(&mut author_names, signature.trim().name));
                 }
                 Token::Committer { signature } => {
                     committer_time = Some(signature.time().context("could not decode committer time")?);
@@ -136,6 +137,17 @@ pub(crate) fn load(
     }
     emit(Event::Complete);
     Ok(())
+}
+
+fn intern(names: &mut HashSet<&'static [u8]>, name: &[u8]) -> &'static BStr {
+    match names.get(name) {
+        Some(name) => name.as_bstr(),
+        None => {
+            let name: &'static [u8] = Box::leak(name.to_vec().into_boxed_slice());
+            names.insert(name);
+            name.as_bstr()
+        }
+    }
 }
 
 fn decorations(repo: &gix::Repository) -> Result<Decorations> {
@@ -290,5 +302,19 @@ mod tests {
         assert_eq!(decoration_kind(b"refs/remotes/origin/main"), DecorationKind::Remote);
         assert_eq!(decoration_kind(b"refs/patches/main/patch"), DecorationKind::Special);
         assert_eq!(decoration_kind(b"refs/stash"), DecorationKind::Special);
+    }
+
+    #[test]
+    fn interns_author_names_as_raw_bytes() {
+        let mut names = HashSet::new();
+
+        let first = intern(&mut names, b"author\xff");
+        let second = intern(&mut names, b"author\xff");
+        let other = intern(&mut names, b"other");
+
+        assert!(std::ptr::eq(first, second), "equal names share one allocation");
+        assert!(!std::ptr::eq(first, other), "different names remain distinct");
+        assert_eq!(names.len(), 2);
+        assert_eq!(first, b"author\xff".as_bstr(), "Git names remain byte strings");
     }
 }

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -30,6 +30,7 @@ pub(crate) enum DecorationKind {
 }
 
 pub(crate) type Decorations = HashMap<ObjectId, Vec<Decoration>>;
+pub(crate) type AuthorNames = HashSet<&'static [u8]>;
 const COMMIT_BATCH_SIZE: usize = 1024;
 
 #[derive(Debug)]
@@ -43,6 +44,8 @@ pub(crate) enum Event {
 pub(crate) fn load(
     repo: &gix::Repository,
     revisions: &[OsString],
+    hidden_revisions: &[OsString],
+    author_names: &mut AuthorNames,
     cancelled: &AtomicBool,
     mut emit: impl FnMut(Event) -> bool,
 ) -> Result<()> {
@@ -61,31 +64,19 @@ pub(crate) fn load(
             }
         }
     } else {
-        revisions
-            .iter()
-            .map(|revision| {
-                let revision = gix::path::os_str_into_bstr(revision)
-                    .with_context(|| format!("revision {} is not valid UTF-8", revision.to_string_lossy()))?;
-                repo.rev_parse_single(revision)
-                    .with_context(|| format!("could not resolve revision {revision}"))?
-                    .object()
-                    .context("could not read revision")?
-                    .peel_to_kind(gix::object::Kind::Commit)
-                    .context("revision does not resolve to a commit")
-                    .map(|object| object.id)
-            })
-            .collect::<Result<Vec<_>>>()?
+        resolve_revisions(repo, revisions, "")?
     };
+    let hidden_tips = resolve_revisions(repo, hidden_revisions, "hidden ")?;
 
     if !emit(Event::Decorations(decorations(repo)?)) {
         return Ok(());
     }
     let walk = repo
         .rev_walk(tips)
+        .with_hidden(hidden_tips)
         .sorting(gix::revision::walk::Sorting::ByCommitTime(Default::default()))
         .all()
         .context("could not start revision walk")?;
-    let mut author_names = HashSet::new();
     let mut rows = Vec::with_capacity(COMMIT_BATCH_SIZE);
     for info in walk {
         if cancelled.load(Ordering::Relaxed) {
@@ -100,7 +91,7 @@ pub(crate) fn load(
         for token in object.iter() {
             match token.context("could not decode commit")? {
                 Token::Author { signature } => {
-                    author_name = Some(intern(&mut author_names, signature.trim().name));
+                    author_name = Some(intern(author_names, signature.trim().name));
                 }
                 Token::Committer { signature } => {
                     committer_time = Some(signature.time().context("could not decode committer time")?);
@@ -139,7 +130,24 @@ pub(crate) fn load(
     Ok(())
 }
 
-fn intern(names: &mut HashSet<&'static [u8]>, name: &[u8]) -> &'static BStr {
+fn resolve_revisions(repo: &gix::Repository, revisions: &[OsString], kind: &str) -> Result<Vec<ObjectId>> {
+    revisions
+        .iter()
+        .map(|revision| {
+            let revision = gix::path::os_str_into_bstr(revision)
+                .with_context(|| format!("{kind}revision {} is not valid UTF-8", revision.to_string_lossy()))?;
+            repo.rev_parse_single(revision)
+                .with_context(|| format!("could not resolve {kind}revision {revision}"))?
+                .object()
+                .with_context(|| format!("could not read {kind}revision"))?
+                .peel_to_kind(gix::object::Kind::Commit)
+                .with_context(|| format!("{kind}revision does not resolve to a commit"))
+                .map(|object| object.id)
+        })
+        .collect()
+}
+
+fn intern(names: &mut AuthorNames, name: &[u8]) -> &'static BStr {
     match names.get(name) {
         Some(name) => name.as_bstr(),
         None => {
@@ -212,12 +220,15 @@ mod tests {
         gix_testtools::scripted_fixture_read_only("history.sh")
     }
 
-    fn loaded(path: &std::path::Path, revisions: &[&str]) -> Result<Vec<Event>> {
+    fn loaded(path: &std::path::Path, revisions: &[&str], hidden_revisions: &[&str]) -> Result<Vec<Event>> {
         let mut events = Vec::new();
+        let mut author_names = AuthorNames::new();
         let repo = gix::open(path)?;
         load(
             &repo,
             &revisions.iter().map(OsString::from).collect::<Vec<_>>(),
+            &hidden_revisions.iter().map(OsString::from).collect::<Vec<_>>(),
+            &mut author_names,
             &AtomicBool::new(false),
             |event| {
                 events.push(event);
@@ -230,7 +241,7 @@ mod tests {
     #[test]
     fn walks_the_same_reachable_set_as_git_for_multiple_tips() -> gix_testtools::Result {
         let fixture = fixture()?;
-        let events = loaded(&fixture, &["main", "topic"])?;
+        let events = loaded(&fixture, &["main", "topic"], &[])?;
         let actual: HashSet<_> = events
             .iter()
             .flat_map(|event| match event {
@@ -268,9 +279,38 @@ mod tests {
     }
 
     #[test]
+    fn hides_tips_and_every_commit_reachable_from_them() -> gix_testtools::Result {
+        let fixture = fixture()?;
+        let events = loaded(&fixture, &["topic"], &["main"])?;
+        let actual: HashSet<_> = events
+            .iter()
+            .flat_map(|event| match event {
+                Event::Commits(rows) => rows.iter().map(|row| row.id.to_hex().to_string()).collect(),
+                _ => Vec::new(),
+            })
+            .collect();
+        let output = Command::new("git")
+            .current_dir(&fixture)
+            .args(["rev-list", "topic", "--not", "main", "--"])
+            .output()?;
+        assert!(
+            output.status.success(),
+            "git rev-list provides the reference result: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let expected = String::from_utf8(output.stdout)?.lines().map(str::to_owned).collect();
+        assert_eq!(actual, expected, "hidden tips use Git's exclusion semantics");
+        assert!(
+            matches!(events.last(), Some(Event::Complete)),
+            "the filtered walk completes"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn reports_decorations_and_honours_cancellation() -> gix_testtools::Result {
         let fixture = fixture()?;
-        let events = loaded(&fixture, &["main"])?;
+        let events = loaded(&fixture, &["main"], &[])?;
         let Event::Decorations(decorations) = &events[0] else {
             panic!("decorations are sent first")
         };
@@ -283,8 +323,9 @@ mod tests {
         );
 
         let mut cancelled = Vec::new();
+        let mut author_names = AuthorNames::new();
         let repo = gix::open(&fixture)?;
-        load(&repo, &[], &AtomicBool::new(true), |event| {
+        load(&repo, &[], &[], &mut author_names, &AtomicBool::new(true), |event| {
             cancelled.push(event);
             true
         })?;

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -11,7 +11,7 @@ use gix::{
     objs::commit::ref_iter::Token,
 };
 
-use crate::app::CommitRow;
+use crate::app::{Commit, LoadedCommit};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Decoration {
@@ -35,7 +35,7 @@ const COMMIT_BATCH_SIZE: usize = 1024;
 #[derive(Debug)]
 pub(crate) enum Event {
     Decorations(Decorations),
-    Commits(Vec<CommitRow>),
+    Commits(Vec<LoadedCommit>),
     Complete,
     Cancelled,
 }
@@ -95,7 +95,7 @@ pub(crate) fn load(
         let object = info.object().context("could not read commit")?;
         let mut committer_time = None;
         let mut author_name = None;
-        let mut subject = None;
+        let mut title = None;
         for token in object.iter() {
             match token.context("could not decode commit")? {
                 Token::Author { signature } => {
@@ -105,7 +105,7 @@ pub(crate) fn load(
                     committer_time = Some(signature.time().context("could not decode committer time")?);
                 }
                 Token::Message(message) => {
-                    subject = Some(
+                    title = Some(
                         gix::objs::commit::MessageRef::from_bytes(message)
                             .summary()
                             .into_owned(),
@@ -114,13 +114,13 @@ pub(crate) fn load(
                 _ => {}
             }
         }
-        rows.push(CommitRow {
+        rows.push(Commit {
             id: info.id,
             parent_ids: info.parent_ids,
             lane: String::new(),
             committer_time: committer_time.context("commit has no committer time")?,
             author_name: author_name.context("commit has no author name")?,
-            subject: subject.context("commit has no message")?,
+            title: title.context("commit has no message")?,
         });
         if rows.len() == COMMIT_BATCH_SIZE
             && !emit(Event::Commits(std::mem::replace(
@@ -241,7 +241,7 @@ mod tests {
         let topic = events
             .iter()
             .filter_map(|event| match event {
-                Event::Commits(rows) => rows.iter().find(|row| row.subject == "topic"),
+                Event::Commits(rows) => rows.iter().find(|row| row.title == "topic"),
                 _ => None,
             })
             .next()

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -44,9 +44,9 @@ pub(crate) fn load(
             .iter()
             .map(|revision| {
                 let revision = gix::path::os_str_into_bstr(revision)
-                    .with_context(|| format!("revision {revision:?} is not valid UTF-8"))?;
+                    .with_context(|| format!("revision {} is not valid UTF-8", revision.to_string_lossy()))?;
                 repo.rev_parse_single(revision)
-                    .with_context(|| format!("could not resolve revision {revision:?}"))?
+                    .with_context(|| format!("could not resolve revision {revision}"))?
                     .object()
                     .context("could not read revision")?
                     .peel_to_kind(gix::object::Kind::Commit)
@@ -147,4 +147,5 @@ mod tests {
         assert!(matches!(cancelled.as_slice(), [Event::Decorations(_), Event::Cancelled]), "cancellation preserves decorations and stops before commits");
         Ok(())
     }
+
 }

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -177,7 +177,10 @@ fn decorations(repo: &gix::Repository) -> Result<Decorations> {
                 kind = DecorationKind::AnnotatedTag;
             }
         }
-        let id = reference.peel_to_id().context("could not peel reference")?.detach();
+        let Ok(id) = reference.peel_to_id() else {
+            continue;
+        };
+        let id = id.detach();
         let mut name = reference.name().shorten().to_owned();
         if matches!(kind, DecorationKind::Tag | DecorationKind::AnnotatedTag) {
             name.insert_str(0, "tag: ");
@@ -320,6 +323,13 @@ mod tests {
                 .flatten()
                 .any(|decoration| { decoration.name == "tag: v1" && decoration.kind == DecorationKind::AnnotatedTag }),
             "annotated tags decorate their commit"
+        );
+        assert!(
+            decorations
+                .values()
+                .flatten()
+                .all(|decoration| decoration.name != "origin/HEAD"),
+            "dangling symbolic references are omitted"
         );
 
         let mut cancelled = Vec::new();

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -14,7 +14,13 @@ use gix::{
 
 use crate::app::CommitRow;
 
-pub(crate) type Decorations = HashMap<ObjectId, Vec<BString>>;
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Decoration {
+    pub name: BString,
+    pub special: bool,
+}
+
+pub(crate) type Decorations = HashMap<ObjectId, Vec<Decoration>>;
 const COMMIT_BATCH_SIZE: usize = 1024;
 
 #[derive(Debug)]
@@ -135,11 +141,12 @@ fn decorations(repo: &gix::Repository) -> Result<Decorations> {
     {
         let mut reference = reference.map_err(|err| anyhow::anyhow!("could not read reference: {err}"))?;
         let id = reference.peel_to_id().context("could not peel reference")?.detach();
+        let special = is_special_ref(reference.name().as_bstr());
         let mut name = reference.name().shorten().to_owned();
         if reference.name().as_bstr().starts_with_str("refs/tags/") {
             name.insert_str(0, "tag: ");
         }
-        out.entry(id).or_default().push(name);
+        out.entry(id).or_default().push(Decoration { name, special });
     }
     if let Some(id) = repo
         .head()
@@ -147,9 +154,16 @@ fn decorations(repo: &gix::Repository) -> Result<Decorations> {
         .try_peel_to_id()
         .context("could not peel HEAD")?
     {
-        out.entry(id.detach()).or_default().push("HEAD".into());
+        out.entry(id.detach()).or_default().push(Decoration {
+            name: "HEAD".into(),
+            special: false,
+        });
     }
     Ok(out)
+}
+
+fn is_special_ref(name: &[u8]) -> bool {
+    !name.starts_with(b"refs/heads/") && !name.starts_with(b"refs/tags/") && !name.starts_with(b"refs/remotes/")
 }
 
 #[cfg(test)]
@@ -224,7 +238,10 @@ mod tests {
             panic!("decorations are sent first")
         };
         assert!(
-            decorations.values().flatten().any(|name| name == "tag: v1"),
+            decorations
+                .values()
+                .flatten()
+                .any(|decoration| decoration.name == "tag: v1"),
             "annotated tags decorate their commit"
         );
 
@@ -238,5 +255,14 @@ mod tests {
             "cancellation preserves decorations and stops before commits"
         );
         Ok(())
+    }
+
+    #[test]
+    fn classifies_refs_outside_standard_namespaces_as_special() {
+        assert!(!is_special_ref(b"refs/heads/main"));
+        assert!(!is_special_ref(b"refs/tags/v1"));
+        assert!(!is_special_ref(b"refs/remotes/origin/main"));
+        assert!(is_special_ref(b"refs/patches/main/patch"));
+        assert!(is_special_ref(b"refs/stash"));
     }
 }

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use gix::{
     ObjectId,
     bstr::{BString, ByteSlice, ByteVec},
+    objs::commit::ref_iter::Token,
 };
 
 use crate::app::CommitRow;
@@ -78,18 +79,35 @@ pub(crate) fn load(
             return Ok(());
         }
         let info = info.context("could not traverse revision history")?;
-        let subject = info
-            .object()
-            .context("could not read commit")?
-            .message()
-            .context("could not decode commit message")?
-            .summary()
-            .into_owned();
+        let object = info.object().context("could not read commit")?;
+        let mut committer_time = None;
+        let mut author_name = None;
+        let mut subject = None;
+        for token in object.iter() {
+            match token.context("could not decode commit")? {
+                Token::Author { signature } => {
+                    author_name = Some(signature.trim().name.to_owned());
+                }
+                Token::Committer { signature } => {
+                    committer_time = Some(signature.time().context("could not decode committer time")?);
+                }
+                Token::Message(message) => {
+                    subject = Some(
+                        gix::objs::commit::MessageRef::from_bytes(message)
+                            .summary()
+                            .into_owned(),
+                    );
+                }
+                _ => {}
+            }
+        }
         rows.push(CommitRow {
             id: info.id,
             parent_ids: info.parent_ids,
             lane: String::new(),
-            subject,
+            committer_time: committer_time.context("commit has no committer time")?,
+            author_name: author_name.context("commit has no author name")?,
+            subject: subject.context("commit has no message")?,
         });
         if rows.len() == COMMIT_BATCH_SIZE
             && !emit(Event::Commits(std::mem::replace(
@@ -181,6 +199,20 @@ mod tests {
         let expected = String::from_utf8(output.stdout)?.lines().map(str::to_owned).collect();
         assert_eq!(actual, expected, "all commits reachable from either tip are shown once");
         assert!(matches!(events.last(), Some(Event::Complete)), "the walk completes");
+        let topic = events
+            .iter()
+            .filter_map(|event| match event {
+                Event::Commits(rows) => rows.iter().find(|row| row.subject == "topic"),
+                _ => None,
+            })
+            .next()
+            .expect("the topic commit is reachable");
+        assert_eq!(topic.author_name, "author", "the author name is retained");
+        assert_eq!(
+            topic.committer_time.format_or_unix(gix::date::time::format::SHORT),
+            "2000-01-04",
+            "the committer date is retained"
+        );
         Ok(())
     }
 

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashMap,
     ffi::OsString,
-    path::Path,
     sync::atomic::{AtomicBool, Ordering},
 };
 
@@ -42,13 +41,11 @@ pub(crate) enum Event {
 }
 
 pub(crate) fn load(
-    repository: &Path,
+    repo: &gix::Repository,
     revisions: &[OsString],
     cancelled: &AtomicBool,
     mut emit: impl FnMut(Event) -> bool,
 ) -> Result<()> {
-    let repo =
-        gix::open(repository).with_context(|| format!("could not open repository at {}", repository.display()))?;
     let tips = if revisions.is_empty() {
         match repo
             .head()
@@ -58,7 +55,7 @@ pub(crate) fn load(
         {
             Some(id) => vec![id.detach()],
             None => {
-                emit(Event::Decorations(decorations(&repo)?));
+                emit(Event::Decorations(decorations(repo)?));
                 emit(Event::Complete);
                 return Ok(());
             }
@@ -80,7 +77,7 @@ pub(crate) fn load(
             .collect::<Result<Vec<_>>>()?
     };
 
-    if !emit(Event::Decorations(decorations(&repo)?)) {
+    if !emit(Event::Decorations(decorations(repo)?)) {
         return Ok(());
     }
     let walk = repo
@@ -151,11 +148,14 @@ fn decorations(repo: &gix::Repository) -> Result<Decorations> {
     {
         let mut reference = reference.map_err(|err| anyhow::anyhow!("could not read reference: {err}"))?;
         let mut kind = decoration_kind(reference.name().as_bstr());
-        if kind == DecorationKind::Tag
-            && let Some(id) = reference.try_id()
-            && id.header().context("could not inspect tag")?.kind() == gix::objs::Kind::Tag
-        {
-            kind = DecorationKind::AnnotatedTag;
+        if kind == DecorationKind::Tag {
+            let annotated = match reference.try_id() {
+                Some(id) => id.header().context("could not inspect tag")?.kind() == gix::objs::Kind::Tag,
+                None => false,
+            };
+            if annotated {
+                kind = DecorationKind::AnnotatedTag;
+            }
         }
         let id = reference.peel_to_id().context("could not peel reference")?.detach();
         let mut name = reference.name().shorten().to_owned();
@@ -200,10 +200,11 @@ mod tests {
         gix_testtools::scripted_fixture_read_only("history.sh")
     }
 
-    fn loaded(path: &Path, revisions: &[&str]) -> Result<Vec<Event>> {
+    fn loaded(path: &std::path::Path, revisions: &[&str]) -> Result<Vec<Event>> {
         let mut events = Vec::new();
+        let repo = gix::open(path)?;
         load(
-            path,
+            &repo,
             &revisions.iter().map(OsString::from).collect::<Vec<_>>(),
             &AtomicBool::new(false),
             |event| {
@@ -270,7 +271,8 @@ mod tests {
         );
 
         let mut cancelled = Vec::new();
-        load(&fixture, &[], &AtomicBool::new(true), |event| {
+        let repo = gix::open(&fixture)?;
+        load(&repo, &[], &AtomicBool::new(true), |event| {
             cancelled.push(event);
             true
         })?;

--- a/gix-tix/src/lib.rs
+++ b/gix-tix/src/lib.rs
@@ -1,4 +1,0 @@
-#![forbid(unsafe_code)]
-
-mod app;
-mod history;

--- a/gix-tix/src/lib.rs
+++ b/gix-tix/src/lib.rs
@@ -13,11 +13,11 @@ use std::{
         atomic::{AtomicBool, Ordering},
         mpsc,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result};
-use app::{Action, App, Effect};
+use app::{Action, App, Effect, State};
 use crossterm::{
     clipboard::CopyToClipboard,
     event::{self, Event as TerminalEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
@@ -26,7 +26,7 @@ use crossterm::{
 use history::{Decorations, Event};
 
 const EVENT_BATCH_SIZE: usize = 256;
-const POLL_INTERVAL: Duration = Duration::from_millis(16);
+const FRAME_INTERVAL: Duration = Duration::from_nanos(16_666_667);
 
 /// Options for [`run()`].
 #[derive(Clone, Copy, Debug, Default)]
@@ -69,10 +69,32 @@ fn event_loop(
 
     let mut app = App::new(1);
     let mut decorations = Decorations::new();
+    draw(terminal, &mut app, &decorations)?;
+    let mut last_draw = Instant::now();
+    let mut dirty = false;
+    let mut urgent = false;
     loop {
+        if urgent {
+            draw(terminal, &mut app, &decorations)?;
+            last_draw = Instant::now();
+            dirty = false;
+            urgent = false;
+            continue;
+        }
         let mut events = 0;
-        for message in receiver.try_iter().take(EVENT_BATCH_SIZE) {
+        while events < EVENT_BATCH_SIZE {
+            let message = match receiver.try_recv() {
+                Ok(message) => message,
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) if matches!(app.state, State::Complete | State::Cancelled) => {
+                    break;
+                }
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    anyhow::bail!("history worker stopped unexpectedly")
+                }
+            };
             events += 1;
+            dirty = true;
             match message? {
                 Event::Decorations(value) => decorations = value,
                 Event::Commits(rows) => app.extend_commits(rows),
@@ -85,17 +107,35 @@ fn event_loop(
                 Event::Cancelled => drop(app.update(Action::Cancelled)),
             }
         }
-        terminal.draw(|frame| ui::draw(frame, &mut app, &decorations))?;
-        if !event::poll(poll_timeout(events))? {
-            continue;
+        let streaming = matches!(app.state, State::Loading | State::Cancelling);
+        if should_draw(dirty, streaming, last_draw.elapsed()) {
+            draw(terminal, &mut app, &decorations)?;
+            last_draw = Instant::now();
+            dirty = false;
         }
-        let TerminalEvent::Key(key) = event::read()? else {
+        let terminal_event = match poll_timeout(streaming, events, dirty, last_draw.elapsed()) {
+            Some(timeout) if event::poll(timeout)? => Some(event::read()?),
+            Some(_) => None,
+            None => Some(event::read()?),
+        };
+        let Some(terminal_event) = terminal_event else {
             continue;
+        };
+        let key = match terminal_event {
+            TerminalEvent::Key(key) => key,
+            TerminalEvent::Resize(_, _) => {
+                dirty = true;
+                urgent = true;
+                continue;
+            }
+            _ => continue,
         };
         if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
             continue;
         }
         let Some(action) = action(key) else { continue };
+        dirty = true;
+        urgent = true;
         for effect in app.update(action) {
             match effect {
                 Effect::Cancel => cancelled.store(true, Ordering::Relaxed),
@@ -109,12 +149,25 @@ fn event_loop(
     }
 }
 
-fn poll_timeout(events: usize) -> Duration {
-    if events == EVENT_BATCH_SIZE {
-        Duration::ZERO
-    } else {
-        POLL_INTERVAL
-    }
+fn draw(terminal: &mut ratatui::DefaultTerminal, app: &mut App, decorations: &Decorations) -> Result<()> {
+    terminal.draw(|frame| ui::draw(frame, app, decorations))?;
+    Ok(())
+}
+
+fn should_draw(dirty: bool, streaming: bool, since_draw: Duration) -> bool {
+    dirty && (!streaming || since_draw >= FRAME_INTERVAL)
+}
+
+fn poll_timeout(streaming: bool, events: usize, dirty: bool, since_draw: Duration) -> Option<Duration> {
+    streaming.then(|| {
+        if events == EVENT_BATCH_SIZE {
+            Duration::ZERO
+        } else if dirty {
+            FRAME_INTERVAL.saturating_sub(since_draw)
+        } else {
+            FRAME_INTERVAL
+        }
+    })
 }
 
 fn action(key: KeyEvent) -> Option<Action> {
@@ -206,8 +259,37 @@ mod tests {
     }
 
     #[test]
-    fn saturated_event_batches_do_not_wait() {
-        assert_eq!(poll_timeout(EVENT_BATCH_SIZE), Duration::ZERO);
-        assert_eq!(poll_timeout(EVENT_BATCH_SIZE - 1), POLL_INTERVAL);
+    fn rendering_is_reactive_and_capped_while_streaming() {
+        assert!(
+            !should_draw(false, false, Duration::MAX),
+            "clean frames are never redrawn"
+        );
+        assert!(
+            should_draw(true, false, Duration::ZERO),
+            "idle changes redraw immediately"
+        );
+        assert!(
+            !should_draw(true, true, FRAME_INTERVAL.saturating_sub(Duration::from_nanos(1))),
+            "streaming frames wait for the 60 fps deadline"
+        );
+        assert!(
+            should_draw(true, true, FRAME_INTERVAL),
+            "streaming frames draw at the deadline"
+        );
+        assert_eq!(
+            poll_timeout(false, 0, false, Duration::ZERO),
+            None,
+            "idle waits reactively for terminal input"
+        );
+        assert_eq!(
+            poll_timeout(true, EVENT_BATCH_SIZE, true, Duration::ZERO),
+            Some(Duration::ZERO),
+            "saturated history batches keep processing"
+        );
+        assert_eq!(
+            poll_timeout(true, 1, true, Duration::from_millis(10)),
+            Some(FRAME_INTERVAL.saturating_sub(Duration::from_millis(10))),
+            "dirty streaming frames wait only until their deadline"
+        );
     }
 }

--- a/gix-tix/src/lib.rs
+++ b/gix-tix/src/lib.rs
@@ -1,3 +1,5 @@
+//! A fast, interactive commit graph for terminals.
+
 #![forbid(unsafe_code)]
 
 mod app;
@@ -26,17 +28,17 @@ use history::{Decorations, Event};
 const EVENT_BATCH_SIZE: usize = 256;
 const POLL_INTERVAL: Duration = Duration::from_millis(16);
 
-fn main() -> Result<()> {
-    let (revisions, quit_on_finish) = arguments(gix::env::args_os().skip(1));
-    if revisions.iter().any(|arg| arg == "-h" || arg == "--help") {
-        println!(
-            "Usage: tix [--quit-on-finish] [REVISION]...\n\nBrowse commits reachable from HEAD or the given revisions."
-        );
-        return Ok(());
-    }
+/// Options for [`run()`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Options {
+    /// Exit once all commits and graph lanes have been computed.
+    pub quit_on_finish: bool,
+}
 
+/// Run the interactive commit graph for `repository`.
+pub fn run(repository: gix::ThreadSafeRepository, revisions: Vec<OsString>, options: Options) -> Result<()> {
     let mut terminal = ratatui::try_init().context("could not initialize terminal")?;
-    let result = run(&mut terminal, revisions, quit_on_finish);
+    let result = event_loop(&mut terminal, repository, revisions, options);
     let restore = ratatui::try_restore().context("could not restore terminal");
     let lane_time = result?;
     restore?;
@@ -46,31 +48,17 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn arguments(args: impl Iterator<Item = OsString>) -> (Vec<OsString>, bool) {
-    let mut quit_on_finish = false;
-    let revisions = args
-        .filter(|arg| {
-            let is_option = arg == "--quit-on-finish";
-            quit_on_finish |= is_option;
-            !is_option
-        })
-        .collect();
-    (revisions, quit_on_finish)
-}
-
-fn run(
+fn event_loop(
     terminal: &mut ratatui::DefaultTerminal,
+    repository: gix::ThreadSafeRepository,
     revisions: Vec<OsString>,
-    quit_on_finish: bool,
+    options: Options,
 ) -> Result<Option<Duration>> {
-    let repository = match std::env::var_os("GIT_DIR") {
-        Some(git_dir) => git_dir.into(),
-        None => std::env::current_dir().context("could not determine current directory")?,
-    };
     let cancelled = Arc::new(AtomicBool::new(false));
     let worker_cancelled = Arc::clone(&cancelled);
     let (sender, receiver) = mpsc::channel();
     std::thread::spawn(move || {
+        let repository = repository.to_thread_local();
         let result = history::load(&repository, &revisions, &worker_cancelled, |event| {
             sender.send(Ok(event)).is_ok()
         });
@@ -90,7 +78,7 @@ fn run(
                 Event::Commits(rows) => app.extend_commits(rows),
                 Event::Complete => {
                     drop(app.update(Action::Complete));
-                    if quit_on_finish {
+                    if options.quit_on_finish {
                         return Ok(app.lane_time);
                     }
                 }
@@ -215,13 +203,6 @@ mod tests {
             Some(Action::Quit)
         );
         assert_eq!(action(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)), None);
-    }
-
-    #[test]
-    fn quit_on_finish_is_not_a_revision() {
-        let (revisions, quit_on_finish) = arguments(["--quit-on-finish", "main"].into_iter().map(OsString::from));
-        assert!(quit_on_finish, "the option is enabled");
-        assert_eq!(revisions, ["main"], "only revisions remain");
     }
 
     #[test]

--- a/gix-tix/src/lib.rs
+++ b/gix-tix/src/lib.rs
@@ -1,1 +1,4 @@
 #![forbid(unsafe_code)]
+
+mod app;
+mod history;

--- a/gix-tix/src/lib.rs
+++ b/gix-tix/src/lib.rs
@@ -23,16 +23,19 @@ use crossterm::{
     event::{self, Event as TerminalEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
     execute,
 };
-use history::{Decorations, Event};
+use history::{AuthorNames, Decorations, Event};
 
 const EVENT_BATCH_SIZE: usize = 256;
 const FRAME_INTERVAL: Duration = Duration::from_nanos(16_666_667);
+type SharedAuthorNames = gix::features::threading::OwnShared<gix::features::threading::Mutable<AuthorNames>>;
 
 /// Options for [`run()`].
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Options {
     /// Exit once all commits and graph lanes have been computed.
     pub quit_on_finish: bool,
+    /// Revisions whose reachable commits should initially be hidden.
+    pub hide: Vec<OsString>,
 }
 
 /// Run the interactive commit graph for `repository`.
@@ -54,20 +57,18 @@ fn event_loop(
     revisions: Vec<OsString>,
     options: Options,
 ) -> Result<Option<Duration>> {
-    let cancelled = Arc::new(AtomicBool::new(false));
-    let worker_cancelled = Arc::clone(&cancelled);
-    let (sender, receiver) = mpsc::channel();
-    std::thread::spawn(move || {
-        let repository = repository.to_thread_local();
-        let result = history::load(&repository, &revisions, &worker_cancelled, |event| {
-            sender.send(Ok(event)).is_ok()
-        });
-        if let Err(err) = result {
-            let _ = sender.send(Err(err));
-        }
-    });
+    let Options { quit_on_finish, hide } = options;
+    let author_names =
+        gix::features::threading::OwnShared::new(gix::features::threading::Mutable::new(AuthorNames::new()));
+    let (mut cancelled, mut receiver) = start_history(
+        &repository,
+        &revisions,
+        &hide,
+        gix::features::threading::OwnShared::clone(&author_names),
+    );
 
     let mut app = App::new(1);
+    app.has_hidden_filter = !hide.is_empty();
     let mut decorations = Decorations::new();
     draw(terminal, &mut app, &decorations)?;
     let mut last_draw = Instant::now();
@@ -100,7 +101,7 @@ fn event_loop(
                 Event::Commits(rows) => app.extend_commits(rows),
                 Event::Complete => {
                     drop(app.update(Action::Complete));
-                    if options.quit_on_finish {
+                    if quit_on_finish {
                         return Ok(app.lane_time);
                     }
                 }
@@ -143,10 +144,52 @@ fn event_loop(
                     terminal.backend_mut(),
                     CopyToClipboard::to_clipboard_from(id.to_hex().to_string())
                 )?,
+                Effect::Reload(show_hidden) => {
+                    cancelled.store(true, Ordering::Relaxed);
+                    app.reload(show_hidden);
+                    decorations.clear();
+                    let hidden = if show_hidden { &[][..] } else { hide.as_slice() };
+                    (cancelled, receiver) = start_history(
+                        &repository,
+                        &revisions,
+                        hidden,
+                        gix::features::threading::OwnShared::clone(&author_names),
+                    );
+                }
                 Effect::Quit => return Ok(None),
             }
         }
     }
+}
+
+fn start_history(
+    repository: &gix::ThreadSafeRepository,
+    revisions: &[OsString],
+    hidden_revisions: &[OsString],
+    author_names: SharedAuthorNames,
+) -> (Arc<AtomicBool>, mpsc::Receiver<Result<Event>>) {
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let worker_cancelled = Arc::clone(&cancelled);
+    let (sender, receiver) = mpsc::channel();
+    let repository = repository.clone();
+    let revisions = revisions.to_vec();
+    let hidden_revisions = hidden_revisions.to_vec();
+    std::thread::spawn(move || {
+        let repository = repository.to_thread_local();
+        let mut author_names = gix::features::threading::lock(&author_names);
+        let result = history::load(
+            &repository,
+            &revisions,
+            &hidden_revisions,
+            &mut author_names,
+            &worker_cancelled,
+            |event| sender.send(Ok(event)).is_ok(),
+        );
+        if let Err(err) = result {
+            let _ = sender.send(Err(err));
+        }
+    });
+    (cancelled, receiver)
 }
 
 fn draw(terminal: &mut ratatui::DefaultTerminal, app: &mut App, decorations: &Decorations) -> Result<()> {
@@ -190,6 +233,7 @@ fn action(key: KeyEvent) -> Option<Action> {
         KeyCode::Char('d') => Some(Action::ToggleDate),
         KeyCode::Char('n') => Some(Action::ToggleName),
         KeyCode::Char('r') => Some(Action::ToggleSpecialRefs),
+        KeyCode::Char('v') => Some(Action::ToggleHidden),
         KeyCode::Char('[') => Some(Action::PinMetadata),
         KeyCode::Char(']') => Some(Action::UnpinMetadata),
         KeyCode::Char('y') => Some(Action::Copy),
@@ -242,6 +286,10 @@ mod tests {
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)),
             Some(Action::ToggleSpecialRefs)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('v'), KeyModifiers::NONE)),
+            Some(Action::ToggleHidden)
         );
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE)),

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -38,7 +38,12 @@ fn main() -> Result<()> {
     let mut terminal = ratatui::try_init().context("could not initialize terminal")?;
     let result = run(&mut terminal, revisions, quit_on_finish);
     let restore = ratatui::try_restore().context("could not restore terminal");
-    result.and(restore)
+    let lane_time = result?;
+    restore?;
+    if let Some(lane_time) = lane_time {
+        eprintln!("lane computation: {:.3}s", lane_time.as_secs_f64());
+    }
+    Ok(())
 }
 
 fn arguments(args: impl Iterator<Item = OsString>) -> (Vec<OsString>, bool) {
@@ -53,14 +58,18 @@ fn arguments(args: impl Iterator<Item = OsString>) -> (Vec<OsString>, bool) {
     (revisions, quit_on_finish)
 }
 
-fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>, quit_on_finish: bool) -> Result<()> {
+fn run(
+    terminal: &mut ratatui::DefaultTerminal,
+    revisions: Vec<OsString>,
+    quit_on_finish: bool,
+) -> Result<Option<Duration>> {
     let repository = match std::env::var_os("GIT_DIR") {
         Some(git_dir) => git_dir.into(),
         None => std::env::current_dir().context("could not determine current directory")?,
     };
     let cancelled = Arc::new(AtomicBool::new(false));
     let worker_cancelled = Arc::clone(&cancelled);
-    let (sender, receiver) = mpsc::sync_channel(1024);
+    let (sender, receiver) = mpsc::channel();
     std::thread::spawn(move || {
         let result = history::load(&repository, &revisions, &worker_cancelled, |event| {
             sender.send(Ok(event)).is_ok()
@@ -78,11 +87,11 @@ fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>, quit_o
             events += 1;
             match message? {
                 Event::Decorations(value) => decorations = value,
-                Event::Commit(row) => drop(app.update(Action::Commit(row))),
+                Event::Commits(rows) => app.extend_commits(rows),
                 Event::Complete => {
                     drop(app.update(Action::Complete));
                     if quit_on_finish {
-                        return Ok(());
+                        return Ok(app.lane_time);
                     }
                 }
                 Event::Cancelled => drop(app.update(Action::Cancelled)),
@@ -106,7 +115,7 @@ fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>, quit_o
                     terminal.backend_mut(),
                     CopyToClipboard::to_clipboard_from(id.to_hex().to_string())
                 )?,
-                Effect::Quit => return Ok(()),
+                Effect::Quit => return Ok(None),
             }
         }
     }

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -5,10 +5,10 @@ use std::ffi::OsString;
 use anyhow::{Context, Result};
 
 fn main() -> Result<()> {
-    let (revisions, quit_on_finish) = arguments(gix::env::args_os().skip(1));
-    if revisions.iter().any(|arg| arg == "-h" || arg == "--help") {
+    let (revisions, options, help) = arguments(gix::env::args_os().skip(1))?;
+    if help {
         println!(
-            "Usage: tix [--quit-on-finish] [REVISION]...\n\nBrowse commits reachable from HEAD or the given revisions."
+            "Usage: tix [--quit-on-finish] [-h|--hide REVSPEC] [REVISION]...\n\nBrowse commits reachable from HEAD or the given revisions.\n\nOptions:\n  -h, --hide REVSPEC  Hide this revision and all commits reachable from it\n      --help          Print help"
         );
         return Ok(());
     }
@@ -16,19 +16,34 @@ fn main() -> Result<()> {
     let current_dir = std::env::current_dir().context("could not determine current directory")?;
     let repository = gix::ThreadSafeRepository::discover_with_environment_overrides(current_dir)
         .context("could not discover repository")?;
-    gix_tix::run(repository, revisions, gix_tix::Options { quit_on_finish })
+    gix_tix::run(repository, revisions, options)
 }
 
-fn arguments(args: impl Iterator<Item = OsString>) -> (Vec<OsString>, bool) {
-    let mut quit_on_finish = false;
-    let revisions = args
-        .filter(|arg| {
-            let is_option = arg == "--quit-on-finish";
-            quit_on_finish |= is_option;
-            !is_option
-        })
-        .collect();
-    (revisions, quit_on_finish)
+fn arguments(mut args: impl Iterator<Item = OsString>) -> Result<(Vec<OsString>, gix_tix::Options, bool)> {
+    let mut revisions = Vec::new();
+    let mut options = gix_tix::Options::default();
+    let mut help = false;
+    while let Some(arg) = args.next() {
+        if arg == "--help" {
+            help = true;
+            break;
+        } else if arg == "--quit-on-finish" {
+            options.quit_on_finish = true;
+        } else if arg == "-h" || arg == "--hide" {
+            let revision = args.next().context("-h/--hide requires a revision to hide")?;
+            if revision == "--help" {
+                help = true;
+                break;
+            }
+            if revision == "-h" || revision == "--hide" || revision == "--quit-on-finish" {
+                anyhow::bail!("-h/--hide requires a revision to hide");
+            }
+            options.hide.push(revision);
+        } else {
+            revisions.push(arg);
+        }
+    }
+    Ok((revisions, options, help))
 }
 
 #[cfg(test)]
@@ -38,10 +53,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn separates_options_from_revisions() {
-        let (revisions, quit_on_finish) = arguments(["--quit-on-finish", "main"].into_iter().map(OsString::from));
+    fn separates_options_from_revisions() -> Result<()> {
+        let (revisions, options, help) = arguments(
+            ["--quit-on-finish", "-h", "main", "--hide", "tag", "topic", "--help"]
+                .into_iter()
+                .map(OsString::from),
+        )?;
 
-        assert!(quit_on_finish);
-        assert_eq!(revisions, ["main"], "only revisions remain");
+        assert!(options.quit_on_finish);
+        assert_eq!(options.hide, ["main", "tag"], "both hide options are retained");
+        assert_eq!(revisions, ["topic"], "only positional revisions remain");
+        assert!(help, "--help remains available without claiming -h");
+        assert!(
+            arguments(["-h"].into_iter().map(OsString::from)).is_err(),
+            "a missing hidden revision is rejected"
+        );
+        for args in [["--help", "-h"], ["-h", "--help"]] {
+            assert!(
+                arguments(args.into_iter().map(OsString::from))?.2,
+                "--help wins regardless of its position"
+            );
+        }
+        Ok(())
     }
 }

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -136,6 +136,8 @@ fn action(key: KeyEvent) -> Option<Action> {
         KeyCode::Esc => Some(Action::Cancel),
         KeyCode::Up | KeyCode::Char('k') => Some(Action::MoveUp),
         KeyCode::Down | KeyCode::Char('j') => Some(Action::MoveDown),
+        KeyCode::Char('h') => Some(Action::ScrollLeft),
+        KeyCode::Char('l') => Some(Action::ScrollRight),
         KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Action::PageUp),
         KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Action::PageDown),
         KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Action::HalfPageUp),
@@ -179,6 +181,14 @@ mod tests {
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL)),
             Some(Action::HalfPageDown)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE)),
+            Some(Action::ScrollLeft)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE)),
+            Some(Action::ScrollRight)
         );
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE)),

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -23,6 +23,9 @@ use crossterm::{
 };
 use history::{Decorations, Event};
 
+const EVENT_BATCH_SIZE: usize = 256;
+const POLL_INTERVAL: Duration = Duration::from_millis(16);
+
 fn main() -> Result<()> {
     let (revisions, quit_on_finish) = arguments(gix::env::args_os().skip(1));
     if revisions.iter().any(|arg| arg == "-h" || arg == "--help") {
@@ -70,7 +73,9 @@ fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>, quit_o
     let mut app = App::new(1);
     let mut decorations = Decorations::new();
     loop {
-        for message in receiver.try_iter().take(256) {
+        let mut events = 0;
+        for message in receiver.try_iter().take(EVENT_BATCH_SIZE) {
+            events += 1;
             match message? {
                 Event::Decorations(value) => decorations = value,
                 Event::Commit(row) => drop(app.update(Action::Commit(row))),
@@ -84,7 +89,7 @@ fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>, quit_o
             }
         }
         terminal.draw(|frame| ui::draw(frame, &mut app, &decorations))?;
-        if !event::poll(Duration::from_millis(16))? {
+        if !event::poll(poll_timeout(events))? {
             continue;
         }
         let TerminalEvent::Key(key) = event::read()? else {
@@ -104,6 +109,14 @@ fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>, quit_o
                 Effect::Quit => return Ok(()),
             }
         }
+    }
+}
+
+fn poll_timeout(events: usize) -> Duration {
+    if events == EVENT_BATCH_SIZE {
+        Duration::ZERO
+    } else {
+        POLL_INTERVAL
     }
 }
 
@@ -165,5 +178,11 @@ mod tests {
         let (revisions, quit_on_finish) = arguments(["--quit-on-finish", "main"].into_iter().map(OsString::from));
         assert!(quit_on_finish, "the option is enabled");
         assert_eq!(revisions, ["main"], "only revisions remain");
+    }
+
+    #[test]
+    fn saturated_event_batches_do_not_wait() {
+        assert_eq!(poll_timeout(EVENT_BATCH_SIZE), Duration::ZERO);
+        assert_eq!(poll_timeout(EVENT_BATCH_SIZE - 1), POLL_INTERVAL);
     }
 }

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -24,19 +24,33 @@ use crossterm::{
 use history::{Decorations, Event};
 
 fn main() -> Result<()> {
-    let revisions: Vec<_> = gix::env::args_os().skip(1).collect();
+    let (revisions, quit_on_finish) = arguments(gix::env::args_os().skip(1));
     if revisions.iter().any(|arg| arg == "-h" || arg == "--help") {
-        println!("Usage: tix [REVISION]...\n\nBrowse commits reachable from HEAD or the given revisions.");
+        println!(
+            "Usage: tix [--quit-on-finish] [REVISION]...\n\nBrowse commits reachable from HEAD or the given revisions."
+        );
         return Ok(());
     }
 
     let mut terminal = ratatui::try_init().context("could not initialize terminal")?;
-    let result = run(&mut terminal, revisions);
+    let result = run(&mut terminal, revisions, quit_on_finish);
     let restore = ratatui::try_restore().context("could not restore terminal");
     result.and(restore)
 }
 
-fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>) -> Result<()> {
+fn arguments(args: impl Iterator<Item = OsString>) -> (Vec<OsString>, bool) {
+    let mut quit_on_finish = false;
+    let revisions = args
+        .filter(|arg| {
+            let is_option = arg == "--quit-on-finish";
+            quit_on_finish |= is_option;
+            !is_option
+        })
+        .collect();
+    (revisions, quit_on_finish)
+}
+
+fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>, quit_on_finish: bool) -> Result<()> {
     let repository = match std::env::var_os("GIT_DIR") {
         Some(git_dir) => git_dir.into(),
         None => std::env::current_dir().context("could not determine current directory")?,
@@ -60,7 +74,12 @@ fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>) -> Res
             match message? {
                 Event::Decorations(value) => decorations = value,
                 Event::Commit(row) => drop(app.update(Action::Commit(row))),
-                Event::Complete => drop(app.update(Action::Complete)),
+                Event::Complete => {
+                    drop(app.update(Action::Complete));
+                    if quit_on_finish {
+                        return Ok(());
+                    }
+                }
                 Event::Cancelled => drop(app.update(Action::Cancelled)),
             }
         }
@@ -119,5 +138,12 @@ mod tests {
             Some(Action::Quit)
         );
         assert_eq!(action(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)), None);
+    }
+
+    #[test]
+    fn quit_on_finish_is_not_a_revision() {
+        let (revisions, quit_on_finish) = arguments(["--quit-on-finish", "main"].into_iter().map(OsString::from));
+        assert!(quit_on_finish, "the option is enabled");
+        assert_eq!(revisions, ["main"], "only revisions remain");
     }
 }

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -144,6 +144,8 @@ fn action(key: KeyEvent) -> Option<Action> {
         KeyCode::PageDown => Some(Action::PageDown),
         KeyCode::Home | KeyCode::Char('g') => Some(Action::First),
         KeyCode::End | KeyCode::Char('G') => Some(Action::Last),
+        KeyCode::Char('d') => Some(Action::ToggleDate),
+        KeyCode::Char('n') => Some(Action::ToggleName),
         KeyCode::Char('y') => Some(Action::Copy),
         _ => None,
     }
@@ -174,6 +176,14 @@ mod tests {
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL)),
             Some(Action::HalfPageDown)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE)),
+            Some(Action::ToggleDate)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)),
+            Some(Action::ToggleName)
         );
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -114,6 +114,10 @@ fn action(key: KeyEvent) -> Option<Action> {
         KeyCode::Esc => Some(Action::Cancel),
         KeyCode::Up | KeyCode::Char('k') => Some(Action::MoveUp),
         KeyCode::Down | KeyCode::Char('j') => Some(Action::MoveDown),
+        KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Action::PageUp),
+        KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Action::PageDown),
+        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Action::HalfPageUp),
+        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Action::HalfPageDown),
         KeyCode::PageUp => Some(Action::PageUp),
         KeyCode::PageDown => Some(Action::PageDown),
         KeyCode::Home | KeyCode::Char('g') => Some(Action::First),
@@ -132,6 +136,22 @@ mod tests {
         assert_eq!(
             action(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)),
             Some(Action::PageUp)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL)),
+            Some(Action::PageUp)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL)),
+            Some(Action::PageDown)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL)),
+            Some(Action::HalfPageUp)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL)),
+            Some(Action::HalfPageDown)
         );
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -1,0 +1,113 @@
+#![forbid(unsafe_code)]
+
+mod app;
+mod history;
+mod ui;
+
+use std::{
+    ffi::OsString,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use app::{Action, App, Effect};
+use crossterm::{
+    clipboard::CopyToClipboard,
+    event::{self, Event as TerminalEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    execute,
+};
+use history::{Decorations, Event};
+
+fn main() -> Result<()> {
+    let revisions: Vec<_> = gix::env::args_os().skip(1).collect();
+    if revisions.iter().any(|arg| arg == "-h" || arg == "--help") {
+        println!("Usage: tix [REVISION]...\n\nBrowse commits reachable from HEAD or the given revisions.");
+        return Ok(());
+    }
+
+    let mut terminal = ratatui::try_init().context("could not initialize terminal")?;
+    let result = run(&mut terminal, revisions);
+    let restore = ratatui::try_restore().context("could not restore terminal");
+    result.and(restore)
+}
+
+fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>) -> Result<()> {
+    let repository = match std::env::var_os("GIT_DIR") {
+        Some(git_dir) => git_dir.into(),
+        None => std::env::current_dir().context("could not determine current directory")?,
+    };
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let worker_cancelled = Arc::clone(&cancelled);
+    let (sender, receiver) = mpsc::sync_channel(1024);
+    std::thread::spawn(move || {
+        let result = history::load(&repository, &revisions, &worker_cancelled, |event| sender.send(Ok(event)).is_ok());
+        if let Err(err) = result {
+            let _ = sender.send(Err(err));
+        }
+    });
+
+    let mut app = App::new(1);
+    let mut decorations = Decorations::new();
+    loop {
+        for message in receiver.try_iter().take(256) {
+            match message? {
+                Event::Decorations(value) => decorations = value,
+                Event::Commit(row) => drop(app.update(Action::Commit(row))),
+                Event::Complete => drop(app.update(Action::Complete)),
+                Event::Cancelled => drop(app.update(Action::Cancelled)),
+            }
+        }
+        terminal.draw(|frame| ui::draw(frame, &mut app, &decorations))?;
+        if !event::poll(Duration::from_millis(16))? {
+            continue;
+        }
+        let TerminalEvent::Key(key) = event::read()? else { continue };
+        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            continue;
+        }
+        let Some(action) = action(key) else { continue };
+        for effect in app.update(action) {
+            match effect {
+                Effect::Cancel => cancelled.store(true, Ordering::Relaxed),
+                Effect::Copy(id) => execute!(
+                    terminal.backend_mut(),
+                    CopyToClipboard::to_clipboard_from(id.to_hex().to_string())
+                )?,
+                Effect::Quit => return Ok(()),
+            }
+        }
+    }
+}
+
+fn action(key: KeyEvent) -> Option<Action> {
+    match key.code {
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => Some(Action::Quit),
+        KeyCode::Char('q') => Some(Action::Quit),
+        KeyCode::Esc => Some(Action::Cancel),
+        KeyCode::Up | KeyCode::Char('k') => Some(Action::MoveUp),
+        KeyCode::Down | KeyCode::Char('j') => Some(Action::MoveDown),
+        KeyCode::PageUp => Some(Action::PageUp),
+        KeyCode::PageDown => Some(Action::PageDown),
+        KeyCode::Home | KeyCode::Char('g') => Some(Action::First),
+        KeyCode::End | KeyCode::Char('G') => Some(Action::Last),
+        KeyCode::Char('y') => Some(Action::Copy),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_navigation_and_control_c() {
+        assert_eq!(action(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)), Some(Action::PageUp));
+        assert_eq!(action(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)), Some(Action::Quit));
+        assert_eq!(action(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)), None);
+    }
+}

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -146,6 +146,7 @@ fn action(key: KeyEvent) -> Option<Action> {
         KeyCode::End | KeyCode::Char('G') => Some(Action::Last),
         KeyCode::Char('d') => Some(Action::ToggleDate),
         KeyCode::Char('n') => Some(Action::ToggleName),
+        KeyCode::Char('r') => Some(Action::ToggleSpecialRefs),
         KeyCode::Char('[') => Some(Action::PinMetadata),
         KeyCode::Char(']') => Some(Action::UnpinMetadata),
         KeyCode::Char('y') => Some(Action::Copy),
@@ -186,6 +187,10 @@ mod tests {
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)),
             Some(Action::ToggleName)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)),
+            Some(Action::ToggleSpecialRefs)
         );
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE)),

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -146,6 +146,8 @@ fn action(key: KeyEvent) -> Option<Action> {
         KeyCode::End | KeyCode::Char('G') => Some(Action::Last),
         KeyCode::Char('d') => Some(Action::ToggleDate),
         KeyCode::Char('n') => Some(Action::ToggleName),
+        KeyCode::Char('[') => Some(Action::PinMetadata),
+        KeyCode::Char(']') => Some(Action::UnpinMetadata),
         KeyCode::Char('y') => Some(Action::Copy),
         _ => None,
     }
@@ -184,6 +186,14 @@ mod tests {
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)),
             Some(Action::ToggleName)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE)),
+            Some(Action::PinMetadata)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char(']'), KeyModifiers::NONE)),
+            Some(Action::UnpinMetadata)
         );
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -1,0 +1,47 @@
+#![forbid(unsafe_code)]
+
+use std::ffi::OsString;
+
+use anyhow::{Context, Result};
+
+fn main() -> Result<()> {
+    let (revisions, quit_on_finish) = arguments(gix::env::args_os().skip(1));
+    if revisions.iter().any(|arg| arg == "-h" || arg == "--help") {
+        println!(
+            "Usage: tix [--quit-on-finish] [REVISION]...\n\nBrowse commits reachable from HEAD or the given revisions."
+        );
+        return Ok(());
+    }
+
+    let current_dir = std::env::current_dir().context("could not determine current directory")?;
+    let repository = gix::ThreadSafeRepository::discover_with_environment_overrides(current_dir)
+        .context("could not discover repository")?;
+    gix_tix::run(repository, revisions, gix_tix::Options { quit_on_finish })
+}
+
+fn arguments(args: impl Iterator<Item = OsString>) -> (Vec<OsString>, bool) {
+    let mut quit_on_finish = false;
+    let revisions = args
+        .filter(|arg| {
+            let is_option = arg == "--quit-on-finish";
+            quit_on_finish |= is_option;
+            !is_option
+        })
+        .collect();
+    (revisions, quit_on_finish)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::*;
+
+    #[test]
+    fn separates_options_from_revisions() {
+        let (revisions, quit_on_finish) = arguments(["--quit-on-finish", "main"].into_iter().map(OsString::from));
+
+        assert!(quit_on_finish);
+        assert_eq!(revisions, ["main"], "only revisions remain");
+    }
+}

--- a/gix-tix/src/main.rs
+++ b/gix-tix/src/main.rs
@@ -45,7 +45,9 @@ fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>) -> Res
     let worker_cancelled = Arc::clone(&cancelled);
     let (sender, receiver) = mpsc::sync_channel(1024);
     std::thread::spawn(move || {
-        let result = history::load(&repository, &revisions, &worker_cancelled, |event| sender.send(Ok(event)).is_ok());
+        let result = history::load(&repository, &revisions, &worker_cancelled, |event| {
+            sender.send(Ok(event)).is_ok()
+        });
         if let Err(err) = result {
             let _ = sender.send(Err(err));
         }
@@ -66,7 +68,9 @@ fn run(terminal: &mut ratatui::DefaultTerminal, revisions: Vec<OsString>) -> Res
         if !event::poll(Duration::from_millis(16))? {
             continue;
         }
-        let TerminalEvent::Key(key) = event::read()? else { continue };
+        let TerminalEvent::Key(key) = event::read()? else {
+            continue;
+        };
         if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
             continue;
         }
@@ -106,8 +110,14 @@ mod tests {
 
     #[test]
     fn maps_navigation_and_control_c() {
-        assert_eq!(action(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)), Some(Action::PageUp));
-        assert_eq!(action(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)), Some(Action::Quit));
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)),
+            Some(Action::PageUp)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            Some(Action::Quit)
+        );
         assert_eq!(action(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)), None);
     }
 }

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -259,7 +259,7 @@ mod tests {
             parent_ids: Default::default(),
             lane: String::new(),
             committer_time: gix::date::Time::default(),
-            author_name: "author".into(),
+            author_name: b"author".as_bstr(),
             title: "subject".into(),
         }]);
         app.update(Action::Complete);
@@ -320,7 +320,7 @@ mod tests {
                     parent_ids: Default::default(),
                     lane: String::new(),
                     committer_time: gix::date::Time::default(),
-                    author_name: "author".into(),
+                    author_name: b"author".as_bstr(),
                     title: format!("subject {n}").into(),
                 })
                 .collect(),
@@ -351,7 +351,7 @@ mod tests {
             parent_ids: Default::default(),
             lane: "● │ │ │ │ │ │ │ ".into(),
             committer_time: gix::date::Time::default(),
-            author_name: "author".into(),
+            author_name: b"author".as_bstr(),
             title: "subject".into(),
         };
         let decorations = Decorations::from([(
@@ -434,7 +434,7 @@ mod tests {
             parent_ids: Default::default(),
             lane: String::new(),
             committer_time: gix::date::Time::default(),
-            author_name: "author".into(),
+            author_name: b"author".as_bstr(),
             title: "subject".into(),
         }]);
         app.update(Action::Complete);

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -71,12 +71,12 @@ mod tests {
     fn renders_rows_decorations_selection_and_footer() -> Result<(), Box<dyn std::error::Error>> {
         let id = gix::ObjectId::Sha1([1; 20]);
         let mut app = App::new(2);
-        app.update(Action::Commit(CommitRow {
+        app.extend_commits(vec![CommitRow {
             id,
             parent_ids: Default::default(),
             lane: String::new(),
             subject: "subject".into(),
-        }));
+        }]);
         app.update(Action::Complete);
         let decorations = Decorations::from([(id, vec!["HEAD".into()])]);
         let mut terminal = Terminal::new(TestBackend::new(54, 2))?;
@@ -100,14 +100,16 @@ mod tests {
     #[test]
     fn renders_only_the_visible_rows() -> Result<(), Box<dyn std::error::Error>> {
         let mut app = App::new(2);
-        for n in 1..=3 {
-            app.update(Action::Commit(CommitRow {
-                id: gix::ObjectId::Sha1([n; 20]),
-                parent_ids: Default::default(),
-                lane: String::new(),
-                subject: format!("subject {n}").into(),
-            }));
-        }
+        app.extend_commits(
+            (1..=3)
+                .map(|n| CommitRow {
+                    id: gix::ObjectId::Sha1([n; 20]),
+                    parent_ids: Default::default(),
+                    lane: String::new(),
+                    subject: format!("subject {n}").into(),
+                })
+                .collect(),
+        );
         app.update(Action::Complete);
         app.update(Action::Last);
         let mut terminal = Terminal::new(TestBackend::new(24, 3))?;

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -2,14 +2,14 @@ use gix::bstr::ByteSlice;
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Clear, Paragraph},
 };
 
 use crate::{
     app::{App, CommitRow, State},
-    history::Decorations,
+    history::{DecorationKind, Decorations},
 };
 
 pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decorations) {
@@ -40,15 +40,18 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     let show_committer_date = app.show_committer_date;
     let show_author_name = app.show_author_name;
     let show_special_refs = app.show_special_refs;
+    let selected = app.selected;
     let metadata: Vec<_> = visible_rows
         .iter()
-        .map(|row| {
+        .enumerate()
+        .map(|(index, row)| {
             metadata_line(
                 row,
                 decorations,
                 show_committer_date,
                 show_author_name,
                 show_special_refs,
+                selected == Some(start + index),
             )
         })
         .collect();
@@ -89,6 +92,7 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
                     .scroll((0, horizontal_offset)),
                 row_area,
             );
+            color_graph(frame, row_area, &row.lane, horizontal_offset as usize, selected);
             let pane = Rect::new(
                 content.x.saturating_add(pane_width as u16),
                 y,
@@ -107,6 +111,7 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
                     .scroll((0, horizontal_offset)),
                 row_area,
             );
+            color_graph(frame, row_area, &row.lane, horizontal_offset as usize, selected);
         }
     }
 
@@ -131,32 +136,106 @@ fn metadata_line(
     show_committer_date: bool,
     show_author_name: bool,
     show_special_refs: bool,
+    selected: bool,
 ) -> Line<'static> {
     let id = row.id.to_hex().to_string();
-    let labels = decorations.get(&row.id).and_then(|labels| {
-        let labels = labels
-            .iter()
-            .filter(|decoration| show_special_refs || !decoration.special)
-            .map(|decoration| decoration.name.to_str_lossy())
-            .collect::<Vec<_>>()
-            .join(", ");
-        (!labels.is_empty()).then_some(labels)
-    });
-    let mut spans = vec![
-        Span::styled(id[..7].to_owned(), Style::default().add_modifier(Modifier::BOLD)),
-        Span::raw(labels.map_or_else(|| " ".into(), |labels| format!(" ({labels}) "))),
-    ];
+    let mut spans = vec![Span::styled(
+        id[..7].to_owned(),
+        color(Color::Magenta, selected).add_modifier(Modifier::BOLD),
+    )];
+    let mut labels = decorations
+        .get(&row.id)
+        .into_iter()
+        .flatten()
+        .filter(|decoration| show_special_refs || decoration.kind != DecorationKind::Special)
+        .peekable();
+    if labels.peek().is_some() {
+        spans.push(Span::raw(" ("));
+        for (index, decoration) in labels.enumerate() {
+            if index != 0 {
+                spans.push(Span::raw(", "));
+            }
+            spans.push(Span::styled(
+                decoration.name.to_str_lossy().into_owned(),
+                decoration_style(decoration.kind, selected),
+            ));
+        }
+        spans.push(Span::raw(") "));
+    } else {
+        spans.push(Span::raw(" "));
+    }
     if show_committer_date {
-        spans.push(Span::raw(format!(
-            "{} ",
-            row.committer_time.format_or_unix(gix::date::time::format::SHORT)
-        )));
+        spans.push(Span::styled(
+            format!("{} ", row.committer_time.format_or_unix(gix::date::time::format::SHORT)),
+            color(Color::Blue, selected),
+        ));
     }
     if show_author_name {
-        spans.push(Span::raw(format!("{} ", row.author_name.to_str_lossy())));
+        spans.push(Span::styled(
+            format!("{} ", row.author_name.to_str_lossy()),
+            color(Color::Green, selected),
+        ));
     }
     spans.push(Span::raw(row.subject.to_str_lossy().into_owned()));
     Line::from(spans)
+}
+
+fn decoration_style(kind: DecorationKind, selected: bool) -> Style {
+    if selected {
+        return Style::default();
+    }
+    match kind {
+        DecorationKind::Head => Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        DecorationKind::Local => Style::default().fg(Color::Cyan),
+        DecorationKind::Remote => Style::default().fg(Color::Yellow),
+        DecorationKind::Tag => Style::default().fg(Color::Magenta),
+        DecorationKind::AnnotatedTag => Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+        DecorationKind::Special => Style::default().fg(Color::Blue),
+    }
+}
+
+fn color(color: Color, selected: bool) -> Style {
+    if selected {
+        Style::default()
+    } else {
+        Style::default().fg(color)
+    }
+}
+
+fn color_graph(frame: &mut Frame<'_>, area: Rect, graph: &str, offset: usize, selected: bool) {
+    if selected {
+        return;
+    }
+    for (x, symbol) in graph.chars().skip(offset).take(area.width as usize).enumerate() {
+        if symbol.is_whitespace() {
+            continue;
+        }
+        let style = if symbol == '●' {
+            Style::default().fg(Color::Blue)
+        } else {
+            graph_style(offset.saturating_add(x) / 2)
+        };
+        frame.buffer_mut()[(area.x + x as u16, area.y)].set_style(style);
+    }
+}
+
+fn graph_style(column: usize) -> Style {
+    const COLORS: [Color; 7] = [
+        Color::Magenta,
+        Color::Yellow,
+        Color::Cyan,
+        Color::Green,
+        Color::Reset,
+        Color::White,
+        Color::Red,
+    ];
+    let index = column % 14;
+    let style = Style::default().fg(COLORS[index % COLORS.len()]);
+    if index >= COLORS.len() {
+        style.add_modifier(Modifier::BOLD)
+    } else {
+        style
+    }
 }
 
 #[cfg(test)]
@@ -166,7 +245,7 @@ mod tests {
     use super::*;
     use crate::{
         app::{Action, CommitRow},
-        history::Decoration,
+        history::{Decoration, DecorationKind},
     };
 
     #[test]
@@ -187,11 +266,11 @@ mod tests {
             vec![
                 Decoration {
                     name: "HEAD".into(),
-                    special: false,
+                    kind: DecorationKind::Head,
                 },
                 Decoration {
                     name: "refs/patches/main/patch".into(),
-                    special: true,
+                    kind: DecorationKind::Special,
                 },
             ],
         )]);
@@ -259,6 +338,88 @@ mod tests {
         );
         assert_eq!(app.selected, Some(2), "drawing preserves the global selection");
         assert_eq!(app.offset, 1, "drawing preserves the global offset");
+        Ok(())
+    }
+
+    #[test]
+    fn uses_the_tig_palette_without_coloring_the_selection() -> Result<(), Box<dyn std::error::Error>> {
+        let id = gix::ObjectId::Sha1([1; 20]);
+        let row = CommitRow {
+            id,
+            parent_ids: Default::default(),
+            lane: "● │ │ │ │ │ │ │ ".into(),
+            committer_time: gix::date::Time::default(),
+            author_name: "author".into(),
+            subject: "subject".into(),
+        };
+        let decorations = Decorations::from([(
+            id,
+            vec![
+                Decoration {
+                    name: "HEAD".into(),
+                    kind: DecorationKind::Head,
+                },
+                Decoration {
+                    name: "main".into(),
+                    kind: DecorationKind::Local,
+                },
+                Decoration {
+                    name: "origin/main".into(),
+                    kind: DecorationKind::Remote,
+                },
+                Decoration {
+                    name: "tag: v1".into(),
+                    kind: DecorationKind::AnnotatedTag,
+                },
+                Decoration {
+                    name: "refs/stash".into(),
+                    kind: DecorationKind::Special,
+                },
+            ],
+        )]);
+        let line = metadata_line(&row, &decorations, true, true, true, false);
+        let style = |text| {
+            line.spans
+                .iter()
+                .find(|span| span.content == text)
+                .expect("the styled field is present")
+                .style
+        };
+        assert_eq!(
+            style("0101010"),
+            Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)
+        );
+        assert_eq!(style("1970-01-01 "), Style::default().fg(Color::Blue));
+        assert_eq!(style("author "), Style::default().fg(Color::Green));
+        assert_eq!(
+            style("HEAD"),
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+        );
+        assert_eq!(style("main"), Style::default().fg(Color::Cyan));
+        assert_eq!(style("origin/main"), Style::default().fg(Color::Yellow));
+        assert_eq!(
+            style("tag: v1"),
+            Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD)
+        );
+        assert_eq!(style("refs/stash"), Style::default().fg(Color::Blue));
+
+        let mut app = App::new(1);
+        app.extend_commits(vec![row]);
+        app.selected = None;
+        let mut terminal = Terminal::new(TestBackend::new(80, 2))?;
+        terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(2, 0)].fg, Color::Blue, "commit dots use graph-commit");
+        assert_eq!(buffer[(4, 0)].fg, Color::Yellow, "lanes cycle through tig's palette");
+        assert_eq!(
+            buffer[(16, 0)].fg,
+            Color::Magenta,
+            "the palette repeats after seven lanes"
+        );
+        assert!(
+            buffer[(16, 0)].modifier.contains(Modifier::BOLD),
+            "the second palette cycle is bold"
+        );
         Ok(())
     }
 

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use gix::bstr::ByteSlice;
 use ratatui::{
     Frame,
@@ -18,9 +20,13 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     app.ensure_visible();
     let start = app.offset.min(app.rows.len());
     let end = start.saturating_add(app.viewport_rows).min(app.rows.len());
+    let visible_rows = &app.rows[start..end];
+    let graph_width = ((body.width as usize) / 3).saturating_sub(2).max(1);
+    let graph_is_wide = visible_rows.iter().any(|row| row.lane.chars().count() > graph_width);
+    let pin_metadata = app.pin_metadata.unwrap_or(graph_is_wide);
     let show_committer_date = app.show_committer_date;
     let show_author_name = app.show_author_name;
-    let rows = app.rows[start..end].iter().map(|row| {
+    let rows = visible_rows.iter().map(|row| {
         let id = row.id.to_hex().to_string();
         let labels = decorations.get(&row.id).map(|labels| {
             labels
@@ -30,7 +36,7 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
                 .join(", ")
         });
         let mut spans = vec![
-            Span::raw(&row.lane),
+            Span::raw(lane_for_pane(&row.lane, graph_width, pin_metadata)),
             Span::styled(id[..7].to_owned(), Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(labels.map_or_else(|| " ".into(), |labels| format!(" ({labels}) "))),
         ];
@@ -65,11 +71,32 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     };
     frame.render_widget(
         Paragraph::new(format!(
-            "{} commits · {status} · ↑↓/jk move · d date · n name · y copy · Esc cancel · q quit",
+            "{} commits · {status} · ↑↓/jk move · [ pane · ] natural · d date · n name · y copy · Esc cancel · q quit",
             app.rows.len()
         )),
         footer,
     );
+}
+
+fn lane_for_pane(lane: &str, width: usize, pinned: bool) -> Cow<'_, str> {
+    if !pinned {
+        return Cow::Borrowed(lane);
+    }
+    let len = lane.chars().count();
+    let mut out = String::with_capacity(width);
+    if len > width {
+        out.extend(lane.chars().take(width.saturating_sub(2)));
+        if width > 1 {
+            out.push('…');
+            out.push(' ');
+        } else {
+            out.push('…');
+        }
+    } else {
+        out.push_str(lane);
+        out.extend(std::iter::repeat_n(' ', width - len));
+    }
+    Cow::Owned(out)
 }
 
 #[cfg(test)]
@@ -93,18 +120,18 @@ mod tests {
         }]);
         app.update(Action::Complete);
         let decorations = Decorations::from([(id, vec!["HEAD".into()])]);
-        let mut terminal = Terminal::new(TestBackend::new(90, 2))?;
+        let mut terminal = Terminal::new(TestBackend::new(120, 2))?;
 
         terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
 
         let mut expected = Buffer::with_lines([
-            format!("{:<90}", "> ● 0101010 (HEAD) 1970-01-01 author subject"),
+            format!("{:<120}", "> ● 0101010 (HEAD) 1970-01-01 author subject"),
             format!(
-                "{:<90}",
-                "1 commits · complete · ↑↓/jk move · d date · n name · y copy · Esc cancel · q quit"
+                "{:<120}",
+                "1 commits · complete · ↑↓/jk move · [ pane · ] natural · d date · n name · y copy · Esc cancel · q quit"
             ),
         ]);
-        for x in 0..90 {
+        for x in 0..120 {
             expected[(x, 0)].set_style(Style::default().add_modifier(Modifier::REVERSED));
         }
         for x in 4..11 {
@@ -115,10 +142,7 @@ mod tests {
         app.update(Action::ToggleDate);
         app.update(Action::ToggleName);
         terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
-        let row = (0..90).fold(String::new(), |mut out, x| {
-            out.push_str(terminal.backend().buffer()[(x, 0)].symbol());
-            out
-        });
+        let row = rendered_row(&terminal);
         assert!(!row.contains("1970-01-01"), "d hides the committer date");
         assert!(!row.contains("author"), "n hides the author name");
         assert!(row.contains("subject"), "the commit subject remains visible");
@@ -156,5 +180,46 @@ mod tests {
         assert_eq!(app.selected, Some(2), "drawing preserves the global selection");
         assert_eq!(app.offset, 1, "drawing preserves the global offset");
         Ok(())
+    }
+
+    #[test]
+    fn overlays_metadata_on_wide_graphs_and_allows_natural_flow() -> Result<(), Box<dyn std::error::Error>> {
+        let mut app = App::new(1);
+        app.extend_commits(vec![CommitRow {
+            id: gix::ObjectId::Sha1([1; 20]),
+            parent_ids: Default::default(),
+            lane: String::new(),
+            committer_time: gix::date::Time::default(),
+            author_name: "author".into(),
+            subject: "subject".into(),
+        }]);
+        app.update(Action::Complete);
+        app.rows[0].lane = "│".repeat(80);
+        let mut terminal = Terminal::new(TestBackend::new(60, 2))?;
+
+        terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
+        assert!(
+            rendered_row(&terminal).contains("0101010"),
+            "wide graphs automatically pin metadata"
+        );
+
+        app.update(Action::UnpinMetadata);
+        terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
+        assert!(
+            !rendered_row(&terminal).contains("0101010"),
+            "] restores natural post-graph placement"
+        );
+
+        app.update(Action::PinMetadata);
+        terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
+        assert!(rendered_row(&terminal).contains("0101010"), "[ pins metadata again");
+        Ok(())
+    }
+
+    fn rendered_row(terminal: &Terminal<TestBackend>) -> String {
+        (0..terminal.backend().buffer().area.width).fold(String::new(), |mut out, x| {
+            out.push_str(terminal.backend().buffer()[(x, 0)].symbol());
+            out
+        })
     }
 }

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -25,6 +25,7 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
                 .join(", ")
         });
         Line::from(vec![
+            Span::raw(&row.lane),
             Span::styled(id[..7].to_owned(), Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(labels.map_or_else(|| " ".into(), |labels| format!(" ({labels}) "))),
             Span::raw(row.subject.to_str_lossy()),
@@ -66,6 +67,8 @@ mod tests {
         let mut app = App::new(2);
         app.update(Action::Commit(CommitRow {
             id,
+            parent_ids: Default::default(),
+            lane: String::new(),
             subject: "subject".into(),
         }));
         app.update(Action::Complete);
@@ -75,13 +78,13 @@ mod tests {
         terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
 
         let mut expected = Buffer::with_lines([
-            "> 0101010 (HEAD) subject                             ",
+            "> ● 0101010 (HEAD) subject                           ",
             "1 commits · complete · ↑↓/jk move · y copy · Esc cance",
         ]);
         for x in 0..54 {
             expected[(x, 0)].set_style(Style::default().add_modifier(Modifier::REVERSED));
         }
-        for x in 2..9 {
+        for x in 4..11 {
             expected[(x, 0)].set_style(Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD));
         }
         terminal.backend().assert_buffer(&expected);

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -1,16 +1,14 @@
-use std::borrow::Cow;
-
 use gix::bstr::ByteSlice;
 use ratatui::{
     Frame,
-    layout::{Constraint, Layout},
+    layout::{Constraint, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{HighlightSpacing, List, ListState, Paragraph},
+    widgets::{Clear, Paragraph},
 };
 
 use crate::{
-    app::{App, State},
+    app::{App, CommitRow, State},
     history::Decorations,
 };
 
@@ -21,50 +19,96 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     let start = app.offset.min(app.rows.len());
     let end = start.saturating_add(app.viewport_rows).min(app.rows.len());
     let visible_rows = &app.rows[start..end];
-    let graph_width = ((body.width as usize) / 3).saturating_sub(2).max(1);
-    let graph_is_wide = visible_rows.iter().any(|row| row.lane.chars().count() > graph_width);
+    let content = Rect::new(
+        body.x.saturating_add(2),
+        body.y,
+        body.width.saturating_sub(2),
+        body.height,
+    );
+    let max_lane_width = visible_rows
+        .iter()
+        .map(|row| row.lane.trim_end().chars().count().saturating_add(1))
+        .max()
+        .unwrap_or_default();
+    let pane_limit = ((body.width as usize) / 3)
+        .saturating_sub(2)
+        .max(1)
+        .min(content.width as usize);
+    let pane_width = max_lane_width.min(pane_limit);
+    let graph_is_wide = max_lane_width > pane_limit;
     let pin_metadata = app.pin_metadata.unwrap_or(graph_is_wide);
     let show_committer_date = app.show_committer_date;
     let show_author_name = app.show_author_name;
     let show_special_refs = app.show_special_refs;
-    let rows = visible_rows.iter().map(|row| {
-        let id = row.id.to_hex().to_string();
-        let labels = decorations.get(&row.id).and_then(|labels| {
-            let labels = labels
-                .iter()
-                .filter(|decoration| show_special_refs || !decoration.special)
-                .map(|decoration| decoration.name.to_str_lossy())
-                .collect::<Vec<_>>()
-                .join(", ");
-            (!labels.is_empty()).then_some(labels)
-        });
-        let mut spans = vec![
-            Span::raw(lane_for_pane(&row.lane, graph_width, pin_metadata)),
-            Span::styled(id[..7].to_owned(), Style::default().add_modifier(Modifier::BOLD)),
-            Span::raw(labels.map_or_else(|| " ".into(), |labels| format!(" ({labels}) "))),
-        ];
-        if show_committer_date {
-            spans.push(Span::raw(format!(
-                "{} ",
-                row.committer_time.format_or_unix(gix::date::time::format::SHORT)
-            )));
+    let metadata: Vec<_> = visible_rows
+        .iter()
+        .map(|row| {
+            metadata_line(
+                row,
+                decorations,
+                show_committer_date,
+                show_author_name,
+                show_special_refs,
+            )
+        })
+        .collect();
+    let max_offset = if pin_metadata {
+        max_lane_width.saturating_sub(pane_width)
+    } else {
+        visible_rows
+            .iter()
+            .zip(&metadata)
+            .map(|(row, metadata)| row.lane.chars().count().saturating_add(metadata.width()))
+            .max()
+            .unwrap_or_default()
+            .saturating_sub(content.width as usize)
+    }
+    .min(u16::MAX as usize);
+    app.set_horizontal_bounds(content.width as usize, max_offset);
+    let horizontal_offset = app.horizontal_offset as u16;
+
+    let visible_rows = &app.rows[start..end];
+    for (index, (row, metadata)) in visible_rows.iter().zip(metadata).enumerate() {
+        let y = body.y.saturating_add(index as u16);
+        let selected = app.selected == Some(start + index);
+        let style = if selected {
+            Style::default().add_modifier(Modifier::REVERSED)
+        } else {
+            Style::default()
+        };
+        frame.render_widget(
+            Paragraph::new(if selected { "> " } else { "  " }).style(style),
+            Rect::new(body.x, y, body.width.min(2), 1),
+        );
+
+        let row_area = Rect::new(content.x, y, content.width, 1);
+        if pin_metadata {
+            frame.render_widget(
+                Paragraph::new(row.lane.as_str())
+                    .style(style)
+                    .scroll((0, horizontal_offset)),
+                row_area,
+            );
+            let pane = Rect::new(
+                content.x.saturating_add(pane_width as u16),
+                y,
+                content.width.saturating_sub(pane_width as u16),
+                1,
+            );
+            frame.render_widget(Clear, pane);
+            frame.render_widget(Paragraph::new(metadata).style(style), pane);
+        } else {
+            let mut spans = Vec::with_capacity(metadata.spans.len() + 1);
+            spans.push(Span::raw(row.lane.as_str()));
+            spans.extend(metadata.spans);
+            frame.render_widget(
+                Paragraph::new(Line::from(spans))
+                    .style(style)
+                    .scroll((0, horizontal_offset)),
+                row_area,
+            );
         }
-        if show_author_name {
-            spans.push(Span::raw(format!("{} ", row.author_name.to_str_lossy())));
-        }
-        spans.push(Span::raw(row.subject.to_str_lossy()));
-        Line::from(spans)
-    });
-    let list = List::new(rows)
-        .highlight_symbol("> ")
-        .highlight_spacing(HighlightSpacing::Always)
-        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
-    let selected = app
-        .selected
-        .and_then(|selected| selected.checked_sub(start))
-        .filter(|selected| *selected < end - start);
-    let mut state = ListState::default().with_selected(selected);
-    frame.render_stateful_widget(list, body, &mut state);
+    }
 
     let status = match app.state {
         State::Loading => "loading",
@@ -74,32 +118,45 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     };
     frame.render_widget(
         Paragraph::new(format!(
-            "{} commits · {status} · ↑↓/jk move · [ pane · ] natural · d date · n name · r refs · y copy · Esc cancel · q quit",
+            "{} commits · {status} · ↑↓/jk move · h/l pan · [ pane · ] natural · d date · n name · r refs · y copy · Esc cancel · q quit",
             app.rows.len()
         )),
         footer,
     );
 }
 
-fn lane_for_pane(lane: &str, width: usize, pinned: bool) -> Cow<'_, str> {
-    if !pinned {
-        return Cow::Borrowed(lane);
+fn metadata_line(
+    row: &CommitRow,
+    decorations: &Decorations,
+    show_committer_date: bool,
+    show_author_name: bool,
+    show_special_refs: bool,
+) -> Line<'static> {
+    let id = row.id.to_hex().to_string();
+    let labels = decorations.get(&row.id).and_then(|labels| {
+        let labels = labels
+            .iter()
+            .filter(|decoration| show_special_refs || !decoration.special)
+            .map(|decoration| decoration.name.to_str_lossy())
+            .collect::<Vec<_>>()
+            .join(", ");
+        (!labels.is_empty()).then_some(labels)
+    });
+    let mut spans = vec![
+        Span::styled(id[..7].to_owned(), Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(labels.map_or_else(|| " ".into(), |labels| format!(" ({labels}) "))),
+    ];
+    if show_committer_date {
+        spans.push(Span::raw(format!(
+            "{} ",
+            row.committer_time.format_or_unix(gix::date::time::format::SHORT)
+        )));
     }
-    let len = lane.chars().count();
-    let mut out = String::with_capacity(width);
-    if len > width {
-        out.extend(lane.chars().take(width.saturating_sub(2)));
-        if width > 1 {
-            out.push('…');
-            out.push(' ');
-        } else {
-            out.push('…');
-        }
-    } else {
-        out.push_str(lane);
-        out.extend(std::iter::repeat_n(' ', width - len));
+    if show_author_name {
+        spans.push(Span::raw(format!("{} ", row.author_name.to_str_lossy())));
     }
-    Cow::Owned(out)
+    spans.push(Span::raw(row.subject.to_str_lossy().into_owned()));
+    Line::from(spans)
 }
 
 #[cfg(test)]
@@ -146,7 +203,7 @@ mod tests {
             format!("{:<130}", "> ● 0101010 (HEAD) 1970-01-01 author subject"),
             format!(
                 "{:<130}",
-                "1 commits · complete · ↑↓/jk move · [ pane · ] natural · d date · n name · r refs · y copy · Esc cancel · q quit"
+                "1 commits · complete · ↑↓/jk move · h/l pan · [ pane · ] natural · d date · n name · r refs · y copy · Esc cancel · q quit"
             ),
         ]);
         for x in 0..130 {
@@ -217,15 +274,29 @@ mod tests {
             subject: "subject".into(),
         }]);
         app.update(Action::Complete);
-        app.rows[0].lane = "│".repeat(80);
+        app.rows[0].lane = format!("{}{}", "A".repeat(40), "B".repeat(40));
         let mut terminal = Terminal::new(TestBackend::new(60, 2))?;
 
         terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
+        let pane_column = rendered_row(&terminal)
+            .find("0101010")
+            .expect("wide graphs automatically pin metadata");
         assert!(
-            rendered_row(&terminal).contains("0101010"),
-            "wide graphs automatically pin metadata"
+            pane_column < 60,
+            "wide graphs automatically pin metadata within the viewport"
         );
 
+        app.update(Action::ScrollRight);
+        terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
+        assert_eq!(terminal.backend().buffer()[(2, 0)].symbol(), "B");
+        assert_eq!(
+            rendered_row(&terminal).find("0101010"),
+            Some(pane_column),
+            "horizontal graph scrolling leaves pinned metadata fixed"
+        );
+
+        app.update(Action::ScrollLeft);
+        terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
         app.update(Action::UnpinMetadata);
         terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
         assert!(
@@ -233,9 +304,21 @@ mod tests {
             "] restores natural post-graph placement"
         );
 
+        app.update(Action::ScrollRight);
+        terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
+        assert!(
+            rendered_row(&terminal).contains("0101010"),
+            "l pages far enough right to reveal natural metadata"
+        );
+
+        app.rows[0].lane = "● ".into();
         app.update(Action::PinMetadata);
         terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
-        assert!(rendered_row(&terminal).contains("0101010"), "[ pins metadata again");
+        assert_eq!(
+            terminal.backend().buffer()[(4, 0)].symbol(),
+            "0",
+            "the pane starts immediately after the widest visible lane"
+        );
         Ok(())
     }
 

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -15,7 +15,10 @@ use crate::{
 pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decorations) {
     let [body, footer] = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(frame.area());
     app.viewport_rows = body.height as usize;
-    let rows = app.rows.iter().map(|row| {
+    app.ensure_visible();
+    let start = app.offset.min(app.rows.len());
+    let end = start.saturating_add(app.viewport_rows).min(app.rows.len());
+    let rows = app.rows[start..end].iter().map(|row| {
         let id = row.id.to_hex().to_string();
         let labels = decorations.get(&row.id).map(|labels| {
             labels
@@ -35,9 +38,12 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
         .highlight_symbol("> ")
         .highlight_spacing(HighlightSpacing::Always)
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
-    let mut state = ListState::default().with_offset(app.offset).with_selected(app.selected);
+    let selected = app
+        .selected
+        .and_then(|selected| selected.checked_sub(start))
+        .filter(|selected| *selected < end - start);
+    let mut state = ListState::default().with_selected(selected);
     frame.render_stateful_widget(list, body, &mut state);
-    app.offset = state.offset();
 
     let status = match app.state {
         State::Loading => "loading",
@@ -88,6 +94,35 @@ mod tests {
             expected[(x, 0)].set_style(Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD));
         }
         terminal.backend().assert_buffer(&expected);
+        Ok(())
+    }
+
+    #[test]
+    fn renders_only_the_visible_rows() -> Result<(), Box<dyn std::error::Error>> {
+        let mut app = App::new(2);
+        for n in 1..=3 {
+            app.update(Action::Commit(CommitRow {
+                id: gix::ObjectId::Sha1([n; 20]),
+                parent_ids: Default::default(),
+                lane: String::new(),
+                subject: format!("subject {n}").into(),
+            }));
+        }
+        app.update(Action::Complete);
+        app.update(Action::Last);
+        let mut terminal = Terminal::new(TestBackend::new(24, 3))?;
+
+        terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(5, 0)].symbol(), "2", "the viewport starts at the second row");
+        assert_eq!(buffer[(5, 1)].symbol(), "3", "the selected third row remains visible");
+        assert!(
+            buffer[(0, 1)].modifier.contains(Modifier::REVERSED),
+            "the slice-local selection highlights the global selection"
+        );
+        assert_eq!(app.selected, Some(2), "drawing preserves the global selection");
+        assert_eq!(app.offset, 1, "drawing preserves the global offset");
         Ok(())
     }
 }

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -26,14 +26,17 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     let pin_metadata = app.pin_metadata.unwrap_or(graph_is_wide);
     let show_committer_date = app.show_committer_date;
     let show_author_name = app.show_author_name;
+    let show_special_refs = app.show_special_refs;
     let rows = visible_rows.iter().map(|row| {
         let id = row.id.to_hex().to_string();
-        let labels = decorations.get(&row.id).map(|labels| {
-            labels
+        let labels = decorations.get(&row.id).and_then(|labels| {
+            let labels = labels
                 .iter()
-                .map(|label| label.to_str_lossy())
+                .filter(|decoration| show_special_refs || !decoration.special)
+                .map(|decoration| decoration.name.to_str_lossy())
                 .collect::<Vec<_>>()
-                .join(", ")
+                .join(", ");
+            (!labels.is_empty()).then_some(labels)
         });
         let mut spans = vec![
             Span::raw(lane_for_pane(&row.lane, graph_width, pin_metadata)),
@@ -71,7 +74,7 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     };
     frame.render_widget(
         Paragraph::new(format!(
-            "{} commits · {status} · ↑↓/jk move · [ pane · ] natural · d date · n name · y copy · Esc cancel · q quit",
+            "{} commits · {status} · ↑↓/jk move · [ pane · ] natural · d date · n name · r refs · y copy · Esc cancel · q quit",
             app.rows.len()
         )),
         footer,
@@ -104,7 +107,10 @@ mod tests {
     use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
 
     use super::*;
-    use crate::app::{Action, CommitRow};
+    use crate::{
+        app::{Action, CommitRow},
+        history::Decoration,
+    };
 
     #[test]
     fn renders_rows_decorations_selection_and_footer() -> Result<(), Box<dyn std::error::Error>> {
@@ -119,19 +125,31 @@ mod tests {
             subject: "subject".into(),
         }]);
         app.update(Action::Complete);
-        let decorations = Decorations::from([(id, vec!["HEAD".into()])]);
-        let mut terminal = Terminal::new(TestBackend::new(120, 2))?;
+        let decorations = Decorations::from([(
+            id,
+            vec![
+                Decoration {
+                    name: "HEAD".into(),
+                    special: false,
+                },
+                Decoration {
+                    name: "refs/patches/main/patch".into(),
+                    special: true,
+                },
+            ],
+        )]);
+        let mut terminal = Terminal::new(TestBackend::new(130, 2))?;
 
         terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
 
         let mut expected = Buffer::with_lines([
-            format!("{:<120}", "> ● 0101010 (HEAD) 1970-01-01 author subject"),
+            format!("{:<130}", "> ● 0101010 (HEAD) 1970-01-01 author subject"),
             format!(
-                "{:<120}",
-                "1 commits · complete · ↑↓/jk move · [ pane · ] natural · d date · n name · y copy · Esc cancel · q quit"
+                "{:<130}",
+                "1 commits · complete · ↑↓/jk move · [ pane · ] natural · d date · n name · r refs · y copy · Esc cancel · q quit"
             ),
         ]);
-        for x in 0..120 {
+        for x in 0..130 {
             expected[(x, 0)].set_style(Style::default().add_modifier(Modifier::REVERSED));
         }
         for x in 4..11 {
@@ -145,7 +163,12 @@ mod tests {
         let row = rendered_row(&terminal);
         assert!(!row.contains("1970-01-01"), "d hides the committer date");
         assert!(!row.contains("author"), "n hides the author name");
+        assert!(!row.contains("refs/patches"), "special refs are hidden until requested");
         assert!(row.contains("subject"), "the commit subject remains visible");
+
+        app.update(Action::ToggleSpecialRefs);
+        terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
+        assert!(rendered_row(&terminal).contains("refs/patches"), "r shows special refs");
         Ok(())
     }
 

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -18,6 +18,8 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     app.ensure_visible();
     let start = app.offset.min(app.rows.len());
     let end = start.saturating_add(app.viewport_rows).min(app.rows.len());
+    let show_committer_date = app.show_committer_date;
+    let show_author_name = app.show_author_name;
     let rows = app.rows[start..end].iter().map(|row| {
         let id = row.id.to_hex().to_string();
         let labels = decorations.get(&row.id).map(|labels| {
@@ -27,12 +29,22 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
                 .collect::<Vec<_>>()
                 .join(", ")
         });
-        Line::from(vec![
+        let mut spans = vec![
             Span::raw(&row.lane),
             Span::styled(id[..7].to_owned(), Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(labels.map_or_else(|| " ".into(), |labels| format!(" ({labels}) "))),
-            Span::raw(row.subject.to_str_lossy()),
-        ])
+        ];
+        if show_committer_date {
+            spans.push(Span::raw(format!(
+                "{} ",
+                row.committer_time.format_or_unix(gix::date::time::format::SHORT)
+            )));
+        }
+        if show_author_name {
+            spans.push(Span::raw(format!("{} ", row.author_name.to_str_lossy())));
+        }
+        spans.push(Span::raw(row.subject.to_str_lossy()));
+        Line::from(spans)
     });
     let list = List::new(rows)
         .highlight_symbol("> ")
@@ -53,7 +65,7 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     };
     frame.render_widget(
         Paragraph::new(format!(
-            "{} commits · {status} · ↑↓/jk move · y copy · Esc cancel · q quit",
+            "{} commits · {status} · ↑↓/jk move · d date · n name · y copy · Esc cancel · q quit",
             app.rows.len()
         )),
         footer,
@@ -75,25 +87,41 @@ mod tests {
             id,
             parent_ids: Default::default(),
             lane: String::new(),
+            committer_time: gix::date::Time::default(),
+            author_name: "author".into(),
             subject: "subject".into(),
         }]);
         app.update(Action::Complete);
         let decorations = Decorations::from([(id, vec!["HEAD".into()])]);
-        let mut terminal = Terminal::new(TestBackend::new(54, 2))?;
+        let mut terminal = Terminal::new(TestBackend::new(90, 2))?;
 
         terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
 
         let mut expected = Buffer::with_lines([
-            "> ● 0101010 (HEAD) subject                           ",
-            "1 commits · complete · ↑↓/jk move · y copy · Esc cance",
+            format!("{:<90}", "> ● 0101010 (HEAD) 1970-01-01 author subject"),
+            format!(
+                "{:<90}",
+                "1 commits · complete · ↑↓/jk move · d date · n name · y copy · Esc cancel · q quit"
+            ),
         ]);
-        for x in 0..54 {
+        for x in 0..90 {
             expected[(x, 0)].set_style(Style::default().add_modifier(Modifier::REVERSED));
         }
         for x in 4..11 {
             expected[(x, 0)].set_style(Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD));
         }
         terminal.backend().assert_buffer(&expected);
+
+        app.update(Action::ToggleDate);
+        app.update(Action::ToggleName);
+        terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
+        let row = (0..90).fold(String::new(), |mut out, x| {
+            out.push_str(terminal.backend().buffer()[(x, 0)].symbol());
+            out
+        });
+        assert!(!row.contains("1970-01-01"), "d hides the committer date");
+        assert!(!row.contains("author"), "n hides the author name");
+        assert!(row.contains("subject"), "the commit subject remains visible");
         Ok(())
     }
 
@@ -106,6 +134,8 @@ mod tests {
                     id: gix::ObjectId::Sha1([n; 20]),
                     parent_ids: Default::default(),
                     lane: String::new(),
+                    committer_time: gix::date::Time::default(),
+                    author_name: "author".into(),
                     subject: format!("subject {n}").into(),
                 })
                 .collect(),

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -1,0 +1,82 @@
+use gix::bstr::ByteSlice;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{HighlightSpacing, List, ListState, Paragraph},
+};
+
+use crate::{
+    app::{App, State},
+    history::Decorations,
+};
+
+pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decorations) {
+    let [body, footer] = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(frame.area());
+    app.viewport_rows = body.height as usize;
+    let rows = app.rows.iter().map(|row| {
+        let id = row.id.to_hex().to_string();
+        let labels = decorations.get(&row.id).map(|labels| {
+            labels.iter().map(|label| label.to_str_lossy()).collect::<Vec<_>>().join(", ")
+        });
+        Line::from(vec![
+            Span::styled(id[..7].to_owned(), Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(labels.map_or_else(|| " ".into(), |labels| format!(" ({labels}) "))),
+            Span::raw(row.subject.to_str_lossy()),
+        ])
+    });
+    let list = List::new(rows)
+        .highlight_symbol("> ")
+        .highlight_spacing(HighlightSpacing::Always)
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+    let mut state = ListState::default().with_offset(app.offset).with_selected(app.selected);
+    frame.render_stateful_widget(list, body, &mut state);
+    app.offset = state.offset();
+
+    let status = match app.state {
+        State::Loading => "loading",
+        State::Cancelling => "cancelling",
+        State::Complete => "complete",
+        State::Cancelled => "cancelled",
+    };
+    frame.render_widget(
+        Paragraph::new(format!("{} commits · {status} · ↑↓/jk move · y copy · Esc cancel · q quit", app.rows.len())),
+        footer,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
+
+    use super::*;
+    use crate::app::{Action, CommitRow};
+
+    #[test]
+    fn renders_rows_decorations_selection_and_footer() -> Result<(), Box<dyn std::error::Error>> {
+        let id = gix::ObjectId::Sha1([1; 20]);
+        let mut app = App::new(2);
+        app.update(Action::Commit(CommitRow { id, subject: "subject".into() }));
+        app.update(Action::Complete);
+        let decorations = Decorations::from([(id, vec!["HEAD".into()])]);
+        let mut terminal = Terminal::new(TestBackend::new(54, 2))?;
+
+        terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
+
+        let mut expected = Buffer::with_lines([
+            "> 0101010 (HEAD) subject                             ",
+            "1 commits · complete · ↑↓/jk move · y copy · Esc cance",
+        ]);
+        for x in 0..54 {
+            expected[(x, 0)].set_style(Style::default().add_modifier(Modifier::REVERSED));
+        }
+        for x in 2..9 {
+            expected[(x, 0)].set_style(
+                Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD),
+            );
+        }
+        terminal.backend().assert_buffer(&expected);
+        Ok(())
+    }
+}

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -1,4 +1,4 @@
-use gix::bstr::ByteSlice;
+use gix::bstr::{BStr, ByteSlice};
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
@@ -47,6 +47,7 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
         .map(|(index, row)| {
             metadata_line(
                 row,
+                app.title(row),
                 decorations,
                 show_committer_date,
                 show_author_name,
@@ -67,8 +68,7 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
             .saturating_sub(content.width as usize)
     }
     .min(u16::MAX as usize);
-    app.set_horizontal_bounds(content.width as usize, max_offset);
-    let horizontal_offset = app.horizontal_offset as u16;
+    let horizontal_offset = app.horizontal_offset.min(max_offset) as u16;
 
     let visible_rows = &app.rows[start..end];
     for (index, (row, metadata)) in visible_rows.iter().zip(metadata).enumerate() {
@@ -114,6 +114,7 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
             color_graph(frame, row_area, &row.lane, horizontal_offset as usize, selected);
         }
     }
+    app.set_horizontal_bounds(content.width as usize, max_offset);
 
     let status = match app.state {
         State::Loading => "loading",
@@ -130,14 +131,15 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     );
 }
 
-fn metadata_line(
+fn metadata_line<'a>(
     row: &CommitRow,
-    decorations: &Decorations,
+    title: &'a BStr,
+    decorations: &'a Decorations,
     show_committer_date: bool,
     show_author_name: bool,
     show_special_refs: bool,
     selected: bool,
-) -> Line<'static> {
+) -> Line<'a> {
     let id = row.id.to_hex().to_string();
     let mut spans = vec![Span::styled(
         id[..7].to_owned(),
@@ -156,7 +158,7 @@ fn metadata_line(
                 spans.push(Span::raw(", "));
             }
             spans.push(Span::styled(
-                decoration.name.to_str_lossy().into_owned(),
+                decoration.name.to_str_lossy(),
                 decoration_style(decoration.kind, selected),
             ));
         }
@@ -176,7 +178,7 @@ fn metadata_line(
             color(Color::Green, selected),
         ));
     }
-    spans.push(Span::raw(row.subject.to_str_lossy().into_owned()));
+    spans.push(Span::raw(title.to_str_lossy()));
     Line::from(spans)
 }
 
@@ -244,7 +246,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        app::{Action, CommitRow},
+        app::{Action, Commit},
         history::{Decoration, DecorationKind},
     };
 
@@ -252,13 +254,13 @@ mod tests {
     fn renders_rows_decorations_selection_and_footer() -> Result<(), Box<dyn std::error::Error>> {
         let id = gix::ObjectId::Sha1([1; 20]);
         let mut app = App::new(2);
-        app.extend_commits(vec![CommitRow {
+        app.extend_commits(vec![Commit {
             id,
             parent_ids: Default::default(),
             lane: String::new(),
             committer_time: gix::date::Time::default(),
             author_name: "author".into(),
-            subject: "subject".into(),
+            title: "subject".into(),
         }]);
         app.update(Action::Complete);
         let decorations = Decorations::from([(
@@ -313,13 +315,13 @@ mod tests {
         let mut app = App::new(2);
         app.extend_commits(
             (1..=3)
-                .map(|n| CommitRow {
+                .map(|n| Commit {
                     id: gix::ObjectId::Sha1([n; 20]),
                     parent_ids: Default::default(),
                     lane: String::new(),
                     committer_time: gix::date::Time::default(),
                     author_name: "author".into(),
-                    subject: format!("subject {n}").into(),
+                    title: format!("subject {n}").into(),
                 })
                 .collect(),
         );
@@ -344,13 +346,13 @@ mod tests {
     #[test]
     fn uses_the_tig_palette_without_coloring_the_selection() -> Result<(), Box<dyn std::error::Error>> {
         let id = gix::ObjectId::Sha1([1; 20]);
-        let row = CommitRow {
+        let commit = Commit {
             id,
             parent_ids: Default::default(),
             lane: "● │ │ │ │ │ │ │ ".into(),
             committer_time: gix::date::Time::default(),
             author_name: "author".into(),
-            subject: "subject".into(),
+            title: "subject".into(),
         };
         let decorations = Decorations::from([(
             id,
@@ -377,7 +379,10 @@ mod tests {
                 },
             ],
         )]);
-        let line = metadata_line(&row, &decorations, true, true, true, false);
+        let mut app = App::new(1);
+        app.extend_commits(vec![commit]);
+        let row = &app.rows[0];
+        let line = metadata_line(row, app.title(row), &decorations, true, true, true, false);
         let style = |text| {
             line.spans
                 .iter()
@@ -403,8 +408,6 @@ mod tests {
         );
         assert_eq!(style("refs/stash"), Style::default().fg(Color::Blue));
 
-        let mut app = App::new(1);
-        app.extend_commits(vec![row]);
         app.selected = None;
         let mut terminal = Terminal::new(TestBackend::new(80, 2))?;
         terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
@@ -426,13 +429,13 @@ mod tests {
     #[test]
     fn overlays_metadata_on_wide_graphs_and_allows_natural_flow() -> Result<(), Box<dyn std::error::Error>> {
         let mut app = App::new(1);
-        app.extend_commits(vec![CommitRow {
+        app.extend_commits(vec![Commit {
             id: gix::ObjectId::Sha1([1; 20]),
             parent_ids: Default::default(),
             lane: String::new(),
             committer_time: gix::date::Time::default(),
             author_name: "author".into(),
-            subject: "subject".into(),
+            title: "subject".into(),
         }]);
         app.update(Action::Complete);
         app.rows[0].lane = format!("{}{}", "A".repeat(40), "B".repeat(40));

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -18,7 +18,11 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     let rows = app.rows.iter().map(|row| {
         let id = row.id.to_hex().to_string();
         let labels = decorations.get(&row.id).map(|labels| {
-            labels.iter().map(|label| label.to_str_lossy()).collect::<Vec<_>>().join(", ")
+            labels
+                .iter()
+                .map(|label| label.to_str_lossy())
+                .collect::<Vec<_>>()
+                .join(", ")
         });
         Line::from(vec![
             Span::styled(id[..7].to_owned(), Style::default().add_modifier(Modifier::BOLD)),
@@ -41,7 +45,10 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
         State::Cancelled => "cancelled",
     };
     frame.render_widget(
-        Paragraph::new(format!("{} commits · {status} · ↑↓/jk move · y copy · Esc cancel · q quit", app.rows.len())),
+        Paragraph::new(format!(
+            "{} commits · {status} · ↑↓/jk move · y copy · Esc cancel · q quit",
+            app.rows.len()
+        )),
         footer,
     );
 }
@@ -57,7 +64,10 @@ mod tests {
     fn renders_rows_decorations_selection_and_footer() -> Result<(), Box<dyn std::error::Error>> {
         let id = gix::ObjectId::Sha1([1; 20]);
         let mut app = App::new(2);
-        app.update(Action::Commit(CommitRow { id, subject: "subject".into() }));
+        app.update(Action::Commit(CommitRow {
+            id,
+            subject: "subject".into(),
+        }));
         app.update(Action::Complete);
         let decorations = Decorations::from([(id, vec!["HEAD".into()])]);
         let mut terminal = Terminal::new(TestBackend::new(54, 2))?;
@@ -72,9 +82,7 @@ mod tests {
             expected[(x, 0)].set_style(Style::default().add_modifier(Modifier::REVERSED));
         }
         for x in 2..9 {
-            expected[(x, 0)].set_style(
-                Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD),
-            );
+            expected[(x, 0)].set_style(Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD));
         }
         terminal.backend().assert_buffer(&expected);
         Ok(())

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -122,9 +122,18 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
         State::Complete => "complete",
         State::Cancelled => "cancelled",
     };
+    let hidden = if app.has_hidden_filter {
+        if app.show_hidden {
+            " · v hide hidden"
+        } else {
+            " · v show hidden"
+        }
+    } else {
+        ""
+    };
     frame.render_widget(
         Paragraph::new(format!(
-            "{} commits · {status} · ↑↓/jk move · h/l pan · [ pane · ] natural · d date · n name · r refs · y copy · Esc cancel · q quit",
+            "{} commits · {status}{hidden} · ↑↓/jk move · h/l pan · [ pane · ] natural · d date · n name · r refs · y copy · Esc cancel · q quit",
             app.rows.len()
         )),
         footer,
@@ -307,6 +316,19 @@ mod tests {
         app.update(Action::ToggleSpecialRefs);
         terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
         assert!(rendered_row(&terminal).contains("refs/patches"), "r shows special refs");
+
+        app.has_hidden_filter = true;
+        terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
+        assert!(
+            rendered_line(&terminal, 1).contains("v show hidden"),
+            "the footer advertises the configured hidden-history toggle"
+        );
+        app.show_hidden = true;
+        terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
+        assert!(
+            rendered_line(&terminal, 1).contains("v hide hidden"),
+            "the footer reflects the unfiltered view"
+        );
         Ok(())
     }
 
@@ -487,8 +509,12 @@ mod tests {
     }
 
     fn rendered_row(terminal: &Terminal<TestBackend>) -> String {
+        rendered_line(terminal, 0)
+    }
+
+    fn rendered_line(terminal: &Terminal<TestBackend>, y: u16) -> String {
         (0..terminal.backend().buffer().area.width).fold(String::new(), |mut out, x| {
-            out.push_str(terminal.backend().buffer()[(x, 0)].symbol());
+            out.push_str(terminal.backend().buffer()[(x, y)].symbol());
             out
         })
     }

--- a/gix-tix/tests/fixtures/history.sh
+++ b/gix-tix/tests/fixtures/history.sh
@@ -22,3 +22,6 @@ git merge -q --no-edit merged
 git switch -q -c topic HEAD~1
 commit topic "2000-01-04T00:00:00"
 git switch -q main
+
+# Decorations are optional, so this unrelated stale remote HEAD must not break history loading.
+git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/missing

--- a/gix-tix/tests/fixtures/history.sh
+++ b/gix-tix/tests/fixtures/history.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+# A merge plus an unmerged topic makes multi-tip reachability and de-duplication observable.
+git init -q -b main .
+git config user.name author
+git config user.email author@example.com
+
+commit () {
+  echo "$1" >"$1"
+  git add "$1"
+  GIT_AUTHOR_DATE="$2 +0000" GIT_COMMITTER_DATE="$2 +0000" git commit -q -m "$1"
+}
+
+commit root "2000-01-01T00:00:00"
+git tag -a v1 -m v1
+git switch -q -c merged
+commit merged "2000-01-02T00:00:00"
+git switch -q main
+commit main "2000-01-03T00:00:00"
+git merge -q --no-edit merged
+git switch -q -c topic HEAD~1
+commit topic "2000-01-04T00:00:00"
+git switch -q main

--- a/gix/src/diff.rs
+++ b/gix/src/diff.rs
@@ -7,7 +7,7 @@ pub mod options {
     pub mod init {
         /// The error returned when instantiating [diff options](crate::diff::Options).
         #[derive(Debug, thiserror::Error)]
-        #[expect(missing_docs)]
+        #[cfg_attr(feature = "blob-diff", expect(missing_docs))]
         pub enum Error {
             #[cfg(feature = "blob-diff")]
             #[error(transparent)]

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -159,12 +159,14 @@ pub fn main() -> Result<()> {
     match cmd {
         #[cfg(feature = "tix")]
         Subcommands::Tix {
+            help: _,
             quit_on_finish,
+            hide,
             revisions,
         } => gix_tix::run(
             repository(Mode::Lenient)?.into_sync(),
             revisions,
-            gix_tix::Options { quit_on_finish },
+            gix_tix::Options { quit_on_finish, hide },
         ),
         Subcommands::Env => prepare_and_run(
             "env",
@@ -1855,5 +1857,20 @@ mod tests {
                 "{name} routes to the tix command"
             );
         }
+
+        let args = Args::try_parse_from(["gix", "tix", "-h", "main", "--hide", "tag", "topic"])
+            .expect("hide options and a visible revision parse");
+        let Subcommands::Tix { hide, revisions, .. } = args.cmd else {
+            panic!("tix arguments route to tix")
+        };
+        assert_eq!(hide, ["main", "tag"], "short and long hide options append");
+        assert_eq!(revisions, ["topic"], "positional revisions remain visible tips");
+        assert_eq!(
+            Args::try_parse_from(["gix", "tix", "--help"])
+                .expect_err("help exits through clap")
+                .kind(),
+            clap::error::ErrorKind::DisplayHelp,
+            "long help remains available while -h belongs to hide"
+        );
     }
 }

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -157,6 +157,15 @@ pub fn main() -> Result<()> {
     }
 
     match cmd {
+        #[cfg(feature = "tix")]
+        Subcommands::Tix {
+            quit_on_finish,
+            revisions,
+        } => gix_tix::run(
+            repository(Mode::Lenient)?.into_sync(),
+            revisions,
+            gix_tix::Options { quit_on_finish },
+        ),
         Subcommands::Env => prepare_and_run(
             "env",
             trace,
@@ -1825,5 +1834,26 @@ mod tests {
     fn clap() {
         use clap::CommandFactory;
         Args::command().debug_assert();
+    }
+
+    #[test]
+    #[cfg(feature = "tix")]
+    fn tix_aliases_are_visible_and_route_to_tix() {
+        use clap::{CommandFactory, Parser};
+
+        let command = Args::command();
+        let tix = command.find_subcommand("tix").expect("tix is registered");
+        assert_eq!(
+            tix.get_visible_aliases().collect::<Vec<_>>(),
+            ["tui", "interactive", "i"],
+            "all aliases are shown in help"
+        );
+        for name in ["tix", "tui", "interactive", "i"] {
+            let args = Args::try_parse_from(["gix", name]).expect("the command or alias parses");
+            assert!(
+                matches!(args.cmd, Subcommands::Tix { .. }),
+                "{name} routes to the tix command"
+            );
+        }
     }
 }

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -165,11 +165,22 @@ pub enum Subcommands {
     Log(log::Platform),
     /// Interactively browse commits and their graph.
     #[cfg(feature = "tix")]
-    #[clap(visible_alias = "tui", visible_alias = "interactive", visible_alias = "i")]
+    #[clap(
+        visible_alias = "tui",
+        visible_alias = "interactive",
+        visible_alias = "i",
+        disable_help_flag = true
+    )]
     Tix {
+        /// Print help.
+        #[clap(long, action = clap::ArgAction::HelpLong)]
+        help: Option<bool>,
         /// Exit once all commits and graph lanes have been computed.
         #[clap(long)]
         quit_on_finish: bool,
+        /// Hide this revision and every commit reachable from it.
+        #[clap(short = 'h', long, value_name = "REVSPEC")]
+        hide: Vec<std::ffi::OsString>,
         /// Revisions whose reachable commits should be shown, or HEAD if omitted.
         revisions: Vec<std::ffi::OsString>,
     },

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -163,6 +163,16 @@ pub enum Subcommands {
     Env,
     Diff(diff::Platform),
     Log(log::Platform),
+    /// Interactively browse commits and their graph.
+    #[cfg(feature = "tix")]
+    #[clap(visible_alias = "tui", visible_alias = "interactive", visible_alias = "i")]
+    Tix {
+        /// Exit once all commits and graph lanes have been computed.
+        #[clap(long)]
+        quit_on_finish: bool,
+        /// Revisions whose reachable commits should be shown, or HEAD if omitted.
+        revisions: Vec<std::ffi::OsString>,
+    },
     Worktree(worktree::Platform),
     /// Subcommands that need no Git repository to run.
     #[clap(subcommand)]


### PR DESCRIPTION
This is the first officially 'vibed' crate just to get something usable quickly. I won't look at the code at all, but also clearly mark it as "agent-maintained".

## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] functional review

----

Everything below this line was generated by GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- turn `gix-tix` into the installed `tix` binary
- stream commits reachable from HEAD or multiple explicit revision tips without blocking terminal input
- render commit subjects, refs, progress, selection, and status with Ratatui
- support paging, newest/oldest jumps, cancellation, and OSC52 copying of the full selected object ID
- keep application state and rendering independently testable

Fixes #325

## Validation

- `cargo test -p gix-tix`
- `cargo clippy -p gix-tix --all-targets -- -D warnings`
- `cargo check -p gix-tix`
- `cargo build --release -p gix-tix`
- fixture reachability compared as a set with `git rev-list` for multiple tips; ordering intentionally need not match

## Linux checkout observations

On `/Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux` at 1,352,640 reachable commits:

- first paint and scripted quit: at most 0.11s
- tix history walker: 7.24s, 1,148,321,792 bytes maximum RSS
- `git rev-list --count HEAD`: 0.61s, 281,296,896 bytes maximum RSS
- `git log --oneline --decorate`: 14.55s, 1,253,752,832 bytes maximum RSS

These are post-implementation observations, not optimization thresholds.