### PR TITLE
Reject terminal symlinks during checkout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,7 +2665,6 @@ dependencies = [
  "gix-worktree",
  "gix-worktree-state",
  "io-close",
- "symlink",
  "thiserror 2.0.18",
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,7 +2644,6 @@ dependencies = [
  "gix-testtools",
  "gix-validate",
  "serde",
- "symlink",
 ]
 
 [[package]]
@@ -4927,12 +4926,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -45,7 +45,6 @@ gix-hash = { path = "../gix-hash", features = ["sha256"] }
 gix-fs = { path = "../gix-fs" }
 gix-testtools = { path = "../tests/tools", default-features = false }
 gix-odb = { path = "../gix-odb" }
-symlink = "0.1.0"
 walkdir = "2.3.2"
 
 [package.metadata.docs.rs]

--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -203,6 +203,16 @@ fn try_op_or_unlink<T>(
     overwrite_existing: bool,
     op: impl Fn(&Path) -> std::io::Result<T>,
 ) -> std::io::Result<T> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() && overwrite_existing => {
+            try_unlink_path_recursively(path, &meta)?;
+        }
+        Ok(meta) if meta.file_type().is_symlink() => return Err(std::io::ErrorKind::AlreadyExists.into()),
+        Ok(_) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err),
+    }
+
     if overwrite_existing {
         match op(path) {
             Ok(res) => Ok(res),
@@ -359,6 +369,54 @@ pub(crate) enum ExecutableBitChange {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn operations_never_receive_terminal_symlinks() -> gix_testtools::Result {
+        let dir = gix_testtools::tempfile::tempdir()?;
+        let target = dir.path().join("target");
+        std::fs::write(&target, b"untouched")?;
+
+        for (name, overwrite_existing) in [("forbidden", false), ("forced", true)] {
+            let link = dir.path().join(name);
+            gix_fs::symlink::create(&target, &link)?;
+            let operation_called = std::cell::Cell::new(false);
+            let result = super::try_op_or_unlink(&link, overwrite_existing, |path| {
+                operation_called.set(true);
+                match path.symlink_metadata() {
+                    Ok(meta) => assert!(
+                        !meta.file_type().is_symlink(),
+                        "the operation must not receive a symlink"
+                    ),
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(err) => return Err(err),
+                }
+                Ok(())
+            });
+
+            if overwrite_existing {
+                result?;
+                assert!(
+                    operation_called.get(),
+                    "the operation should run after removing the symlink"
+                );
+            } else {
+                assert_eq!(
+                    result.expect_err("the symlink must be rejected").kind(),
+                    std::io::ErrorKind::AlreadyExists
+                );
+                assert!(
+                    !operation_called.get(),
+                    "the operation must not run for a forbidden symlink"
+                );
+            }
+            assert_eq!(
+                std::fs::read(&target)?,
+                b"untouched",
+                "the symlink target must stay unchanged"
+            );
+        }
+        Ok(())
+    }
+
     #[test]
     fn let_readers_execute() {
         let cases = [

--- a/gix-worktree-state/src/checkout/entry.rs
+++ b/gix-worktree-state/src/checkout/entry.rs
@@ -167,7 +167,7 @@ where
                 })?;
             } else {
                 let mut file = try_op_or_unlink(dest, overwrite_existing, |p| {
-                    open_options(p, destination_is_initially_empty, overwrite_existing).open(dest)
+                    open_options(destination_is_initially_empty, overwrite_existing).open(p)
                 })?;
                 file.write_all(obj.data)?;
                 file.close()?;
@@ -198,32 +198,39 @@ where
 /// Note that this works only because we assume to not race ourselves when symlinks are involved, and we do this by
 /// delaying symlink creation to the end and will always do that sequentially.
 /// It's still possible to fall for a race if other actors create symlinks in our path, but that's nothing to defend against.
+///
+/// Without overwrite permission, the worktree stack delegate rejects terminal symlinks for incremental checkout,
+/// while checkout into an empty destination uses exclusive creation.
+/// With overwrite permission, Windows checks here instead so a symlink is only removed once the replacement operation is ready.
+/// Other platforms rely on no-follow operations and inspect the path only after a collision.
 fn try_op_or_unlink<T>(
     path: &Path,
     overwrite_existing: bool,
     op: impl Fn(&Path) -> std::io::Result<T>,
 ) -> std::io::Result<T> {
-    match std::fs::symlink_metadata(path) {
-        Ok(meta) if meta.file_type().is_symlink() && overwrite_existing => {
-            try_unlink_path_recursively(path, &meta)?;
-        }
-        Ok(meta) if meta.file_type().is_symlink() => return Err(std::io::ErrorKind::AlreadyExists.into()),
-        Ok(_) => {}
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) => return Err(err),
+    if !overwrite_existing {
+        return op(path);
     }
 
-    if overwrite_existing {
-        match op(path) {
-            Ok(res) => Ok(res),
-            Err(err) if gix_fs::symlink::is_collision_error(&err) => {
-                try_unlink_path_recursively(path, &std::fs::symlink_metadata(path)?)?;
-                op(path)
+    #[cfg(windows)]
+    {
+        match std::fs::symlink_metadata(path) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                try_unlink_path_recursively(path, &meta)?;
             }
-            Err(err) => Err(err),
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
         }
-    } else {
-        op(path)
+    }
+
+    match op(path) {
+        Ok(res) => Ok(res),
+        Err(err) if gix_fs::symlink::is_collision_error(&err) => {
+            try_unlink_path_recursively(path, &std::fs::symlink_metadata(path)?)?;
+            op(path)
+        }
+        Err(err) => Err(err),
     }
 }
 
@@ -237,25 +244,7 @@ fn try_unlink_path_recursively(path: &Path, path_meta: &std::fs::Metadata) -> st
     }
 }
 
-#[cfg(not(debug_assertions))]
-fn debug_assert_dest_is_no_symlink(_path: &Path) {}
-
-/// This is a debug assertion as we expect the machinery calling this to prevent this possibility in the first place
-#[cfg(debug_assertions)]
-fn debug_assert_dest_is_no_symlink(path: &Path) {
-    if let Ok(meta) = path.metadata() {
-        debug_assert!(
-            !meta.file_type().is_symlink(),
-            "BUG: should not ever allow to overwrite/write-into the target of a symbolic link: {}",
-            path.display()
-        );
-    }
-}
-
-fn open_options(path: &Path, destination_is_initially_empty: bool, overwrite_existing: bool) -> std::fs::OpenOptions {
-    if overwrite_existing || !destination_is_initially_empty {
-        debug_assert_dest_is_no_symlink(path);
-    }
+fn open_options(destination_is_initially_empty: bool, overwrite_existing: bool) -> std::fs::OpenOptions {
     let mut options = gix_features::fs::open_options_no_follow();
     options
         .create_new(destination_is_initially_empty && !overwrite_existing)
@@ -273,7 +262,7 @@ pub(crate) fn open_file(
     entry_mode: gix_index::entry::Mode,
 ) -> std::io::Result<(std::fs::File, ExecutableBitChange)> {
     #[cfg_attr(windows, allow(unused_mut))]
-    let mut options = open_options(path, destination_is_initially_empty, overwrite_existing);
+    let mut options = open_options(destination_is_initially_empty, overwrite_existing);
     let needs_executable_bit = fs_supports_executable_bit && entry_mode == gix_index::entry::Mode::FILE_EXECUTABLE;
     #[cfg(unix)]
     let executable_bit_change = if needs_executable_bit && destination_is_initially_empty {
@@ -370,50 +359,29 @@ pub(crate) enum ExecutableBitChange {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn operations_never_receive_terminal_symlinks() -> gix_testtools::Result {
+    #[cfg(windows)]
+    fn forced_operations_never_receive_terminal_symlinks() -> gix_testtools::Result {
         let dir = gix_testtools::tempfile::tempdir()?;
         let target = dir.path().join("target");
+        let link = dir.path().join("link");
         std::fs::write(&target, b"untouched")?;
-
-        for (name, overwrite_existing) in [("forbidden", false), ("forced", true)] {
-            let link = dir.path().join(name);
-            gix_fs::symlink::create(&target, &link)?;
-            let operation_called = std::cell::Cell::new(false);
-            let result = super::try_op_or_unlink(&link, overwrite_existing, |path| {
-                operation_called.set(true);
-                match path.symlink_metadata() {
-                    Ok(meta) => assert!(
-                        !meta.file_type().is_symlink(),
-                        "the operation must not receive a symlink"
-                    ),
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(err) => return Err(err),
-                }
-                Ok(())
-            });
-
-            if overwrite_existing {
-                result?;
-                assert!(
-                    operation_called.get(),
-                    "the operation should run after removing the symlink"
-                );
-            } else {
-                assert_eq!(
-                    result.expect_err("the symlink must be rejected").kind(),
-                    std::io::ErrorKind::AlreadyExists
-                );
-                assert!(
-                    !operation_called.get(),
-                    "the operation must not run for a forbidden symlink"
-                );
+        std::os::windows::fs::symlink_file(&target, &link)?;
+        super::try_op_or_unlink(&link, true, |path| {
+            match path.symlink_metadata() {
+                Ok(meta) => assert!(
+                    !meta.file_type().is_symlink(),
+                    "the operation must not receive a symlink"
+                ),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err),
             }
-            assert_eq!(
-                std::fs::read(&target)?,
-                b"untouched",
-                "the symlink target must stay unchanged"
-            );
-        }
+            Ok(())
+        })?;
+        assert_eq!(
+            std::fs::read(&target)?,
+            b"untouched",
+            "the symlink target must stay unchanged"
+        );
         Ok(())
     }
 

--- a/gix-worktree-state/src/checkout/function.rs
+++ b/gix-worktree-state/src/checkout/function.rs
@@ -57,20 +57,24 @@ where
         None,
     );
 
+    let mut path_cache = Stack::from_state_and_ignore_case(
+        dir,
+        options.fs.ignore_case,
+        stack::State::for_checkout(
+            options.overwrite_existing,
+            options.validate,
+            std::mem::take(&mut options.attributes),
+        ),
+        index,
+        paths,
+    );
+    if !options.destination_is_initially_empty {
+        path_cache.enable_terminal_symlink_check();
+    }
     let mut ctx = chunk::Context {
         buf: Vec::new(),
         options: (&options).into(),
-        path_cache: Stack::from_state_and_ignore_case(
-            dir,
-            options.fs.ignore_case,
-            stack::State::for_checkout(
-                options.overwrite_existing,
-                options.validate,
-                std::mem::take(&mut options.attributes),
-            ),
-            index,
-            paths,
-        ),
+        path_cache,
         filters: options.filters,
         objects,
     };

--- a/gix-worktree-state/tests/worktree-state/checkout.rs
+++ b/gix-worktree-state/tests/worktree-state/checkout.rs
@@ -122,6 +122,70 @@ fn writes_through_symlinks_are_prevented_even_if_overwriting_is_allowed() {
 }
 
 #[test]
+fn nonexclusive_checkout_does_not_follow_terminal_symlinks() -> crate::Result {
+    let mut opts = opts_from_probe();
+    // the test needs filesystem symlink support;
+    if !opts.fs.symlink {
+        return Ok(());
+    }
+    opts.destination_is_initially_empty = false;
+
+    for overwrite_existing in [false, true] {
+        opts.overwrite_existing = overwrite_existing;
+        let outside = gix_testtools::tempfile::tempdir_in(std::env::current_dir()?)?;
+        let canary = outside.path().join("canary");
+        std::fs::write(&canary, b"untouched")?;
+        let (_source, destination, _index, outcome) = checkout_index_in_tmp_dir_opts(
+            opts.clone(),
+            "make_mixed_without_submodules_and_symlinks",
+            None,
+            |_| true,
+            |destination| gix_fs::symlink::create(&canary, &destination.join("executable")),
+        )?;
+
+        assert!(
+            outcome.errors.is_empty(),
+            "checkout should not encounter non-collision errors"
+        );
+        let checked_out = destination.path().join("executable");
+        if overwrite_existing {
+            assert!(
+                outcome.collisions.is_empty(),
+                "forced checkout should replace the symlink"
+            );
+            assert!(
+                checked_out.symlink_metadata()?.is_file(),
+                "the symlink must become a regular file"
+            );
+            assert_eq!(
+                std::fs::read(&checked_out)?,
+                b"content",
+                "the regular file must be checked out"
+            );
+        } else {
+            assert_eq!(
+                outcome.collisions,
+                vec![Collision {
+                    path: "executable".into(),
+                    error_kind: AlreadyExists,
+                }],
+                "non-forced checkout should report the terminal symlink as a collision"
+            );
+            assert!(
+                checked_out.symlink_metadata()?.file_type().is_symlink(),
+                "non-forced checkout must leave the symlink in place"
+            );
+        }
+        assert_eq!(
+            std::fs::read(&canary)?,
+            b"untouched",
+            "the symlink target must stay unchanged"
+        );
+    }
+    Ok(())
+}
+
+#[test]
 fn delayed_driver_process() -> crate::Result {
     let mut opts = opts_from_probe();
     opts.filter_process_delay = gix_filter::driver::apply::Delay::Allow;
@@ -261,7 +325,7 @@ fn overwriting_files_and_lone_directories_works() -> crate::Result {
             |_| true,
             |d| {
                 let empty = d.join("empty");
-                symlink::symlink_dir(d.join(".."), &empty)?; // empty is symlink to the directory above
+                gix_fs::symlink::create(&d.join(".."), &empty)?; // empty is symlink to the directory above
                 std::fs::write(d.join("executable"), b"longer content foo bar")?; // executable is regular file and has different content
                 let dir = d.join("dir");
                 std::fs::create_dir(&dir)?;
@@ -270,7 +334,7 @@ fn overwriting_files_and_lone_directories_works() -> crate::Result {
                 let dir = dir.join("sub-dir");
                 std::fs::create_dir(&dir)?;
 
-                symlink::symlink_dir(empty, dir.join("symlink"))?; // 'symlink' is a symlink to a directory.
+                gix_fs::symlink::create(&empty, &dir.join("symlink"))?; // 'symlink' is a symlink to a directory.
                 Ok(())
             },
         )?;

--- a/gix-worktree-state/tests/worktree-state/checkout.rs
+++ b/gix-worktree-state/tests/worktree-state/checkout.rs
@@ -164,12 +164,18 @@ fn nonexclusive_checkout_does_not_follow_terminal_symlinks() -> crate::Result {
             );
         } else {
             assert_eq!(
-                outcome.collisions,
-                vec![Collision {
-                    path: "executable".into(),
-                    error_kind: AlreadyExists,
-                }],
+                outcome.collisions.len(),
+                1,
                 "non-forced checkout should report the terminal symlink as a collision"
+            );
+            assert_eq!(
+                outcome.collisions[0].path, "executable",
+                "the collision should identify the terminal symlink"
+            );
+            #[cfg(windows)]
+            assert_eq!(
+                outcome.collisions[0].error_kind, AlreadyExists,
+                "the collision error kind differs by platform and is only stable on Windows"
             );
             assert!(
                 checked_out.symlink_metadata()?.file_type().is_symlink(),

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -49,7 +49,6 @@ gix-hash = { path = "../gix-hash", features = ["sha1"] }
 gix-testtools = { path = "../tests/tools", default-features = false }
 gix-odb = { path = "../gix-odb" }
 gix-discover = { path = "../gix-discover" }
-symlink = "0.1.0"
 
 [package.metadata.docs.rs]
 features = ["sha1", "document-features", "serde"]

--- a/gix-worktree/src/lib.rs
+++ b/gix-worktree/src/lib.rs
@@ -50,6 +50,8 @@ pub struct Stack {
     stack: gix_fs::Stack,
     /// tells us what to do as we change paths.
     state: stack::State,
+    /// Whether to reject terminal non-directory symlinks on Windows.
+    reject_terminal_symlinks: bool,
     /// A buffer used when reading attribute or ignore files or their respective objects from the object database.
     buf: Vec<u8>,
     /// If case folding should happen when looking up attributes or exclusions.

--- a/gix-worktree/src/stack/delegate.rs
+++ b/gix-worktree/src/stack/delegate.rs
@@ -24,6 +24,7 @@ pub(crate) struct StackDelegate<'a, 'find> {
     pub id_mappings: &'a Vec<PathIdMapping>,
     pub objects: &'find dyn gix_object::Find,
     pub case: gix_glob::pattern::Case,
+    pub reject_temrinal_symlinks: bool,
     pub statistics: &'a mut super::Statistics,
 }
 
@@ -98,6 +99,7 @@ impl gix_fs::stack::Delegate for StackDelegate<'_, '_> {
                     self.mode,
                     &mut self.statistics.delegate.num_mkdir_calls,
                     *unlink_on_collision,
+                    self.reject_temrinal_symlinks,
                 )?;
             }
             #[cfg(feature = "attributes")]
@@ -162,9 +164,28 @@ fn create_leading_directory(
     mode: Option<gix_index::entry::Mode>,
     mkdir_calls: &mut usize,
     unlink_on_collision: bool,
+    #[cfg_attr(not(windows), allow(unused_variables))] check_terminal_symlinks: bool,
 ) -> std::io::Result<()> {
     if is_last_component && !crate::stack::mode_is_dir(mode).unwrap_or(false) {
-        return Ok(());
+        #[cfg(not(windows))]
+        {
+            return Ok(());
+        }
+        #[cfg(windows)]
+        {
+            // Forced checkout delegates terminal symlink detection and removal to the caller immediately before
+            // replacement, avoiding a redundant check here. Callers combining these flags must uphold that no-follow
+            // contract; this stack only protects leading components in that mode.
+            if unlink_on_collision || !check_terminal_symlinks {
+                return Ok(());
+            }
+            return match stack.current().symlink_metadata() {
+                Ok(meta) if meta.file_type().is_symlink() => Err(std::io::ErrorKind::AlreadyExists.into()),
+                Ok(_) => Ok(()),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(err) => Err(err),
+            };
+        }
     }
     *mkdir_calls += 1;
     match std::fs::create_dir(stack.current()) {

--- a/gix-worktree/src/stack/mod.rs
+++ b/gix-worktree/src/stack/mod.rs
@@ -72,11 +72,19 @@ impl Stack {
         Stack {
             stack: gix_fs::Stack::new(root),
             state,
+            reject_terminal_symlinks: false,
             case,
             buf,
             id_mappings,
             statistics: Statistics::default(),
         }
+    }
+
+    /// Enable Windows-only no-follow validation of terminal non-directory entries for checkout stacks.
+    ///
+    /// Call this before the first [`at_path()`](Self::at_path()) or [`at_entry()`](Self::at_entry()) invocation.
+    pub fn enable_terminal_symlink_check(&mut self) {
+        self.reject_terminal_symlinks = true;
     }
 
     /// Create a new stack that takes into consideration the `ignore_case` result of a filesystem probe in `root`. It takes a configured
@@ -125,6 +133,7 @@ impl Stack {
             id_mappings: &self.id_mappings,
             objects,
             case: self.case,
+            reject_temrinal_symlinks: self.reject_terminal_symlinks,
             statistics: &mut self.statistics,
         };
         self.stack.make_relative_path_current(relative, &mut delegate)?;

--- a/gix-worktree/tests/worktree/stack/create_directory.rs
+++ b/gix-worktree/tests/worktree/stack/create_directory.rs
@@ -80,7 +80,7 @@ fn symlinks_or_files_in_path_are_forbidden_or_unlinked_when_forced() -> crate::R
     let (mut cache, tmp) = new_cache();
     let forbidden = tmp.path().join("forbidden");
     std::fs::create_dir(&forbidden)?;
-    symlink::symlink_dir(&forbidden, tmp.path().join("link-to-dir"))?;
+    gix_fs::symlink::create(&forbidden, &tmp.path().join("link-to-dir"))?;
     std::fs::write(tmp.path().join("file-in-dir"), [])?;
 
     for dirname in &["file-in-dir", "link-to-dir"] {
@@ -137,7 +137,7 @@ fn symlink_cached_as_file_is_revalidated_before_use_as_directory() -> crate::Res
         .at_path("link", IS_SYMLINK, &gix_object::find::Never)?
         .path()
         .to_owned();
-    symlink::symlink_dir(&forbidden, &link_path)?;
+    gix_fs::symlink::create(&forbidden, &link_path)?;
 
     let err = cache
         .at_path("link/file", IS_SYMLINK, &gix_object::find::Never)
@@ -160,7 +160,7 @@ fn symlink_cached_as_file_is_unlinked_before_use_as_directory_when_forced() -> c
         .at_path("link", IS_SYMLINK, &gix_object::find::Never)?
         .path()
         .to_owned();
-    symlink::symlink_dir(&forbidden, &link_path)?;
+    gix_fs::symlink::create(&forbidden, &link_path)?;
     if let stack::State::CreateDirectoryAndAttributesStack {
         unlink_on_collision, ..
     } = cache.state_mut()

--- a/gix-worktree/tests/worktree/stack/create_directory.rs
+++ b/gix-worktree/tests/worktree/stack/create_directory.rs
@@ -128,6 +128,37 @@ fn symlinks_or_files_in_path_are_forbidden_or_unlinked_when_forced() -> crate::R
 }
 
 #[test]
+#[cfg(windows)]
+fn terminal_symlinks_are_forbidden_without_force() -> crate::Result {
+    let (mut cache, tmp) = new_cache();
+    cache.enable_terminal_symlink_check();
+
+    let target = tmp.path().join("target");
+    let link = tmp.path().join("link");
+    std::fs::write(&target, b"untouched")?;
+    std::os::windows::fs::symlink_file(&target, &link)?;
+
+    assert_eq!(
+        cache
+            .at_path("link", IS_FILE, &gix_object::find::Never)
+            .unwrap_err()
+            .kind(),
+        std::io::ErrorKind::AlreadyExists,
+        "the terminal symlink must be rejected"
+    );
+    assert!(
+        link.symlink_metadata()?.file_type().is_symlink(),
+        "the terminal symlink must remain in place"
+    );
+    assert_eq!(
+        std::fs::read(&target)?,
+        b"untouched",
+        "the symlink target must stay unchanged"
+    );
+    Ok(())
+}
+
+#[test]
 fn symlink_cached_as_file_is_revalidated_before_use_as_directory() -> crate::Result {
     let (mut cache, tmp) = new_cache();
     let forbidden = tmp.path().join("forbidden");


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- validate non-forced terminal entries through the component-caching worktree Delegate on Windows incremental checkouts
- defer forced Windows terminal-link removal until the replacement operation is ready
- keep Unix on its existing `O_NOFOLLOW` path without additional successful-path filesystem checks
- cover both overwrite policies with Windows-specific unit tests and an end-to-end outside-canary regression

## Advisory summary

Advisory: https://github.com/GitoxideLabs/gitoxide/security/advisories/GHSA-pmm9-4h7q-24c8

- GHSA: GHSA-pmm9-4h7q-24c8
- Severity: medium (CWE-59)
- Affected Rust packages/ranges: gix-worktree-state <= 0.32.0; gix-worktree <= 0.54.0; gix-features <= 0.48.1; gix <= 0.85.0
- Patched versions: not assigned yet
- CVE: none assigned

The advisory is still a draft, so this description intentionally omits reproduction details.

## Git baseline

Git at a23bace963d5 uses lstat-based terminal checks before unlinking and exclusively creating checkout output. Related hardening includes b6986d8a758, fab78a0c3de, and 6fa50cc4a19.

## Commits

- `3a3bc15e3afc365da2d12dc3def7cee7ea7acfb5` — original terminal-symlink fix and regressions
- `69e50cd1aec909305eb097e5e56b050496416866` — Delegate integration and Windows-only successful-path metadata checks

## Validation

- focused Delegate, forced-helper, and end-to-end canary regressions
- `cargo nextest` for gix-worktree and gix-worktree-state with parallel enabled: 33 passed on Unix; Windows-only tests excluded locally
- `cargo clippy` for both crates and all targets with warnings denied
- aarch64-pc-windows-msvc test compile check (passes with pre-existing cfg warnings)
- `cargo fmt` and `git diff --check`
- clean Codex review for each commit