### PR TITLE
feat: show bots and commit attributions in tix

### DIFF
--- a/gix-tix/src/app.rs
+++ b/gix-tix/src/app.rs
@@ -17,7 +17,25 @@ pub(crate) struct Commit<T> {
     pub lane: String,
     pub committer_time: gix::date::Time,
     pub author_name: &'static BStr,
+    pub author_is_bot: bool,
+    pub attributions: Box<[Attribution]>,
     pub title: T,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct Attribution {
+    pub kind: AttributionKind,
+    pub name: &'static BStr,
+    pub is_bot: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AttributionKind {
+    CoAuthor,
+    Reviewed,
+    Acked,
+    Tested,
+    SignedOff,
 }
 
 pub(crate) type LoadedCommit = Commit<BString>;
@@ -47,6 +65,7 @@ pub(crate) enum Action {
     Last,
     ToggleDate,
     ToggleName,
+    ToggleTrailers,
     ToggleSpecialRefs,
     ToggleHidden,
     PinMetadata,
@@ -75,6 +94,7 @@ pub(crate) struct App {
     pub lane_time: Option<Duration>,
     pub show_committer_date: bool,
     pub show_author_name: bool,
+    pub show_trailers: bool,
     pub show_special_refs: bool,
     pub has_hidden_filter: bool,
     pub show_hidden: bool,
@@ -97,6 +117,7 @@ impl App {
             lane_time: None,
             show_committer_date: true,
             show_author_name: true,
+            show_trailers: true,
             show_special_refs: false,
             has_hidden_filter: false,
             show_hidden: false,
@@ -122,6 +143,8 @@ impl App {
                 lane,
                 committer_time,
                 author_name,
+                author_is_bot,
+                attributions,
                 title,
             } = row;
             let start = self.titles.len();
@@ -132,6 +155,8 @@ impl App {
                 lane,
                 committer_time,
                 author_name,
+                author_is_bot,
+                attributions,
                 title: start..self.titles.len(),
             });
         }
@@ -186,6 +211,7 @@ impl App {
             }
             Action::ToggleDate => self.show_committer_date = !self.show_committer_date,
             Action::ToggleName => self.show_author_name = !self.show_author_name,
+            Action::ToggleTrailers => self.show_trailers = !self.show_trailers,
             Action::ToggleSpecialRefs => self.show_special_refs = !self.show_special_refs,
             Action::ToggleHidden
                 if self.has_hidden_filter && matches!(self.state, State::Complete | State::Cancelled) =>
@@ -435,6 +461,8 @@ mod tests {
             lane: String::new(),
             committer_time: gix::date::Time::default(),
             author_name: b"author".as_bstr(),
+            author_is_bot: false,
+            attributions: Box::default(),
             title: format!("commit {n}").into(),
         }
     }
@@ -569,14 +597,17 @@ mod tests {
     #[test]
     fn toggles_metadata_columns() {
         let mut app = App::new(1);
+        assert!(app.show_trailers, "trailer attribution is visible by default");
 
         app.update(Action::ToggleDate);
         app.update(Action::ToggleName);
+        app.update(Action::ToggleTrailers);
         app.update(Action::ToggleSpecialRefs);
         app.update(Action::PinMetadata);
 
         assert!(!app.show_committer_date);
         assert!(!app.show_author_name);
+        assert!(!app.show_trailers);
         assert!(app.show_special_refs);
         assert_eq!(app.pin_metadata, Some(true));
         app.update(Action::UnpinMetadata);

--- a/gix-tix/src/history.rs
+++ b/gix-tix/src/history.rs
@@ -11,7 +11,7 @@ use gix::{
     objs::commit::ref_iter::Token,
 };
 
-use crate::app::{Commit, LoadedCommit};
+use crate::app::{Attribution, AttributionKind, Commit, LoadedCommit};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct Decoration {
@@ -87,21 +87,42 @@ pub(crate) fn load(
         let object = info.object().context("could not read commit")?;
         let mut committer_time = None;
         let mut author_name = None;
+        let mut author_is_bot = false;
+        let mut attributions = Vec::new();
         let mut title = None;
         for token in object.iter() {
             match token.context("could not decode commit")? {
                 Token::Author { signature } => {
-                    author_name = Some(intern(author_names, signature.trim().name));
+                    let signature = signature.trim();
+                    author_name = Some(intern(author_names, signature.name));
+                    author_is_bot = is_bot(signature.email);
                 }
                 Token::Committer { signature } => {
                     committer_time = Some(signature.time().context("could not decode committer time")?);
                 }
                 Token::Message(message) => {
-                    title = Some(
-                        gix::objs::commit::MessageRef::from_bytes(message)
-                            .summary()
-                            .into_owned(),
-                    );
+                    let message = gix::objs::commit::MessageRef::from_bytes(message);
+                    title = Some(message.summary().into_owned());
+                    if let Some(body) = message.body() {
+                        for trailer in body.trailers() {
+                            let Some(kind) = attribution_kind(&trailer) else {
+                                continue;
+                            };
+                            let mut value: &[u8] = trailer.value.as_ref();
+                            let Ok(identity) = gix::actor::IdentityRef::from_bytes_consuming(&mut value) else {
+                                continue;
+                            };
+                            if !value.trim().is_empty() {
+                                continue;
+                            }
+                            let identity = identity.trim();
+                            attributions.push(Attribution {
+                                kind,
+                                name: intern(author_names, identity.name),
+                                is_bot: is_bot(identity.email),
+                            });
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -112,6 +133,8 @@ pub(crate) fn load(
             lane: String::new(),
             committer_time: committer_time.context("commit has no committer time")?,
             author_name: author_name.context("commit has no author name")?,
+            author_is_bot,
+            attributions: attributions.into_boxed_slice(),
             title: title.context("commit has no message")?,
         });
         if rows.len() == COMMIT_BATCH_SIZE
@@ -128,6 +151,28 @@ pub(crate) fn load(
     }
     emit(Event::Complete);
     Ok(())
+}
+
+fn is_bot(email: &BStr) -> bool {
+    [b"codex@openai.com".as_slice(), b"noreply@anthropic.com".as_slice()]
+        .iter()
+        .any(|candidate| email.eq_ignore_ascii_case(candidate))
+}
+
+fn attribution_kind(trailer: &gix::objs::commit::message::body::TrailerRef<'_>) -> Option<AttributionKind> {
+    if trailer.is_co_authored_by() {
+        Some(AttributionKind::CoAuthor)
+    } else if trailer.is_reviewed_by() {
+        Some(AttributionKind::Reviewed)
+    } else if trailer.is_acked_by() {
+        Some(AttributionKind::Acked)
+    } else if trailer.is_tested_by() {
+        Some(AttributionKind::Tested)
+    } else if trailer.is_signed_off_by() {
+        Some(AttributionKind::SignedOff)
+    } else {
+        None
+    }
 }
 
 fn resolve_revisions(repo: &gix::Repository, revisions: &[OsString], kind: &str) -> Result<Vec<ObjectId>> {
@@ -218,6 +263,7 @@ mod tests {
     use std::{collections::HashSet, process::Command};
 
     use super::*;
+    use crate::app::AttributionKind;
 
     fn fixture() -> gix_testtools::Result<std::path::PathBuf> {
         gix_testtools::scripted_fixture_read_only("history.sh")
@@ -272,7 +318,27 @@ mod tests {
             })
             .next()
             .expect("the topic commit is reachable");
-        assert_eq!(topic.author_name, "author", "the author name is retained");
+        assert_eq!(topic.author_name, "Codex", "the author name is retained");
+        assert!(
+            topic.author_is_bot,
+            "well-known bot email addresses identify bot authors"
+        );
+        assert_eq!(
+            topic
+                .attributions
+                .iter()
+                .map(|attribution| (attribution.kind, attribution.name, attribution.is_bot))
+                .collect::<Vec<_>>(),
+            [
+                (AttributionKind::CoAuthor, b"Human Coauthor".as_bstr(), false),
+                (AttributionKind::CoAuthor, b"Claude".as_bstr(), true),
+                (AttributionKind::Reviewed, b"Reviewer".as_bstr(), false),
+                (AttributionKind::Acked, b"Acknowledger".as_bstr(), false),
+                (AttributionKind::Tested, b"Tester".as_bstr(), false),
+                (AttributionKind::SignedOff, b"Signer".as_bstr(), false),
+            ],
+            "known attribution trailers retain their order and malformed identities are omitted"
+        );
         assert_eq!(
             topic.committer_time.format_or_unix(gix::date::time::format::SHORT),
             "2000-01-04",

--- a/gix-tix/src/lib.rs
+++ b/gix-tix/src/lib.rs
@@ -232,6 +232,7 @@ fn action(key: KeyEvent) -> Option<Action> {
         KeyCode::End | KeyCode::Char('G') => Some(Action::Last),
         KeyCode::Char('d') => Some(Action::ToggleDate),
         KeyCode::Char('n') => Some(Action::ToggleName),
+        KeyCode::Char('t') => Some(Action::ToggleTrailers),
         KeyCode::Char('r') => Some(Action::ToggleSpecialRefs),
         KeyCode::Char('v') => Some(Action::ToggleHidden),
         KeyCode::Char('[') => Some(Action::PinMetadata),
@@ -282,6 +283,10 @@ mod tests {
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE)),
             Some(Action::ToggleName)
+        );
+        assert_eq!(
+            action(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE)),
+            Some(Action::ToggleTrailers)
         );
         assert_eq!(
             action(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)),

--- a/gix-tix/src/ui.rs
+++ b/gix-tix/src/ui.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 
 use crate::{
-    app::{App, CommitRow, State},
+    app::{App, AttributionKind, CommitRow, State},
     history::{DecorationKind, Decorations},
 };
 
@@ -39,6 +39,7 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     let pin_metadata = app.pin_metadata.unwrap_or(graph_is_wide);
     let show_committer_date = app.show_committer_date;
     let show_author_name = app.show_author_name;
+    let show_trailers = app.show_trailers;
     let show_special_refs = app.show_special_refs;
     let selected = app.selected;
     let metadata: Vec<_> = visible_rows
@@ -49,10 +50,13 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
                 row,
                 app.title(row),
                 decorations,
-                show_committer_date,
-                show_author_name,
-                show_special_refs,
-                selected == Some(start + index),
+                MetadataOptions {
+                    show_committer_date,
+                    show_author_name,
+                    show_trailers,
+                    show_special_refs,
+                    selected: selected == Some(start + index),
+                },
             )
         })
         .collect();
@@ -133,22 +137,35 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut App, decorations: &Decoratio
     };
     frame.render_widget(
         Paragraph::new(format!(
-            "{} commits · {status}{hidden} · ↑↓/jk move · h/l pan · [ pane · ] natural · d date · n name · r refs · y copy · Esc cancel · q quit",
+            "{} commits · {status}{hidden} · ↑↓/jk move · h/l pan · [ pane · ] natural · d date · n name · t trailers · r refs · y copy · Esc cancel · q quit",
             app.rows.len()
         )),
         footer,
     );
 }
 
+#[derive(Clone, Copy)]
+struct MetadataOptions {
+    show_committer_date: bool,
+    show_author_name: bool,
+    show_trailers: bool,
+    show_special_refs: bool,
+    selected: bool,
+}
+
 fn metadata_line<'a>(
     row: &CommitRow,
     title: &'a BStr,
     decorations: &'a Decorations,
-    show_committer_date: bool,
-    show_author_name: bool,
-    show_special_refs: bool,
-    selected: bool,
+    options: MetadataOptions,
 ) -> Line<'a> {
+    let MetadataOptions {
+        show_committer_date,
+        show_author_name,
+        show_trailers,
+        show_special_refs,
+        selected,
+    } = options;
     let id = row.id.to_hex().to_string();
     let mut spans = vec![Span::styled(
         id[..7].to_owned(),
@@ -182,10 +199,55 @@ fn metadata_line<'a>(
         ));
     }
     if show_author_name {
+        let author = row.author_name.to_str_lossy();
         spans.push(Span::styled(
-            format!("{} ", row.author_name.to_str_lossy()),
-            color(Color::Green, selected),
+            if row.author_is_bot {
+                format!("[{author}] ")
+            } else {
+                format!("{author} ")
+            },
+            color(
+                if row.author_is_bot {
+                    Color::LightYellow
+                } else {
+                    Color::Green
+                },
+                selected,
+            ),
         ));
+        if show_trailers {
+            for (kind, marker) in [
+                (AttributionKind::CoAuthor, "Co: "),
+                (AttributionKind::Reviewed, "Re: "),
+                (AttributionKind::Acked, "Ack: "),
+                (AttributionKind::Tested, "Te: "),
+                (AttributionKind::SignedOff, "So: "),
+            ] {
+                let mut actors = row.attributions.iter().filter(|actor| actor.kind == kind).peekable();
+                if actors.peek().is_none() {
+                    continue;
+                }
+                spans.push(Span::styled(
+                    marker,
+                    color(Color::LightYellow, selected).add_modifier(Modifier::DIM),
+                ));
+                for (index, actor) in actors.enumerate() {
+                    if index != 0 {
+                        spans.push(Span::raw(", "));
+                    }
+                    let name = actor.name.to_str_lossy();
+                    spans.push(Span::styled(
+                        if actor.is_bot {
+                            format!("[{name}]")
+                        } else {
+                            name.into_owned()
+                        },
+                        color(if actor.is_bot { Color::LightYellow } else { Color::Green }, selected),
+                    ));
+                }
+                spans.push(Span::raw(" "));
+            }
+        }
     }
     spans.push(Span::raw(title.to_str_lossy()));
     Line::from(spans)
@@ -255,9 +317,111 @@ mod tests {
 
     use super::*;
     use crate::{
-        app::{Action, Commit},
+        app::{Action, Attribution, AttributionKind, Commit},
         history::{Decoration, DecorationKind},
     };
+
+    #[test]
+    fn renders_grouped_attributions_and_bot_names() -> Result<(), Box<dyn std::error::Error>> {
+        let mut app = App::new(1);
+        app.extend_commits(vec![Commit {
+            id: gix::ObjectId::Sha1([1; 20]),
+            parent_ids: Default::default(),
+            lane: String::new(),
+            committer_time: gix::date::Time::default(),
+            author_name: b"Codex".as_bstr(),
+            author_is_bot: true,
+            attributions: vec![
+                Attribution {
+                    kind: AttributionKind::CoAuthor,
+                    name: b"Human".as_bstr(),
+                    is_bot: false,
+                },
+                Attribution {
+                    kind: AttributionKind::CoAuthor,
+                    name: b"Claude".as_bstr(),
+                    is_bot: true,
+                },
+                Attribution {
+                    kind: AttributionKind::Reviewed,
+                    name: b"Reviewer".as_bstr(),
+                    is_bot: false,
+                },
+                Attribution {
+                    kind: AttributionKind::Acked,
+                    name: b"Acknowledger".as_bstr(),
+                    is_bot: false,
+                },
+                Attribution {
+                    kind: AttributionKind::Tested,
+                    name: b"Tester".as_bstr(),
+                    is_bot: false,
+                },
+                Attribution {
+                    kind: AttributionKind::SignedOff,
+                    name: b"Signer".as_bstr(),
+                    is_bot: false,
+                },
+            ]
+            .into_boxed_slice(),
+            title: "subject".into(),
+        }]);
+        app.selected = None;
+        let mut terminal = Terminal::new(TestBackend::new(160, 2))?;
+
+        terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
+
+        let row = rendered_row(&terminal);
+        assert!(
+            row.contains("[Codex] Co: Human, [Claude] Re: Reviewer Ack: Acknowledger Te: Tester So: Signer subject"),
+            "same-kind trailers share one marker and bots use bracketed names"
+        );
+        let buffer = terminal.backend().buffer();
+        let style_at = |needle: &str| {
+            let x = row.find(needle).expect("rendered metadata contains the named actor") as u16;
+            buffer[(x, 0)].fg
+        };
+        assert_eq!(
+            style_at("[Codex]"),
+            Color::LightYellow,
+            "bot authors use the agent color"
+        );
+        assert_eq!(
+            style_at("Co:"),
+            Color::LightYellow,
+            "attribution markers use the agent color"
+        );
+        let marker_x = row.find("Co:").expect("rendered metadata contains a trailer marker") as u16;
+        assert!(
+            buffer[(marker_x, 0)].modifier.contains(Modifier::DIM),
+            "attribution markers are dimmed"
+        );
+        assert_eq!(style_at("Human"), Color::Green, "human trailer actors are green");
+        assert_eq!(
+            style_at("[Claude]"),
+            Color::LightYellow,
+            "bot co-authors use agent styling"
+        );
+        assert!(
+            rendered_line(&terminal, 1).contains("t trailers"),
+            "the footer advertises the trailer toggle"
+        );
+
+        app.update(Action::ToggleTrailers);
+        terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
+        assert!(!rendered_row(&terminal).contains("Co:"), "t hides trailer attribution");
+
+        app.update(Action::ToggleTrailers);
+        app.update(Action::ToggleName);
+        terminal.draw(|frame| draw(frame, &mut app, &Decorations::new()))?;
+        let row = rendered_row(&terminal);
+        assert!(!row.contains("Codex"), "n hides the primary actor");
+        assert!(
+            !row.contains("Reviewer"),
+            "n hides trailer actors while trailers are enabled"
+        );
+        Ok(())
+    }
 
     #[test]
     fn renders_rows_decorations_selection_and_footer() -> Result<(), Box<dyn std::error::Error>> {
@@ -269,6 +433,8 @@ mod tests {
             lane: String::new(),
             committer_time: gix::date::Time::default(),
             author_name: b"author".as_bstr(),
+            author_is_bot: false,
+            attributions: Box::default(),
             title: "subject".into(),
         }]);
         app.update(Action::Complete);
@@ -285,18 +451,18 @@ mod tests {
                 },
             ],
         )]);
-        let mut terminal = Terminal::new(TestBackend::new(130, 2))?;
+        let mut terminal = Terminal::new(TestBackend::new(140, 2))?;
 
         terminal.draw(|frame| draw(frame, &mut app, &decorations))?;
 
         let mut expected = Buffer::with_lines([
-            format!("{:<130}", "> ● 0101010 (HEAD) 1970-01-01 author subject"),
+            format!("{:<140}", "> ● 0101010 (HEAD) 1970-01-01 author subject"),
             format!(
-                "{:<130}",
-                "1 commits · complete · ↑↓/jk move · h/l pan · [ pane · ] natural · d date · n name · r refs · y copy · Esc cancel · q quit"
+                "{:<140}",
+                "1 commits · complete · ↑↓/jk move · h/l pan · [ pane · ] natural · d date · n name · t trailers · r refs · y copy · Esc cancel · q quit"
             ),
         ]);
-        for x in 0..130 {
+        for x in 0..140 {
             expected[(x, 0)].set_style(Style::default().add_modifier(Modifier::REVERSED));
         }
         for x in 4..11 {
@@ -343,6 +509,8 @@ mod tests {
                     lane: String::new(),
                     committer_time: gix::date::Time::default(),
                     author_name: b"author".as_bstr(),
+                    author_is_bot: false,
+                    attributions: Box::default(),
                     title: format!("subject {n}").into(),
                 })
                 .collect(),
@@ -374,6 +542,8 @@ mod tests {
             lane: "● │ │ │ │ │ │ │ ".into(),
             committer_time: gix::date::Time::default(),
             author_name: b"author".as_bstr(),
+            author_is_bot: false,
+            attributions: Box::default(),
             title: "subject".into(),
         };
         let decorations = Decorations::from([(
@@ -404,7 +574,18 @@ mod tests {
         let mut app = App::new(1);
         app.extend_commits(vec![commit]);
         let row = &app.rows[0];
-        let line = metadata_line(row, app.title(row), &decorations, true, true, true, false);
+        let line = metadata_line(
+            row,
+            app.title(row),
+            &decorations,
+            MetadataOptions {
+                show_committer_date: true,
+                show_author_name: true,
+                show_trailers: true,
+                show_special_refs: true,
+                selected: false,
+            },
+        );
         let style = |text| {
             line.spans
                 .iter()
@@ -457,6 +638,8 @@ mod tests {
             lane: String::new(),
             committer_time: gix::date::Time::default(),
             author_name: b"author".as_bstr(),
+            author_is_bot: false,
+            attributions: Box::default(),
             title: "subject".into(),
         }]);
         app.update(Action::Complete);

--- a/gix-tix/tests/fixtures/history.sh
+++ b/gix-tix/tests/fixtures/history.sh
@@ -20,7 +20,17 @@ git switch -q main
 commit main "2000-01-03T00:00:00"
 git merge -q --no-edit merged
 git switch -q -c topic HEAD~1
-commit topic "2000-01-04T00:00:00"
+echo topic >topic
+git add topic
+GIT_AUTHOR_DATE="2000-01-04T00:00:00 +0000" GIT_COMMITTER_DATE="2000-01-04T00:00:00 +0000" \
+  git commit -q --author="Codex <Codex@OpenAI.com>" -m topic \
+    -m "Co-authored-by: Human Coauthor <human@example.com>
+Co-authored-by: Claude <noreply@anthropic.com>
+rEvIeWeD-bY: Reviewer <reviewer@example.com>
+Acked-by: Acknowledger <ack@example.com>
+Tested-by: Tester <tester@example.com>
+Signed-off-by: Signer <signer@example.com>
+Co-authored-by: Broken <broken@example.com> trailing garbage"
 git switch -q main
 
 # Decorations are optional, so this unrelated stale remote HEAD must not break history loading.


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] functional

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

If the author is a bot as identified by a couple of well-known email addresses, display them in yellow or orange with `[<name>]`. If there are co-authors or other well-known trailers signalling a corporation, after the author name, use the bot color as marker, like `Re: ` for review, or `Co:` for co-authors, followed by the name, to also make these visible. If there are multiple of the same type, group them behind one prefix/marker.

Lastly, add a hotkey to toggle trailer-based information, which is enabled by default.
And yes, if bots are co-authors, they are displayed in their style, just as if they were authors.

## Implementation

- Highlight Codex and Claude identities in yellow with bracketed names.
- Parse and group co-author, review, acknowledgement, test, and sign-off trailers after the primary author.
- Add a default-on `t` trailer toggle; `n` hides all actor names.
- Reject malformed trailer identities, including valid identities followed by trailing garbage.

## Validation

- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix-tix --features sha1`
- `cargo check -p gix-tix --no-default-features --features sha256`
- `cargo clippy -p gix-tix --all-targets --features sha1 --no-deps`
- `cargo fmt --all -- --check`
- `codex review --commit 2297a138c3a730f841f63b5e3ebf1e773ff52bbe`