### PR TITLE
fix: run Git for Windows sh shim in POSIX mode

### DIFF
--- a/gix-command/src/lib.rs
+++ b/gix-command/src/lib.rs
@@ -303,18 +303,20 @@ mod prepare {
                         cmd
                     }
                     None => {
-                        let shell = prep.shell_program.unwrap_or_else(|| gix_path::env::shell().into());
+                        let mut cmd = match prep.shell_program {
+                            Some(shell) => Command::new(shell),
+                            None => gix_path::env::shell_command(),
+                        };
                         // Passed as `command_name` after `-c <script>`; the shell uses it
                         // as `$0`, which prefixes its own diagnostic messages. If the
                         // shell path has no extractable basename — reachable only via
                         // degenerate input like `""` or `/` — fall back to `_`, the
                         // conventional placeholder for an unused `$0`, rather than
                         // making a false claim about which shell is running.
-                        let arg0 = std::path::Path::new(&shell)
+                        let arg0 = std::path::Path::new(cmd.get_program())
                             .file_name()
                             .unwrap_or(std::ffi::OsStr::new("_"))
                             .to_os_string();
-                        let mut cmd = Command::new(shell);
                         cmd.arg("-c");
                         if !prep.args.is_empty() {
                             if prep.command.to_str().is_none_or(|cmd| !cmd.contains("$@")) {

--- a/gix-command/tests/command.rs
+++ b/gix-command/tests/command.rs
@@ -222,20 +222,38 @@ mod context {
 mod prepare {
     use std::sync::LazyLock;
 
-    static SH: LazyLock<&'static str> = LazyLock::new(|| {
-        gix_path::env::shell()
-            .to_str()
+    fn default_shell() -> &'static str {
+        static SH: LazyLock<std::ffi::OsString> =
+            LazyLock::new(|| gix_path::env::shell_command().get_program().to_owned());
+        SH.to_str()
             .expect("`prepare` tests must be run where 'sh' path is valid Unicode")
-    });
+    }
 
     // The basename of the default shell, used as the `command_name` operand
     // after `-c <script>` and observable inside the shell as `$0`. The default
-    // shell is `gix_path::env::shell()`, documented as `/bin/sh` on Unix and a
-    // path ending in `sh.exe` on Windows.
+    // shell command uses `/bin/sh` on Unix and a path ending in `sh.exe` on
+    // Windows.
     const SH_BASENAME: &str = if cfg!(windows) { "sh.exe" } else { "sh" };
 
     fn quoted(input: &[&str]) -> String {
         input.iter().map(|s| format!("\"{s}\"")).collect::<Vec<_>>().join(" ")
+    }
+
+    fn quoted_default_shell(input: &[&str]) -> String {
+        let shell = gix_path::env::shell_command();
+        let mut args = vec![
+            shell
+                .get_program()
+                .to_str()
+                .expect("the default shell path must be valid Unicode in these tests"),
+        ];
+        args.extend(
+            shell
+                .get_args()
+                .map(|arg| arg.to_str().expect("default shell arguments must be valid Unicode")),
+        );
+        args.extend(input.iter().copied());
+        quoted(&args)
     }
 
     #[test]
@@ -255,7 +273,7 @@ mod prepare {
         let cmd = std::process::Command::from(
             gix_command::prepare("   ").command_may_be_shell_script_allow_manual_argument_splitting(),
         );
-        assert_eq!(format!("{cmd:?}"), quoted(&[*SH, "-c", "   ", SH_BASENAME]));
+        assert_eq!(format!("{cmd:?}"), quoted_default_shell(&["-c", "   ", SH_BASENAME]));
     }
 
     #[test]
@@ -296,7 +314,7 @@ mod prepare {
             if cfg!(windows) {
                 quoted(&["ls", "first", "second", "third"])
             } else {
-                quoted(&[*SH, "-c", "ls first second third", SH_BASENAME])
+                quoted(&[default_shell(), "-c", "ls first second third", SH_BASENAME])
             },
             "with shell, this works as it performs word splitting"
         );
@@ -332,7 +350,7 @@ mod prepare {
             if cfg!(windows) {
                 quoted(&["ls", "--foo", "a b", "additional"])
             } else {
-                let sh = *SH;
+                let sh = default_shell();
                 format!(r#""{sh}" "-c" "ls --foo \"a b\" \"$@\"" "{SH_BASENAME}" "additional""#)
             },
             "with shell, this works as it performs word splitting, on windows we can avoid the shell"
@@ -358,7 +376,7 @@ mod prepare {
         );
         assert_eq!(
             format!("{cmd:?}"),
-            quoted(&[*SH, "-c", r#"ls --foo=\"a b\""#, SH_BASENAME])
+            quoted_default_shell(&["-c", r#"ls --foo=\"a b\""#, SH_BASENAME])
         );
     }
 
@@ -367,7 +385,7 @@ mod prepare {
         let cmd = std::process::Command::from(gix_command::prepare("ls").arg("--foo=a b").with_shell());
         assert_eq!(
             format!("{cmd:?}"),
-            quoted(&[*SH, "-c", r#"ls \"$@\""#, SH_BASENAME, "--foo=a b"])
+            quoted_default_shell(&["-c", r#"ls \"$@\""#, SH_BASENAME, "--foo=a b"])
         );
     }
 
@@ -381,7 +399,7 @@ mod prepare {
         );
         assert_eq!(
             format!("{cmd:?}"),
-            quoted(&[*SH, "-c", r#"'ls' \"$@\""#, SH_BASENAME, "--foo=a b"]),
+            quoted_default_shell(&["-c", r#"'ls' \"$@\""#, SH_BASENAME, "--foo=a b"]),
             "looks strange thanks to debug printing, but is the right amount of quotes actually"
         );
     }
@@ -396,8 +414,7 @@ mod prepare {
         );
         assert_eq!(
             format!("{cmd:?}"),
-            quoted(&[
-                *SH,
+            quoted_default_shell(&[
                 "-c",
                 r#"'C:\\Users\\O'\\''Shaughnessy\\with space.exe' \"$@\""#,
                 SH_BASENAME,
@@ -412,10 +429,9 @@ mod prepare {
         let cmd = std::process::Command::from(
             gix_command::prepare("ls --foo=~/path").command_may_be_shell_script_allow_manual_argument_splitting(),
         );
-        let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "ls --foo=~/path" "{SH_BASENAME}""#),
+            quoted_default_shell(&["-c", "ls --foo=~/path", SH_BASENAME]),
             "splitting can also handle quotes"
         );
     }
@@ -424,10 +440,9 @@ mod prepare {
     fn tilde_path_and_multiple_arguments_as_part_of_command_with_shell() {
         let cmd =
             std::process::Command::from(gix_command::prepare(r#"~/bin/exe --foo "a b""#).command_may_be_shell_script());
-        let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "~/bin/exe --foo \"a b\"" "{SH_BASENAME}""#),
+            quoted_default_shell(&["-c", r#"~/bin/exe --foo \"a b\""#, SH_BASENAME]),
             "this always needs a shell as we need tilde expansion"
         );
     }
@@ -439,10 +454,9 @@ mod prepare {
                 .command_may_be_shell_script()
                 .arg("store"),
         );
-        let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "echo \"$@\" >&2" "{SH_BASENAME}" "store""#),
+            quoted_default_shell(&["-c", r#"echo \"$@\" >&2"#, SH_BASENAME, "store"]),
             "this is how credential helpers have to work as for some reason they don't get '$@' added in Git.\
             We deal with it by not doubling the '$@' argument, which seems more flexible."
         );
@@ -456,10 +470,9 @@ mod prepare {
                 .with_quoted_command()
                 .arg("store"),
         );
-        let sh = *SH;
         assert_eq!(
             format!("{cmd:?}"),
-            format!(r#""{sh}" "-c" "echo \"$@\" >&2" "{SH_BASENAME}" "store""#)
+            quoted_default_shell(&["-c", r#"echo \"$@\" >&2"#, SH_BASENAME, "store"])
         );
     }
 

--- a/gix-credentials/tests/program/from_custom_definition.rs
+++ b/gix-credentials/tests/program/from_custom_definition.rs
@@ -58,12 +58,12 @@ fn name_with_args() {
 fn name_with_special_args() {
     let input = "name --arg --bar=~/folder/in/home";
     let prog = Program::from_custom_definition(input);
-    let sh = *SH;
+    let sh = gix_path::env::shell_command();
     let git = *GIT;
     assert!(matches!(&prog.kind, Kind::ExternalName{name_and_args} if name_and_args == input));
     assert_eq!(
         format!("{:?}", prog.to_command(&helper::Action::Store("egal".into()))),
-        format!(r#""{sh}" "-c" "{git} credential-name --arg --bar=~/folder/in/home \"$@\"" "{SH_BASENAME}" "store""#)
+        format!(r#"{sh:?} "-c" "{git} credential-name --arg --bar=~/folder/in/home \"$@\"" "{SH_BASENAME}" "store""#)
     );
 }
 

--- a/gix-path/src/env/auxiliary.rs
+++ b/gix-path/src/env/auxiliary.rs
@@ -5,6 +5,13 @@ use std::{
 
 use std::sync::LazyLock;
 
+pub(super) struct WindowsExecutable {
+    pub program: OsString,
+    /// Whether `program` was found in `<git-root>/bin`, where Git for Windows
+    /// installs executable shims.
+    pub is_shim: bool,
+}
+
 /// `usr`-like directory component names that MSYS2 may provide, other than for `/usr` itself.
 ///
 /// These are the values of the "Prefix" column of the "Environments" and "Legacy Environments"
@@ -89,7 +96,7 @@ const BIN_DIR_FRAGMENTS: &[&str] = &["bin", "usr/bin"];
 /// depending on desired semantics, it should possibly also check a `cmd` directory; directories
 /// like `<platform>/bin`, for any applicable variants (such as `mingw64`); and `super::core_dir()`
 /// itself, which it could safely check even if its value is not safe for inferring other paths.
-fn find_git_associated_windows_executable(stem: &str) -> Option<OsString> {
+fn find_git_associated_windows_executable(stem: &str) -> Option<WindowsExecutable> {
     let git_root = git_for_windows_root()?;
 
     BIN_DIR_FRAGMENTS
@@ -102,17 +109,23 @@ fn find_git_associated_windows_executable(stem: &str) -> Option<OsString> {
             raw_path.push("/");
             raw_path.push(stem);
             raw_path.push(".exe");
-            raw_path
+            WindowsExecutable {
+                program: raw_path,
+                is_shim: *bin_dir_fragment == "bin",
+            }
         })
-        .find(|raw_path| Path::new(raw_path).is_file())
+        .find(|executable| Path::new(&executable.program).is_file())
 }
 
 /// Like `find_associated_windows_executable`, but if not found, fall back to a simple filename.
-pub(super) fn find_git_associated_windows_executable_with_fallback(stem: &str) -> OsString {
+pub(super) fn find_git_associated_windows_executable_with_fallback(stem: &str) -> WindowsExecutable {
     find_git_associated_windows_executable(stem).unwrap_or_else(|| {
         let mut raw_path = OsString::from(stem);
         raw_path.push(".exe");
-        raw_path
+        WindowsExecutable {
+            program: raw_path,
+            is_shim: false,
+        }
     })
 }
 
@@ -154,7 +167,7 @@ mod tests {
     fn find_git_associated_windows_executable_no_extra() {
         for stem in SHOULD_NOT_FIND {
             let path = super::find_git_associated_windows_executable(stem);
-            assert_eq!(path, None, "should not find {stem:?}");
+            assert!(path.is_none(), "should not find {stem:?}");
         }
     }
 
@@ -162,8 +175,8 @@ mod tests {
     #[cfg_attr(not(windows), ignore = "only meaningful on Windows")]
     fn find_git_associated_windows_executable_with_fallback() {
         for stem in SHOULD_FIND {
-            let path = super::find_git_associated_windows_executable_with_fallback(stem);
-            assert!(Path::new(&path).is_absolute(), "should find {stem:?}");
+            let executable = super::find_git_associated_windows_executable_with_fallback(stem);
+            assert!(Path::new(&executable.program).is_absolute(), "should find {stem:?}");
         }
     }
 
@@ -172,6 +185,7 @@ mod tests {
     fn find_git_associated_windows_executable_with_fallback_falls_back() {
         for stem in SHOULD_NOT_FIND {
             let path = super::find_git_associated_windows_executable_with_fallback(stem)
+                .program
                 .to_str()
                 .expect("valid Unicode")
                 .to_owned();

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -37,17 +37,52 @@ pub fn installation_config_prefix() -> Option<&'static Path> {
 /// If the bundled shell on Windows cannot be found, `sh.exe` is returned as the name of a shell,
 /// as it could possibly be found in `PATH`. On Unix it's `/bin/sh` as the POSIX-compatible shell.
 ///
+/// Use [`shell_command()`] when constructing a command. On Windows, it passes `--posix` to the
+/// Git for Windows `bin/sh.exe` shim so its delegated `bash.exe` behaves like `sh`.
+///
 /// Note that the returned path might not be a path on disk, if it is a fallback path or if the
 /// file was moved or deleted since the first time this function is called.
 pub fn shell() -> &'static OsStr {
-    static PATH: LazyLock<OsString> = LazyLock::new(|| {
+    &shell_configuration().program
+}
+
+struct Shell {
+    program: OsString,
+    /// Whether `program` requires `--posix` to behave like `sh`.
+    needs_posix_mode: bool,
+}
+
+fn shell_configuration() -> &'static Shell {
+    static SHELL: LazyLock<Shell> = LazyLock::new(|| {
         if cfg!(windows) {
-            auxiliary::find_git_associated_windows_executable_with_fallback("sh")
+            let shell = auxiliary::find_git_associated_windows_executable_with_fallback("sh");
+            Shell {
+                program: shell.program,
+                needs_posix_mode: shell.is_shim,
+            }
         } else {
-            "/bin/sh".into()
+            Shell {
+                program: "/bin/sh".into(),
+                needs_posix_mode: false,
+            }
         }
     });
-    PATH.as_ref()
+    &SHELL
+}
+
+/// Return a command configured to run the shell that Git would use.
+///
+/// On Windows, when [`shell()`] selected the Git for Windows `sh.exe` shim, this also requests
+/// POSIX mode explicitly. The shim delegates to `bash.exe`, which otherwise behaves as Bash
+/// rather than as `sh`. Other shells, including a caller-provided shell, must not receive this
+/// Bash-specific option.
+pub fn shell_command() -> std::process::Command {
+    let shell = shell_configuration();
+    let mut command = std::process::Command::new(&shell.program);
+    if shell.needs_posix_mode {
+        command.arg("--posix");
+    }
+    command
 }
 
 /// Return the name of the Git executable to invoke it.


### PR DESCRIPTION

### Tasks

* [x] refackiew

Everything below this line is Codex

----

## What changed

- retain whether `gix_path::env::shell()` selected Git for Windows' `bin/sh.exe` shim
- add `gix_path::env::shell_command()` to configure that shim with `--posix`
- use the configured default shell command from `gix-command` while leaving `with_shell_program()` unchanged
- add a Windows regression test that verifies Bash has POSIX mode enabled

## Why

Git for Windows' `bin/sh.exe` shim delegates to `bash.exe`. Unlike the non-shim
`usr/bin/sh.exe`, that starts Bash without POSIX mode, so shell commands run by
`gix-command` behave differently from shell commands run by Git.

The POSIX option is applied only when the known Git for Windows shim was selected.
Fallback shells and caller-provided shell programs do not receive the Bash-specific
option.

Fixes #1868.

## Validation

- `cargo test -p gix-command`
- `cargo test -p gix-path -- --test-threads=1`
- `cargo clippy -p gix-path -p gix-command --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo doc -p gix-path --no-deps`
