### PR TITLE
feat: support cloning a single revision

### DIFF
--- a/gitoxide-core/src/repository/clone.rs
+++ b/gitoxide-core/src/repository/clone.rs
@@ -7,6 +7,7 @@ pub struct Options {
     pub no_tags: bool,
     pub shallow: gix::remote::fetch::Shallow,
     pub ref_name: Option<gix::refs::PartialName>,
+    pub revision: Option<gix::bstr::BString>,
 }
 
 pub const PROGRESS_RANGE: std::ops::RangeInclusive<u8> = 1..=3;
@@ -33,6 +34,7 @@ pub(crate) mod function {
             bare,
             no_tags,
             ref_name,
+            revision,
             shallow,
         }: Options,
     ) -> anyhow::Result<()>
@@ -78,6 +80,7 @@ pub(crate) mod function {
         let (mut checkout, fetch_outcome) = prepare
             .with_shallow(shallow)
             .with_ref_name(ref_name.as_ref())?
+            .with_revision(revision)?
             .fetch_then_checkout(&mut progress, &gix::interrupt::IS_INTERRUPTED)?;
 
         let (repo, outcome) = if bare {

--- a/gix-transport/src/client/blocking_io/request.rs
+++ b/gix-transport/src/client/blocking_io/request.rs
@@ -18,8 +18,7 @@ pub struct RequestWriter<'a> {
 impl io::Write for RequestWriter<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if self.trace {
-            use bstr::ByteSlice;
-            gix_features::trace::trace!(">> {}", buf.as_bstr());
+            gix_features::trace::trace!(">> {}", bstr::BStr::new(buf));
         }
         self.writer.write(buf)
     }
@@ -78,8 +77,7 @@ impl<'a> RequestWriter<'a> {
             }
             MessageKind::Text(t) => {
                 if self.trace {
-                    use bstr::ByteSlice;
-                    gix_features::trace::trace!(">> {}", t.as_bstr());
+                    gix_features::trace::trace!(">> {}", bstr::BStr::new(t));
                 }
                 encode::write_text(&gix_packetline::TextRef::from(t), self.writer.inner_mut())
             }

--- a/gix/src/clone/access.rs
+++ b/gix/src/clone/access.rs
@@ -1,4 +1,8 @@
-use crate::{Repository, bstr::BString, clone::PrepareFetch};
+use crate::{
+    Repository,
+    bstr::{BString, ByteSlice},
+    clone::PrepareFetch,
+};
 
 /// Builder
 impl PrepareFetch {
@@ -49,15 +53,48 @@ impl PrepareFetch {
     /// Note that `name` should be a partial name like `main` or `feat/one`, but can be a full ref name.
     /// If a branch on the remote matches, it will automatically be retrieved even without a refspec.
     ///
-    /// # Panics
-    ///
-    /// Calling this method with a valid refspec that is not a branch name, like an object-id as hex-hash,
-    /// currently causes subsequent calls to [`PrepareFetch::fetch_only`] or [`PrepareFetch::fetch_then_checkout`] to panic.
+    /// Setting `name` to `Some(_)` clears a revision previously set with [`with_revision()`](Self::with_revision).
+    /// Passing `None` leaves the revision unchanged.
     pub fn with_ref_name<'a, Name, E>(mut self, name: Option<Name>) -> Result<Self, E>
     where
         Name: TryInto<&'a gix_ref::PartialNameRef, Error = E>,
     {
         self.ref_name = name.map(TryInto::try_into).transpose()?.map(ToOwned::to_owned);
+        if self.ref_name.is_some() {
+            self.revision = None;
+        }
+        Ok(self)
+    }
+
+    /// Fetch only `revision` and check it out with a detached `HEAD`.
+    ///
+    /// A revision is either `HEAD`, a full reference name like `refs/heads/main`, or a full object ID.
+    /// No local or remote-tracking references are created and no fetch refspec is persisted.
+    /// It replaces any extra refspecs supplied with [`with_fetch_options()`](Self::with_fetch_options)
+    /// before fetching.
+    /// Setting `revision` to `Some(_)` clears a ref name previously set with [`with_ref_name()`](Self::with_ref_name).
+    /// Passing `None` leaves the ref name unchanged.
+    pub fn with_revision(
+        mut self,
+        revision: Option<impl Into<BString>>,
+    ) -> Result<Self, crate::clone::with_revision::Error> {
+        self.revision = revision
+            .map(|revision| {
+                let revision = revision.into();
+                let spec = gix_refspec::parse(revision.as_ref(), gix_refspec::parse::Operation::Fetch)?;
+                let source = spec.source().expect("one-sided non-empty fetch refspec");
+                let is_full_ref = source.starts_with(b"refs/") && source.find_byteset(b"*?[]\\").is_none();
+                let is_valid = revision.as_bstr() == source
+                    && spec.destination().is_none()
+                    && (source == "HEAD" || is_full_ref || gix_hash::ObjectId::from_hex(source).is_ok());
+                is_valid
+                    .then(|| spec.to_owned())
+                    .ok_or(crate::clone::with_revision::Error::Invalid { revision })
+            })
+            .transpose()?;
+        if self.revision.is_some() {
+            self.ref_name = None;
+        }
         Ok(self)
     }
 }

--- a/gix/src/clone/fetch/mod.rs
+++ b/gix/src/clone/fetch/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bstr::{BString, ByteSlice},
+    bstr::{BStr, BString, ByteSlice},
     clone::PrepareFetch,
 };
 use gix_ref::Category;
@@ -54,6 +54,12 @@ pub enum Error {
         wanted: gix_ref::PartialName,
         candidates: Vec<BString>,
     },
+    #[error("The remote didn't have the requested revision {wanted:?}")]
+    RevisionMissing { wanted: BString },
+    #[error("The requested revision could not be read")]
+    FindRevision(#[from] crate::object::find::existing::Error),
+    #[error("The requested revision did not peel to a commit")]
+    PeelRevision(#[from] crate::object::peel::to_kind::Error),
     #[error(transparent)]
     CommitterOrFallback(#[from] crate::config::commit_signature::Error),
     #[error(transparent)]
@@ -136,7 +142,8 @@ impl PrepareFetch {
         // to match git's behavior (matching git's single-branch behavior for shallow clones).
         let use_single_branch_for_shallow = self.shallow != remote::fetch::Shallow::NoChange
             && remote.fetch_specs.is_empty()
-            && self.fetch_options.extra_refspecs.is_empty();
+            && self.fetch_options.extra_refspecs.is_empty()
+            && self.revision.is_none();
 
         let target_ref = if use_single_branch_for_shallow {
             // Determine target branch from user-specified ref_name or default branch
@@ -218,7 +225,7 @@ impl PrepareFetch {
 
         // Set up refspec based on whether we're doing a single-branch shallow clone,
         // which requires a single ref to match Git unless it's overridden.
-        if remote.fetch_specs.is_empty() {
+        if remote.fetch_specs.is_empty() && self.revision.is_none() {
             if let Some(target_ref) = &target_ref {
                 // Single-branch refspec for shallow clones
                 let destination = match target_ref.category_and_short_name() {
@@ -247,8 +254,14 @@ impl PrepareFetch {
         let mut clone_fetch_tags = None;
         if let Some(f) = self.configure_remote.as_mut() {
             remote = f(remote).map_err(Error::RemoteConfiguration)?;
-        } else {
+        } else if self.revision.is_none() {
             clone_fetch_tags = remote::fetch::Tags::All.into();
+        }
+        if self.revision.is_some() {
+            remote
+                .replace_refspecs(std::iter::empty::<&BStr>(), remote::Direction::Fetch)
+                .expect("an empty refspec list is always valid");
+            remote = remote.with_fetch_tags(remote::fetch::Tags::None);
         }
 
         // The remote section just written to `.git/config`, kept around so we can
@@ -284,15 +297,20 @@ impl PrepareFetch {
             let connection = connection.into_detached();
             let mut fetch_opts = {
                 let mut opts = self.fetch_options.clone();
-                if !opts.extra_refspecs.contains(&head_refspec) {
-                    opts.extra_refspecs.push(head_refspec.clone());
-                }
-                if let Some(ref_name) = &self.ref_name {
-                    opts.extra_refspecs.push(
-                        gix_refspec::parse(ref_name.as_ref().as_bstr(), gix_refspec::parse::Operation::Fetch)
-                            .expect("partial names are valid refspecs")
-                            .to_owned(),
-                    );
+                if let Some(revision) = &self.revision {
+                    opts.extra_refspecs.clear();
+                    opts.extra_refspecs.push(revision.clone());
+                } else {
+                    if !opts.extra_refspecs.contains(&head_refspec) {
+                        opts.extra_refspecs.push(head_refspec.clone());
+                    }
+                    if let Some(ref_name) = &self.ref_name {
+                        opts.extra_refspecs.push(
+                            gix_refspec::parse(ref_name.as_ref().as_bstr(), gix_refspec::parse::Operation::Fetch)
+                                .expect("partial names are valid refspecs")
+                                .to_owned(),
+                        );
+                    }
                 }
                 opts
             };
@@ -332,6 +350,9 @@ impl PrepareFetch {
         // Assure problems with custom branch names fail early, not after getting the pack or during negotiation.
         if let Some(ref_name) = &self.ref_name {
             util::find_custom_refname(pending_pack.ref_map(), ref_name)?;
+        }
+        if let Some(revision) = &self.revision {
+            util::find_revision(pending_pack.ref_map(), revision)?;
         }
         // On an object-format mismatch: adopt the remote's format before receiving the pack.
         // Only reachable with sha256, otherwise `gix_hash::Kind` has a single variant, so
@@ -388,6 +409,7 @@ impl PrepareFetch {
             reflog_message.as_ref(),
             remote_name.as_ref(),
             self.ref_name.as_ref(),
+            self.revision.as_ref(),
         )?;
 
         drop(self.repo.take().expect("still present"));

--- a/gix/src/clone/fetch/util.rs
+++ b/gix/src/clone/fetch/util.rs
@@ -128,33 +128,46 @@ pub fn update_head(
     reflog_message: &BStr,
     remote_name: &BStr,
     ref_name: Option<&PartialName>,
+    revision: Option<&gix_refspec::RefSpec>,
 ) -> Result<(), Error> {
     use gix_ref::{
         Target,
         transaction::{PreviousValue, RefEdit},
     };
-    let head_info = match ref_name {
-        Some(ref_name) => {
-            let (target, full_ref_name) = find_custom_refname(ref_map, ref_name)?;
-            Some((Some(target), Some(full_ref_name)))
-        }
-        None => ref_map.remote_refs.iter().find_map(|r| {
-            Some(match r {
-                gix_protocol::handshake::Ref::Symbolic {
-                    full_ref_name,
-                    target,
-                    tag: _,
-                    object,
-                } if full_ref_name == "HEAD" => (Some(object.as_ref()), Some(target.as_bstr())),
-                gix_protocol::handshake::Ref::Direct { full_ref_name, object } if full_ref_name == "HEAD" => {
-                    (Some(object.as_ref()), None)
-                }
-                gix_protocol::handshake::Ref::Unborn { full_ref_name, target } if full_ref_name == "HEAD" => {
-                    (None, Some(target.as_bstr()))
-                }
-                _ => return None,
-            })
-        }),
+    let revision_head_id = revision
+        .map(|revision| -> Result<gix_hash::ObjectId, Error> {
+            let mapping = find_revision(ref_map, revision)?;
+            let id = mapping.remote.peeled_id().ok_or_else(|| Error::RevisionMissing {
+                wanted: revision.to_ref().source().expect("validated revision").to_owned(),
+            })?;
+            Ok(repo.find_object(id)?.peel_to_commit()?.id)
+        })
+        .transpose()?;
+    let head_info = match revision_head_id.as_ref() {
+        Some(id) => Some((Some(id.as_ref()), None)),
+        None => match ref_name {
+            Some(ref_name) => {
+                let (target, full_ref_name) = find_custom_refname(ref_map, ref_name)?;
+                Some((Some(target), Some(full_ref_name)))
+            }
+            None => ref_map.remote_refs.iter().find_map(|r| {
+                Some(match r {
+                    gix_protocol::handshake::Ref::Symbolic {
+                        full_ref_name,
+                        target,
+                        tag: _,
+                        object,
+                    } if full_ref_name == "HEAD" => (Some(object.as_ref()), Some(target.as_bstr())),
+                    gix_protocol::handshake::Ref::Direct { full_ref_name, object } if full_ref_name == "HEAD" => {
+                        (Some(object.as_ref()), None)
+                    }
+                    gix_protocol::handshake::Ref::Unborn { full_ref_name, target } if full_ref_name == "HEAD" => {
+                        (None, Some(target.as_bstr()))
+                    }
+                    _ => return None,
+                })
+            }),
+        },
     };
     let Some((head_peeled_id, head_ref)) = head_info else {
         return Ok(());
@@ -247,6 +260,31 @@ pub fn update_head(
     Ok(())
 }
 
+/// Find the mapping produced by the exact refspec used to request `revision`.
+///
+/// Returns [`Error::RevisionMissing`] if the remote did not map that refspec.
+pub(super) fn find_revision<'a>(
+    ref_map: &'a crate::remote::fetch::RefMap,
+    revision: &gix_refspec::RefSpec,
+) -> Result<&'a gix_protocol::fetch::refmap::Mapping, Error> {
+    ref_map
+        .mappings
+        .iter()
+        .find(|mapping| {
+            mapping
+                .spec_index
+                .get(&ref_map.refspecs, &ref_map.extra_refspecs)
+                .is_some_and(|spec| spec == revision)
+        })
+        .ok_or_else(|| Error::RevisionMissing {
+            wanted: revision.to_ref().source().expect("validated revision").to_owned(),
+        })
+}
+
+/// Resolve `ref_name` to its object ID and full name among the mapped remote references.
+///
+/// Full names match directly. Partial names prefer branches over tags, then use normal refspec matching.
+/// Returns [`Error::RefNameMissing`] or [`Error::RefNameAmbiguous`] when there is no unique match.
 pub(super) fn find_custom_refname<'a>(
     ref_map: &'a crate::remote::fetch::RefMap,
     ref_name: &PartialName,

--- a/gix/src/clone/mod.rs
+++ b/gix/src/clone/mod.rs
@@ -42,8 +42,24 @@ pub struct PrepareFetch {
     /// The name of the reference to fetch. If `None`, the reference pointed to by `HEAD` will be checked out.
     #[cfg_attr(not(feature = "blocking-network-client"), allow(dead_code))]
     ref_name: Option<gix_ref::PartialName>,
+    /// The single revision to fetch and check out with a detached `HEAD`.
+    #[cfg_attr(not(feature = "blocking-network-client"), allow(dead_code))]
+    revision: Option<gix_refspec::RefSpec>,
     /// If `true`, drop removes the entire worktree. Otherwise leave it alone.
     remove_worktree_on_drop: bool,
+}
+
+/// Errors returned by [`PrepareFetch::with_revision()`].
+pub mod with_revision {
+    /// An invalid revision for a single-revision clone.
+    #[derive(Debug, thiserror::Error)]
+    #[expect(missing_docs)]
+    pub enum Error {
+        #[error(transparent)]
+        Parse(#[from] gix_refspec::parse::Error),
+        #[error("A clone revision must be HEAD, a full reference name, or a full object ID, got {revision:?}")]
+        Invalid { revision: crate::bstr::BString },
+    }
 }
 
 /// The error returned by [`PrepareFetch::new()`].
@@ -159,6 +175,7 @@ impl PrepareFetch {
             configure_connection: None,
             shallow: remote::fetch::Shallow::NoChange,
             ref_name: None,
+            revision: None,
             remove_worktree_on_drop,
         })
     }

--- a/gix/tests/gix/clone.rs
+++ b/gix/tests/gix/clone.rs
@@ -920,6 +920,153 @@ mod blocking_io {
     }
 
     #[test]
+    fn fetch_and_checkout_specific_revision() -> crate::Result {
+        let tmp = gix_testtools::tempfile::TempDir::new()?;
+        let remote_repo = remote::repo("base");
+        let branch_id = remote_repo.find_reference("refs/heads/a")?.peel_to_id()?.detach();
+        let tag_id = remote_repo
+            .find_reference("refs/tags/annotated-detached-tag")?
+            .peel_to_commit()?
+            .id;
+        let head_id = remote_repo.head_id()?.detach();
+        for (name, revision, expected) in [
+            ("branch", "refs/heads/a".to_owned(), branch_id),
+            ("tag", "refs/tags/annotated-detached-tag".to_owned(), tag_id),
+            ("head", "HEAD".to_owned(), head_id),
+            ("object-id", branch_id.to_string(), branch_id),
+        ] {
+            let mut prepare = gix::clone::PrepareFetch::new(
+                remote_repo.path(),
+                tmp.path().join(name),
+                gix::create::Kind::WithWorktree,
+                Default::default(),
+                restricted(),
+            )?
+            .with_revision(Some(revision))?;
+
+            let (mut checkout, _) = prepare.fetch_then_checkout(gix::progress::Discard, &AtomicBool::default())?;
+            let (repo, _) = checkout.main_worktree(gix::progress::Discard, &AtomicBool::default())?;
+
+            assert_eq!(repo.head_id()?, expected, "HEAD points at the requested revision");
+            assert!(repo.head_ref()?.is_none(), "HEAD is detached");
+            assert_eq!(
+                repo.references()?.all()?.count(),
+                0,
+                "single-revision clones create no ordinary references"
+            );
+            let remote = repo.find_remote("origin")?;
+            assert!(
+                remote.refspecs(Direction::Fetch).is_empty(),
+                "single-revision clones persist no fetch refspec"
+            );
+            assert_eq!(
+                remote.fetch_tags(),
+                gix::remote::fetch::Tags::None,
+                "later fetches do not follow tags"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn fetch_specific_revision_bare_and_shallow() -> crate::Result {
+        let tmp = gix_testtools::tempfile::TempDir::new()?;
+        let remote_repo = remote::repo("base");
+        let revision = "refs/heads/a";
+        let expected = remote_repo.find_reference(revision)?.peel_to_id()?;
+
+        let mut bare = gix::clone::PrepareFetch::new(
+            remote_repo.path(),
+            tmp.path().join("bare"),
+            gix::create::Kind::Bare,
+            Default::default(),
+            restricted(),
+        )?
+        .with_revision(Some(revision))?;
+        let (repo, _) = bare.fetch_only(gix::progress::Discard, &AtomicBool::default())?;
+        assert_eq!(repo.head_id()?, expected, "bare clones retain a detached HEAD");
+        assert_eq!(
+            repo.references()?.all()?.count(),
+            0,
+            "bare clones create no ordinary references"
+        );
+
+        let mut shallow = gix::clone::PrepareFetch::new(
+            remote_repo.path(),
+            tmp.path().join("shallow"),
+            gix::create::Kind::WithWorktree,
+            Default::default(),
+            restricted(),
+        )?
+        .with_revision(Some(revision))?
+        .with_shallow(Shallow::DepthAtRemote(1.try_into()?));
+        let (mut checkout, _) = shallow.fetch_then_checkout(gix::progress::Discard, &AtomicBool::default())?;
+        let (repo, _) = checkout.main_worktree(gix::progress::Discard, &AtomicBool::default())?;
+        assert!(repo.is_shallow(), "depth applies to a single-revision clone");
+        assert_eq!(repo.head_id()?, expected, "the requested revision is checked out");
+        assert_eq!(
+            repo.references()?.all()?.count(),
+            0,
+            "shallow clones also create no ordinary references"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_specific_revisions_are_rejected() -> crate::Result {
+        let tmp = gix_testtools::tempfile::TempDir::new()?;
+        let remote_repo = remote::repo("base");
+        for invalid in ["main", "deadbeef", "refs/heads/main^"] {
+            let result = gix::clone::PrepareFetch::new(
+                remote_repo.path(),
+                tmp.path().join(invalid.replace('/', "_")),
+                gix::create::Kind::Bare,
+                Default::default(),
+                restricted(),
+            )?
+            .with_revision(Some(invalid));
+            assert!(result.is_err(), "{invalid:?} is not a full revision");
+        }
+
+        let mut missing = gix::clone::PrepareFetch::new(
+            remote_repo.path(),
+            tmp.path().join("missing"),
+            gix::create::Kind::Bare,
+            Default::default(),
+            restricted(),
+        )?
+        .with_revision(Some("refs/heads/does-not-exist"))?;
+        let err = missing
+            .fetch_only(gix::progress::Discard, &AtomicBool::default())
+            .expect_err("missing full references fail");
+        assert!(
+            matches!(err, gix::clone::fetch::Error::RevisionMissing { .. }),
+            "the missing revision is reported directly: {err}"
+        );
+
+        let tree_id = remote_repo
+            .find_reference("refs/heads/a")?
+            .peel_to_commit()?
+            .tree_id()?;
+        let mut tree = gix::clone::PrepareFetch::new(
+            remote_repo.path(),
+            tmp.path().join("tree"),
+            gix::create::Kind::Bare,
+            Default::default(),
+            restricted(),
+        )?
+        .with_revision(Some(tree_id.to_string()))?;
+        let err = tree
+            .fetch_only(gix::progress::Discard, &AtomicBool::default())
+            .expect_err("tree revisions cannot become HEAD");
+        assert!(
+            matches!(err, gix::clone::fetch::Error::PeelRevision(_)),
+            "non-commit revisions are rejected: {err}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn fetch_and_checkout_specific_non_existing() -> crate::Result {
         let tmp = gix_testtools::tempfile::TempDir::new()?;
         let remote_repo = remote::repo("base");

--- a/src/plumbing/main.rs
+++ b/src/plumbing/main.rs
@@ -672,6 +672,7 @@ pub fn main() -> Result<()> {
             bare,
             no_tags,
             ref_name,
+            revision,
             remote,
             shallow,
             directory,
@@ -682,6 +683,7 @@ pub fn main() -> Result<()> {
                 handshake_info,
                 no_tags,
                 ref_name,
+                revision,
                 shallow: shallow.into(),
             };
             prepare_and_run(

--- a/src/plumbing/options/mod.rs
+++ b/src/plumbing/options/mod.rs
@@ -798,8 +798,17 @@ pub mod clone {
         pub remote: OsString,
 
         /// The name of the reference to check out.
-        #[clap(long = "ref", value_parser = crate::shared::AsPartialRefName, value_name = "REF_NAME")]
+        #[clap(
+            long = "ref",
+            value_parser = crate::shared::AsPartialRefName,
+            value_name = "REF_NAME",
+            conflicts_with = "revision"
+        )]
         pub ref_name: Option<gix::refs::PartialName>,
+
+        /// Fetch only this full reference or object ID and check it out with a detached HEAD.
+        #[clap(long, value_parser = crate::shared::AsBString, value_name = "REVISION")]
+        pub revision: Option<gix::bstr::BString>,
 
         /// The directory to initialize with the new repository and to which all data should be written.
         pub directory: Option<PathBuf>,


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #1930

## Summary

- add `PrepareFetch::with_revision()` for cloning `HEAD`, a full ref name, or a full object ID into a detached HEAD
- add the plumbing `--revision` option while preserving the existing `--ref` behavior
- avoid creating ordinary refs or persisting a fetch refspec for revision-only clones

The behavior follows Git commit `337855629f59` and its `t/t5621-clone-revision.sh` coverage.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p gix --features blocking-network-client,blocking-http-transport-curl clone`
- `cargo test -p gitoxide clone_revision_is_distinct_from_ref`
- `cargo check -p gix --no-default-features --features sha1,blocking-network-client,worktree-mutation`
- `cargo check -p gix --no-default-features --features sha1,async-network-client-async-std,worktree-mutation`
- `cargo doc -p gix --no-deps --features blocking-network-client,worktree-mutation`