### PR TITLE
fix: resolve in-pack ref deltas while indexing

### DIFF
--- a/gix-pack/src/cache/delta/traverse/mod.rs
+++ b/gix-pack/src/cache/delta/traverse/mod.rs
@@ -18,6 +18,9 @@ use crate::{
 mod resolve;
 pub(crate) mod util;
 
+/// Shared access to ref-delta child indices awaiting a resolved base, keyed by its object ID.
+pub(super) type SharedRefDeltaChildren = OwnShared<Mutable<super::tree::RefDeltaChildren>>;
+
 /// Returned by [`Tree::traverse()`]
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -43,6 +46,13 @@ pub enum Error {
         /// The base's offset which was from a resolved ref-delta that didn't actually get added to the tree
         base_pack_offset: crate::data::Offset,
     },
+    #[error("The ref-delta base object {base_id} could not be found")]
+    UnresolvedRefDelta {
+        /// The id named by one or more unresolved ref-delta entries.
+        base_id: gix_hash::ObjectId,
+    },
+    #[error("Failed to hash an object while resolving in-pack ref-deltas")]
+    ObjectHash(#[from] gix_hash::hasher::Error),
     #[error("Failed to spawn thread when switching to work-stealing mode")]
     SpawnThread(#[from] std::io::Error),
     #[error(transparent)]
@@ -151,7 +161,9 @@ where
         let object_progress = OwnShared::new(Mutable::new(object_progress));
 
         let start = std::time::Instant::now();
-        let (mut root_items, mut child_items_vec) = self.take_root_and_child();
+        let (mut root_items, mut child_items_vec, ref_delta_children) = self.take_root_child_and_refs();
+        let ref_delta_children =
+            (!ref_delta_children.is_empty()).then(|| OwnShared::new(Mutable::new(ref_delta_children)));
         let child_items = ItemSliceSync::new(&mut child_items_vec);
         let child_items = &child_items;
         in_parallel_with_slice(
@@ -160,6 +172,7 @@ where
             {
                 {
                     let object_progress = object_progress.clone();
+                    let ref_delta_children = ref_delta_children.clone();
                     move |thread_index| resolve::State {
                         delta_bytes: Vec::<u8>::with_capacity(4096),
                         fully_resolved_delta_bytes: Vec::<u8>::with_capacity(4096),
@@ -169,6 +182,7 @@ where
                         resolve: resolve.clone(),
                         modify_base: inspect_object.clone(),
                         child_items,
+                        ref_delta_children: ref_delta_children.clone(),
                     }
                 }
             },
@@ -196,6 +210,12 @@ where
             || (!should_interrupt.load(Ordering::Relaxed)).then(|| std::time::Duration::from_millis(50)),
             |_| (),
         )?;
+
+        if let Some(ref_delta_children) = ref_delta_children {
+            if let Some((base_id, _children)) = threading::lock(&ref_delta_children).first_key_value() {
+                return Err(Error::UnresolvedRefDelta { base_id: *base_id });
+            }
+        }
 
         threading::lock(&object_progress).show_throughput(start);
         size_progress.show_throughput(start);

--- a/gix-pack/src/cache/delta/traverse/resolve.rs
+++ b/gix-pack/src/cache/delta/traverse/resolve.rs
@@ -63,6 +63,10 @@ mod root {
             !self.item.children().is_empty()
         }
 
+        pub fn add_children(&mut self, children: impl IntoIterator<Item = u32>) {
+            self.item.extend_children(children);
+        }
+
         /// Transform this `Node` into an iterator over its children.
         ///
         /// Children are `Node`s referring to pack entries whose base object is this pack entry.
@@ -81,6 +85,28 @@ mod root {
     }
 }
 
+fn attach_ref_delta_children<T: Send>(
+    node: &mut root::Node<'_, T>,
+    entry: &data::Entry,
+    decompressed: &[u8],
+    ref_delta_children: Option<&super::SharedRefDeltaChildren>,
+    object_hash: gix_hash::Kind,
+) -> Result<(), Error> {
+    let Some(ref_delta_children) = ref_delta_children else {
+        return Ok(());
+    };
+    if threading::lock(ref_delta_children).is_empty() {
+        return Ok(());
+    }
+
+    let kind = entry.header.as_kind().expect("a fully resolved object has a base kind");
+    let id = gix_object::compute_hash(object_hash, kind, decompressed)?;
+    if let Some(children) = threading::lock(ref_delta_children).remove(&id) {
+        node.add_children(children);
+    }
+    Ok(())
+}
+
 pub(super) struct State<'items, F, MBFN, T: Send> {
     pub delta_bytes: Vec<u8>,
     pub fully_resolved_delta_bytes: Vec<u8>,
@@ -88,14 +114,29 @@ pub(super) struct State<'items, F, MBFN, T: Send> {
     pub resolve: F,
     pub modify_base: MBFN,
     pub child_items: &'items ItemSliceSync<'items, Item<T>>,
+    pub ref_delta_children: Option<super::SharedRefDeltaChildren>,
 }
 
-/// SAFETY: `item.children` must uniquely reference elements in child_items that no other currently alive
-/// item does. All child_items must also have unique children.
+/// Resolve and visit the complete delta subtree rooted at `item`.
+///
+/// The root entry is read and inflated through `resolve`. Each child entry is inflated as delta instructions and applied
+/// to its resolved parent's bytes. The resulting object inherits its parent's object kind and is passed to `modify_base`;
+/// objects which are themselves bases retain their bytes until their children have been processed.
+///
+/// After resolving an object, its ID is computed if ref-deltas are waiting for a matching base. Those children are then
+/// attached to the object and traversed like children whose bases were known by pack offset.
+///
+/// # Safety
 ///
 /// This safety invariant can be reliably upheld by making sure `item` comes from a Tree and `child_items`
 /// was constructed using that Tree's child_items. This works since Tree has this invariant as well: all
 /// child_items are referenced at most once (really, exactly once) by a node in the tree.
+///
+/// So: `item.children` must contain valid, unique indices into `child_items`, and every child item must recursively uphold the
+/// same rule. No index may be reachable from another live root or child. This gives each worker exclusive access to every
+/// `Item<T>` it obtains through [`ItemSliceSync`], despite that type using a shared raw pointer internally.
+/// The caller can satisfy this contract by taking `item` and `child_items` from the same
+/// [`Tree`](crate::cache::delta::Tree), whose construction maintains the single-parent invariant.
 #[expect(clippy::too_many_arguments, unsafe_code)]
 #[deny(unsafe_op_in_unsafe_fn)] // this is a big function, require unsafe for the one small unsafe op we have
 pub(super) unsafe fn deltas<T, F, MBFN, E, R>(
@@ -109,6 +150,7 @@ pub(super) unsafe fn deltas<T, F, MBFN, E, R>(
         resolve,
         modify_base,
         child_items,
+        ref_delta_children,
     }: &mut State<'_, F, MBFN, T>,
     resolve_data: &R,
     object_hash: gix_hash::Kind,
@@ -175,6 +217,13 @@ where
             objects.fetch_add(1, Ordering::Relaxed);
             size.fetch_add(base_bytes.len(), Ordering::Relaxed);
         }
+        attach_ref_delta_children(
+            &mut base,
+            &base_entry,
+            &base_bytes,
+            ref_delta_children.as_ref(),
+            object_hash,
+        )?;
 
         for mut child in base.into_child_iter() {
             let (mut child_entry, entry_end) = decompress_from_resolver(child.entry_slice(), delta_bytes)?;
@@ -197,6 +246,13 @@ where
             // FIXME: this actually invalidates the "pack_offset()" computation, which is not obvious to consumers
             //        at all
             child_entry.header = base_entry.header; // assign the actual object type, instead of 'delta'
+            attach_ref_delta_children(
+                &mut child,
+                &child_entry,
+                fully_resolved_delta_bytes,
+                ref_delta_children.as_ref(),
+                object_hash,
+            )?;
             if child.has_children() {
                 decompressed_bytes_by_pack_offset.insert(
                     child.offset(),
@@ -243,6 +299,7 @@ where
                     resolve.clone(),
                     resolve_data,
                     modify_base.clone(),
+                    ref_delta_children.clone(),
                     object_hash,
                     alloc_limit_bytes,
                     threads_left,
@@ -269,6 +326,7 @@ fn deltas_mt<T, F, MBFN, E, R>(
     resolve: F,
     resolve_data: &R,
     modify_base: MBFN,
+    ref_delta_children: Option<super::SharedRefDeltaChildren>,
     object_hash: gix_hash::Kind,
     alloc_limit_bytes: Option<usize>,
     threads_left: &AtomicIsize,
@@ -298,6 +356,7 @@ where
                         let decompressed_bytes_by_pack_offset = &decompressed_bytes_by_pack_offset;
                         let resolve = resolve.clone();
                         let mut modify_base = modify_base.clone();
+                        let ref_delta_children = ref_delta_children.clone();
                         let objects = &objects;
                         let size = &size;
 
@@ -360,6 +419,13 @@ where
                                     objects.fetch_add(1, Ordering::Relaxed);
                                     size.fetch_add(base_bytes.len(), Ordering::Relaxed);
                                 }
+                                attach_ref_delta_children(
+                                    &mut base,
+                                    &base_entry,
+                                    &base_bytes,
+                                    ref_delta_children.as_ref(),
+                                    object_hash,
+                                )?;
 
                                 for mut child in base.into_child_iter() {
                                     let (mut child_entry, entry_end) =
@@ -388,6 +454,13 @@ where
                                     // FIXME: this actually invalidates the "pack_offset()" computation, which is not obvious to consumers
                                     //        at all
                                     child_entry.header = base_entry.header; // assign the actual object type, instead of 'delta'
+                                    attach_ref_delta_children(
+                                        &mut child,
+                                        &child_entry,
+                                        &fully_resolved_delta_bytes,
+                                        ref_delta_children.as_ref(),
+                                        object_hash,
+                                    )?;
                                     if child.has_children() {
                                         threading::lock(decompressed_bytes_by_pack_offset).insert(
                                             child.offset(),

--- a/gix-pack/src/cache/delta/traverse/util.rs
+++ b/gix-pack/src/cache/delta/traverse/util.rs
@@ -4,16 +4,9 @@ use std::marker::PhantomData;
 /// tree, and we need to access it concurrently with each thread taking its own root node,
 /// and working its way through all the reachable leaves.
 ///
-/// The tree was built by decoding a pack whose entries refer to its bases only by OFS_DELTA -
-/// they are pointing backwards only which assures bases have to be listed first, and that each entry
-/// only has a single parent.
-///
-/// REF_DELTA entries aren't supported here, and cause immediate failure - they are expected to have
-/// been resolved before as part of the thin-pack handling.
-///
-/// If we somehow would allow REF_DELTA entries to point to an in-pack object, then in theory malicious packs could
-/// cause all kinds of graphs as they can point anywhere in the pack, but they still can't link an entry to
-/// more than one base. And that's what one would really have to do for two threads to encounter the same child.
+/// The tree was built by decoding a pack whose entries refer to exactly one base. OFS_DELTA entries point
+/// backwards, while in-pack REF_DELTA entries are attached once their base object id is known.
+/// Ref children are removed from a shared lookup before attachment, so no child can be reached by two threads.
 ///
 /// Thus I believe it's impossible for this data structure to end up in a place where it violates its assumption.
 pub(super) struct ItemSliceSync<'a, T>

--- a/gix-pack/src/cache/delta/tree.rs
+++ b/gix-pack/src/cache/delta/tree.rs
@@ -1,5 +1,11 @@
+use std::collections::BTreeMap;
+
 use super::{Error, traverse};
 use crate::exact_vec;
+
+/// Maps each referenced base object ID to indices in `Tree::child_items` of ref-deltas waiting for it.
+pub(super) type RefDeltaChildren = BTreeMap<gix_hash::ObjectId, Vec<u32>>;
+
 /// An item stored within the [`Tree`] whose data is stored in a pack file, identified by
 /// the offset of its first (`offset`) and last (`next_offset`) bytes.
 ///
@@ -17,7 +23,7 @@ pub struct Item<T> {
     /// Limited to u32 as that's the maximum amount of objects in a pack.
     // SAFETY INVARIANT:
     //    - only one Item in a tree may have any given child index. `future_child_offsets`
-    //      should also not contain any indices found in `children`.\
+    //      and `ref_child_indices` should also not contain any indices found in `children`.
     //    - These indices should be in bounds for tree.child_items
     children: Vec<u32>,
 }
@@ -27,6 +33,10 @@ impl<T> Item<T> {
     // (we don't want to expose mutable access)
     pub fn children(&self) -> &[u32] {
         &self.children
+    }
+
+    pub(super) fn extend_children(&mut self, children: impl IntoIterator<Item = u32>) {
+        self.children.extend(children);
     }
 }
 
@@ -56,6 +66,8 @@ pub struct Tree<T> {
     //      in Item.children. Indices should be found here at most once.
     //    - These indices should be in bounds for tree.child_items.
     future_child_offsets: Vec<(crate::data::Offset, usize)>,
+    /// Child indices waiting for an in-pack object with the given id to be resolved.
+    ref_child_indices: RefDeltaChildren,
 }
 
 impl<T> Tree<T> {
@@ -66,6 +78,7 @@ impl<T> Tree<T> {
             child_items: exact_vec(num_objects / 2),
             last_seen: None,
             future_child_offsets: Vec::new(),
+            ref_child_indices: BTreeMap::new(),
         })
     }
 
@@ -76,8 +89,8 @@ impl<T> Tree<T> {
     /// Returns self's root and child items.
     ///
     /// You can rely on them following the same `children` invariants as they did in the tree
-    pub(super) fn take_root_and_child(self) -> (Vec<Item<T>>, Vec<Item<T>>) {
-        (self.root_items, self.child_items)
+    pub(super) fn take_root_child_and_refs(self) -> (Vec<Item<T>>, Vec<Item<T>>, RefDeltaChildren) {
+        (self.root_items, self.child_items, self.ref_child_indices)
     }
 
     pub(super) fn assert_is_incrementing_and_update_next_offset(
@@ -181,6 +194,28 @@ impl<T> Tree<T> {
             next_offset: 0,
             data,
             // SAFETY INVARIANT upheld: there are no children
+            children: Default::default(),
+        });
+        Ok(())
+    }
+
+    /// Add a child whose base is identified by object id and may occur anywhere in the pack.
+    #[cfg(feature = "streaming-input")]
+    pub(crate) fn add_child_by_id(
+        &mut self,
+        base_id: gix_hash::ObjectId,
+        offset: crate::data::Offset,
+        data: T,
+    ) -> Result<(), Error> {
+        self.assert_is_incrementing_and_update_next_offset(offset)?;
+
+        let child_index = self.child_items.len() as u32;
+        self.ref_child_indices.entry(base_id).or_default().push(child_index);
+        self.last_seen = NodeKind::Child.into();
+        self.child_items.push(Item {
+            offset,
+            next_offset: 0,
+            data,
             children: Default::default(),
         });
         Ok(())

--- a/gix-pack/src/data/entry/header.rs
+++ b/gix-pack/src/data/entry/header.rs
@@ -16,14 +16,8 @@ pub enum Header {
     Blob,
     /// The object is a tag
     Tag,
-    /// Describes a delta-object which needs to be applied to a base. The base object is identified by the `base_id` field
-    /// which is found within the parent repository.
-    /// Most commonly used for **thin-packs** when receiving pack files from the server to refer to objects that are not
-    /// part of the pack but expected to be present in the receivers repository.
-    ///
-    /// # Note
-    /// This could also be an object within this pack if the LSB encoded offset would be larger than 20 bytes, which is unlikely to
-    /// happen.
+    /// Describes a delta-object which needs to be applied to a base identified by `base_id`.
+    /// The base may occur anywhere in the same pack or in the parent repository, as it does in a **thin-pack**.
     ///
     /// **The naming** is exactly the same as the canonical implementation uses, namely **REF_DELTA**.
     RefDelta { base_id: gix_hash::ObjectId },

--- a/gix-pack/src/data/input/lookup_ref_delta_objects.rs
+++ b/gix-pack/src/data/input/lookup_ref_delta_objects.rs
@@ -11,8 +11,6 @@ pub struct LookupRefDeltaObjectsIter<I, Find> {
     compression: gix_zlib::Compression,
     /// The cached delta to provide next time we are called, it's the delta to go with the base we just resolved in its place.
     next_delta: Option<input::Entry>,
-    /// Fuse to stop iteration after first missing object.
-    error: bool,
     /// The overall pack-offset we accumulated thus far. Each inserted entry offsets all following
     /// objects by its length. We need to determine exactly where the object was inserted to see if its affected at all.
     inserted_entry_length_at_offset: Vec<Change>,
@@ -33,7 +31,6 @@ where
             inner: iter,
             lookup,
             compression,
-            error: false,
             inserted_entry_length_at_offset: Vec::new(),
             inserted_entries_length_in_bytes: 0,
             next_delta: None,
@@ -84,9 +81,6 @@ where
     type Item = Result<input::Entry, input::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.error {
-            return None;
-        }
         if let Some(delta) = self.next_delta.take() {
             return Some(Ok(delta));
         }
@@ -112,8 +106,8 @@ where
                                     entry
                                 }
                                 None => {
-                                    self.error = true;
-                                    return Some(Err(input::Error::NotFound { object_id: base_id }));
+                                    entry.pack_offset = self.shifted_pack_offset(entry.pack_offset);
+                                    return Some(Ok(entry));
                                 }
                             };
 

--- a/gix-pack/src/index/write/mod.rs
+++ b/gix-pack/src/index/write/mod.rs
@@ -68,6 +68,17 @@ pub(super) mod function {
     /// The resolver produced by `make_resolver` must resolve pack entries from the same pack data file that produced the
     /// `entries` iterator.
     ///
+    /// # Ref-delta bases
+    ///
+    /// Bases available through an ODB lookup are handled by wrapping `entries` in
+    /// [`crate::data::input::LookupRefDeltaObjectsIter`]. As entries are consumed, it inserts each full base immediately
+    /// before the first delta that needs it, then rewrites that and later references to the same base as `OFS_DELTA`s.
+    ///
+    /// Remaining `REF_DELTA`s are resolved in-pack here. They are recorded by base object ID; while traversing the delta
+    /// tree, each fully resolved object is hashed and any deltas waiting for that ID are attached as its children. Thus an
+    /// in-pack base may occur before or after its delta, and forward-reference chains are supported. Resolution fails if a
+    /// referenced base was neither inserted by the wrapper nor found among the pack entries.
+    ///
     /// * `kind` is the version of pack index to produce, use [`crate::index::Version::default()`] if in doubt.
     /// * `tread_limit` is used for a parallel tree traversal for obtaining object hashes with optimal performance.
     /// * `root_progress` is the top-level progress to stay informed about the progress of this potentially long-running
@@ -80,7 +91,6 @@ pub(super) mod function {
     ///
     /// # Remarks
     ///
-    /// * neither in-pack nor out-of-pack Ref Deltas are supported here, these must have been resolved beforehand.
     /// * `make_resolver()` will only be called after the iterator stopped returning elements and produces a function that
     ///   provides all bytes belonging to a pack entry writing them to the given mutable output `Vec`.
     ///   It should return `None` if the entry cannot be resolved from the pack that produced the `entries` iterator, causing
@@ -151,7 +161,16 @@ pub(super) mod function {
                         },
                     )?;
                 }
-                RefDelta { .. } => return Err(Error::IteratorInvariantNoRefDelta),
+                RefDelta { base_id } => {
+                    tree.add_child_by_id(
+                        base_id,
+                        pack_offset,
+                        TreeEntry {
+                            id: object_hash.null(),
+                            crc32,
+                        },
+                    )?;
+                }
                 OfsDelta { base_distance } => {
                     let base_pack_offset =
                         crate::data::entry::Header::verified_base_pack_offset(pack_offset, base_distance).ok_or(

--- a/gix-pack/tests/pack/bundle.rs
+++ b/gix-pack/tests/pack/bundle.rs
@@ -87,7 +87,12 @@ mod locate {
 
 #[cfg(all(not(feature = "wasm"), feature = "streaming-input"))]
 mod write_to_directory {
-    use std::{fs, path::Path, sync::atomic::AtomicBool};
+    use std::{
+        fs,
+        io::{Cursor, Write},
+        path::Path,
+        sync::atomic::AtomicBool,
+    };
 
     use gix_features::progress;
     use gix_odb::pack;
@@ -150,6 +155,105 @@ mod write_to_directory {
         Ok(())
     }
 
+    /// A forward reference is a `REF_DELTA` stored before the object named as its base.
+    /// Unlike `OFS_DELTA`, its object ID can name an object at any position in the pack.
+    ///
+    /// Git normally writes bases first, but sends thin packs which omit bases the receiver
+    /// already has. `index-pack --fix-thin` makes such packs self-contained by appending
+    /// those bases, leaving the original deltas as forward references.
+    #[test]
+    fn in_pack_ref_deltas_with_forward_references() -> Result<(), Box<dyn std::error::Error>> {
+        for object_hash in [gix_hash::Kind::Sha1, gix_hash::Kind::Sha256] {
+            for objects in [
+                &[b"A".as_slice(), b"B".as_slice()][..],
+                &[b"A".as_slice(), b"B".as_slice(), b"C".as_slice()][..],
+            ] {
+                let pack_data = ref_delta_pack(object_hash, objects)?;
+                for lookup in [None, Some(gix_object::find::Never)] {
+                    let dir = TempDir::new()?;
+                    let mut input = Cursor::new(pack_data.clone());
+                    let outcome = pack::Bundle::write_to_directory(
+                        &mut input,
+                        Some(dir.as_ref()),
+                        &mut progress::Discard,
+                        &AtomicBool::new(false),
+                        lookup,
+                        pack::bundle::write::Options {
+                            thread_limit: None,
+                            iteration_mode: pack::data::input::Mode::Verify,
+                            index_version: pack::index::Version::V2,
+                            object_hash,
+                            alloc_limit_bytes: None,
+                            compression: gix_zlib::Compression::BEST_SPEED,
+                        },
+                    )?;
+                    assert_eq!(
+                        outcome.index.num_objects as usize,
+                        objects.len(),
+                        "all in-pack objects are indexed"
+                    );
+
+                    let bundle = outcome
+                        .to_bundle()
+                        .transpose()?
+                        .expect("writing to a directory creates a bundle");
+                    let mut buf = Vec::new();
+                    for expected in objects {
+                        let id = gix_object::compute_hash(object_hash, gix_object::Kind::Blob, expected)?;
+                        let object = bundle
+                            .find(
+                                &id,
+                                &mut buf,
+                                &mut gix_zlib::Inflate::default(),
+                                &mut pack::cache::Never,
+                            )?
+                            .expect("object is indexed")
+                            .0;
+                        assert_eq!(object.kind, gix_object::Kind::Blob);
+                        assert_eq!(object.data, *expected, "the ref-delta is fully resolved");
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn unresolved_ref_delta_base_is_reported() -> Result<(), Box<dyn std::error::Error>> {
+        let object_hash = gix_hash::Kind::Sha1;
+        let base_id = object_hash.null();
+        let delta = [0, 0];
+        let mut pack_data = pack::data::header::encode(pack::data::Version::V2, 1).to_vec();
+        pack::data::entry::Header::RefDelta { base_id }.write_to(delta.len() as u64, &mut pack_data)?;
+        pack_data.extend(deflate(&delta)?);
+        let mut hasher = gix_hash::hasher(object_hash);
+        hasher.update(&pack_data);
+        pack_data.extend_from_slice(hasher.try_finalize()?.as_slice());
+
+        let err = pack::Bundle::write_to_directory(
+            &mut Cursor::new(pack_data),
+            None,
+            &mut progress::Discard,
+            &AtomicBool::new(false),
+            None::<gix_object::find::Never>,
+            pack::bundle::write::Options {
+                thread_limit: None,
+                iteration_mode: pack::data::input::Mode::Verify,
+                index_version: pack::index::Version::V2,
+                object_hash,
+                alloc_limit_bytes: None,
+                compression: gix_zlib::Compression::BEST_SPEED,
+            },
+        )
+        .expect_err("a ref-delta without an in-pack or external base cannot be indexed");
+        let expected = format!("The ref-delta base object {base_id} could not be found");
+        assert!(
+            error_chain_contains_message(&err, &expected),
+            "the missing base id is retained in the error chain"
+        );
+        Ok(())
+    }
+
     #[test]
     fn respects_alloc_limit_bytes() -> Result<(), Box<dyn std::error::Error>> {
         let pack_file = fs::File::open(fixture_path(SMALL_PACK))?;
@@ -208,5 +312,46 @@ mod write_to_directory {
             },
         )
         .map_err(Into::into)
+    }
+
+    /// Build a complete pack whose one-byte blobs form a forward `REF_DELTA` chain.
+    /// `objects` lists the base first, but entries are written in reverse dependency order:
+    ///
+    /// ```text
+    /// objects = [A, B, C]
+    ///
+    /// increasing pack offset ────────────────────────────────────────────────►
+    /// [REF_DELTA base=oid(B), yields C] → [REF_DELTA base=oid(A), yields B] → [BLOB A]
+    /// ```
+    ///
+    /// Each arrow points to the entry needed as the base, so every delta refers forward.
+    /// With `[A, B]`, the first entry is omitted, leaving `B → A`.
+    fn ref_delta_pack(
+        object_hash: gix_hash::Kind,
+        objects: &[&'static [u8]],
+    ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let mut pack_data = pack::data::header::encode(pack::data::Version::V2, objects.len() as u32).to_vec();
+        for pair in objects.windows(2).rev() {
+            let (base, resolved) = (pair[0], pair[1]);
+            let base_id = gix_object::compute_hash(object_hash, gix_object::Kind::Blob, base)?;
+            let delta = [1, 1, 1, resolved[0]];
+            pack::data::entry::Header::RefDelta { base_id }.write_to(delta.len() as u64, &mut pack_data)?;
+            pack_data.extend(deflate(&delta)?);
+        }
+        let base = objects[0];
+        pack::data::entry::Header::Blob.write_to(base.len() as u64, &mut pack_data)?;
+        pack_data.extend(deflate(base)?);
+
+        let mut hasher = gix_hash::hasher(object_hash);
+        hasher.update(&pack_data);
+        pack_data.extend_from_slice(hasher.try_finalize()?.as_slice());
+        Ok(pack_data)
+    }
+
+    fn deflate(input: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let mut out = gix_zlib::stream::deflate::Write::new(Vec::new(), gix_zlib::Compression::BEST_SPEED);
+        out.write_all(input)?;
+        out.flush()?;
+        Ok(out.into_inner())
     }
 }

--- a/gix-pack/tests/pack/data/input.rs
+++ b/gix-pack/tests/pack/data/input.rs
@@ -182,21 +182,19 @@ mod lookup_ref_delta_objects {
     }
 
     #[test]
-    fn lookup_errors_trigger_a_fuse_and_stop_iteration() {
-        let input = vec![entry(delta_ref(gix_hash::Kind::Sha1.null()), D_A), entry(base(), D_B)];
+    fn missing_bases_are_left_for_in_pack_resolution() {
+        let input = compute_offsets(vec![
+            entry(delta_ref(gix_hash::Kind::Sha1.null()), D_A),
+            entry(base(), D_B),
+        ]);
+        let expected = input.clone();
         let calls = AtomicUsize::default();
         let db = FindData::new(None, &calls);
-        let mut result =
-            LookupRefDeltaObjectsIter::new(into_results_iter(input), &db, gix_zlib::Compression::BEST_SPEED)
-                .collect::<Vec<_>>();
+        let result = LookupRefDeltaObjectsIter::new(into_results_iter(input), &db, gix_zlib::Compression::BEST_SPEED)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("missing objects may be in the pack itself");
         assert_eq!(calls.load(Ordering::Relaxed), 1, "it tries to lookup the object");
-        assert_eq!(result.len(), 1, "the error stops iteration");
-        assert!(matches!(
-            result.pop().expect("one"),
-            Err(input::Error::NotFound {
-                object_id
-            }) if object_id == gix_hash::Kind::Sha1.null()
-        ));
+        assert_eq!(result, expected, "the unresolved ref-delta is unchanged");
     }
 
     #[test]


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew
- [x] `gix clone https://github.com/Unstructured-IO/irs-manual-demo.git` works
- [x] memory consumption unchanged (2GB real mem for decoding the linux kernel pack, same for speed)

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Refs #1025
Discussion: https://github.com/GitoxideLabs/gitoxide/discussions/2819

## Summary

- leave object-database misses as REF_DELTA entries so index construction can resolve in-pack bases
- attach pending children by object ID while traversing the existing delta tree, including forward references and REF_DELTA chains
- generate minimal two-object SHA-1/SHA-256 reproducer packs and cover chained and unresolved-base cases

## Git reference

Compared with Git a23bace963d508bd96983cc637131392d3face18, particularly builtin/index-pack.c and t/t5300-pack-object.sh. Git retains unresolved REF_DELTA children by base object ID until that base is resolved.

## Validation

- GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix-pack --test pack
- GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix-pack --all-features
- just clippy -D warnings -A unknown-lints --no-deps
- cargo check -p gix-pack --no-default-features --features sha1
- cargo check -p gix-pack --no-default-features --features sha256
- indexed gix-pack/tests/fixtures/objects/pack-with-forward-delta successfully
- live bare clone plus git fsck: https://github.com/Byron/DApp-Pack-Testing
- live bare clone plus git fsck: https://dev.azure.com/bittrance/public/_git/gitoxide

The committed change was reviewed once with codex review --commit dd661e39d8ef889a8be82248816657892eb17d81; it reported no actionable issues.