### PR TITLE
fix: preserve colons in URL usernames

### DIFF
--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -390,7 +390,7 @@ impl Url {
     }
 
     fn write_canonical_form_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
-        fn percent_encode(s: &str) -> Cow<'_, str> {
+        fn percent_encode(s: &str, encode_colon: bool) -> Cow<'_, str> {
             /// Characters that must be percent-encoded in the userinfo component of a URL.
             ///
             /// According to RFC 3986, userinfo can contain:
@@ -419,7 +419,14 @@ impl Url {
                 .add(b'{')
                 .add(b'|')
                 .add(b'}');
-            percent_encoding::utf8_percent_encode(s, USERINFO_ENCODE_SET).into()
+            const USERNAME_ENCODE_SET: &percent_encoding::AsciiSet = &USERINFO_ENCODE_SET.add(b':');
+
+            let encode_set = if encode_colon {
+                USERNAME_ENCODE_SET
+            } else {
+                USERINFO_ENCODE_SET
+            };
+            percent_encoding::utf8_percent_encode(s, encode_set).into()
         }
 
         out.write_all(self.scheme.as_str().as_bytes())?;
@@ -429,10 +436,10 @@ impl Url {
 
         match (&self.user, &self.host) {
             (Some(user), Some(host)) => {
-                out.write_all(percent_encode(user).as_bytes())?;
+                out.write_all(percent_encode(user, true).as_bytes())?;
                 if let Some(password) = &self.password {
                     out.write_all(b":")?;
-                    out.write_all(percent_encode(password).as_bytes())?;
+                    out.write_all(percent_encode(password, false).as_bytes())?;
                 }
                 out.write_all(b"@")?;
                 if needs_brackets {

--- a/gix-url/tests/url/parse/http.rs
+++ b/gix-url/tests/url/parse/http.rs
@@ -32,6 +32,22 @@ fn username_and_password() -> crate::Result {
 }
 
 #[test]
+fn colon_in_username_roundtrips() -> crate::Result {
+    assert_url_roundtrip(
+        "http://a%3Ab@example.com/",
+        url(Scheme::Http, "a:b", "example.com", None, b"/"),
+    )
+}
+
+#[test]
+fn colon_in_password_roundtrips() -> crate::Result {
+    assert_url_roundtrip(
+        "http://user:a:b@example.com/",
+        url_with_pass(Scheme::Http, "user", "a:b", "example.com", None, b"/"),
+    )
+}
+
+#[test]
 fn username_and_password_and_port() -> crate::Result {
     assert_url_roundtrip(
         "http://user:password@example.com:8080/~byron/hello",


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #2827

## Summary

- percent-encode `:` when serializing decoded usernames so it cannot become the username/password delimiter
- retain literal colons in passwords
- cover the reported parse/serialize/parse round trip

## Git baseline

Git `a23bace963d508bd96983cc637131392d3face18` treats the first literal colon in URL userinfo as the username/password boundary and percent-decodes the separated fields (`credential.c`).

## Validation

- `cargo test -p gix-url colon_in_username_roundtrips`
- `cargo test -p gix-url`
- `cargo clippy -p gix-url --all-targets -- -D warnings`
- `git diff --check`
- `codex review --commit 8fa4fe693e5fd93691e33d0e6adbeadc14386023`