### PR TITLE
fix: let GIT_WORK_TREE override core.bare

### DIFF
--- a/gix-path/src/convert.rs
+++ b/gix-path/src/convert.rs
@@ -260,6 +260,15 @@ pub fn to_windows_separators<'a>(path: impl Into<Cow<'a, BStr>>) -> Cow<'a, BStr
 /// can be exhausted by paths like `../../r`, `None` will be returned to indicate the inability to
 /// produce a logically consistent path.
 pub fn normalize<'a>(path: Cow<'a, Path>, current_dir: &Path) -> Option<Cow<'a, Path>> {
+    normalize_inner(path, current_dir, false)
+}
+
+/// Like [`normalize()`], but treats `..` components beyond the filesystem root as no-ops.
+pub fn normalize_saturating<'a>(path: Cow<'a, Path>, current_dir: &Path) -> Cow<'a, Path> {
+    normalize_inner(path, current_dir, true).expect("saturating normalization always produces a path")
+}
+
+fn normalize_inner<'a>(path: Cow<'a, Path>, current_dir: &Path, saturate_at_root: bool) -> Option<Cow<'a, Path>> {
     use std::path::Component::ParentDir;
 
     if !path.components().any(|c| matches!(c, ParentDir)) {
@@ -275,7 +284,7 @@ pub fn normalize<'a>(path: Cow<'a, Path>, current_dir: &Path) -> Option<Cow<'a, 
             if path.as_os_str().is_empty() || path_was_dot {
                 path.push(current_dir_opt.take()?);
             }
-            if !path.pop() {
+            if !path.pop() && !saturate_at_root {
                 return None;
             }
         } else {

--- a/gix-path/tests/path/convert/mod.rs
+++ b/gix-path/tests/path/convert/mod.rs
@@ -20,6 +20,91 @@ fn assure_windows_separators() {
 
 mod normalize;
 
+mod normalize_and_clean {
+    use std::{borrow::Cow, path::Path};
+
+    use gix_path::normalize_and_clean;
+
+    fn p(input: &str) -> &Path {
+        Path::new(input)
+    }
+
+    #[test]
+    fn clean_paths_and_use_the_cwd_for_empty_results() {
+        let cwd = p("/cwd");
+        for (input, expected) in [
+            ("", "/cwd"),
+            (".", "/cwd"),
+            ("./a", "a"),
+            ("a/./b", "a/b"),
+            ("a//b/", "a/b"),
+            ("a/..", "/cwd"),
+        ] {
+            assert_eq!(
+                normalize_and_clean(p(input).into(), cwd).expect("path can be normalized"),
+                p(expected),
+                "'{input}' cleans to '{expected}'"
+            );
+        }
+        assert_eq!(
+            normalize_and_clean(p(".").into(), p(""))
+                .expect("path can be normalized")
+                .as_ref(),
+            p(""),
+            "an empty CWD allows an empty normalized path"
+        );
+        assert_eq!(
+            normalize_and_clean(p(".").into(), cwd)
+                .expect("path can be normalized")
+                .as_ref(),
+            cwd,
+            "an empty input path is the CWD"
+        );
+        assert!(
+            matches!(normalize_and_clean(p("a/b").into(), cwd), Some(Cow::Borrowed(path)) if path == p("a/b")),
+            "already-clean borrowed paths stay borrowed"
+        );
+    }
+}
+
+mod normalize_saturating {
+    use std::{borrow::Cow, path::Path};
+
+    use gix_path::normalize_saturating;
+
+    fn p(input: &str) -> &Path {
+        Path::new(input)
+    }
+
+    #[test]
+    fn walking_up_too_much_stays_at_the_root() {
+        let cwd = "/users/name".as_ref();
+        assert_eq!(
+            normalize_saturating(p("./a/b/../../../../../actually-valid").into(), cwd).as_ref(),
+            p("/actually-valid")
+        );
+        assert_eq!(
+            normalize_saturating(p("/a/b/../../../../actually-valid").into(), cwd).as_ref(),
+            p("/actually-valid")
+        );
+        assert_eq!(
+            normalize_saturating(p("/a/b/../../../../..").into(), cwd).as_ref(),
+            p("/")
+        );
+    }
+
+    #[test]
+    fn preserves_normal_paths() {
+        let path = p("a/b");
+        assert!(matches!(normalize_saturating(path.into(), p("/users")), Cow::Borrowed(actual) if actual == path));
+        assert_eq!(
+            normalize_saturating(p("a/../b").into(), p("/users")).as_ref(),
+            p("b"),
+            "paths that do not reach the root normalize as usual"
+        );
+    }
+}
+
 mod join_bstr_unix_pathsep {
     use bstr::BStr;
     use gix_path::join_bstr_unix_pathsep;

--- a/gix-path/tests/path/convert/normalize.rs
+++ b/gix-path/tests/path/convert/normalize.rs
@@ -1,46 +1,9 @@
 use std::{borrow::Cow, path::Path};
 
-use gix_path::{normalize, normalize_and_clean};
+use gix_path::normalize;
 
 fn p(input: &str) -> &Path {
     Path::new(input)
-}
-
-#[test]
-fn clean_paths_and_use_the_cwd_for_empty_results() {
-    let cwd = p("/cwd");
-    for (input, expected) in [
-        ("", "/cwd"),
-        (".", "/cwd"),
-        ("./a", "a"),
-        ("a/./b", "a/b"),
-        ("a//b/", "a/b"),
-        ("a/..", "/cwd"),
-    ] {
-        assert_eq!(
-            normalize_and_clean(p(input).into(), cwd).expect("path can be normalized"),
-            p(expected),
-            "'{input}' cleans to '{expected}'"
-        );
-    }
-    assert_eq!(
-        normalize_and_clean(p(".").into(), p(""))
-            .expect("path can be normalized")
-            .as_ref(),
-        p(""),
-        "an empty CWD allows an empty normalized path"
-    );
-    assert_eq!(
-        normalize_and_clean(p(".").into(), cwd)
-            .expect("path can be normalized")
-            .as_ref(),
-        cwd,
-        "an empty input path is the CWD"
-    );
-    assert!(
-        matches!(normalize_and_clean(p("a/b").into(), cwd), Some(Cow::Borrowed(path)) if path == p("a/b")),
-        "already-clean borrowed paths stay borrowed"
-    );
 }
 
 #[test]

--- a/gix/src/config/cache/access.rs
+++ b/gix/src/config/cache/access.rs
@@ -17,11 +17,6 @@ use crate::{
 
 /// Access
 impl Cache {
-    /// Returns `true` if the configuration value isn't set, so we assume bare for safety.
-    pub(crate) fn is_bare_but_assume_bare_if_unconfigured(&self) -> bool {
-        self.is_bare.unwrap_or(true)
-    }
-
     #[cfg(feature = "blob-diff")]
     pub(crate) fn diff_algorithm(&self) -> Result<gix_diff::blob::Algorithm, config::diff::algorithm::Error> {
         use crate::config::{cache::util::ApplyLeniencyDefault, diff::algorithm::Error, tree::Diff};

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -256,124 +256,80 @@ impl ThreadSafeRepository {
             cli_config_overrides,
         )?;
 
-        // core.worktree might be used to overwrite the worktree directory
-        let worktree_dir_override_from_configuration = {
-            fn assure_config_is_from_current_repo(
-                section: &gix_config::file::Metadata,
-                git_dir: &Path,
-                current_dir: &Path,
-                filter_config_section: &mut fn(&Metadata) -> bool,
-            ) -> bool {
-                if !filter_config_section(section) {
-                    return false;
-                }
-                if section.source == gix_config::Source::EnvOverride {
-                    return true;
-                }
-                // ignore worktree settings that aren't from our repository. This can happen
-                // with worktrees of submodules for instance.
-                section
-                    .path
-                    .as_deref()
-                    .and_then(|p| gix_path::normalize(p.into(), current_dir))
-                    .is_some_and(|config_path| config_path.starts_with(git_dir))
-            }
-            /// Normalize a worktree path.
-            ///
-            /// If `..` components exhaust `current_dir`, ordinary normalization rejects the path.
-            /// For explicit environment overrides, Git instead ignores the remaining `..` components.
-            fn normalize_worktree_path<'a>(
-                path: Cow<'a, Path>,
-                current_dir: &Path,
-                saturate_at_root: bool,
-            ) -> Option<Cow<'a, Path>> {
-                if saturate_at_root {
-                    Some(gix_path::normalize_saturating(path, current_dir))
-                } else {
-                    gix_path::normalize(path, current_dir)
-                }
-            }
-            let worktree_path = config
-                .resolved
-                .raw_value_with_section_filter(Core::WORKTREE, |section| {
-                    assure_config_is_from_current_repo(section, &git_dir, current_dir, &mut filter_config_section)
-                })
-                .ok()
-                .map(|(value, section)| (gix_config::Path::from(value), section.meta().source));
-            let worktree_overrides_bare = worktree_path
-                .as_ref()
-                .is_some_and(|(_, source)| *source == gix_config::Source::EnvOverride);
-            if let Some((wt, key_source)) =
-                worktree_path.filter(|_| !config.is_bare_but_assume_bare_if_unconfigured() || worktree_overrides_bare)
-            {
-                let wt_clone = wt.clone();
-                let wt_path = wt
-                    .interpolate(interpolate_context(git_install_dir.as_deref(), home.as_deref()))
-                    .map_err(|err| config::Error::PathInterpolation {
-                        path: wt_clone.value,
-                        source: err,
-                    })?;
-                let wt_path = match key_source {
-                    gix_config::Source::Env
-                    | gix_config::Source::Cli
-                    | gix_config::Source::Api
-                    | gix_config::Source::EnvOverride => wt_path,
-                    _ => worktree_dir_from_repository_config(&git_dir, wt_path, current_dir),
-                };
-                worktree_dir =
-                    normalize_worktree_path(wt_path.into(), current_dir, worktree_overrides_bare).map(Cow::into_owned);
-                #[allow(unused_variables, reason = "Used when tracing is enabled at compile time.")]
-                if let Some(worktree_path) = worktree_dir.as_deref().filter(|wtd| !wtd.is_dir()) {
-                    gix_trace::warn!(
-                        "The configured worktree path '{}' is not a directory or doesn't exist - `core.worktree` may be misleading",
-                        worktree_path.display()
-                    );
-                }
-                if worktree_overrides_bare {
-                    config.is_bare = Some(false);
-                }
-            } else if !config.lenient_config
-                && !config.is_bare_but_assume_bare_if_unconfigured()
-                && config
-                    .resolved
-                    .boolean_filter(Core::WORKTREE, |section| {
-                        assure_config_is_from_current_repo(section, &git_dir, current_dir, &mut filter_config_section)
-                    })
-                    .map_err(|err| {
-                        Error::from(config::Error::ConfigTypedString(
-                            config::key::GenericErrorWithValue::from(&Core::WORKTREE).with_source(err),
-                        ))
-                    })?
-                    .is_some()
-            {
-                return Err(Error::from(config::Error::ConfigTypedString(
-                    config::key::GenericErrorWithValue::from(&Core::WORKTREE),
-                )));
-            }
-            !config.is_bare_but_assume_bare_if_unconfigured()
-        };
+        // Git's precedence is: GIT_WORK_TREE, core.bare, core.worktree, inferred worktree.
+        let configured_worktree = config
+            .resolved
+            .raw_value_with_section_filter(Core::WORKTREE, |section| {
+                is_eligible_worktree_config_section(section, &git_dir, current_dir, &mut filter_config_section)
+            })
+            .ok()
+            .map(|(value, section)| (gix_config::Path::from(value), section.meta().source));
+        let worktree_from_environment = configured_worktree
+            .as_ref()
+            .is_some_and(|(_, source)| *source == gix_config::Source::EnvOverride);
+        let may_use_configured_worktree = config.is_bare == Some(false) || worktree_from_environment;
 
-        {
-            let looks_like_standard_git_dir =
-                || refs.git_dir().file_name() == Some(OsStr::new(gix_discover::DOT_GIT_DIR));
-            match worktree_dir {
-                None if !config.is_bare_but_assume_bare_if_unconfigured() && looks_like_standard_git_dir() => {
-                    worktree_dir = Some(git_dir.parent().expect("parent is always available").to_owned());
-                }
-                // We may assume that the presence of a worktree-dir means it's not bare, but only if there
-                // is no configuration saying otherwise.
-                // Thus, if we are here and the common-dir config claims it's bare, and we have inferred a worktree anyway,
-                // forget about it.
-                Some(_)
-                    if !worktree_dir_override_from_configuration
-                        && refs.git_dir().ancestors().nth(1).and_then(|p| p.file_name())
-                            != Some("worktrees".as_ref())
-                        && config.is_bare.unwrap_or_default() =>
-                {
-                    worktree_dir = None;
-                }
-                None | Some(_) => {}
+        if let Some((worktree, source)) = configured_worktree.filter(|_| may_use_configured_worktree) {
+            let original = worktree.clone();
+            let worktree = worktree
+                .interpolate(interpolate_context(git_install_dir.as_deref(), home.as_deref()))
+                .map_err(|err| config::Error::PathInterpolation {
+                    path: original.value,
+                    source: err,
+                })?;
+            let worktree = match source {
+                gix_config::Source::Env
+                | gix_config::Source::Cli
+                | gix_config::Source::Api
+                | gix_config::Source::EnvOverride => worktree,
+                _ => worktree_dir_from_repository_config(&git_dir, worktree, current_dir),
+            };
+            worktree_dir = if worktree_from_environment {
+                Some(gix_path::normalize_saturating(worktree.into(), current_dir).into_owned())
+            } else {
+                gix_path::normalize(worktree.into(), current_dir).map(Cow::into_owned)
+            };
+            #[allow(unused_variables, reason = "Used when tracing is enabled at compile time.")]
+            if let Some(worktree_path) = worktree_dir.as_deref().filter(|wtd| !wtd.is_dir()) {
+                gix_trace::warn!(
+                    "The configured worktree path '{}' is not a directory or doesn't exist - `core.worktree` may be misleading",
+                    worktree_path.display()
+                );
             }
+            if worktree_from_environment {
+                config.is_bare = Some(false);
+            }
+        } else if !config.lenient_config
+            && config.is_bare == Some(false)
+            && config
+                .resolved
+                .boolean_filter(Core::WORKTREE, |section| {
+                    is_eligible_worktree_config_section(section, &git_dir, current_dir, &mut filter_config_section)
+                })
+                .map_err(|err| {
+                    Error::from(config::Error::ConfigTypedString(
+                        config::key::GenericErrorWithValue::from(&Core::WORKTREE).with_source(err),
+                    ))
+                })?
+                .is_some()
+        {
+            return Err(Error::from(config::Error::ConfigTypedString(
+                config::key::GenericErrorWithValue::from(&Core::WORKTREE),
+            )));
+        }
+
+        // Without an explicit path, a non-bare `.git` directory implies its parent as worktree.
+        if worktree_dir.is_none()
+            && config.is_bare == Some(false)
+            && refs.git_dir().file_name() == Some(OsStr::new(gix_discover::DOT_GIT_DIR))
+        {
+            worktree_dir = Some(git_dir.parent().expect("parent is always available").to_owned());
+        }
+        let is_linked_worktree = refs.git_dir().parent().and_then(Path::file_name) == Some("worktrees".as_ref());
+        if config.is_bare == Some(true) && !is_linked_worktree {
+            // Linked worktrees may inherit core.bare=true from their common repository; all other
+            // worktrees are suppressed by an explicit bare configuration.
+            worktree_dir = None;
         }
 
         // TODO: Testing - it's hard to get non-ownership reliably and without root.
@@ -531,6 +487,31 @@ impl ThreadSafeRepository {
             modules: gix_fs::SharedFileSnapshotMut::new().into(),
         })
     }
+}
+
+/// Return whether `section` may provide `core.worktree` while opening `git_dir`.
+///
+/// The section must pass the caller's trust filter. `GIT_WORK_TREE` has no configuration-file
+/// path and is accepted directly; all other values must come from within this repository to keep
+/// a parent repository's `core.worktree` from leaking into submodules.
+fn is_eligible_worktree_config_section(
+    section: &Metadata,
+    git_dir: &Path,
+    current_dir: &Path,
+    filter_config_section: &mut fn(&Metadata) -> bool,
+) -> bool {
+    if !filter_config_section(section) {
+        return false;
+    }
+    if section.source == gix_config::Source::EnvOverride {
+        return true;
+    }
+    // Ignore worktree settings from another repository, as can happen while opening submodules.
+    section
+        .path
+        .as_deref()
+        .and_then(|path| gix_path::normalize(path.into(), current_dir))
+        .is_some_and(|config_path| config_path.starts_with(git_dir))
 }
 
 /// Return the worktree directory implied by the `core.worktree` value `wt_path` from repository-owned

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -257,7 +257,7 @@ impl ThreadSafeRepository {
         )?;
 
         // core.worktree might be used to overwrite the worktree directory
-        let worktree_dir_override_from_configuration = if !config.is_bare_but_assume_bare_if_unconfigured() {
+        let worktree_dir_override_from_configuration = {
             fn assure_config_is_from_current_repo(
                 section: &gix_config::file::Metadata,
                 git_dir: &Path,
@@ -267,6 +267,9 @@ impl ThreadSafeRepository {
                 if !filter_config_section(section) {
                     return false;
                 }
+                if section.source == gix_config::Source::EnvOverride {
+                    return true;
+                }
                 // ignore worktree settings that aren't from our repository. This can happen
                 // with worktrees of submodules for instance.
                 section
@@ -275,6 +278,33 @@ impl ThreadSafeRepository {
                     .and_then(|p| gix_path::normalize(p.into(), current_dir))
                     .is_some_and(|config_path| config_path.starts_with(git_dir))
             }
+            fn normalize_worktree_path<'a>(
+                path: Cow<'a, Path>,
+                current_dir: &Path,
+                saturate_at_root: bool,
+            ) -> Option<Cow<'a, Path>> {
+                match gix_path::normalize(path.clone(), current_dir) {
+                    Some(path) => Some(path),
+                    None if saturate_at_root => {
+                        let mut normalized = if path.is_absolute() {
+                            PathBuf::new()
+                        } else {
+                            current_dir.to_owned()
+                        };
+                        for component in path.components() {
+                            match component {
+                                std::path::Component::CurDir => {}
+                                std::path::Component::ParentDir => {
+                                    normalized.pop();
+                                }
+                                component => normalized.push(component.as_os_str()),
+                            }
+                        }
+                        Some(Cow::Owned(normalized))
+                    }
+                    None => None,
+                }
+            }
             let worktree_path = config
                 .resolved
                 .raw_value_with_section_filter(Core::WORKTREE, |section| {
@@ -282,7 +312,12 @@ impl ThreadSafeRepository {
                 })
                 .ok()
                 .map(|(value, section)| (gix_config::Path::from(value), section.meta().source));
-            if let Some((wt, key_source)) = worktree_path {
+            let worktree_overrides_bare = worktree_path
+                .as_ref()
+                .is_some_and(|(_, source)| *source == gix_config::Source::EnvOverride);
+            if let Some((wt, key_source)) =
+                worktree_path.filter(|_| !config.is_bare_but_assume_bare_if_unconfigured() || worktree_overrides_bare)
+            {
                 let wt_clone = wt.clone();
                 let wt_path = wt
                     .interpolate(interpolate_context(git_install_dir.as_deref(), home.as_deref()))
@@ -297,7 +332,8 @@ impl ThreadSafeRepository {
                     | gix_config::Source::EnvOverride => wt_path,
                     _ => worktree_dir_from_repository_config(&git_dir, wt_path, current_dir),
                 };
-                worktree_dir = gix_path::normalize(wt_path.into(), current_dir).map(Cow::into_owned);
+                worktree_dir =
+                    normalize_worktree_path(wt_path.into(), current_dir, worktree_overrides_bare).map(Cow::into_owned);
                 #[allow(unused_variables, reason = "Used when tracing is enabled at compile time.")]
                 if let Some(worktree_path) = worktree_dir.as_deref().filter(|wtd| !wtd.is_dir()) {
                     gix_trace::warn!(
@@ -305,7 +341,11 @@ impl ThreadSafeRepository {
                         worktree_path.display()
                     );
                 }
+                if worktree_overrides_bare {
+                    config.is_bare = Some(false);
+                }
             } else if !config.lenient_config
+                && !config.is_bare_but_assume_bare_if_unconfigured()
                 && config
                     .resolved
                     .boolean_filter(Core::WORKTREE, |section| {
@@ -322,9 +362,7 @@ impl ThreadSafeRepository {
                     config::key::GenericErrorWithValue::from(&Core::WORKTREE),
                 )));
             }
-            true
-        } else {
-            false
+            !config.is_bare_but_assume_bare_if_unconfigured()
         };
 
         {

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -278,31 +278,19 @@ impl ThreadSafeRepository {
                     .and_then(|p| gix_path::normalize(p.into(), current_dir))
                     .is_some_and(|config_path| config_path.starts_with(git_dir))
             }
+            /// Normalize a worktree path.
+            ///
+            /// If `..` components exhaust `current_dir`, ordinary normalization rejects the path.
+            /// For explicit environment overrides, Git instead ignores the remaining `..` components.
             fn normalize_worktree_path<'a>(
                 path: Cow<'a, Path>,
                 current_dir: &Path,
                 saturate_at_root: bool,
             ) -> Option<Cow<'a, Path>> {
-                match gix_path::normalize(path.clone(), current_dir) {
-                    Some(path) => Some(path),
-                    None if saturate_at_root => {
-                        let mut normalized = if path.is_absolute() {
-                            PathBuf::new()
-                        } else {
-                            current_dir.to_owned()
-                        };
-                        for component in path.components() {
-                            match component {
-                                std::path::Component::CurDir => {}
-                                std::path::Component::ParentDir => {
-                                    normalized.pop();
-                                }
-                                component => normalized.push(component.as_os_str()),
-                            }
-                        }
-                        Some(Cow::Owned(normalized))
-                    }
-                    None => None,
+                if saturate_at_root {
+                    Some(gix_path::normalize_saturating(path, current_dir))
+                } else {
+                    gix_path::normalize(path, current_dir)
                 }
             }
             let worktree_path = config

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -251,3 +251,77 @@ fn git_worktree_and_strict_config() -> gix_testtools::Result {
     )?;
     Ok(())
 }
+
+#[test]
+#[serial]
+fn git_worktree_overrides_bare() -> gix_testtools::Result {
+    let fixture = gix_testtools::scripted_fixture_read_only("make_config_repos.sh")?;
+    let worktree = gix_testtools::tempfile::TempDir::new()?;
+    let _env = gix_testtools::Env::new()
+        .unset("GIT_DIR")
+        .set("GIT_WORK_TREE", worktree.path().to_string_lossy());
+
+    let repo =
+        gix::ThreadSafeRepository::discover_with_environment_overrides(fixture.join("bare-repo"))?.to_thread_local();
+
+    assert_eq!(
+        repo.workdir(),
+        Some(worktree.path()),
+        "GIT_WORK_TREE overrides core.bare just like it does in Git"
+    );
+    assert!(
+        !repo.is_bare(),
+        "a repository with an explicit GIT_WORK_TREE is not bare according to Git"
+    );
+    #[cfg(feature = "status")]
+    {
+        std::fs::write(worktree.path().join("untracked"), b"content")?;
+        assert_eq!(
+            repo.status(gix::progress::Discard)?
+                .into_index_worktree_iter(None)?
+                .count(),
+            1,
+            "status observes files in the explicit worktree"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[cfg(unix)]
+fn git_worktree_over_root_overrides_bare() -> gix_testtools::Result {
+    let fixture = gix_testtools::scripted_fixture_read_only("make_config_repos.sh")?;
+    let worktree = gix_testtools::tempfile::TempDir::new()?;
+    let current_dir = std::env::current_dir()?;
+    let mut relative_worktree = std::path::PathBuf::new();
+    for _ in 0..current_dir.components().count() + 2 {
+        relative_worktree.push("..");
+    }
+    relative_worktree.push(worktree.path().strip_prefix("/")?);
+    let _env = gix_testtools::Env::new()
+        .unset("GIT_DIR")
+        .set("GIT_WORK_TREE", relative_worktree.to_string_lossy());
+
+    let repo =
+        gix::ThreadSafeRepository::discover_with_environment_overrides(fixture.join("bare-repo"))?.to_thread_local();
+
+    assert_eq!(
+        repo.workdir(),
+        Some(worktree.path()),
+        "parent components beyond the root saturate there, just like they do in Git"
+    );
+    assert!(!repo.is_bare(), "the explicit worktree makes the repository non-bare");
+    #[cfg(feature = "status")]
+    {
+        std::fs::write(worktree.path().join("untracked"), b"content")?;
+        assert_eq!(
+            repo.status(gix::progress::Discard)?
+                .into_index_worktree_iter(None)?
+                .count(),
+            1,
+            "status observes files through the over-root worktree path"
+        );
+    }
+    Ok(())
+}

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::result_large_err)]
 
+use std::path::Path;
+
 use gix::open::Permissions;
 use gix::{Repository, ThreadSafeRepository};
 use gix_sec::Permission;
@@ -12,6 +14,22 @@ pub fn named_subrepo_opts(
 ) -> std::result::Result<Repository, gix::open::Error> {
     let repo_path = gix_testtools::scripted_fixture_read_only(fixture).unwrap().join(name);
     Ok(ThreadSafeRepository::open_opts(repo_path, opts)?.to_thread_local())
+}
+
+fn discover_with_environment_overrides_isolated(
+    directory: impl AsRef<Path>,
+) -> Result<Repository, gix::discover::Error> {
+    let mut options = gix::open::Options::isolated();
+    options.permissions.env.git_prefix = Permission::Allow;
+    ThreadSafeRepository::discover_with_environment_overrides_opts(
+        directory,
+        Default::default(),
+        gix_sec::trust::Mapping {
+            full: options.clone(),
+            reduced: options,
+        },
+    )
+    .map(|repo| repo.to_thread_local())
 }
 
 mod with_overrides {
@@ -261,8 +279,19 @@ fn git_worktree_overrides_bare() -> gix_testtools::Result {
         .unset("GIT_DIR")
         .set("GIT_WORK_TREE", worktree.path().to_string_lossy());
 
-    let repo =
-        gix::ThreadSafeRepository::discover_with_environment_overrides(fixture.join("bare-repo"))?.to_thread_local();
+    let repo = gix::discover_opts(
+        fixture.join("bare-repo"),
+        Default::default(),
+        gix::open::Options::isolated(),
+    )?;
+    assert_eq!(
+        repo.workdir(),
+        None,
+        "without environment overrides the bare repository has no worktree"
+    );
+    assert!(repo.is_bare(), "without environment overrides it remains bare");
+
+    let repo = discover_with_environment_overrides_isolated(fixture.join("bare-repo"))?;
 
     assert_eq!(
         repo.workdir(),
@@ -273,6 +302,7 @@ fn git_worktree_overrides_bare() -> gix_testtools::Result {
         !repo.is_bare(),
         "a repository with an explicit GIT_WORK_TREE is not bare according to Git"
     );
+
     #[cfg(feature = "status")]
     {
         std::fs::write(worktree.path().join("untracked"), b"content")?;
@@ -295,16 +325,31 @@ fn git_worktree_over_root_overrides_bare() -> gix_testtools::Result {
     let worktree = gix_testtools::tempfile::TempDir::new()?;
     let current_dir = std::env::current_dir()?;
     let mut relative_worktree = std::path::PathBuf::new();
+    // Use more parent components than `current_dir` has components: the `+2` ensures that
+    // at least one `..` remains after reaching the filesystem root.
     for _ in 0..current_dir.components().count() + 2 {
         relative_worktree.push("..");
     }
+    // The absolute worktree path, without its leading `/`, is appended after those excess `..` components.
+    // Thus Git ignores the excess parents at `/` and then resolves this suffix back to `worktree`.
     relative_worktree.push(worktree.path().strip_prefix("/")?);
     let _env = gix_testtools::Env::new()
         .unset("GIT_DIR")
         .set("GIT_WORK_TREE", relative_worktree.to_string_lossy());
 
-    let repo =
-        gix::ThreadSafeRepository::discover_with_environment_overrides(fixture.join("bare-repo"))?.to_thread_local();
+    let repo = gix::discover_opts(
+        fixture.join("bare-repo"),
+        Default::default(),
+        gix::open::Options::isolated(),
+    )?;
+    assert_eq!(
+        repo.workdir(),
+        None,
+        "without environment overrides the bare repository has no worktree"
+    );
+    assert!(repo.is_bare(), "without environment overrides it remains bare");
+
+    let repo = discover_with_environment_overrides_isolated(fixture.join("bare-repo"))?;
 
     assert_eq!(
         repo.workdir(),
@@ -323,5 +368,28 @@ fn git_worktree_over_root_overrides_bare() -> gix_testtools::Result {
             "status observes files through the over-root worktree path"
         );
     }
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[cfg(unix)]
+fn git_worktree_absolute_over_root_overrides_bare() -> gix_testtools::Result {
+    let fixture = gix_testtools::scripted_fixture_read_only("make_config_repos.sh")?;
+    let worktree = gix_testtools::tempfile::TempDir::new()?;
+    let mut absolute_worktree = std::path::PathBuf::from("/");
+    absolute_worktree.push("..");
+    absolute_worktree.push(worktree.path().strip_prefix("/")?);
+    let _env = gix_testtools::Env::new()
+        .unset("GIT_DIR")
+        .set("GIT_WORK_TREE", absolute_worktree.to_string_lossy());
+
+    let repo = discover_with_environment_overrides_isolated(fixture.join("bare-repo"))?;
+
+    assert_eq!(
+        repo.workdir(),
+        Some(worktree.path()),
+        "an absolute path with `..` beyond the root resolves to the configured worktree"
+    );
     Ok(())
 }

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -272,31 +272,38 @@ fn git_worktree_and_strict_config() -> gix_testtools::Result {
 
 #[test]
 #[serial]
-fn git_worktree_overrides_bare() -> gix_testtools::Result {
-    let fixture = gix_testtools::scripted_fixture_read_only("make_config_repos.sh")?;
+fn git_worktree_overrides_core_worktree_and_bare() -> gix_testtools::Result {
+    use std::io::Write;
+
+    let bare = gix_testtools::tempfile::TempDir::new()?;
+    gix::init_bare(bare.path())?;
     let worktree = gix_testtools::tempfile::TempDir::new()?;
+    let configured_worktree = gix_testtools::tempfile::TempDir::new()?;
+    writeln!(
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(bare.path().join("config"))?,
+        "\n[core]\n\tworktree = {wt_path}",
+        wt_path = configured_worktree.path().to_string_lossy().replace('\\', "/")
+    )?;
     let _env = gix_testtools::Env::new()
         .unset("GIT_DIR")
         .set("GIT_WORK_TREE", worktree.path().to_string_lossy());
 
-    let repo = gix::discover_opts(
-        fixture.join("bare-repo"),
-        Default::default(),
-        gix::open::Options::isolated(),
-    )?;
+    let repo = gix::discover_opts(bare.path(), Default::default(), gix::open::Options::isolated())?;
     assert_eq!(
         repo.workdir(),
         None,
-        "without environment overrides the bare repository has no worktree"
+        "without environment overrides the bare repository has no worktree even if configured"
     );
     assert!(repo.is_bare(), "without environment overrides it remains bare");
 
-    let repo = discover_with_environment_overrides_isolated(fixture.join("bare-repo"))?;
+    let repo = discover_with_environment_overrides_isolated(bare.path())?;
 
     assert_eq!(
         repo.workdir(),
         Some(worktree.path()),
-        "GIT_WORK_TREE overrides core.bare just like it does in Git"
+        "GIT_WORK_TREE overrides core.worktree and core.bare just like it does in Git"
     );
     assert!(
         !repo.is_bare(),
@@ -314,6 +321,26 @@ fn git_worktree_overrides_bare() -> gix_testtools::Result {
             "status observes files in the explicit worktree"
         );
     }
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn git_worktree_overrides_discovered_worktree() -> gix_testtools::Result {
+    let repository = gix_testtools::tempfile::TempDir::new()?;
+    gix::init(repository.path())?;
+    let worktree = gix_testtools::tempfile::TempDir::new()?;
+    let _env = gix_testtools::Env::new()
+        .unset("GIT_DIR")
+        .set("GIT_WORK_TREE", worktree.path().to_string_lossy());
+
+    let repo = discover_with_environment_overrides_isolated(repository.path())?;
+
+    assert_eq!(
+        repo.workdir(),
+        Some(worktree.path()),
+        "GIT_WORK_TREE takes precedence over the worktree found during discovery"
+    );
     Ok(())
 }
 

--- a/gix/tests/gix/repository/open.rs
+++ b/gix/tests/gix/repository/open.rs
@@ -37,6 +37,24 @@ fn discover_with_git_dir_environment_override_sets_trust() -> crate::Result {
 }
 
 #[test]
+fn core_worktree_cli_override_does_not_override_bare() -> crate::Result {
+    let fixture = gix_testtools::scripted_fixture_read_only("make_config_repos.sh")?;
+    let worktree = gix_testtools::tempfile::TempDir::new()?;
+    let repo = gix::open_opts(
+        fixture.join("bare-repo"),
+        gix::open::Options::isolated().cli_overrides([format!("core.worktree={}", worktree.path().display())]),
+    )?;
+
+    assert_eq!(
+        repo.workdir(),
+        None,
+        "core.worktree from -c does not override core.bare in Git"
+    );
+    assert!(repo.is_bare(), "the CLI override leaves the bare repository bare");
+    Ok(())
+}
+
+#[test]
 fn on_root_with_decomposed_unicode() -> crate::Result {
     let tmp = gix_testtools::tempfile::TempDir::new()?;
 


### PR DESCRIPTION
## Description

Honor the `GIT_WORK_TREE` environment override when opening a repository configured with `core.bare=true`.

Git treats an explicit `GIT_WORK_TREE` as an effective worktree and reports the repository as non-bare. `gix` previously retained `workdir: None`, which prevented downstream consumers such as Starship from computing repository status.

The override is deliberately limited to `GIT_WORK_TREE`. A `core.worktree` CLI override still does not supersede `core.bare`, matching Git behavior.

Related downstream issue: starship/starship#7609  
Supersedes the downstream workaround proposed in starship/starship#7617.

GitoxideLabs/gitoxide#1985 and #1987 addressed the strict-config error associated with `GIT_WORK_TREE`, but did not cover its interaction with `core.bare`.

## Tests

- Added a regression test for a bare repository with an external `GIT_WORK_TREE`.
- Confirmed the repository becomes non-bare and status observes files in the external worktree.
- Added a negative control proving that `-c core.worktree=...` does not override `core.bare`.
- `cargo fmt --all -- --check`
- Strict Clippy for `gix`
- Complete `cargo test -p gix --no-fail-fast`: 410 passed

## AI assistance

Codex assisted with investigation, implementation, testing, and preparation of this pull request. I reviewed the changes and verified the behavior locally against Git.
