### PR TITLE
fix: quote Git paths in credential helper shell commands

### DIFF
--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -22,6 +22,7 @@ serde = ["dep:serde", "bstr/serde", "gix-sec/serde"]
 gix-sec = { version = "^0.14.2", path = "../gix-sec" }
 gix-url = { version = "^0.37.0", path = "../gix-url" }
 gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-quote = { version = "^0.7.2", path = "../gix-quote" }
 gix-command = { version = "^0.9.1", path = "../gix-command" }
 gix-config-value = { version = "^0.19.0", path = "../gix-config-value" }
 gix-prompt = { version = "^0.16.0", path = "../gix-prompt" }
@@ -37,7 +38,6 @@ bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 document-features = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
-gix-quote = { path = "../gix-quote" }
 gix-sec = { path = "../gix-sec" }
 gix-testtools = { path = "../tests/tools" }
 

--- a/gix-credentials/src/program/mod.rs
+++ b/gix-credentials/src/program/mod.rs
@@ -1,8 +1,27 @@
-use std::process::{Command, Stdio};
+use std::{
+    path::Path,
+    process::{Command, Stdio},
+};
 
 use bstr::{BString, ByteSlice, ByteVec};
 
 use crate::{Program, helper};
+
+/// Correctly quotes `git_progarm`, while assuming `name_and_args` are good to be put into a script.
+fn external_name_command(
+    git_program: &Path,
+    name_and_args: &bstr::BStr,
+    action: &helper::Action,
+) -> std::process::Command {
+    let git_program = gix_path::to_unix_separators_on_windows(gix_path::into_bstr(git_program));
+    let mut args = gix_quote::single(git_program.as_ref());
+    args.push_str(" credential-");
+    args.push_str(name_and_args);
+    gix_command::prepare(gix_path::from_bstr(args.as_bstr()).into_owned())
+        .arg(action.as_arg(true))
+        .command_may_be_shell_script_allow_manual_argument_splitting()
+        .into()
+}
 
 /// The kind of helper program to use.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -75,16 +94,7 @@ impl Program {
                 cmd.arg("credential").arg(action.as_arg(false));
                 cmd
             }
-            Kind::ExternalName { name_and_args } => {
-                let mut args = name_and_args.clone();
-                args.insert_str(0, "credential-");
-                args.insert_str(0, " ");
-                args.insert_str(0, git_program.to_string_lossy().as_ref());
-                gix_command::prepare(gix_path::from_bstr(args.as_bstr()).into_owned())
-                    .arg(action.as_arg(true))
-                    .command_may_be_shell_script_allow_manual_argument_splitting()
-                    .into()
-            }
+            Kind::ExternalName { name_and_args } => external_name_command(git_program, name_and_args.as_bstr(), action),
             Kind::ExternalShellScript(for_shell)
             | Kind::ExternalPath {
                 path_and_args: for_shell,
@@ -146,3 +156,34 @@ impl Program {
 ///
 pub mod main;
 pub use main::function::main;
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsStr, path::Path};
+
+    use crate::helper;
+
+    #[test]
+    fn git_program_with_spaces_is_quoted_in_external_name_shell_scripts() {
+        let cmd = super::external_name_command(
+            Path::new(r"C:\Program Files\Git\mingw64\bin\git.exe"),
+            "manager --config=~/credentials".into(),
+            &helper::Action::Get(Default::default()),
+        );
+        let script = cmd
+            .get_args()
+            .skip_while(|arg| *arg != OsStr::new("-c"))
+            .nth(1)
+            .expect("a shell invocation has its script after the '-c' argument");
+
+        assert_eq!(
+            script,
+            OsStr::new(if cfg!(windows) {
+                r#"'C:/Program Files/Git/mingw64/bin/git.exe' credential-manager --config=~/credentials "$@""#
+            } else {
+                r#"'C:\Program Files\Git\mingw64\bin\git.exe' credential-manager --config=~/credentials "$@""#
+            }),
+            "the Git executable is a single shell token even when its path contains spaces"
+        );
+    }
+}

--- a/gix-credentials/tests/program/from_custom_definition.rs
+++ b/gix-credentials/tests/program/from_custom_definition.rs
@@ -22,7 +22,7 @@ const SH_BASENAME: &str = if cfg!(windows) { "sh.exe" } else { "sh" };
 #[test]
 fn empty() {
     let prog = Program::from_custom_definition("");
-    let git = *GIT;
+    let git = gix_path::to_unix_separators_on_windows(gix_path::into_bstr(std::path::Path::new(*GIT)));
     assert!(matches!(&prog.kind, Kind::ExternalName { name_and_args } if name_and_args.is_empty()));
     assert_eq!(
         format!("{:?}", prog.to_command(&helper::Action::Store("egal".into()))),
@@ -46,7 +46,7 @@ fn simple_script_in_path() {
 fn name_with_args() {
     let input = "name --arg --bar=\"a b\"";
     let prog = Program::from_custom_definition(input);
-    let git = *GIT;
+    let git = gix_path::to_unix_separators_on_windows(gix_path::into_bstr(std::path::Path::new(*GIT)));
     assert!(matches!(&prog.kind, Kind::ExternalName{name_and_args} if name_and_args == input));
     assert_eq!(
         format!("{:?}", prog.to_command(&helper::Action::Store("egal".into()))),
@@ -59,11 +59,14 @@ fn name_with_special_args() {
     let input = "name --arg --bar=~/folder/in/home";
     let prog = Program::from_custom_definition(input);
     let sh = gix_path::env::shell_command();
-    let git = *GIT;
+    let git = gix_path::to_unix_separators_on_windows(gix_path::into_bstr(std::path::Path::new(*GIT)));
+    let quoted_git = gix_quote::single(git.as_ref());
     assert!(matches!(&prog.kind, Kind::ExternalName{name_and_args} if name_and_args == input));
     assert_eq!(
         format!("{:?}", prog.to_command(&helper::Action::Store("egal".into()))),
-        format!(r#"{sh:?} "-c" "{git} credential-name --arg --bar=~/folder/in/home \"$@\"" "{SH_BASENAME}" "store""#)
+        format!(
+            r#"{sh:?} "-c" "{quoted_git} credential-name --arg --bar=~/folder/in/home \"$@\"" "{SH_BASENAME}" "store""#
+        )
     );
 }
 
@@ -71,7 +74,7 @@ fn name_with_special_args() {
 fn name() {
     let input = "name";
     let prog = Program::from_custom_definition(input);
-    let git = *GIT;
+    let git = gix_path::to_unix_separators_on_windows(gix_path::into_bstr(std::path::Path::new(*GIT)));
     assert!(matches!(&prog.kind, Kind::ExternalName{name_and_args} if name_and_args == input));
     assert_eq!(
         format!("{:?}", prog.to_command(&helper::Action::Store("egal".into()))),


### PR DESCRIPTION
> **This draft PR was created by Codex. It will still be reviewed by a human maintainer before merge.**

## Summary

Fix credential helper invocation when Git for Windows is found at an absolute path containing spaces and a POSIX shell is available.

## Root cause

For named helpers such as `credential.helper=manager`, `gix-credentials` embedded the resolved `git.exe` path directly into a `sh -c` script. A path such as `C:\Program Files\Git\mingw64\bin\git.exe` was therefore split and interpreted as `C:Program`.

The command builder now converts Windows separators for the POSIX shell and single-quotes only the Git executable token. Simple helper commands continue to use direct execution where manual argument splitting is safe.

Fixes #2844.

## Tests

- Added a regression test for a Git executable path containing spaces.
- `cargo test -p gix-credentials`
- `cargo test -p gix-command`
- `cargo check -p gix-credentials`
- `cargo clippy -p gix-credentials --all-targets --all-features`
- `cargo fmt --all --check`
- Manual Git for Windows `sh -c` verification with the quoted executable path

Strict Clippy with `-D warnings` additionally reports five pre-existing Rust 1.97 warnings in `gix-sec`, outside this diff.