### PR TITLE
fix: respect inherited core.symlinks when cloning

### DIFF
--- a/gix-config/src/file/includes/mod.rs
+++ b/gix-config/src/file/includes/mod.rs
@@ -292,10 +292,12 @@ fn gitdir_matches(
         return Ok(true);
     }
 
-    let expanded_git_dir = gix_path::into_bstr(gix_path::realpath(gix_path::from_byte_slice(&git_dir))?);
+    let expanded_git_dir = gix_path::to_unix_separators_on_windows(gix_path::into_bstr(gix_path::realpath(
+        gix_path::from_byte_slice(&git_dir),
+    )?));
     Ok(gix_glob::wildmatch(
         pattern_path.as_bstr(),
-        expanded_git_dir.as_bstr(),
+        expanded_git_dir.as_ref(),
         match_mode,
     ))
 }

--- a/gix-config/tests/config/file/init/from_paths/includes/conditional/gitdir/mod.rs
+++ b/gix-config/tests/config/file/init/from_paths/includes/conditional/gitdir/mod.rs
@@ -89,14 +89,13 @@ fn dot_slash_path_is_replaced_with_directory_containing_the_including_config_fil
 #[serial]
 fn dot_slash_from_environment_causes_error() -> crate::Result {
     let env = GitEnv::repo_name("worktree")?;
+    // Only slashes can be used as matches, even on Windows.
+    let git_dir = env.git_dir().to_string_lossy().replace('\\', "/");
 
     {
         let _environment = Env::new()
             .set("GIT_CONFIG_COUNT", "1")
-            .set(
-                "GIT_CONFIG_KEY_0",
-                format!("includeIf.gitdir:{}.path", escape_backslashes(env.git_dir())),
-            )
+            .set("GIT_CONFIG_KEY_0", format!("includeIf.gitdir:{git_dir}.path"))
             .set("GIT_CONFIG_VALUE_0", "./include.path");
 
         let res = gix_config::File::from_env(env.to_init_options());
@@ -133,10 +132,7 @@ fn dot_slash_from_environment_causes_error() -> crate::Result {
     {
         let _environment = Env::new()
             .set("GIT_CONFIG_COUNT", "1")
-            .set(
-                "GIT_CONFIG_KEY_0",
-                format!("includeIf.gitdir:{}.path", escape_backslashes(env.git_dir())),
-            )
+            .set("GIT_CONFIG_KEY_0", format!("includeIf.gitdir:{git_dir}.path"))
             .set("GIT_CONFIG_VALUE_0", absolute_path);
 
         let res = gix_config::File::from_env(env.to_init_options());

--- a/gix/src/clone/mod.rs
+++ b/gix/src/clone/mod.rs
@@ -51,6 +51,8 @@ pub struct PrepareFetch {
 #[expect(missing_docs)]
 pub enum Error {
     #[error(transparent)]
+    Config(#[from] crate::config::Error),
+    #[error(transparent)]
     Init(#[from] crate::init::Error),
     #[error(transparent)]
     CommitterOrFallback(#[from] crate::config::commit_signature::Error),
@@ -108,10 +110,25 @@ impl PrepareFetch {
         path: &std::path::Path,
         kind: crate::create::Kind,
         mut create_opts: crate::create::Options,
-        open_opts: crate::open::Options,
+        mut open_opts: crate::open::Options,
     ) -> Result<Self, Error> {
         if create_opts.destination_must_be_empty.is_none() {
             create_opts.destination_must_be_empty = Some(true);
+        }
+
+        let git_dir = match kind {
+            crate::create::Kind::WithWorktree => path.join(gix_discover::DOT_GIT_DIR),
+            crate::create::Kind::Bare => path.to_owned(),
+        };
+        let config = crate::config(Some(&git_dir), &open_opts)?;
+        if crate::config::cache::util::config_bool_opt(
+            &config,
+            &crate::config::tree::Core::SYMLINKS,
+            "core.symlinks",
+            open_opts.lenient_config,
+        )? == Some(false)
+        {
+            open_opts.api_config_overrides.push("core.symlinks=false".into());
         }
 
         // Capture this before init_opts creates `.git`, otherwise the check below would see our own files.

--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -35,111 +35,27 @@ impl Cache {
         filter_config_section: fn(&gix_config::file::Metadata) -> bool,
         git_install_dir: Option<&std::path::Path>,
         home: Option<&std::path::Path>,
-        environment @ open::permissions::Environment {
-            git_prefix,
-            ssh_prefix: _,
-            xdg_config_home: _,
-            home: _,
-            http_transport,
-            identity,
-            objects,
-        }: open::permissions::Environment,
+        environment: open::permissions::Environment,
         attributes: open::permissions::Attributes,
-        open::permissions::Config {
-            git_binary: use_installation,
-            system: use_system,
-            git: use_git,
-            user: use_user,
-            env: use_env,
-            includes: use_includes,
-        }: open::permissions::Config,
+        config_permissions: open::permissions::Config,
         lenient_config: bool,
         api_config_overrides: &[BString],
         cli_config_overrides: &[BString],
     ) -> Result<Self, Error> {
-        let options = gix_config::file::init::Options {
-            includes: if use_includes {
-                gix_config::file::includes::Options::follow(
-                    interpolate_context(git_install_dir, home),
-                    gix_config::file::includes::conditional::Context {
-                        git_dir: git_dir.into(),
-                        branch_name,
-                    },
-                )
-            } else {
-                gix_config::file::includes::Options::no_follow()
-            },
-            ..util::base_options(lossy, lenient_config)
-        };
-
-        let config = {
-            let git_prefix = &git_prefix;
-            let mut metas = [
-                gix_config::source::Kind::GitInstallation,
-                gix_config::source::Kind::System,
-                gix_config::source::Kind::Global,
-            ]
-            .iter()
-            .flat_map(|kind| kind.sources())
-            .filter_map(|source| {
-                match source {
-                    gix_config::Source::GitInstallation if !use_installation => return None,
-                    gix_config::Source::System if !use_system => return None,
-                    gix_config::Source::Git if !use_git => return None,
-                    gix_config::Source::User if !use_user => return None,
-                    _ => {}
-                }
-                source
-                    .storage_location(&mut Self::make_source_env(environment))
-                    .map(|p| (source, p))
-            })
-            .map(|(source, path)| gix_config::file::Metadata {
-                path: Some(path),
-                source: *source,
-                level: 0,
-                trust: gix_sec::Trust::Full,
-            });
-
-            let err_on_nonexisting_paths = false;
-            let mut globals = gix_config::File::from_paths_metadata_buf(
-                &mut metas,
-                &mut buf,
-                err_on_nonexisting_paths,
-                gix_config::file::init::Options {
-                    includes: gix_config::file::includes::Options::no_follow(),
-                    ..options
-                },
-            )
-            .map_err(|err| match err {
-                gix_config::file::init::from_paths::Error::Init(err) => Error::from(err),
-                gix_config::file::init::from_paths::Error::Io { source, path } => Error::Io { source, path },
-            })?
-            .unwrap_or_default();
-
-            let local_meta = git_dir_config.meta_owned();
-            globals.append(git_dir_config)?;
-            globals.resolve_includes(options)?;
-            if use_env {
-                globals.append(gix_config::File::from_env(options)?.unwrap_or_default())?;
-            }
-            if !cli_config_overrides.is_empty() {
-                config::overrides::append(&mut globals, cli_config_overrides, gix_config::Source::Cli, |_| None)
-                    .map_err(|err| Error::ConfigOverrides {
-                        err,
-                        source: gix_config::Source::Cli,
-                    })?;
-            }
-            if !api_config_overrides.is_empty() {
-                config::overrides::append(&mut globals, api_config_overrides, gix_config::Source::Api, |_| None)
-                    .map_err(|err| Error::ConfigOverrides {
-                        err,
-                        source: gix_config::Source::Api,
-                    })?;
-            }
-            apply_environment_overrides(&mut globals, *git_prefix, http_transport, identity, objects)?;
-            globals.set_meta(local_meta);
-            globals
-        };
+        let config = load(
+            Some(git_dir_config),
+            &mut buf,
+            Some(git_dir),
+            branch_name,
+            git_install_dir,
+            home,
+            environment,
+            config_permissions,
+            lossy,
+            lenient_config,
+            api_config_overrides,
+            cli_config_overrides,
+        )?;
 
         let hex_len = util::parse_core_abbrev(&config, object_hash).with_leniency(lenient_config)?;
 
@@ -285,6 +201,123 @@ impl Cache {
             .and_then(|perm| perm.check_opt(name).and_then(gix_path::env::var))
         }
     }
+}
+
+/// Load global configuration and optional repository-local configuration using the same ordering and overrides as
+/// repository opening.
+#[expect(clippy::too_many_arguments)]
+pub(crate) fn load(
+    git_dir_config: Option<gix_config::File>,
+    buf: &mut Vec<u8>,
+    git_dir: Option<&std::path::Path>,
+    branch_name: Option<&gix_ref::FullNameRef>,
+    git_install_dir: Option<&std::path::Path>,
+    home: Option<&std::path::Path>,
+    environment @ open::permissions::Environment {
+        git_prefix,
+        ssh_prefix: _,
+        xdg_config_home: _,
+        home: _,
+        http_transport,
+        identity,
+        objects,
+    }: open::permissions::Environment,
+    open::permissions::Config {
+        git_binary: use_installation,
+        system: use_system,
+        git: use_git,
+        user: use_user,
+        env: use_env,
+        includes: use_includes,
+    }: open::permissions::Config,
+    lossy: bool,
+    lenient: bool,
+    api_config_overrides: &[BString],
+    cli_config_overrides: &[BString],
+) -> Result<gix_config::File, Error> {
+    let options = gix_config::file::init::Options {
+        includes: if use_includes {
+            gix_config::file::includes::Options::follow(
+                interpolate_context(git_install_dir, home),
+                gix_config::file::includes::conditional::Context { git_dir, branch_name },
+            )
+        } else {
+            gix_config::file::includes::Options::no_follow()
+        },
+        ..util::base_options(lossy, lenient)
+    };
+    let git_prefix = &git_prefix;
+    let mut metas = [
+        gix_config::source::Kind::GitInstallation,
+        gix_config::source::Kind::System,
+        gix_config::source::Kind::Global,
+    ]
+    .iter()
+    .flat_map(|kind| kind.sources())
+    .filter_map(|source| {
+        match source {
+            gix_config::Source::GitInstallation if !use_installation => return None,
+            gix_config::Source::System if !use_system => return None,
+            gix_config::Source::Git if !use_git => return None,
+            gix_config::Source::User if !use_user => return None,
+            _ => {}
+        }
+        source
+            .storage_location(&mut Cache::make_source_env(environment))
+            .map(|p| (source, p))
+    })
+    .map(|(source, path)| gix_config::file::Metadata {
+        path: Some(path),
+        source: *source,
+        level: 0,
+        trust: gix_sec::Trust::Full,
+    });
+
+    let err_on_nonexisting_paths = false;
+    let mut globals = gix_config::File::from_paths_metadata_buf(
+        &mut metas,
+        buf,
+        err_on_nonexisting_paths,
+        gix_config::file::init::Options {
+            includes: gix_config::file::includes::Options::no_follow(),
+            ..options
+        },
+    )
+    .map_err(|err| match err {
+        gix_config::file::init::from_paths::Error::Init(err) => Error::from(err),
+        gix_config::file::init::from_paths::Error::Io { source, path } => Error::Io { source, path },
+    })?
+    .unwrap_or_default();
+
+    let local_meta = git_dir_config.as_ref().map(gix_config::File::meta_owned);
+    if let Some(git_dir_config) = git_dir_config {
+        globals.append(git_dir_config)?;
+    }
+    globals.resolve_includes(options)?;
+    if use_env {
+        globals.append(gix_config::File::from_env(options)?.unwrap_or_default())?;
+    }
+    if !cli_config_overrides.is_empty() {
+        config::overrides::append(&mut globals, cli_config_overrides, gix_config::Source::Cli, |_| None).map_err(
+            |err| Error::ConfigOverrides {
+                err,
+                source: gix_config::Source::Cli,
+            },
+        )?;
+    }
+    if !api_config_overrides.is_empty() {
+        config::overrides::append(&mut globals, api_config_overrides, gix_config::Source::Api, |_| None).map_err(
+            |err| Error::ConfigOverrides {
+                err,
+                source: gix_config::Source::Api,
+            },
+        )?;
+    }
+    apply_environment_overrides(&mut globals, *git_prefix, http_transport, identity, objects)?;
+    if let Some(local_meta) = local_meta {
+        globals.set_meta(local_meta);
+    }
+    Ok(globals)
 }
 
 impl crate::Repository {

--- a/gix/src/config/cache/mod.rs
+++ b/gix/src/config/cache/mod.rs
@@ -4,6 +4,7 @@ mod incubate;
 pub(crate) use incubate::StageOne;
 
 mod init;
+pub(crate) use init::load;
 
 impl std::fmt::Debug for Cache {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/gix/src/create.rs
+++ b/gix/src/create.rs
@@ -170,12 +170,20 @@ fn default_object_hash() -> Option<gix_hash::Kind> {
 pub fn into(
     directory: impl Into<PathBuf>,
     kind: Kind,
+    options: Options,
+) -> Result<gix_discover::repository::Path, Error> {
+    into_with_capabilities(directory, kind, options).map(|(path, _)| path)
+}
+
+pub(crate) fn into_with_capabilities(
+    directory: impl Into<PathBuf>,
+    kind: Kind,
     Options {
         fs_capabilities,
         destination_must_be_empty,
         object_hash,
     }: Options,
-) -> Result<gix_discover::repository::Path, Error> {
+) -> Result<(gix_discover::repository::Path, gix_fs::Capabilities), Error> {
     let mut dot_git = directory.into();
     let bare = matches!(kind, Kind::Bare);
 
@@ -261,7 +269,9 @@ pub fn into(
             core.push("filemode", bool(caps.executable_bit))?;
             core.push("bare", bool(bare))?;
             core.push("logallrefupdates", bool(!bare))?;
-            core.push("symlinks", bool(caps.symlink))?;
+            if !caps.symlink {
+                core.push("symlinks", bool(false))?;
+            }
             core.push("ignorecase", bool(caps.ignore_case))?;
             core.push("precomposeunicode", bool(caps.precompose_unicode))?;
 
@@ -289,16 +299,19 @@ pub fn into(
         caps
     };
 
-    Ok(gix_discover::repository::Path::from_dot_git_dir(
-        dot_git,
-        if bare {
-            gix_discover::repository::Kind::PossiblyBare
-        } else {
-            gix_discover::repository::Kind::WorkTree { linked_git_dir: None }
-        },
-        &gix_fs::current_dir(caps.precompose_unicode)?,
-    )
-    .expect("by now the `dot_git` dir is valid as we have accessed it"))
+    Ok((
+        gix_discover::repository::Path::from_dot_git_dir(
+            dot_git,
+            if bare {
+                gix_discover::repository::Kind::PossiblyBare
+            } else {
+                gix_discover::repository::Kind::WorkTree { linked_git_dir: None }
+            },
+            &gix_fs::current_dir(caps.precompose_unicode)?,
+        )
+        .expect("by now the `dot_git` dir is valid as we have accessed it"),
+        caps,
+    ))
 }
 
 fn bool(v: bool) -> &'static str {

--- a/gix/src/init.rs
+++ b/gix/src/init.rs
@@ -68,7 +68,10 @@ impl ThreadSafeRepository {
         create_options: crate::create::Options,
         mut open_options: crate::open::Options,
     ) -> Result<Self, Error> {
-        let path = crate::create::into(directory.as_ref(), kind, create_options)?;
+        let (path, capabilities) = crate::create::into_with_capabilities(directory.as_ref(), kind, create_options)?;
+        if !capabilities.symlink {
+            open_options.api_config_overrides.push("core.symlinks=false".into());
+        }
         let (git_dir, worktree_dir) = path.into_repository_and_work_tree_directories();
         open_options.git_dir_trust = Some(gix_sec::Trust::Full);
         // The repo will use `core.precomposeUnicode` to adjust the value as needed.

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -428,6 +428,30 @@ pub fn open_opts(directory: impl Into<std::path::PathBuf>, options: open::Option
     ThreadSafeRepository::open_opts(directory, options).map(Into::into)
 }
 
+/// Load configuration available without an existing repository, using the configuration-related portions of `options`.
+///
+/// `git_dir` supplies context for `includeIf.gitdir` conditions and must exist if includes are enabled. Without it,
+/// these conditions aren't matched. Repository-local and branch-dependent configuration isn't available at this stage.
+pub fn config(git_dir: Option<&std::path::Path>, options: &open::Options) -> Result<config::File, config::Error> {
+    let environment = options.permissions.env;
+    let git_install_dir = path::install_dir().ok();
+    let home = gix_path::env::home_dir().and_then(|home| environment.home.check_opt(home));
+    config::cache::load(
+        None,
+        &mut Vec::new(),
+        git_dir,
+        None,
+        git_install_dir.as_deref(),
+        home.as_deref(),
+        environment,
+        options.permissions.config,
+        options.lossy_config,
+        options.lenient_config,
+        &options.api_config_overrides,
+        &options.cli_config_overrides,
+    )
+}
+
 ///
 pub mod create;
 

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -430,8 +430,8 @@ pub fn open_opts(directory: impl Into<std::path::PathBuf>, options: open::Option
 
 /// Load configuration available without an existing repository, using the configuration-related portions of `options`.
 ///
-/// `git_dir` supplies context for `includeIf.gitdir` conditions and must exist if includes are enabled. Without it,
-/// these conditions aren't matched. Repository-local and branch-dependent configuration isn't available at this stage.
+/// `git_dir` supplies context for `includeIf.gitdir` conditions and does not have to exist. Without it, these
+/// conditions aren't matched. Repository-local and branch-dependent configuration isn't available at this stage.
 pub fn config(git_dir: Option<&std::path::Path>, options: &open::Options) -> Result<config::File, config::Error> {
     let environment = options.permissions.env;
     let git_install_dir = path::install_dir().ok();

--- a/gix/tests/fixtures/make_clone_with_symlink.sh
+++ b/gix/tests/fixtures/make_clone_with_symlink.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# Build the symlink entry through Git's object plumbing so this fixture works even
+# on systems where creating filesystem symlinks requires additional privileges.
+git init --bare source.git
+cd source.git
+target_blob=$(printf 'target contents\n' | git hash-object -w --stdin)
+link_blob=$(printf 'target' | git hash-object -w --stdin)
+tree=$(printf '120000 blob %s\tlink\n100644 blob %s\ttarget\n' "$link_blob" "$target_blob" | git mktree)
+commit=$(git commit-tree "$tree" -m 'Initial commit')
+git update-ref refs/heads/main "$commit"
+git symbolic-ref HEAD refs/heads/main

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -32,6 +32,94 @@ fn discover_with_environment_overrides_isolated(
     .map(|repo| repo.to_thread_local())
 }
 
+#[test]
+#[serial]
+fn globals_from_open_options_match_repository_opening() -> gix_testtools::Result {
+    let temp = gix_testtools::tempfile::TempDir::new()?;
+    let _cwd = gix_testtools::set_current_dir(temp.path())?;
+
+    let repo_path = std::env::current_dir()?.join("project");
+    let git_dir = repo_path.join(".git");
+    let included = temp.path().join("included.config");
+    let global = temp.path().join("global.config");
+    std::fs::write(
+        &included,
+        "[marker]
+            included = true",
+    )?;
+    std::fs::write(
+        &global,
+        format!(
+            "[marker]
+                global = true
+            [includeIf \"gitdir:{git_dir}\"]
+                path = {included}
+            [includeIf \"gitdir:**/unrelated/.git\"]
+                path = {included}",
+            git_dir = git_dir.display().to_string().replace('\\', "/"),
+            included = included.display().to_string().replace('\\', "/"),
+        ),
+    )?;
+    let _env = gix_testtools::Env::new().set("GIT_CONFIG_GLOBAL", global.display().to_string());
+
+    let mut permissions = gix::open::Permissions::isolated();
+    permissions.config.user = true;
+    permissions.config.includes = true;
+    permissions.env.git_prefix = Permission::Allow;
+    let options = gix::open::Options::isolated()
+        .permissions(permissions)
+        .cli_overrides(["marker.precedence=cli"])
+        .config_overrides(["marker.precedence=api"]);
+
+    let repo = gix::ThreadSafeRepository::init_opts(
+        &repo_path,
+        gix::create::Kind::WithWorktree,
+        Default::default(),
+        options.clone(),
+    )?
+    .to_thread_local();
+    let repo = repo.config_snapshot();
+
+    let globals = gix::config(Some(std::path::Path::new("project/.git")), &options)?;
+    assert_eq!(globals.boolean("marker.global")?, Some(true), "global files are loaded");
+    assert_eq!(
+        globals.boolean("marker.included")?,
+        Some(true),
+        "git-dir conditional includes use the provided repository path"
+    );
+    assert_eq!(
+        globals.string("marker.precedence").expect("API override is present"),
+        "api",
+        "API overrides retain repository-opening precedence"
+    );
+
+    let globals_without_repo = gix::config(None, &options)?;
+    assert_eq!(
+        globals_without_repo.boolean("marker.global")?,
+        Some(true),
+        "global files are loaded without repository context"
+    );
+    assert_eq!(
+        globals_without_repo.boolean("marker.included")?,
+        None,
+        "git-dir conditional includes aren't loaded without repository context"
+    );
+
+    for key in ["marker.global", "marker.included"] {
+        assert_eq!(
+            globals.boolean(key)?,
+            repo.try_boolean(key)?,
+            "{key} is loaded identically before and during repository opening"
+        );
+    }
+    assert_eq!(
+        globals.string("marker.precedence"),
+        repo.string("marker.precedence"),
+        "overrides are loaded identically before and during repository opening"
+    );
+    Ok(())
+}
+
 mod with_overrides {
     use crate::named_subrepo_opts;
     use gix_sec::Permission;

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -71,21 +71,12 @@ fn globals_from_open_options_match_repository_opening() -> gix_testtools::Result
         .cli_overrides(["marker.precedence=cli"])
         .config_overrides(["marker.precedence=api"]);
 
-    let repo = gix::ThreadSafeRepository::init_opts(
-        &repo_path,
-        gix::create::Kind::WithWorktree,
-        Default::default(),
-        options.clone(),
-    )?
-    .to_thread_local();
-    let repo = repo.config_snapshot();
-
     let globals = gix::config(Some(std::path::Path::new("project/.git")), &options)?;
     assert_eq!(globals.boolean("marker.global")?, Some(true), "global files are loaded");
     assert_eq!(
         globals.boolean("marker.included")?,
         Some(true),
-        "git-dir conditional includes use the provided repository path"
+        "git-dir conditional includes use the provided future repository path"
     );
     assert_eq!(
         globals.string("marker.precedence").expect("API override is present"),
@@ -104,6 +95,11 @@ fn globals_from_open_options_match_repository_opening() -> gix_testtools::Result
         None,
         "git-dir conditional includes aren't loaded without repository context"
     );
+
+    let repo =
+        gix::ThreadSafeRepository::init_opts(&repo_path, gix::create::Kind::WithWorktree, Default::default(), options)?
+            .to_thread_local();
+    let repo = repo.config_snapshot();
 
     for key in ["marker.global", "marker.included"] {
         assert_eq!(

--- a/gix/tests/gix/clone.rs
+++ b/gix/tests/gix/clone.rs
@@ -24,6 +24,90 @@ mod blocking_io {
     const EXISTING_CONTENT: &[u8] = b"Pre-existing user content.\n";
     const EXISTING_HEAD_CONTENT: &[u8] = b"ref: refs/heads/pre-existing\n";
 
+    #[test]
+    #[serial_test::serial]
+    fn inherited_core_symlinks_false_is_respected() -> crate::Result {
+        use gix_sec::Permission;
+
+        let fixture = gix_testtools::scripted_fixture_read_only("make_clone_with_symlink.sh")?;
+        let destination = gix_testtools::tempfile::TempDir::new()?;
+        let global = destination.path().join("global.config");
+        std::fs::write(
+            &global,
+            "[core]
+                symlinks = false",
+        )?;
+        let _env = gix_testtools::Env::new().set("GIT_CONFIG_GLOBAL", global.display().to_string());
+
+        let mut permissions = gix::open::Permissions::isolated();
+        permissions.config.user = true;
+        permissions.env.git_prefix = Permission::Allow;
+        let mut capabilities = gix_fs::Capabilities {
+            symlink: true,
+            ..Default::default()
+        };
+        let mut prepare = gix::clone::PrepareFetch::new(
+            fixture.join("source.git"),
+            destination.path().join("clone"),
+            gix::create::Kind::WithWorktree,
+            gix::create::Options {
+                fs_capabilities: Some(capabilities),
+                ..Default::default()
+            },
+            gix::open::Options::isolated().permissions(permissions),
+        )?;
+        let (mut checkout, _) = prepare.fetch_then_checkout(gix::progress::Discard, &AtomicBool::default())?;
+        let (repo, _) = checkout.main_worktree(gix::progress::Discard, &AtomicBool::default())?;
+
+        let link = repo.workdir().expect("worktree repository").join("link");
+        assert!(
+            !std::fs::symlink_metadata(&link)?.file_type().is_symlink(),
+            "inherited core.symlinks=false must disable symlink checkout even if the probe supports them"
+        );
+        assert_eq!(
+            std::fs::read(link)?,
+            b"target",
+            "the link target is written as a plain file"
+        );
+        assert_eq!(
+            gix::open_opts(repo.git_dir(), gix::open::Options::isolated())?
+                .config_snapshot()
+                .boolean(gix::config::tree::Core::SYMLINKS),
+            None,
+            "a successful probe must not persist core.symlinks=true and mask inherited configuration"
+        );
+
+        capabilities.symlink = false;
+        let mut prepare = gix::clone::PrepareFetch::new(
+            fixture.join("source.git"),
+            destination.path().join("probe-disables-symlinks"),
+            gix::create::Kind::WithWorktree,
+            gix::create::Options {
+                fs_capabilities: Some(capabilities),
+                ..Default::default()
+            },
+            gix::open::Options::isolated()
+                .permissions(permissions)
+                .config_overrides(["core.symlinks=true"]),
+        )?;
+        let (mut checkout, _) = prepare.fetch_then_checkout(gix::progress::Discard, &AtomicBool::default())?;
+        let (repo, _) = checkout.main_worktree(gix::progress::Discard, &AtomicBool::default())?;
+        assert!(
+            !std::fs::symlink_metadata(repo.workdir().expect("worktree repository").join("link"))?
+                .file_type()
+                .is_symlink(),
+            "a failed symlink probe must override configuration that enables symlinks"
+        );
+        assert_eq!(
+            gix::open_opts(repo.git_dir(), gix::open::Options::isolated())?
+                .config_snapshot()
+                .boolean(gix::config::tree::Core::SYMLINKS),
+            Some(false),
+            "a failed probe is persisted like Git"
+        );
+        Ok(())
+    }
+
     fn shallow_ids(repo: &gix::Repository, expected: &'static str) -> crate::Result<Vec<gix::ObjectId>> {
         let commits = repo.shallow_commits()?.expect(expected);
         // `gix_shallow::read` returns these sorted by id; the expected side is sorted via `sorted(...)`.


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #1353.

## Summary

- expose `gix::config(git_dir, &open::Options)` for loading the non-repository portion of configuration with the same permissions, includes, environment handling, and overrides as repository opening
- load that configuration during clone initialization and preserve an effective `core.symlinks=false`
- combine configuration with filesystem probing so either can disable symlinks, while only persisting local `core.symlinks=false` when probing fails, matching Git
- add a portable symlink-entry clone fixture and regression coverage for both configuration-false/probe-true and configuration-true/probe-false

## Validation

- `cargo test -p gix --features blocking-network-client --test gix config:: --no-fail-fast`
- `cargo test -p gix-config --test config file::init::from_paths::includes::conditional::gitdir --no-fail-fast`
- `cargo test -p gix --features blocking-network-client --test gix clone:: --no-fail-fast`
- `cargo test -p gix --features blocking-network-client --test gix init:: --no-fail-fast`
- `cargo check -p gix --features blocking-network-client`
- `cargo fmt --all -- --check`

Git reference behavior was checked against `setup.c:init_db()`: Git only writes local `core.symlinks=false` after a failed probe and does not persist `true`.