### PR TITLE
Find `git` portably in `make_remote_repos` fixture

### DIFF
--- a/gix/tests/fixtures/make_remote_repos.sh
+++ b/gix/tests/fixtures/make_remote_repos.sh
@@ -108,7 +108,7 @@ git init base
   git branch -D tmp
 )
 
-git clone --shared --depth 2 file://$PWD/base base.shallow
+git clone --shared --depth 2 "file://$PWD/base" base.shallow
 
 
 git clone --shared base clone

--- a/gix/tests/fixtures/make_remote_repos.sh
+++ b/gix/tests/fixtures/make_remote_repos.sh
@@ -316,8 +316,8 @@ git clone --shared base credential-helpers
     function baseline() {
       local url=${1:?need url}
       {
-        echo $url
-        echo url=$url | GIT_TRACE=1 $git credential fill 2>&1 | grep -E '^[a-z]+:' || :
+        echo "$url"
+        echo "url=$url" | GIT_TRACE=1 "$git" credential fill 2>&1 | grep -E '^[a-z]+:' || :
       } >> baseline.git
     }
 

--- a/gix/tests/fixtures/make_remote_repos.sh
+++ b/gix/tests/fixtures/make_remote_repos.sh
@@ -312,7 +312,7 @@ EOF
 git clone --shared base credential-helpers
 (cd credential-helpers
     export GIT_TERMINAL_PROMPT=0
-    git=$(which git)
+    git=$(command -v git)
     function baseline() {
       local url=${1:?need url}
       {


### PR DESCRIPTION
*Written by Claude Opus 5, an AI agent, working in Claude Code at Eliah Kagan's direction.*

Two fixes in `gix/tests/fixtures/make_remote_repos.sh`:

- `which` → `command -v` for locating `git`. `which` is not POSIX and Rocky Linux 10 does not ship it, where its absence aborts the fixture and so fails every test that uses it. See: [Why not use `which`? What to use then?](https://unix.stackexchange.com/questions/85249/why-not-use-which-what-to-use-then)
- Quote the interpolated paths and URLs, which break the fixture — silently, in one case — when `git` or the checkout lives under a path containing whitespace.

See commit messages for details.
