### PR TITLE
feat: add Repository::reset_hard orchestration

### DIFF
--- a/crate-status.md
+++ b/crate-status.md
@@ -69,6 +69,7 @@ The top-level crate that acts as hub to all functionality provided by the `gix-*
 * [ ] strict hash verification (validate that objects actually have the hashes they claim to have)
 * **workflow composition**
     * [ ] checkout, switch, restore and reset orchestration over refs, index and worktree mutation
+        * [x] hard-reset (`Repository::reset_hard`) — soft/mixed, hooks, sparse and submodules still open
     * [ ] merge workflow orchestration
         * [ ] persist and resume conflicted merges with [`MERGE_HEAD`](https://git-scm.com/docs/gitrepository-layout), [`MERGE_MSG`](https://git-scm.com/docs/git-merge) and [`MERGE_MODE`](https://github.com/git/git/blob/ce74208c2fa13943fffa58f168ac27a76d0eb789/path.c#L1585) compatible state
     * [ ] rebase workflow orchestration

--- a/gix/src/repository/mod.rs
+++ b/gix/src/repository/mod.rs
@@ -23,6 +23,9 @@ mod cache;
 #[cfg(feature = "worktree-mutation")]
 mod checkout;
 mod config;
+/// Hard-reset orchestration over refs, index and worktree (`git reset --hard`).
+#[cfg(feature = "worktree-mutation")]
+pub mod reset;
 
 ///
 #[cfg(feature = "blob-diff")]

--- a/gix/src/repository/reset.rs
+++ b/gix/src/repository/reset.rs
@@ -1,0 +1,300 @@
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    sync::atomic::AtomicBool,
+};
+
+use gix_hash::ObjectId;
+use gix_ref::transaction::PreviousValue;
+
+use crate::{Progress, Repository, bstr::BString};
+
+/// Options for [`Repository::reset_hard()`].
+#[derive(Debug, Clone, Default)]
+pub struct Options {
+    /// If `true`, fail unless the current `HEAD` commit is an ancestor of `target`
+    /// (including equality). This is the `git reset --hard` equivalent of a
+    /// fast-forward-only policy often used after a fetch.
+    ///
+    /// Requires the `revision` feature so merge-base can be computed; if that
+    /// feature is off, setting this flag returns [`Error::FastForwardRequiresRevision`].
+    pub require_fast_forward: bool,
+    /// Message written into the reflog when updating the current branch or detached `HEAD`.
+    /// Defaults to `"reset: moving to <id>"` when `None`.
+    pub reflog_message: Option<BString>,
+}
+
+/// Outcome of a successful hard reset.
+#[derive(Debug)]
+pub struct Outcome {
+    /// The commit `HEAD` now points at (after peeling tags).
+    pub commit_id: ObjectId,
+    /// The tree that was checked out into the index and worktree.
+    pub tree_id: ObjectId,
+    /// Details from the low-level worktree checkout.
+    pub checkout: gix_worktree_state::checkout::Outcome,
+}
+
+///
+pub mod error {
+    use std::path::PathBuf;
+
+    /// The error returned by [`Repository::reset_hard()`](crate::Repository::reset_hard).
+    #[derive(Debug, thiserror::Error)]
+    #[expect(missing_docs)]
+    pub enum Error {
+        #[error("Repository at \"{}\" is bare and cannot be hard-reset", git_dir.display())]
+        BareRepository { git_dir: PathBuf },
+        #[error("HEAD is unborn; there is no commit to reset from")]
+        UnbornHead,
+        #[error("require_fast_forward needs the `revision` cargo feature (merge-base)")]
+        FastForwardRequiresRevision,
+        #[error("not a fast-forward: HEAD is not an ancestor of the reset target")]
+        NotFastForward {
+            head: gix_hash::ObjectId,
+            target: gix_hash::ObjectId,
+        },
+        #[error(transparent)]
+        HeadId(#[from] crate::reference::head_id::Error),
+        #[error(transparent)]
+        FindObject(#[from] crate::object::find::existing::Error),
+        #[error(transparent)]
+        PeelToKind(#[from] crate::object::peel::to_kind::Error),
+        #[error(transparent)]
+        DecodeObject(#[from] gix_object::decode::Error),
+        #[error(transparent)]
+        FindHead(#[from] crate::reference::find::existing::Error),
+        #[error(transparent)]
+        ReferenceEdit(#[from] crate::reference::edit::Error),
+        #[error(transparent)]
+        IndexFromTree(#[from] crate::repository::index_from_tree::Error),
+        #[error(transparent)]
+        CheckoutOptions(#[from] crate::config::checkout_options::Error),
+        #[error(transparent)]
+        IndexCheckout(#[from] gix_worktree_state::checkout::Error),
+        #[error(transparent)]
+        WriteIndex(#[from] gix_index::file::write::Error),
+        #[error("Failed to reopen object database as Arc (only if thread-safety wasn't compiled in)")]
+        OpenArcOdb(#[from] std::io::Error),
+        #[cfg(feature = "revision")]
+        #[error(transparent)]
+        MergeBase(#[from] crate::repository::merge_base::Error),
+    }
+}
+pub use error::Error;
+
+/// Progress ids used in [`Repository::reset_hard()`].
+///
+/// Use this information to selectively extract the progress of interest when the parent
+/// application has custom visualization.
+#[derive(Debug, Copy, Clone)]
+pub enum ProgressId {
+    /// The amount of files checked out thus far.
+    CheckoutFiles,
+    /// The amount of bytes written in total.
+    BytesWritten,
+}
+
+impl From<ProgressId> for gix_features::progress::Id {
+    fn from(v: ProgressId) -> Self {
+        match v {
+            ProgressId::CheckoutFiles => *b"RSCF",
+            ProgressId::BytesWritten => *b"RSCB",
+        }
+    }
+}
+
+/// Hard-reset of `HEAD`, index and worktree.
+impl Repository {
+    /// Hard-reset `HEAD`, the index and the worktree to the tree of `target`.
+    ///
+    /// This is the equivalent of `git reset --hard <target>`:
+    ///
+    /// 1. Peel `target` to a commit and its tree.
+    /// 2. Optionally enforce that the current `HEAD` is an ancestor of `target`
+    ///    ([`Options::require_fast_forward`]).
+    /// 3. Move the current branch (or detached `HEAD`) to that commit.
+    /// 4. Build a fresh index from the target tree.
+    /// 5. Delete worktree paths that were tracked before but are absent from the new tree
+    ///    (untracked files are left alone, matching Git).
+    /// 6. Force-checkout the new index into the worktree (`overwrite_existing`).
+    /// 7. Write the new index to disk.
+    ///
+    /// Hooks (`reset`, `post-checkout`) are **not** run yet.
+    ///
+    /// ### Notes
+    ///
+    /// * Soft and mixed modes are not implemented; open a follow-up if those are needed.
+    /// * Sparse-checkout and submodules are not handled specially.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::BareRepository`] if there is no worktree, and
+    /// [`Error::NotFastForward`] when fast-forward is required but the history diverged.
+    pub fn reset_hard<P>(
+        &self,
+        target: impl Into<ObjectId>,
+        mut progress: P,
+        should_interrupt: &AtomicBool,
+        options: Options,
+    ) -> Result<Outcome, Error>
+    where
+        P: gix_features::progress::NestedProgress,
+        P::SubProgress: gix_features::progress::NestedProgress + 'static,
+    {
+        self.reset_hard_inner(target.into(), &mut progress, should_interrupt, options)
+    }
+
+    fn reset_hard_inner(
+        &self,
+        target: ObjectId,
+        progress: &mut dyn gix_features::progress::DynNestedProgress,
+        should_interrupt: &AtomicBool,
+        options: Options,
+    ) -> Result<Outcome, Error> {
+        let _span = gix_trace::coarse!("gix::Repository::reset_hard()");
+        let workdir = self.workdir().ok_or_else(|| Error::BareRepository {
+            git_dir: self.git_dir().to_owned(),
+        })?;
+
+        let commit = self.find_object(target)?.peel_to_commit()?;
+        let commit_id = commit.id;
+        let tree_id = commit.tree_id()?.detach();
+
+        if options.require_fast_forward {
+            self.ensure_fast_forward(commit_id)?;
+        }
+
+        // Snapshot old index paths so we can delete tracked files that vanish.
+        let old_paths: Vec<PathBuf> = match self.open_index() {
+            Ok(idx) => idx
+                .entries()
+                .iter()
+                .filter(|e| e.stage_raw() == 0)
+                .filter_map(|e| {
+                    let rela = e.path_in(idx.path_backing());
+                    self.workdir_path(rela)
+                })
+                .collect(),
+            Err(_) => Vec::new(),
+        };
+
+        // 1) Move the current branch (or detached HEAD) to the target commit.
+        let reflog = options
+            .reflog_message
+            .unwrap_or_else(|| format!("reset: moving to {commit_id}").into());
+        update_head_to(self, commit_id, reflog)?;
+
+        // 2) New index from the target tree.
+        let mut index = self.index_from_tree(&tree_id)?;
+
+        // 3) Remove worktree files that were tracked before and are gone now.
+        let new_paths: HashSet<PathBuf> = index
+            .entries()
+            .iter()
+            .filter(|e| e.stage_raw() == 0)
+            .filter_map(|e| {
+                let rela = e.path_in(index.path_backing());
+                self.workdir_path(rela)
+            })
+            .collect();
+        for path in old_paths {
+            if !new_paths.contains(&path) {
+                remove_path_and_empty_parents(&path, workdir);
+            }
+        }
+
+        // 4) Force-checkout the new index into the worktree.
+        let mut opts = self.checkout_options(gix_worktree::stack::state::attributes::Source::IdMapping)?;
+        opts.overwrite_existing = true;
+        opts.destination_is_initially_empty = false;
+
+        let mut files = progress.add_child_with_id("checkout".into(), ProgressId::CheckoutFiles.into());
+        let mut bytes = progress.add_child_with_id("writing".into(), ProgressId::BytesWritten.into());
+        files.init(Some(index.entries().len()), crate::progress::count("files"));
+        bytes.init(None, crate::progress::bytes());
+
+        let start = std::time::Instant::now();
+        let checkout = gix_worktree_state::checkout(
+            &mut index,
+            workdir,
+            self.objects.clone().into_arc()?,
+            &files,
+            &bytes,
+            should_interrupt,
+            opts,
+        )?;
+        files.show_throughput(start);
+        bytes.show_throughput(start);
+
+        // 5) Persist the index.
+        index.write(Default::default())?;
+
+        Ok(Outcome {
+            commit_id,
+            tree_id,
+            checkout,
+        })
+    }
+
+    fn ensure_fast_forward(&self, target: ObjectId) -> Result<(), Error> {
+        #[cfg(feature = "revision")]
+        {
+            let head = self.head_id()?.detach();
+            if head == target {
+                return Ok(());
+            }
+            match self.merge_base(head, target) {
+                Ok(base) if base.detach() == head => Ok(()),
+                Ok(_) | Err(crate::repository::merge_base::Error::NotFound { .. }) => {
+                    Err(Error::NotFastForward { head, target })
+                }
+                Err(err) => Err(err.into()),
+            }
+        }
+        #[cfg(not(feature = "revision"))]
+        {
+            let _ = target;
+            Err(Error::FastForwardRequiresRevision)
+        }
+    }
+}
+
+fn update_head_to(repo: &Repository, target: ObjectId, reflog_message: BString) -> Result<(), Error> {
+    let head = repo.head()?;
+    if head.is_unborn() {
+        return Err(Error::UnbornHead);
+    }
+
+    if let Some(branch) = head.try_into_referent() {
+        // Force-update the current branch (hard-reset always moves the tip).
+        repo.reference(branch.name().to_owned(), target, PreviousValue::Any, reflog_message)?;
+    } else {
+        // Detached HEAD: update HEAD as a direct ref.
+        repo.reference("HEAD", target, PreviousValue::Any, reflog_message)?;
+    }
+    Ok(())
+}
+
+fn remove_path_and_empty_parents(path: &Path, workdir: &Path) {
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+    let _ = if meta.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    };
+
+    let mut parent = path.parent();
+    while let Some(dir) = parent {
+        if dir == workdir {
+            break;
+        }
+        match std::fs::remove_dir(dir) {
+            Ok(()) => parent = dir.parent(),
+            Err(_) => break,
+        }
+    }
+}

--- a/gix/tests/gix/repository/mod.rs
+++ b/gix/tests/gix/repository/mod.rs
@@ -27,6 +27,9 @@ mod state;
 mod submodule;
 mod worktree;
 
+#[cfg(feature = "worktree-mutation")]
+mod reset;
+
 #[cfg(feature = "revision")]
 mod revision {
     use crate::util::hex_to_id_sha1_only;

--- a/gix/tests/gix/repository/reset.rs
+++ b/gix/tests/gix/repository/reset.rs
@@ -1,0 +1,138 @@
+use std::{path::Path, process::Command, sync::atomic::AtomicBool};
+
+use gix::progress::Discard;
+
+fn git(cwd: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .status()
+        .expect("git available");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn open(path: &Path) -> gix::Repository {
+    gix::open_opts(
+        path,
+        gix::open::Options::isolated().config_overrides(["user.name=gitoxide", "user.email=gitoxide@localhost"]),
+    )
+    .expect("open repo")
+}
+
+#[test]
+fn hard_reset_moves_branch_index_and_worktree() -> crate::Result {
+    let tmp = gix_testtools::tempfile::tempdir()?;
+    let work = tmp.path().join("work");
+    git(tmp.path(), &["init", "-b", "master", work.to_str().unwrap()]);
+
+    std::fs::write(work.join("a.txt"), "one\n")?;
+    git(&work, &["add", "a.txt"]);
+    git(&work, &["commit", "-m", "one"]);
+    let first = open(&work).head_id()?.detach();
+
+    std::fs::write(work.join("a.txt"), "two\n")?;
+    std::fs::write(work.join("b.txt"), "new\n")?;
+    git(&work, &["add", "-A"]);
+    git(&work, &["commit", "-m", "two"]);
+
+    std::fs::remove_file(work.join("b.txt"))?;
+    git(&work, &["add", "-A"]);
+    git(&work, &["commit", "-m", "three"]);
+    let tip = open(&work).head_id()?.detach();
+
+    // Walk back so HEAD/index/worktree look like the intermediate commit that still had b.txt.
+    git(&work, &["reset", "--hard", &first.to_hex().to_string()]);
+    // Re-introduce a tracked b.txt that the tip no longer has.
+    std::fs::write(work.join("b.txt"), "stale\n")?;
+    git(&work, &["add", "b.txt"]);
+    // Leave a dirty tracked a.txt as well.
+    std::fs::write(work.join("a.txt"), "dirty\n")?;
+
+    let repo = open(&work);
+    let outcome = repo.reset_hard(
+        tip,
+        Discard,
+        &AtomicBool::default(),
+        gix::repository::reset::Options::default(),
+    )?;
+    assert_eq!(outcome.commit_id, tip);
+
+    assert_eq!(std::fs::read_to_string(work.join("a.txt"))?, "two\n");
+    assert!(
+        !work.join("b.txt").exists(),
+        "tracked path removed by hard reset must disappear from the worktree"
+    );
+    let head = open(&work).head_id()?.detach();
+    assert_eq!(head, tip);
+    Ok(())
+}
+
+#[test]
+fn hard_reset_ff_only_rejects_diverged_history() -> crate::Result {
+    let tmp = gix_testtools::tempfile::tempdir()?;
+    let work = tmp.path().join("work");
+    git(tmp.path(), &["init", "-b", "master", work.to_str().unwrap()]);
+    std::fs::write(work.join("a.txt"), "base\n")?;
+    git(&work, &["add", "a.txt"]);
+    git(&work, &["commit", "-m", "base"]);
+
+    git(&work, &["checkout", "-b", "side"]);
+    std::fs::write(work.join("a.txt"), "side\n")?;
+    git(&work, &["add", "a.txt"]);
+    git(&work, &["commit", "-m", "side"]);
+    let side = open(&work).head_id()?.detach();
+
+    git(&work, &["checkout", "master"]);
+    std::fs::write(work.join("a.txt"), "main\n")?;
+    git(&work, &["add", "a.txt"]);
+    git(&work, &["commit", "-m", "main"]);
+
+    let repo = open(&work);
+    let err = repo
+        .reset_hard(
+            side,
+            Discard,
+            &AtomicBool::default(),
+            gix::repository::reset::Options {
+                require_fast_forward: true,
+                ..Default::default()
+            },
+        )
+        .expect_err("diverged histories must fail with require_fast_forward");
+    assert!(
+        matches!(err, gix::repository::reset::Error::NotFastForward { .. }),
+        "unexpected error: {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn hard_reset_leaves_untracked_files_alone() -> crate::Result {
+    let tmp = gix_testtools::tempfile::tempdir()?;
+    let work = tmp.path().join("work");
+    git(tmp.path(), &["init", "-b", "master", work.to_str().unwrap()]);
+    std::fs::write(work.join("a.txt"), "one\n")?;
+    git(&work, &["add", "a.txt"]);
+    git(&work, &["commit", "-m", "one"]);
+
+    std::fs::write(work.join("a.txt"), "dirty\n")?;
+    std::fs::write(work.join("untracked.txt"), "keep me\n")?;
+
+    let repo = open(&work);
+    let tip = repo.head_id()?.detach();
+    // Reset to same commit: discards dirty tracked content, keeps untracked.
+    repo.reset_hard(
+        tip,
+        Discard,
+        &AtomicBool::default(),
+        gix::repository::reset::Options::default(),
+    )?;
+
+    assert_eq!(std::fs::read_to_string(work.join("a.txt"))?, "one\n");
+    assert_eq!(std::fs::read_to_string(work.join("untracked.txt"))?, "keep me\n");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

<!-- agent -->

Adds `Repository::reset_hard()` — pure-gix composition of existing plumbing into a `git reset --hard <target>` workflow listed as unfinished in `crate-status.md` (*checkout, switch, restore and reset orchestration*).

Algorithm:

1. Peel `target` to a commit / tree
2. Optionally require that `HEAD` is an ancestor of `target` (fast-forward-only, via merge-base)
3. Move the current branch (or detached `HEAD`) to that commit
4. Build a fresh index from the target tree
5. Delete worktree paths that were tracked before but absent from the new tree (untracked files left alone)
6. Force-checkout the new index (`overwrite_existing`)
7. Write the index

### API

```rust
repo.reset_hard(
    target,
    progress,
    &should_interrupt,
    gix::repository::reset::Options {
        require_fast_forward: false,
        reflog_message: None, // default: "reset: moving to <id>"
    },
)?;
```

Gated on the `worktree-mutation` feature (same as low-level checkout options). Fast-forward checks need `revision`.

### Out of scope (follow-ups welcome)

- Soft / mixed reset modes
- Client-side hooks (`reset`, `post-checkout`)
- Sparse-checkout and submodule special-cases
- Switch / restore orchestration

### Motivation / dogfood

Portage's `em` (`lu-zero/portage-cli`) uses pure-gix fetch + hard-reset for `em sync` / `em maint sync` of git-backed overlays. The same composition lived in application code first; this PR offers it upstream so other callers can share it.

## Test plan

- [x] `cargo test -p gix --test gix repository::reset`
  - moves branch, index and worktree; removes vanished tracked paths
  - `require_fast_forward` rejects diverged history
  - untracked files are preserved
- [ ] CI green on this PR

Assisted-by: Grok:4.5