### PR TITLE
fix: resolve delta trees lazily in a lock-free pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,6 +2203,7 @@ dependencies = [
  "bstr",
  "clru",
  "criterion",
+ "crossbeam-deque",
  "document-features",
  "gix-chunk",
  "gix-diff",

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -38,7 +38,7 @@ object-cache-dynamic = ["dep:clru", "dep:gix-hashtable"]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde = ["dep:serde", "gix-object/serde", "gix-zlib/serde"]
 ## Enable parallel algorithms.
-parallel = ["gix-features/parallel"]
+parallel = ["gix-features/parallel", "dep:crossbeam-deque"]
 ## Make it possible to compile to the `wasm32-unknown-unknown` target.
 wasm = ["gix-diff?/wasm"]
 
@@ -60,6 +60,7 @@ memmap2 = "0.9.11"
 smallvec = "1.15.1"
 parking_lot = { version = "0.12.4", default-features = false, optional = true }
 thiserror = "2.0.18"
+crossbeam-deque = { version = "0.8.6", optional = true }
 
 # for caching
 uluru = { version = "3.0.0", optional = true }
@@ -74,7 +75,7 @@ document-features = { version = "0.2.0", optional = true }
 gix-tempfile = { version = "^24.0.0", default-features = false, path = "../gix-tempfile", optional = true }
 
 [dev-dependencies]
-gix-pack = { path = ".", features = ["sha1", "sha256", "pack-cache-lru-dynamic", "pack-cache-lru-static", "object-cache-dynamic", "serde", "parallel"] }
+gix-pack = { path = ".", features = ["sha1", "sha256", "pack-cache-lru-dynamic", "pack-cache-lru-static", "object-cache-dynamic", "serde"] }
 gix-testtools = { path = "../tests/tools", default-features = false }
 gix-odb = { path = "../gix-odb", features = ["sha1", "sha256"] }
 gix-object = { path = "../gix-object" }

--- a/gix-pack/src/cache/delta/traverse/mod.rs
+++ b/gix-pack/src/cache/delta/traverse/mod.rs
@@ -1,10 +1,6 @@
-use std::{
-    collections::TryReserveError,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use std::{collections::TryReserveError, sync::atomic::AtomicBool};
 
 use gix_features::{
-    parallel::in_parallel_with_slice,
     progress::{self, DynNestedProgress, Progress},
     threading,
     threading::{Mutable, OwnShared},
@@ -158,58 +154,33 @@ where
         };
         size_progress.init(None, progress::bytes());
         let size_counter = size_progress.counter();
-        let object_progress = OwnShared::new(Mutable::new(object_progress));
+        let resolver_progress = object_progress.add_child("delta resolver".into());
 
         let start = std::time::Instant::now();
         let (mut root_items, mut child_items_vec, ref_delta_children) = self.take_root_child_and_refs();
         let ref_delta_children =
             (!ref_delta_children.is_empty()).then(|| OwnShared::new(Mutable::new(ref_delta_children)));
         let child_items = ItemSliceSync::new(&mut child_items_vec);
-        let child_items = &child_items;
-        in_parallel_with_slice(
-            &mut root_items,
-            thread_limit,
-            {
-                {
-                    let object_progress = object_progress.clone();
-                    let ref_delta_children = ref_delta_children.clone();
-                    move |thread_index| resolve::State {
-                        delta_bytes: Vec::<u8>::with_capacity(4096),
-                        fully_resolved_delta_bytes: Vec::<u8>::with_capacity(4096),
-                        progress: Box::new(
-                            threading::lock(&object_progress).add_child(format!("thread {thread_index}")),
-                        ),
-                        resolve: resolve.clone(),
-                        modify_base: inspect_object.clone(),
-                        child_items,
-                        ref_delta_children: ref_delta_children.clone(),
-                    }
-                }
-            },
-            {
-                move |node, state, threads_left, should_interrupt| {
-                    // SAFETY: This invariant is upheld since `child_items` and `node` come from the same Tree.
-                    // This means we can rely on Tree's invariant that node.children will be the only `children` array in
-                    // for nodes in this tree that will contain any of those children.
-                    #[expect(unsafe_code)]
-                    unsafe {
-                        resolve::deltas(
-                            object_counter.clone(),
-                            size_counter.clone(),
-                            node,
-                            state,
-                            resolve_data,
-                            object_hash,
-                            alloc_limit_bytes,
-                            threads_left,
-                            should_interrupt,
-                        )
-                    }
-                }
-            },
-            || (!should_interrupt.load(Ordering::Relaxed)).then(|| std::time::Duration::from_millis(50)),
-            |_| (),
-        )?;
+        // SAFETY: Both item slices come from the same Tree, whose child-index uniqueness invariant still holds.
+        #[expect(unsafe_code)]
+        unsafe {
+            resolve::all(
+                &mut root_items,
+                &child_items,
+                thread_limit,
+                num_objects,
+                object_counter,
+                size_counter,
+                &resolver_progress,
+                resolve,
+                resolve_data,
+                inspect_object,
+                ref_delta_children.clone(),
+                object_hash,
+                alloc_limit_bytes,
+                should_interrupt,
+            )?;
+        }
 
         if let Some(ref_delta_children) = ref_delta_children {
             if let Some((base_id, _children)) = threading::lock(&ref_delta_children).first_key_value() {
@@ -217,7 +188,7 @@ where
             }
         }
 
-        threading::lock(&object_progress).show_throughput(start);
+        object_progress.show_throughput(start);
         size_progress.show_throughput(start);
 
         Ok(Outcome {

--- a/gix-pack/src/cache/delta/traverse/resolve.rs
+++ b/gix-pack/src/cache/delta/traverse/resolve.rs
@@ -1,9 +1,9 @@
-use std::{
-    collections::BTreeMap,
-    sync::atomic::{AtomicBool, AtomicIsize, Ordering},
-};
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use gix_features::{progress::Progress, threading};
+use gix_features::{
+    progress::Progress,
+    threading::{self, OwnShared},
+};
 
 use crate::{
     cache::delta::{
@@ -14,10 +14,10 @@ use crate::{
     data::EntryRange,
 };
 
-mod root {
+mod node {
     use crate::cache::delta::{Item, traverse::util::ItemSliceSync};
 
-    /// An item returned by `iter_root_chunks`, allowing access to the `data` stored alongside nodes in a [`Tree`].
+    /// A node in a delta tree, with exclusive access to its item data.
     pub(crate) struct Node<'a, T: Send> {
         // SAFETY INVARIANT: see Node::new(). That function is the only one used
         // to create or modify these fields.
@@ -26,39 +26,24 @@ mod root {
     }
 
     impl<'a, T: Send> Node<'a, T> {
-        /// SAFETY: `item.children` must uniquely reference elements in child_items that no other currently alive
-        /// item does. All child_items must also have unique children, unless the child_item is itself `item`,
-        /// in which case no other live item should reference it in its `item.children`.
-        ///
-        /// This safety invariant can be reliably upheld by making sure `item` comes from a Tree and `child_items`
-        /// was constructed using that Tree's child_items. This works since Tree has this invariant as well: all
-        /// child_items are referenced at most once (really, exactly once) by a node in the tree.
-        ///
-        /// Note that this invariant is a bit more relaxed than that on `deltas()`, because this function can be called
-        /// for traversal within a child item, which happens in into_child_iter()
+        /// SAFETY: `item.children` must uniquely reference elements in `child_items` that no other live item does.
+        /// All child items must uphold the same invariant.
         #[expect(unsafe_code)]
         pub(super) unsafe fn new(item: &'a mut Item<T>, child_items: &'a ItemSliceSync<'a, Item<T>>) -> Self {
             Node { item, child_items }
         }
-    }
 
-    impl<'a, T: Send> Node<'a, T> {
-        /// Returns the offset into the pack at which the `Node`s data is located.
-        pub fn offset(&self) -> u64 {
-            self.item.offset
-        }
-
-        /// Returns the slice into the data pack at which the pack entry is located.
+        /// Return the pack byte range used to resolve this entry's header and compressed data.
         pub fn entry_slice(&self) -> crate::data::EntryRange {
             self.item.offset..self.item.next_offset
         }
 
-        /// Returns the node data associated with this node.
+        /// Return the data associated with this node.
         pub fn data(&mut self) -> &mut T {
             &mut self.item.data
         }
 
-        /// Returns true if this node has children, e.g. is not a leaf in the tree.
+        /// Return true if this node is a base for other deltas.
         pub fn has_children(&self) -> bool {
             !self.item.children().is_empty()
         }
@@ -67,26 +52,24 @@ mod root {
             self.item.extend_children(children);
         }
 
-        /// Transform this `Node` into an iterator over its children.
-        ///
-        /// Children are `Node`s referring to pack entries whose base object is this pack entry.
+        /// Transform this node into an iterator over its children.
         pub fn into_child_iter(self) -> impl Iterator<Item = Node<'a, T>> + 'a {
             let children = self.child_items;
             #[expect(unsafe_code)]
             self.item.children().iter().map(move |&index| {
-                // SAFETY: Due to the invariant on new(), we can rely on these indices
-                // being unique.
+                // SAFETY: Tree guarantees that each child index belongs to exactly one parent.
                 let item = unsafe { children.get_mut(index as usize) };
-                // SAFETY: Since every child_item is also required to uphold the uniqueness guarantee,
-                // creating a Node with one of the child_items that we are allowed access to is still fine.
+                // SAFETY: The child inherits the same uniqueness guarantee.
                 unsafe { Node::new(item, children) }
             })
         }
     }
 }
 
+use node::Node;
+
 fn attach_ref_delta_children<T: Send>(
-    node: &mut root::Node<'_, T>,
+    node: &mut Node<'_, T>,
     entry: &data::Entry,
     decompressed: &[u8],
     ref_delta_children: Option<&super::SharedRefDeltaChildren>,
@@ -95,6 +78,7 @@ fn attach_ref_delta_children<T: Send>(
     let Some(ref_delta_children) = ref_delta_children else {
         return Ok(());
     };
+    // Avoid hashing every remaining object once all pending ref-deltas have found their bases.
     if threading::lock(ref_delta_children).is_empty() {
         return Ok(());
     }
@@ -107,229 +91,56 @@ fn attach_ref_delta_children<T: Send>(
     Ok(())
 }
 
-pub(super) struct State<'items, F, MBFN, T: Send> {
-    pub delta_bytes: Vec<u8>,
-    pub fully_resolved_delta_bytes: Vec<u8>,
-    pub progress: Box<dyn Progress>,
-    pub resolve: F,
-    pub modify_base: MBFN,
-    pub child_items: &'items ItemSliceSync<'items, Item<T>>,
-    pub ref_delta_children: Option<super::SharedRefDeltaChildren>,
+/// A parsed entry and its decompressed bytes, ready to serve as a delta base.
+struct ResolvedBase {
+    /// The pack entry, with a delta header replaced by its resolved object kind.
+    entry: data::Entry,
+    /// The pack offset immediately after the entry.
+    entry_end: u64,
+    /// The fully resolved object bytes.
+    bytes: Vec<u8>,
 }
 
-/// Resolve and visit the complete delta subtree rooted at `item`.
+/// A resolved base shared by sibling work items.
 ///
-/// The root entry is read and inflated through `resolve`. Each child entry is inflated as delta instructions and applied
-/// to its resolved parent's bytes. The resulting object inherits its parent's object kind and is passed to `modify_base`;
-/// objects which are themselves bases retain their bytes until their children have been processed.
+/// [`OwnShared`] uses an `Arc` for parallel builds and an `Rc` otherwise. Once all siblings have released their clones,
+/// the task holding the sole reference can use [`OwnShared::try_unwrap()`] to recover the base and reuse its `Vec`
+/// allocation as scratch space.
+type SharedResolvedBase = OwnShared<ResolvedBase>;
+
+/// A schedulable delta-tree node.
 ///
-/// After resolving an object, its ID is computed if ref-deltas are waiting for a matching base. Those children are then
-/// attached to the object and traversed like children whose bases were known by pack offset.
+/// Work items can move between workers because each [`Node`] grants exclusive access to one item, while siblings
+/// share their parent only through an immutable [`SharedResolvedBase`].
+struct WorkItem<'a, T: Send> {
+    /// The traversal level, with roots at level `0`.
+    level: u16,
+    /// The exclusive handle to the tree item being resolved.
+    node: Node<'a, T>,
+    /// The resolved parent's entry and bytes needed to apply this node's delta, or `None` for roots.
+    parent: Option<SharedResolvedBase>,
+}
+
+/// Resolve all delta trees from a shared, lock-free work-stealing pool.
+/// It's `unsafe` as there is safety-constraints on `items` and `child_items`.
 ///
-/// # Safety
-///
-/// This safety invariant can be reliably upheld by making sure `item` comes from a Tree and `child_items`
-/// was constructed using that Tree's child_items. This works since Tree has this invariant as well: all
-/// child_items are referenced at most once (really, exactly once) by a node in the tree.
-///
-/// So: `item.children` must contain valid, unique indices into `child_items`, and every child item must recursively uphold the
-/// same rule. No index may be reachable from another live root or child. This gives each worker exclusive access to every
-/// `Item<T>` it obtains through [`ItemSliceSync`], despite that type using a shared raw pointer internally.
-/// The caller can satisfy this contract by taking `item` and `child_items` from the same
-/// [`Tree`](crate::cache::delta::Tree), whose construction maintains the single-parent invariant.
+/// SAFETY: `items` and `child_items` must originate from the same [`crate::cache::delta::Tree`].
 #[expect(clippy::too_many_arguments, unsafe_code)]
-#[deny(unsafe_op_in_unsafe_fn)] // this is a big function, require unsafe for the one small unsafe op we have
-pub(super) unsafe fn deltas<T, F, MBFN, E, R>(
-    objects: gix_features::progress::StepShared,
-    size: gix_features::progress::StepShared,
-    item: &mut Item<T>,
-    State {
-        delta_bytes,
-        fully_resolved_delta_bytes,
-        progress,
-        resolve,
-        modify_base,
-        child_items,
-        ref_delta_children,
-    }: &mut State<'_, F, MBFN, T>,
-    resolve_data: &R,
-    object_hash: gix_hash::Kind,
-    alloc_limit_bytes: Option<usize>,
-    threads_left: &AtomicIsize,
-    should_interrupt: &AtomicBool,
-) -> Result<(), Error>
-where
-    T: Send,
-    R: Send + Sync,
-    F: for<'r> Fn(EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
-    MBFN: FnMut(&mut T, &dyn Progress, Context<'_>) -> Result<(), E> + Send + Clone,
-    E: std::error::Error + Send + Sync + 'static,
-{
-    let mut decompressed_bytes_by_pack_offset = BTreeMap::new();
-    let mut inflate = gix_zlib::Inflate::default();
-    let mut decompress_from_resolver = |slice: EntryRange, out: &mut Vec<u8>| -> Result<(data::Entry, u64), Error> {
-        let bytes = resolve(slice.clone(), resolve_data).ok_or(Error::ResolveFailed {
-            pack_offset: slice.start,
-        })?;
-        let entry = data::Entry::from_bytes(bytes, slice.start, object_hash)?;
-        let compressed = &bytes[entry.header_size()..];
-        let decompressed_len = decoded_size_limited(entry.decompressed_size, alloc_limit_bytes)?;
-        decompress_all_at_once_with(&mut inflate, compressed, decompressed_len, out, alloc_limit_bytes)?;
-        Ok((entry, slice.end))
-    };
-
-    // each node is a base, and its children always start out as deltas which become a base after applying them.
-    // These will be pushed onto our stack until all are processed
-    let root_level = 0;
-    // SAFETY: This invariant is required from the caller
-    #[expect(unsafe_code)]
-    let root_node = unsafe { root::Node::new(item, child_items) };
-    let mut nodes: Vec<_> = vec![(root_level, root_node)];
-    while let Some((level, mut base)) = nodes.pop() {
-        if should_interrupt.load(Ordering::Relaxed) {
-            return Err(Error::Interrupted);
-        }
-        let (base_entry, entry_end, base_bytes) = if level == root_level {
-            let mut buf = Vec::new();
-            let (a, b) = decompress_from_resolver(base.entry_slice(), &mut buf)?;
-            (a, b, buf)
-        } else {
-            decompressed_bytes_by_pack_offset
-                .remove(&base.offset())
-                .expect("we store the resolved delta buffer when done")
-        };
-
-        // anything done here must be repeated further down for leaf-nodes.
-        // This way we avoid retaining their decompressed memory longer than needed (they have no children,
-        // thus their memory can be released right away, using 18% less peak memory on the linux kernel).
-        {
-            modify_base(
-                base.data(),
-                progress,
-                Context {
-                    entry: &base_entry,
-                    entry_end,
-                    decompressed: &base_bytes,
-                    level,
-                },
-            )
-            .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)?;
-            objects.fetch_add(1, Ordering::Relaxed);
-            size.fetch_add(base_bytes.len(), Ordering::Relaxed);
-        }
-        attach_ref_delta_children(
-            &mut base,
-            &base_entry,
-            &base_bytes,
-            ref_delta_children.as_ref(),
-            object_hash,
-        )?;
-
-        for mut child in base.into_child_iter() {
-            let (mut child_entry, entry_end) = decompress_from_resolver(child.entry_slice(), delta_bytes)?;
-            let (base_size, consumed) = data::delta::decode_header_size(delta_bytes)?;
-            let base_size = decoded_size_limited(base_size, alloc_limit_bytes)?;
-            let mut header_ofs = consumed;
-            if base_bytes.len() != base_size {
-                return Err(data::delta::apply::Error::Corrupt {
-                    message: "delta base size does not match base object size",
-                }
-                .into());
-            }
-            let (result_size, consumed) = data::delta::decode_header_size(&delta_bytes[consumed..])?;
-            let result_size = decoded_size_limited(result_size, alloc_limit_bytes)?;
-            header_ofs += consumed;
-
-            resize_with_limit(fully_resolved_delta_bytes, result_size, alloc_limit_bytes)?;
-            data::delta::apply(&base_bytes, fully_resolved_delta_bytes, &delta_bytes[header_ofs..])?;
-
-            // FIXME: this actually invalidates the "pack_offset()" computation, which is not obvious to consumers
-            //        at all
-            child_entry.header = base_entry.header; // assign the actual object type, instead of 'delta'
-            attach_ref_delta_children(
-                &mut child,
-                &child_entry,
-                fully_resolved_delta_bytes,
-                ref_delta_children.as_ref(),
-                object_hash,
-            )?;
-            if child.has_children() {
-                decompressed_bytes_by_pack_offset.insert(
-                    child.offset(),
-                    (child_entry, entry_end, std::mem::take(fully_resolved_delta_bytes)),
-                );
-                nodes.push((level + 1, child));
-            } else {
-                modify_base(
-                    child.data(),
-                    &progress,
-                    Context {
-                        entry: &child_entry,
-                        entry_end,
-                        decompressed: fully_resolved_delta_bytes,
-                        level: level + 1,
-                    },
-                )
-                .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)?;
-                objects.fetch_add(1, Ordering::Relaxed);
-                size.fetch_add(base_bytes.len(), Ordering::Relaxed);
-            }
-        }
-
-        // After the first round, see if we can use additional threads, and if so we enter multi-threaded mode.
-        // In it we will keep using new threads as they become available while using this thread for coordination.
-        // We optimize for a low memory footprint as we are likely to get here if long delta-chains with large objects are involved.
-        // Try to avoid going into threaded mode if there isn't more than one unit of work anyway.
-        if nodes.len() > 1 {
-            if let Ok(initial_threads) =
-                threads_left.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |threads_available| {
-                    (threads_available > 0).then_some(0)
-                })
-            {
-                // Assure no memory is held here.
-                *delta_bytes = Vec::new();
-                *fully_resolved_delta_bytes = Vec::new();
-                return deltas_mt(
-                    initial_threads,
-                    decompressed_bytes_by_pack_offset,
-                    objects,
-                    size,
-                    &progress,
-                    nodes,
-                    resolve.clone(),
-                    resolve_data,
-                    modify_base.clone(),
-                    ref_delta_children.clone(),
-                    object_hash,
-                    alloc_limit_bytes,
-                    threads_left,
-                    should_interrupt,
-                );
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// * `initial_threads` is the threads we may spawn, not accounting for our own thread which is still considered used by the parent
-///   system. Since this thread will take a controlling function, we may spawn one more than that. In threaded mode, we will finish
-///   all remaining work.
-#[expect(clippy::too_many_arguments)]
-fn deltas_mt<T, F, MBFN, E, R>(
-    mut threads_to_create: isize,
-    decompressed_bytes_by_pack_offset: BTreeMap<u64, (data::Entry, u64, Vec<u8>)>,
+#[deny(unsafe_op_in_unsafe_fn)]
+pub(super) unsafe fn all<T, F, MBFN, E, R>(
+    items: &mut [Item<T>],
+    child_items: &ItemSliceSync<'_, Item<T>>,
+    thread_limit: Option<usize>,
+    num_objects: usize,
     objects: gix_features::progress::StepShared,
     size: gix_features::progress::StepShared,
     progress: &dyn Progress,
-    nodes: Vec<(u16, root::Node<'_, T>)>,
     resolve: F,
     resolve_data: &R,
     modify_base: MBFN,
     ref_delta_children: Option<super::SharedRefDeltaChildren>,
     object_hash: gix_hash::Kind,
     alloc_limit_bytes: Option<usize>,
-    threads_left: &AtomicIsize,
     should_interrupt: &AtomicBool,
 ) -> Result<(), Error>
 where
@@ -339,209 +150,481 @@ where
     MBFN: FnMut(&mut T, &dyn Progress, Context<'_>) -> Result<(), E> + Send + Clone,
     E: std::error::Error + Send + Sync + 'static,
 {
-    let nodes = gix_features::threading::Mutable::new(nodes);
-    let decompressed_bytes_by_pack_offset = gix_features::threading::Mutable::new(decompressed_bytes_by_pack_offset);
-    threads_to_create += 1; // ourselves
-    let mut returned_ourselves = false;
+    let work = items
+        .iter_mut()
+        .map(|item| {
+            // SAFETY: Required from the caller, and each root item is unique.
+            #[expect(unsafe_code)]
+            let node = unsafe { Node::new(item, child_items) };
+            WorkItem {
+                level: 0,
+                node,
+                parent: None,
+            }
+        })
+        .collect::<Vec<_>>();
 
-    gix_features::parallel::threads(|s| -> Result<(), Error> {
-        let mut threads = Vec::new();
-        let poll_interval = std::time::Duration::from_millis(100);
-        loop {
-            for tid in 0..threads_to_create {
-                let thread = gix_features::parallel::build_thread()
-                    .name(format!("gix-pack.traverse_deltas.{tid}"))
-                    .spawn_scoped(s, {
-                        let nodes = &nodes;
-                        let decompressed_bytes_by_pack_offset = &decompressed_bytes_by_pack_offset;
-                        let resolve = resolve.clone();
-                        let mut modify_base = modify_base.clone();
-                        let ref_delta_children = ref_delta_children.clone();
-                        let objects = &objects;
-                        let size = &size;
+    #[cfg(feature = "parallel")]
+    {
+        resolve_parallel(
+            gix_features::parallel::num_threads(thread_limit).min(num_objects),
+            work,
+            objects,
+            size,
+            progress,
+            resolve,
+            resolve_data,
+            modify_base,
+            ref_delta_children,
+            object_hash,
+            alloc_limit_bytes,
+            should_interrupt,
+        )
+    }
+    #[cfg(not(feature = "parallel"))]
+    {
+        let _ = thread_limit;
+        let _ = num_objects;
+        resolve_serial(
+            work,
+            objects,
+            size,
+            progress,
+            resolve,
+            resolve_data,
+            modify_base,
+            ref_delta_children,
+            object_hash,
+            alloc_limit_bytes,
+            should_interrupt,
+        )
+    }
+}
 
-                        move || -> Result<(), Error> {
-                            let mut fully_resolved_delta_bytes = Vec::new();
+/// Resolve all work on the current thread using `work` as a LIFO stack.
+///
+/// `work` initially contains only roots. Resolving a node adds a [`WorkItem`] for each child to the same stack consumed by
+/// the loop, so processing continues through dynamically scheduled descendants, including ref-delta children attached
+/// during resolution, until both they and the remaining roots are exhausted. LIFO order makes children of the current
+/// node run before roots that were already waiting.
+#[cfg(not(feature = "parallel"))]
+#[expect(clippy::too_many_arguments)]
+fn resolve_serial<T, F, MBFN, E, R>(
+    mut work: Vec<WorkItem<'_, T>>,
+    objects: gix_features::progress::StepShared,
+    size: gix_features::progress::StepShared,
+    progress: &dyn Progress,
+    resolve: F,
+    resolve_data: &R,
+    mut modify_base: MBFN,
+    ref_delta_children: Option<super::SharedRefDeltaChildren>,
+    object_hash: gix_hash::Kind,
+    alloc_limit_bytes: Option<usize>,
+    should_interrupt: &AtomicBool,
+) -> Result<(), Error>
+where
+    T: Send,
+    R: Send + Sync,
+    F: for<'r> Fn(EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
+    MBFN: FnMut(&mut T, &dyn Progress, Context<'_>) -> Result<(), E> + Send + Clone,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let mut delta_bytes = Vec::new();
+    let mut fully_resolved_delta_bytes = Vec::new();
+    let mut inflate = gix_zlib::Inflate::default();
+    while let Some(task) = work.pop() {
+        if should_interrupt.load(Ordering::Relaxed) {
+            return Err(Error::Interrupted);
+        }
+        resolve_task(
+            task,
+            &mut delta_bytes,
+            &mut fully_resolved_delta_bytes,
+            &mut inflate,
+            progress,
+            &resolve,
+            resolve_data,
+            &mut modify_base,
+            ref_delta_children.as_ref(),
+            object_hash,
+            alloc_limit_bytes,
+            &objects,
+            &size,
+            |child| work.push(child),
+        )?;
+    }
+    Ok(())
+}
+
+/// Resolve work in parallel with per-worker LIFO queues and work stealing.
+///
+/// Roots start in a shared queue. Each worker prefers children on its own queue, then steals from peer queues, and finally
+/// takes another root. This favors completing active trees before starting more roots.
+///
+/// Newly discovered children are scheduled on the current worker, where idle peers can steal them and help with an active
+/// tree. A worker that temporarily finds no task yields while other work is queued or in progress, since it may expose
+/// more descendants, and exits only when no work remains.
+#[cfg(feature = "parallel")]
+#[expect(clippy::too_many_arguments)]
+fn resolve_parallel<T, F, MBFN, E, R>(
+    num_threads: usize,
+    work: Vec<WorkItem<'_, T>>,
+    objects: gix_features::progress::StepShared,
+    size: gix_features::progress::StepShared,
+    progress: &dyn Progress,
+    resolve: F,
+    resolve_data: &R,
+    modify_base: MBFN,
+    ref_delta_children: Option<super::SharedRefDeltaChildren>,
+    object_hash: gix_hash::Kind,
+    alloc_limit_bytes: Option<usize>,
+    should_interrupt: &AtomicBool,
+) -> Result<(), Error>
+where
+    T: Send,
+    R: Send + Sync,
+    F: for<'r> Fn(EntryRange, &'r R) -> Option<&'r [u8]> + Send + Clone,
+    MBFN: FnMut(&mut T, &dyn Progress, Context<'_>) -> Result<(), E> + Send + Clone,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    use std::sync::atomic::AtomicUsize;
+
+    if num_threads == 0 {
+        return Ok(());
+    }
+    let roots = crossbeam_deque::Injector::new();
+    let remaining = AtomicUsize::new(work.len());
+    for task in work {
+        roots.push(task);
+    }
+    let workers: Vec<_> = (0..num_threads).map(|_| crossbeam_deque::Worker::new_lifo()).collect();
+    let stealers: Vec<_> = workers.iter().map(crossbeam_deque::Worker::stealer).collect();
+    let abort = AtomicBool::new(false);
+
+    gix_features::parallel::threads(|scope| {
+        let mut handles = Vec::with_capacity(num_threads);
+        for (tid, worker) in workers.into_iter().enumerate() {
+            let result = gix_features::parallel::build_thread()
+                .name(format!("gix-pack.traverse_deltas.{tid}"))
+                .spawn_scoped(scope, {
+                    let stealers = &stealers;
+                    let roots = &roots;
+                    let remaining = &remaining;
+                    let abort = &abort;
+                    let objects = &objects;
+                    let size = &size;
+                    let resolve = resolve.clone();
+                    let mut modify_base = modify_base.clone();
+                    let ref_delta_children = ref_delta_children.clone();
+                    move || {
+                        // Make sure we never deadlock because a panicking worker can't update `remaining` anymore.
+                        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                             let mut delta_bytes = Vec::new();
+                            let mut fully_resolved_delta_bytes = Vec::new();
                             let mut inflate = gix_zlib::Inflate::default();
-                            let mut decompress_from_resolver =
-                                |slice: EntryRange, out: &mut Vec<u8>| -> Result<(data::Entry, u64), Error> {
-                                    let bytes = resolve(slice.clone(), resolve_data).ok_or(Error::ResolveFailed {
-                                        pack_offset: slice.start,
-                                    })?;
-                                    let entry = data::Entry::from_bytes(bytes, slice.start, object_hash)?;
-                                    let compressed = &bytes[entry.header_size()..];
-                                    let decompressed_len =
-                                        decoded_size_limited(entry.decompressed_size, alloc_limit_bytes)?;
-                                    decompress_all_at_once_with(
-                                        &mut inflate,
-                                        compressed,
-                                        decompressed_len,
-                                        out,
-                                        alloc_limit_bytes,
-                                    )?;
-                                    Ok((entry, slice.end))
-                                };
-
                             loop {
-                                let (level, mut base) = match threading::lock(nodes).pop() {
-                                    Some(v) => v,
-                                    None => break,
-                                };
+                                if abort.load(Ordering::Relaxed) {
+                                    return Ok(());
+                                }
                                 if should_interrupt.load(Ordering::Relaxed) {
+                                    abort.store(true, Ordering::Relaxed);
                                     return Err(Error::Interrupted);
                                 }
-                                let (base_entry, entry_end, base_bytes) = if level == 0 {
-                                    let mut buf = Vec::new();
-                                    let (a, b) = decompress_from_resolver(base.entry_slice(), &mut buf)?;
-                                    (a, b, buf)
-                                } else {
-                                    threading::lock(decompressed_bytes_by_pack_offset)
-                                        .remove(&base.offset())
-                                        .expect("we store the resolved delta buffer when done")
+                                let Some(task) = steal(&worker, stealers, roots) else {
+                                    if remaining.load(Ordering::Acquire) == 0 {
+                                        return Ok(());
+                                    }
+                                    std::thread::yield_now();
+                                    continue;
                                 };
 
-                                // anything done here must be repeated further down for leaf-nodes.
-                                // This way we avoid retaining their decompressed memory longer than needed (they have no children,
-                                // thus their memory can be released right away, using 18% less peak memory on the linux kernel).
-                                {
-                                    modify_base(
-                                        base.data(),
-                                        progress,
-                                        Context {
-                                            entry: &base_entry,
-                                            entry_end,
-                                            decompressed: &base_bytes,
-                                            level,
-                                        },
-                                    )
-                                    .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)?;
-                                    objects.fetch_add(1, Ordering::Relaxed);
-                                    size.fetch_add(base_bytes.len(), Ordering::Relaxed);
-                                }
-                                attach_ref_delta_children(
-                                    &mut base,
-                                    &base_entry,
-                                    &base_bytes,
+                                let task_result = resolve_task(
+                                    task,
+                                    &mut delta_bytes,
+                                    &mut fully_resolved_delta_bytes,
+                                    &mut inflate,
+                                    progress,
+                                    &resolve,
+                                    resolve_data,
+                                    &mut modify_base,
                                     ref_delta_children.as_ref(),
                                     object_hash,
-                                )?;
-
-                                for mut child in base.into_child_iter() {
-                                    let (mut child_entry, entry_end) =
-                                        decompress_from_resolver(child.entry_slice(), &mut delta_bytes)?;
-                                    let (base_size, consumed) = data::delta::decode_header_size(&delta_bytes)?;
-                                    let base_size = decoded_size_limited(base_size, alloc_limit_bytes)?;
-                                    let mut header_ofs = consumed;
-                                    if base_bytes.len() != base_size {
-                                        return Err(data::delta::apply::Error::Corrupt {
-                                            message: "delta base size does not match base object size",
-                                        }
-                                        .into());
-                                    }
-                                    let (result_size, consumed) =
-                                        data::delta::decode_header_size(&delta_bytes[consumed..])?;
-                                    let result_size = decoded_size_limited(result_size, alloc_limit_bytes)?;
-                                    header_ofs += consumed;
-
-                                    resize_with_limit(&mut fully_resolved_delta_bytes, result_size, alloc_limit_bytes)?;
-                                    data::delta::apply(
-                                        &base_bytes,
-                                        &mut fully_resolved_delta_bytes,
-                                        &delta_bytes[header_ofs..],
-                                    )?;
-
-                                    // FIXME: this actually invalidates the "pack_offset()" computation, which is not obvious to consumers
-                                    //        at all
-                                    child_entry.header = base_entry.header; // assign the actual object type, instead of 'delta'
-                                    attach_ref_delta_children(
-                                        &mut child,
-                                        &child_entry,
-                                        &fully_resolved_delta_bytes,
-                                        ref_delta_children.as_ref(),
-                                        object_hash,
-                                    )?;
-                                    if child.has_children() {
-                                        threading::lock(decompressed_bytes_by_pack_offset).insert(
-                                            child.offset(),
-                                            (child_entry, entry_end, std::mem::take(&mut fully_resolved_delta_bytes)),
-                                        );
-                                        threading::lock(nodes).push((level + 1, child));
-                                    } else {
-                                        modify_base(
-                                            child.data(),
-                                            progress,
-                                            Context {
-                                                entry: &child_entry,
-                                                entry_end,
-                                                decompressed: &fully_resolved_delta_bytes,
-                                                level: level + 1,
-                                            },
-                                        )
-                                        .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)?;
-                                        objects.fetch_add(1, Ordering::Relaxed);
-                                        size.fetch_add(base_bytes.len(), Ordering::Relaxed);
-                                    }
+                                    alloc_limit_bytes,
+                                    objects,
+                                    size,
+                                    |child| {
+                                        remaining.fetch_add(1, Ordering::Release);
+                                        worker.push(child);
+                                    },
+                                );
+                                remaining.fetch_sub(1, Ordering::AcqRel);
+                                if let Err(err) = task_result {
+                                    abort.store(true, Ordering::Relaxed);
+                                    return Err(err);
                                 }
                             }
-                            Ok(())
+                        }));
+                        if result.is_err() {
+                            abort.store(true, Ordering::Relaxed);
                         }
-                    })?;
-                threads.push(thread);
-            }
-            if threads_left
-                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |threads_available: isize| {
-                    (threads_available > 0).then(|| {
-                        threads_to_create = threads_available.min(threading::lock(&nodes).len() as isize);
-                        threads_available - threads_to_create
-                    })
-                })
-                .is_err()
-            {
-                threads_to_create = 0;
-            }
-
-            // What we really want to do is either wait for one of our threads to go down
-            // or for another scheduled thread to become available. Unfortunately we can't do that,
-            // but may instead find a good way to set the polling interval instead of hard-coding it.
-            std::thread::sleep(poll_interval);
-            // Get out of threads are already starving or they would be starving soon as no work is left.
-            //
-            // Lint: ScopedJoinHandle is not the same depending on active features and is not exposed in some cases.
-            #[allow(
-                clippy::redundant_closure_for_method_calls,
-                reason = "the closure supports both real and serial scoped thread handles"
-            )]
-            if threads.iter().any(|thread| thread.is_finished()) {
-                let mut running_threads = Vec::new();
-                for thread in threads.drain(..) {
-                    if thread.is_finished() {
-                        match thread.join() {
-                            Ok(Err(err)) => return Err(err),
-                            Ok(Ok(())) => {
-                                if !returned_ourselves {
-                                    returned_ourselves = true;
-                                } else {
-                                    threads_left.fetch_add(1, Ordering::SeqCst);
-                                }
-                            }
-                            Err(err) => {
-                                std::panic::resume_unwind(err);
-                            }
-                        }
-                    } else {
-                        running_threads.push(thread);
+                        result.unwrap_or_else(|payload| std::panic::resume_unwind(payload))
                     }
+                });
+            match result {
+                Ok(handle) => handles.push(handle),
+                Err(err) => {
+                    abort.store(true, Ordering::Relaxed);
+                    for handle in handles {
+                        if let Err(payload) = handle.join() {
+                            std::panic::resume_unwind(payload);
+                        }
+                    }
+                    return Err(Error::SpawnThread(err));
                 }
-                if running_threads.is_empty() && threading::lock(&nodes).is_empty() {
-                    break;
-                }
-                threads = running_threads;
             }
         }
 
-        Ok(())
+        let mut error = None;
+        for handle in handles {
+            match handle.join() {
+                Ok(Err(err)) if error.is_none() => error = Some(err),
+                Ok(_) => {}
+                Err(payload) => std::panic::resume_unwind(payload),
+            }
+        }
+        error.map_or(Ok(()), Err)
     })
+}
+
+/// Take local work or steal it from another worker or the shared root queue, in that order.
+///
+/// Work in peer queues belongs to already active trees and retains shared base buffers. Preferring it advances those
+/// trees toward completion and releases their buffers before another root starts a new tree.
+#[cfg(feature = "parallel")]
+fn steal<T>(
+    worker: &crossbeam_deque::Worker<T>,
+    stealers: &[crossbeam_deque::Stealer<T>],
+    roots: &crossbeam_deque::Injector<T>,
+) -> Option<T> {
+    if let Some(task) = worker.pop() {
+        return Some(task);
+    }
+    loop {
+        let mut retry = false;
+        for stealer in stealers {
+            match stealer.steal() {
+                crossbeam_deque::Steal::Success(task) => return Some(task),
+                crossbeam_deque::Steal::Retry => retry = true,
+                crossbeam_deque::Steal::Empty => {}
+            }
+        }
+        match roots.steal() {
+            crossbeam_deque::Steal::Success(task) => return Some(task),
+            crossbeam_deque::Steal::Retry => retry = true,
+            crossbeam_deque::Steal::Empty => {}
+        }
+        if !retry {
+            return None;
+        }
+    }
+}
+
+/// Resolve one work item using scratch buffers owned by the calling worker.
+///
+/// `delta_bytes` holds inflated delta instructions, while `fully_resolved_delta_bytes` receives the object produced by
+/// applying them. Passing both by mutable reference preserves their allocations across tasks handled by the same worker.
+///
+/// A resolved delta that has children moves its output buffer into [`SharedResolvedBase`]. Once the last sibling releases
+/// that base, [`OwnShared::try_unwrap()`] can recover its allocation; the largest available delta buffer is retained as
+/// `fully_resolved_delta_bytes` for a later task. Root objects deliberately use a task-local buffer instead.
+///
+/// `push` separates discovering children from scheduling them. This function calls it with each child [`WorkItem`];
+/// serial traversal pushes that item onto its `Vec`, while parallel traversal pushes it onto the current worker's deque
+/// and updates the shared count of unfinished work.
+#[expect(clippy::too_many_arguments)]
+fn resolve_task<'a, T, F, MBFN, E, R>(
+    WorkItem {
+        level,
+        mut node,
+        parent,
+    }: WorkItem<'a, T>,
+    delta_bytes: &mut Vec<u8>,
+    fully_resolved_delta_bytes: &mut Vec<u8>,
+    inflate: &mut gix_zlib::Inflate,
+    progress: &dyn Progress,
+    resolve: &F,
+    resolve_data: &R,
+    modify_base: &mut MBFN,
+    ref_delta_children: Option<&super::SharedRefDeltaChildren>,
+    object_hash: gix_hash::Kind,
+    alloc_limit_bytes: Option<usize>,
+    objects: &gix_features::progress::StepShared,
+    size: &gix_features::progress::StepShared,
+    mut push: impl FnMut(WorkItem<'a, T>),
+) -> Result<(), Error>
+where
+    T: Send,
+    R: Send + Sync,
+    F: for<'r> Fn(EntryRange, &'r R) -> Option<&'r [u8]> + Send,
+    MBFN: FnMut(&mut T, &dyn Progress, Context<'_>) -> Result<(), E> + Send,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let is_root = parent.is_none();
+    // Root buffers either become shared bases or are dropped after inspection. Keeping leaf-root allocations out of
+    // worker scratch avoids retaining an occasionally huge capacity for the worker's lifetime.
+    let mut root_bytes = Vec::new();
+    let (entry, entry_end) = if let Some(parent) = parent.as_ref() {
+        let (mut entry, entry_end) = decompress_from_resolver(
+            node.entry_slice(),
+            delta_bytes,
+            inflate,
+            resolve,
+            resolve_data,
+            object_hash,
+            alloc_limit_bytes,
+        )?;
+        let (base_size, consumed) = data::delta::decode_header_size(delta_bytes)?;
+        let base_size = decoded_size_limited(base_size, alloc_limit_bytes)?;
+        if parent.bytes.len() != base_size {
+            return Err(data::delta::apply::Error::Corrupt {
+                message: "delta base size does not match base object size",
+            }
+            .into());
+        }
+        let (result_size, result_header_size) = data::delta::decode_header_size(&delta_bytes[consumed..])?;
+        let result_size = decoded_size_limited(result_size, alloc_limit_bytes)?;
+        resize_with_limit(fully_resolved_delta_bytes, result_size, alloc_limit_bytes)?;
+        data::delta::apply(
+            &parent.bytes,
+            fully_resolved_delta_bytes,
+            &delta_bytes[consumed + result_header_size..],
+        )?;
+        entry.header = parent.entry.header;
+        (entry, entry_end)
+    } else {
+        decompress_from_resolver(
+            node.entry_slice(),
+            &mut root_bytes,
+            inflate,
+            resolve,
+            resolve_data,
+            object_hash,
+            alloc_limit_bytes,
+        )?
+    };
+
+    let resolved = ResolvedBase {
+        entry,
+        entry_end,
+        bytes: if is_root {
+            root_bytes
+        } else {
+            std::mem::take(fully_resolved_delta_bytes)
+        },
+    };
+    attach_ref_delta_children(
+        &mut node,
+        &resolved.entry,
+        &resolved.bytes,
+        ref_delta_children,
+        object_hash,
+    )?;
+    let has_children = node.has_children();
+    inspect(&mut node, level, &resolved, progress, modify_base, objects, size)?;
+    let mut reusable = if has_children {
+        let resolved = OwnShared::new(resolved);
+        for child in node.into_child_iter() {
+            push(WorkItem {
+                level: level + 1,
+                node: child,
+                parent: Some(OwnShared::clone(&resolved)),
+            });
+        }
+        None
+    } else if is_root {
+        None
+    } else {
+        Some(resolved.bytes)
+    };
+
+    // This might be a leaf, while its base buffer now is also exclusively available,
+    // and if so, keep the larger buffer.
+    if let Some(parent) = parent {
+        if let Ok(parent) = OwnShared::try_unwrap(parent) {
+            if reusable
+                .as_ref()
+                .is_none_or(|reusable| parent.bytes.capacity() > reusable.capacity())
+            {
+                reusable = Some(parent.bytes);
+            }
+        }
+    }
+    if let Some(reusable) = reusable {
+        *fully_resolved_delta_bytes = reusable;
+    }
+    fully_resolved_delta_bytes.clear();
+    Ok(())
+}
+
+/// Hand one fully resolved node to the caller's inspector and record its progress.
+///
+/// `modify_base` receives mutable access to the node's associated data and a [`Context`] containing the parsed entry,
+/// its end offset, the resolved object bytes, and its delta-tree level. Only a successful inspection increments the
+/// object counter and the total number of resolved bytes; inspector errors abort traversal as [`Error::Inspect`].
+fn inspect<T, MBFN, E>(
+    node: &mut Node<'_, T>,
+    level: u16,
+    resolved: &ResolvedBase,
+    progress: &dyn Progress,
+    modify_base: &mut MBFN,
+    objects: &gix_features::progress::StepShared,
+    size: &gix_features::progress::StepShared,
+) -> Result<(), Error>
+where
+    T: Send,
+    MBFN: FnMut(&mut T, &dyn Progress, Context<'_>) -> Result<(), E> + Send,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    modify_base(
+        node.data(),
+        progress,
+        Context {
+            entry: &resolved.entry,
+            entry_end: resolved.entry_end,
+            decompressed: &resolved.bytes,
+            level,
+        },
+    )
+    .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)?;
+    objects.fetch_add(1, Ordering::Relaxed);
+    size.fetch_add(resolved.bytes.len(), Ordering::Relaxed);
+    Ok(())
+}
+
+/// Resolve and decompress one pack entry into `out`, returning its parsed metadata and end offset.
+///
+/// `resolve` keeps traversal independent of pack storage by borrowing the bytes for `slice` from caller-owned
+/// `resolve_data`, such as an in-memory buffer or mapped file.
+fn decompress_from_resolver<F, R>(
+    slice: EntryRange,
+    out: &mut Vec<u8>,
+    inflate: &mut gix_zlib::Inflate,
+    resolve: &F,
+    resolve_data: &R,
+    object_hash: gix_hash::Kind,
+    alloc_limit_bytes: Option<usize>,
+) -> Result<(data::Entry, u64), Error>
+where
+    F: for<'r> Fn(EntryRange, &'r R) -> Option<&'r [u8]> + Send,
+{
+    let bytes = resolve(slice.clone(), resolve_data).ok_or(Error::ResolveFailed {
+        pack_offset: slice.start,
+    })?;
+    let entry = data::Entry::from_bytes(bytes, slice.start, object_hash)?;
+    let compressed = &bytes[entry.header_size()..];
+    let decompressed_len = decoded_size_limited(entry.decompressed_size, alloc_limit_bytes)?;
+    decompress_all_at_once_with(inflate, compressed, decompressed_len, out, alloc_limit_bytes)?;
+    Ok((entry, slice.end))
 }
 
 fn decompress_all_at_once_with(
@@ -579,7 +662,11 @@ fn resize_with_limit(out: &mut Vec<u8>, len: usize, alloc_limit_bytes: Option<us
 
 #[cfg(test)]
 mod tests {
-    use std::{io::Write, sync::atomic::AtomicBool};
+    use std::{
+        io::Write,
+        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+        time::Duration,
+    };
 
     use gix_features::progress;
 
@@ -587,6 +674,95 @@ mod tests {
         cache::delta::{Tree, traverse},
         data,
     };
+
+    #[test]
+    fn traversal_resolves_children_lazily() {
+        let mut pack = Vec::new();
+        let root_offset = append_entry(&mut pack, data::entry::Header::Blob, 1, b"A");
+        let first_child = append_delta(&mut pack, root_offset, b'B');
+        let second_child = append_delta(&mut pack, root_offset, b'C');
+        let first_leaf = append_delta(&mut pack, first_child, b'D');
+        let second_leaf = append_delta(&mut pack, second_child, b'E');
+
+        let mut tree = Tree::with_capacity(5).expect("capacity is small");
+        tree.add_root(root_offset, ()).expect("offsets are increasing");
+        tree.add_child(root_offset, first_child, ())
+            .expect("offsets are increasing");
+        tree.add_child(root_offset, second_child, ())
+            .expect("offsets are increasing");
+        tree.add_child(first_child, first_leaf, ())
+            .expect("offsets are increasing");
+        tree.add_child(second_child, second_leaf, ())
+            .expect("offsets are increasing");
+
+        let resolve_calls = AtomicUsize::new(0);
+        let calls_at_first_child = AtomicUsize::new(usize::MAX);
+        traverse(
+            tree,
+            &pack,
+            Some(1),
+            None,
+            |slice, pack| {
+                resolve_calls.fetch_add(1, Ordering::Relaxed);
+                pack.get(slice.start as usize..slice.end as usize)
+            },
+            |(), _progress, context| {
+                if context.level == 1 {
+                    calls_at_first_child.fetch_min(resolve_calls.load(Ordering::Relaxed), Ordering::Relaxed);
+                }
+                Ok::<_, std::io::Error>(())
+            },
+        )
+        .expect("valid delta tree");
+
+        assert_eq!(
+            calls_at_first_child.load(Ordering::Relaxed),
+            2,
+            "the first child must be inspected before its siblings are materialized"
+        );
+    }
+
+    #[test]
+    fn traversal_parallelizes_children_of_one_root() {
+        let mut pack = Vec::new();
+        let root_offset = append_entry(&mut pack, data::entry::Header::Blob, 1, b"A");
+        let child_offsets: Vec<_> = (b'B'..=b'I')
+            .map(|byte| append_delta(&mut pack, root_offset, byte))
+            .collect();
+
+        let mut tree = Tree::with_capacity(1 + child_offsets.len()).expect("capacity is small");
+        tree.add_root(root_offset, ()).expect("offsets are increasing");
+        for child_offset in child_offsets {
+            tree.add_child(root_offset, child_offset, ())
+                .expect("offsets are increasing");
+        }
+
+        let active = AtomicUsize::new(0);
+        let max_active = AtomicUsize::new(0);
+        traverse(
+            tree,
+            &pack,
+            Some(2),
+            None,
+            |slice, pack| pack.get(slice.start as usize..slice.end as usize),
+            |(), _progress, context| {
+                if context.level > 0 {
+                    let now_active = active.fetch_add(1, Ordering::Relaxed) + 1;
+                    max_active.fetch_max(now_active, Ordering::Relaxed);
+                    std::thread::sleep(Duration::from_millis(20));
+                    active.fetch_sub(1, Ordering::Relaxed);
+                }
+                Ok::<_, std::io::Error>(())
+            },
+        )
+        .expect("valid delta tree");
+
+        let expected = if cfg!(feature = "parallel") { 1 } else { 0 };
+        assert!(
+            max_active.load(Ordering::Relaxed) > expected,
+            "idle workers must help with children of the last remaining root (if in parallel mode)"
+        );
+    }
 
     #[test]
     fn traversal_rejects_declared_decompressed_size_over_alloc_limit() {
@@ -662,23 +838,59 @@ mod tests {
     }
 
     fn traverse_with_limit(tree: Tree<()>, pack: &Vec<u8>) -> Result<(), traverse::Error> {
+        traverse(
+            tree,
+            pack,
+            Some(1),
+            Some(0),
+            |slice, pack| pack.get(slice.start as usize..slice.end as usize),
+            |(), _progress, _context| Ok::<_, std::io::Error>(()),
+        )
+    }
+
+    fn traverse<F, MBFN>(
+        tree: Tree<()>,
+        pack: &Vec<u8>,
+        thread_limit: Option<usize>,
+        alloc_limit_bytes: Option<usize>,
+        resolve: F,
+        inspect: MBFN,
+    ) -> Result<(), traverse::Error>
+    where
+        F: for<'r> Fn(data::EntryRange, &'r Vec<u8>) -> Option<&'r [u8]> + Send + Clone,
+        MBFN:
+            FnMut(&mut (), &dyn progress::Progress, traverse::Context<'_>) -> Result<(), std::io::Error> + Send + Clone,
+    {
         let should_interrupt = AtomicBool::new(false);
         let mut size_progress = progress::Discard;
         tree.traverse(
-            |slice, pack| pack.get(slice.start as usize..slice.end as usize),
+            resolve,
             pack,
             pack.len() as u64,
-            |(), _progress, _context| Ok::<_, std::io::Error>(()),
+            inspect,
             traverse::Options {
                 object_progress: Box::new(progress::Discard),
                 size_progress: &mut size_progress,
-                thread_limit: Some(1),
+                thread_limit,
                 should_interrupt: &should_interrupt,
                 object_hash: gix_hash::Kind::Sha1,
-                alloc_limit_bytes: Some(0),
+                alloc_limit_bytes,
             },
         )
         .map(|_| ())
+    }
+
+    fn append_delta(pack: &mut Vec<u8>, base_offset: data::Offset, byte: u8) -> data::Offset {
+        let delta = [1, 1, 1, byte];
+        let offset = pack.len() as data::Offset;
+        append_entry(
+            pack,
+            data::entry::Header::OfsDelta {
+                base_distance: offset - base_offset,
+            },
+            delta.len() as u64,
+            &delta,
+        )
     }
 
     fn append_entry(

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -269,6 +269,7 @@ hp-tempfile-registry = ["gix-tempfile/hp-hashmap"]
 ## If unset, most of `gix` can only be used in a single thread as data structures won't be `Send` anymore.
 parallel = [
     "gix-features/parallel",
+    "gix-pack/parallel",
     "gix-attributes?/parallel",
     "gix-filter?/parallel",
     "gix-pathspec?/parallel",


### PR DESCRIPTION
## Tasks

This section is maintained by humans. Do not edit it automatically.

- [x] refackiew
----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- resolve delta children lazily from immutable shared bases instead of retaining the internal-node frontier
- use lock-free local deques plus a shared root injector so idle workers can help the last expensive root
- recycle the final base reference, keeping a linear chain to roughly two object buffers per active worker
- propagate `gix`'s parallel feature to the new `gix-pack` scheduler

## Regression coverage

- proves internal siblings are not all materialized before descending
- proves two workers concurrently resolve children from a single remaining root

## Benchmarks

### Git index-pack thread selection

Git `index-pack` accepts `--threads=<n>` even though the option is omitted from its short usage text. With no explicit value or `pack.threads` configuration, it starts from the online CPU count, uses all CPUs below four, uses three threads for four or five CPUs, halves the count from six through 39 CPUs, and caps it at 20 from 40 CPUs onward. This 16-core machine therefore defaults to eight resolver threads. Existing unqualified Git measurements below have been relabeled as `-t8 (default)`. Git multiplies its delta-base cache limit by the selected thread count.

### phpstan pathological pack

The pathological phpstan pack contains 100.7k objects and decodes to 174.6 GB.

For this comparison Git's aggregate delta-base cache allowance is kept at or above the default eight-thread allowance of 8 × 96 MiB. Because Git multiplies `core.deltaBaseCacheLimit` by its worker count, the per-thread limits are 768, 384, 192, 96, and 96 MiB for 1, 2, 4, 8, and 16 threads respectively. The 16-thread run therefore retains Git's default 96 MiB per worker and has a 1.5 GiB aggregate allowance.

Git `index-pack` scaling:

| Threads | Cache/worker | Aggregate cache | Wall time | Speedup vs `-t1` | Parallel efficiency | Incremental scaling              | User CPU time | Max RSS | Peak memory footprint |
|--------:|-------------:|----------------:|----------:|------------------:|--------------------:|----------------------------------|--------------:|--------:|----------------------:|
|       1 |      768 MiB |         768 MiB |  304.51 s |             1.00x |              100.0% | —                                |      301.16 s | 1.47 GB |               1.45 GB |
|       2 |      384 MiB |         768 MiB |  168.06 s |             1.81x |               90.6% | 1.81x for 2x threads             |      304.74 s | 1.19 GB |               1.17 GB |
|       4 |      192 MiB |         768 MiB |   98.80 s |             3.08x |               77.1% | 1.70x from `-t2` for 2x threads  |      306.05 s | 1.55 GB |               1.55 GB |
|       8 |       96 MiB |         768 MiB |   65.41 s |             4.65x |               58.2% | 1.51x from `-t4` for 2x threads  |      317.78 s | 1.91 GB |               1.90 GB |
|      16 |       96 MiB |         1.5 GiB |   52.79 s |             5.77x |               36.1% | 1.24x from `-t8` for 2x threads  |      378.49 s | 2.34 GB |               2.33 GB |

Same-thread wall-time comparison:

| Threads | Git index-pack | This PR | gix speedup vs Git |
|--------:|---------------:|--------:|-------------------:|
|       1 |       304.51 s | 283.41 s |              1.07x |
|       4 |        98.80 s |  71.94 s |              1.37x |
|       8 |        65.41 s |  36.42 s |              1.80x |
|      16 |        52.79 s |  22.83 s |              2.31x |

gix results:

| Metric                | Baseline gix | This PR, `-t1` | This PR, `-t4` | This PR, `-t8` | This PR, `-t16` |
|-----------------------|-------------:|----------------:|----------------:|----------------:|-----------------:|
| Wall time             |      98.53 s |        283.41 s |         71.94 s |         36.42 s |          22.83 s |
| Resolver time         |      98.38 s |        283.30 s |         71.82 s |         36.27 s |          22.70 s |
| User CPU time         |     301.79 s |        289.67 s |        293.27 s |        296.01 s |         344.48 s |
| Max RSS               |     19.81 GB |          7.20 GB |          7.42 GB |          7.86 GB |           8.90 GB |
| Peak memory footprint |     13.14 GB |          0.68 GB |          0.75 GB |          1.17 GB |           2.16 GB |

gix resolver scaling and memory growth:

| Threads | Resolver time | Speedup vs `-t1` | Parallel efficiency | Incremental scaling              | Max RSS vs `-t1` | Peak footprint vs `-t1` |
|--------:|--------------:|------------------:|--------------------:|----------------------------------|------------------:|-------------------------:|
|       1 |      283.30 s |             1.00x |              100.0% | —                                |             1.00x |                    1.00x |
|       4 |       71.82 s |             3.94x |               98.6% | 3.94x for 4x threads             |             1.03x |                    1.10x |
|       8 |       36.27 s |             7.81x |               97.6% | 1.98x from `-t4` for 2x threads  |             1.09x |                    1.72x |
|      16 |       22.70 s |            12.48x |               78.0% | 1.60x from `-t8` for 2x threads  |             1.24x |                    3.18x |

gix scaling is nearly linear through eight workers. Doubling from eight to sixteen workers yields another 1.60x speedup at 79.9% incremental efficiency, while max RSS rises by 13% and peak footprint by 85%.

At the nearest wall-time operating points, gix `-t4` takes 71.94 s versus Git `-t8` at 65.41 s. gix reports 7.42 GB max RSS versus Git's 1.91 GB because its RSS includes clean file-backed pages from the 6.9 GB pack mapping, while Git reads through bounded `pread()` buffers. Charged peak footprint is 0.75 GB for gix versus 1.90 GB for Git, 61% lower.

Commands:

```sh
/usr/bin/time -lp /Users/byron/dev/github.com/git/git/bin-wrappers/git -c core.deltaBaseCacheLimit=768m index-pack --verify --threads=1 /Users/byron/dev/github.com/phpstan/phpstan/.git/objects/pack/pack-fc5a93b6903e792e5c65ce2f8f02054775c35c94.pack
/usr/bin/time -lp /Users/byron/dev/github.com/git/git/bin-wrappers/git -c core.deltaBaseCacheLimit=384m index-pack --verify --threads=2 /Users/byron/dev/github.com/phpstan/phpstan/.git/objects/pack/pack-fc5a93b6903e792e5c65ce2f8f02054775c35c94.pack
/usr/bin/time -lp /Users/byron/dev/github.com/git/git/bin-wrappers/git -c core.deltaBaseCacheLimit=192m index-pack --verify --threads=4 /Users/byron/dev/github.com/phpstan/phpstan/.git/objects/pack/pack-fc5a93b6903e792e5c65ce2f8f02054775c35c94.pack
/usr/bin/time -lp /Users/byron/dev/github.com/git/git/bin-wrappers/git -c core.deltaBaseCacheLimit=96m index-pack --verify --threads=8 /Users/byron/dev/github.com/phpstan/phpstan/.git/objects/pack/pack-fc5a93b6903e792e5c65ce2f8f02054775c35c94.pack
/usr/bin/time -lp /Users/byron/dev/github.com/git/git/bin-wrappers/git -c core.deltaBaseCacheLimit=96m index-pack --verify --threads=16 /Users/byron/dev/github.com/phpstan/phpstan/.git/objects/pack/pack-fc5a93b6903e792e5c65ce2f8f02054775c35c94.pack
/usr/bin/time -lp target/release/gix -t1 -v free pack verify /Users/byron/dev/github.com/phpstan/phpstan/.git/objects/pack/pack-fc5a93b6903e792e5c65ce2f8f02054775c35c94.idx
/usr/bin/time -lp target/release/gix -t4 -v free pack verify /Users/byron/dev/github.com/phpstan/phpstan/.git/objects/pack/pack-fc5a93b6903e792e5c65ce2f8f02054775c35c94.idx
/usr/bin/time -lp target/release/gix -t8 -v free pack verify /Users/byron/dev/github.com/phpstan/phpstan/.git/objects/pack/pack-fc5a93b6903e792e5c65ce2f8f02054775c35c94.idx
/usr/bin/time -lp target/release/gix -t16 -v free pack verify /Users/byron/dev/github.com/phpstan/phpstan/.git/objects/pack/pack-fc5a93b6903e792e5c65ce2f8f02054775c35c94.idx
```

Linux best-case pack:

Git `index-pack` on the Linux best-case pack:

| Threads | Wall time | Speedup vs `-t1` | Parallel efficiency | Incremental scaling             | User CPU time | Max RSS | Peak memory footprint |
|--------:|----------:|-----------------:|--------------------:|---------------------------------|--------------:|--------:|----------------------:|
|       1 |  156.65 s |            1.00x |              100.0% | —                               |      153.38 s | 0.79 GB |               0.77 GB |
|       4 |   60.48 s |            2.59x |               64.8% | 2.59x for 4x threads            |      164.45 s | 1.02 GB |               0.99 GB |
|       8 |   45.48 s |            3.44x |               43.1% | 1.33x from `-t4` for 2x threads |      170.33 s | 1.04 GB |               1.02 GB |
|      16 |   42.97 s |            3.65x |               22.8% | 1.06x from `-t8` for 2x threads |      190.96 s | 1.10 GB |               1.08 GB |

Same-thread wall-time comparison:

| Threads | Git index-pack | This PR | gix speedup vs Git |
|--------:|---------------:|--------:|-------------------:|
|       1 |       156.65 s | 137.48 s |              1.14x |
|       4 |        60.48 s |  36.75 s |              1.65x |
|       8 |        45.48 s |  19.81 s |              2.30x |
|      16 |        42.97 s |  13.16 s |              3.27x |

Commands:

```sh
/usr/bin/time -lp /Users/byron/dev/github.com/git/git/bin-wrappers/git index-pack --threads=1 --verify -v /Users/byron/dev/github.com/GitoxideLabs/gitoxide/tests/fixtures/repos/linux.git/objects/pack/pack-3ee05b0f4e4c2cb59757c95c68e2d13c0a491289.pack
/usr/bin/time -lp /Users/byron/dev/github.com/git/git/bin-wrappers/git index-pack --threads=4 --verify -v /Users/byron/dev/github.com/GitoxideLabs/gitoxide/tests/fixtures/repos/linux.git/objects/pack/pack-3ee05b0f4e4c2cb59757c95c68e2d13c0a491289.pack
/usr/bin/time -lp /Users/byron/dev/github.com/git/git/bin-wrappers/git index-pack --threads=8 --verify -v /Users/byron/dev/github.com/GitoxideLabs/gitoxide/tests/fixtures/repos/linux.git/objects/pack/pack-3ee05b0f4e4c2cb59757c95c68e2d13c0a491289.pack
/usr/bin/time -lp /Users/byron/dev/github.com/git/git/bin-wrappers/git index-pack --threads=16 --verify -v /Users/byron/dev/github.com/GitoxideLabs/gitoxide/tests/fixtures/repos/linux.git/objects/pack/pack-3ee05b0f4e4c2cb59757c95c68e2d13c0a491289.pack
```

| | Baseline gix | This PR, `-t1` | This PR, `-t4` | This PR, `-t8` | This PR, `-t16` |
|---|---:|---:|---:|---:|---:|
| wall time | 13.68 s | 137.48 s | 36.75 s | 19.81 s | 13.16 s |
| resolver time | 11.81 s | 135.58 s | 34.92 s | 17.92 s | 11.33 s |
| user CPU time | — | 138.36 s | 142.86 s | 146.56 s | 178.05 s |
| max RSS | 3.54 GB | 2.74 GB | 2.76 GB | 2.89 GB | 2.97 GB |
| peak memory footprint | 1.96 GB | 1.76 GB | 1.76 GB | 1.76 GB | 1.76 GB |

Resolver scaling and memory growth:

| Threads | Resolver time | Speedup vs `-t1` | Parallel efficiency | Incremental scaling | Max RSS vs `-t1` | Peak footprint vs `-t1` |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 135.58 s | 1.00× | 100% | — | 1.00× | 1.00× |
| 4 | 34.92 s | 3.88× | 97.1% | 3.88× for 4× threads | 1.01× | 1.00× |
| 8 | 17.92 s | 7.57× | 94.6% | 1.95× from `-t4` for 2× threads | 1.06× | 1.00× |
| 16 | 11.33 s | 11.97× | 74.8% | 1.58× from `-t8` for 2× threads | 1.09× | 1.00× |

Scaling is nearly linear through eight workers. Doubling from eight to sixteen yields another 1.58× speedup at 79.1% incremental efficiency. Across the entire one-to-sixteen-thread range, max RSS rises by 9% while peak footprint remains effectively unchanged.

At `-t16`, the best-case pack is slightly faster than baseline: 13.16 s versus 13.68 s wall time and 11.33 s versus 11.81 s resolver time. It also uses less memory: 2.97 GB versus 3.54 GB max RSS and 1.76 GB versus 1.96 GB peak footprint.

Commands:

```sh
/usr/bin/time -lp target/release/gix -t1 -v free pack verify /Users/byron/dev/github.com/GitoxideLabs/gitoxide/tests/fixtures/repos/linux.git/objects/pack/pack-3ee05b0f4e4c2cb59757c95c68e2d13c0a491289.idx
/usr/bin/time -lp target/release/gix -t4 -v free pack verify /Users/byron/dev/github.com/GitoxideLabs/gitoxide/tests/fixtures/repos/linux.git/objects/pack/pack-3ee05b0f4e4c2cb59757c95c68e2d13c0a491289.idx
/usr/bin/time -lp target/release/gix -t8 -v free pack verify /Users/byron/dev/github.com/GitoxideLabs/gitoxide/tests/fixtures/repos/linux.git/objects/pack/pack-3ee05b0f4e4c2cb59757c95c68e2d13c0a491289.idx
/usr/bin/time -lp target/release/gix -t16 -v free pack verify /Users/byron/dev/github.com/GitoxideLabs/gitoxide/tests/fixtures/repos/linux.git/objects/pack/pack-3ee05b0f4e4c2cb59757c95c68e2d13c0a491289.idx
```


### SHA-1 sibling-pack comparison

This is the original SHA-1 sibling of the 10.9M-object SHA-256 benchmark pack below, with the same compressed payload and delta topology and 146.7 GB of decoded data. It is distinct from the 7.6M-object `tests/fixtures/repos/linux.git` pack above, whose `-t16` wall time is 13.16 s.

| Metric                | Git index-pack, `-t8` (default) | This PR, `-t1` | This PR, `-t4` | This PR, `-t8` | This PR, `-t16` |
|-----------------------|---------------:|---------------:|---------------:|---------------:|----------------:|
| Wall time             |       125.11 s |       212.57 s |        56.58 s |        30.60 s |         20.74 s |
| Resolver time         |              — |       210.35 s |        54.36 s |        28.33 s |         18.51 s |
| User CPU time         |       323.69 s |       215.06 s |       222.58 s |       231.29 s |        281.72 s |
| Max RSS               |        5.42 GB |         4.89 GB |         5.18 GB |         5.29 GB |          5.46 GB |
| Peak memory footprint |        1.81 GB |         2.54 GB |         2.54 GB |         2.54 GB |          2.54 GB |
| Wall speedup vs Git   |          1.00x |           0.59x |           2.21x |           4.09x |             6.03x |

Resolver scaling:

| Threads | Resolver time | Speedup vs `-t1` | Parallel efficiency | Incremental scaling             |
|--------:|--------------:|-----------------:|--------------------:|---------------------------------|
|       1 |      210.35 s |            1.00x |              100.0% | —                               |
|       4 |       54.36 s |            3.87x |               96.7% | 3.87x for 4x threads            |
|       8 |       28.33 s |            7.42x |               92.8% | 1.92x from `-t4` for 2x threads |
|      16 |       18.51 s |           11.36x |               71.0% | 1.53x from `-t8` for 2x threads |

Commands:

```sh
/usr/bin/time -lp /Users/byron/dev/github.com/git/git/bin-wrappers/git -C /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256.git index-pack --verify -v /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256.git/objects/pack/pack-6f64e91eccd8f68e174dc2c01416b392c66867e7.pack
/usr/bin/time -lp target/release/gix --object-hash sha1 -t1 -v free pack verify /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256.git/objects/pack/pack-6f64e91eccd8f68e174dc2c01416b392c66867e7.idx
/usr/bin/time -lp target/release/gix --object-hash sha1 -t4 -v free pack verify /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256.git/objects/pack/pack-6f64e91eccd8f68e174dc2c01416b392c66867e7.idx
/usr/bin/time -lp target/release/gix --object-hash sha1 -t8 -v free pack verify /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256.git/objects/pack/pack-6f64e91eccd8f68e174dc2c01416b392c66867e7.idx
/usr/bin/time -lp target/release/gix --object-hash sha1 -t16 -v free pack verify /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256.git/objects/pack/pack-6f64e91eccd8f68e174dc2c01416b392c66867e7.idx
```

### SHA-256 hasher comparison

To isolate object hashing from scheduling, the 10.9M-object Linux pack was converted by preserving its compressed payload and delta topology byte-for-byte, replacing the SHA-1 pack trailer with SHA-256, and regenerating the index in a SHA-256 repository. It decodes to 146.7 GB. This is a pack-verification fixture rather than a valid converted repository: commit and tree payloads still contain SHA-1 references.

The original Git build used the portable `SHA256_BLK` backend, while gix's RustCrypto SHA-256 dispatches to ARMv8 SHA-2 instructions on this machine. To avoid disadvantaging Git, the comparison was rerun with Git `cf5497b14c` built with `SHA1_DC` for SHA-1 and `SHA256_OPENSSL` from OpenSSL 3.6.3 for SHA-256. At `-t8`, changing only Git's SHA-256 backend reduced wall time from 144.15 s to 40.45 s (3.56x faster) and user CPU time from 471.94 s to 99.81 s (4.73x less). All Git SHA-256 comparison values below use the OpenSSL build; the SHA-1 measurements above remain from the original `SHA1_DC` build.

Git `index-pack` SHA-256 scaling:

| Threads | Wall time | Speedup vs `-t1` | Parallel efficiency | Incremental scaling              | User CPU time | System CPU time | Max RSS | Peak memory footprint |
|--------:|----------:|------------------:|--------------------:|----------------------------------|--------------:|----------------:|--------:|----------------------:|
|       1 |   87.85 s |             1.00x |              100.0% | —                                |       84.23 s |          3.57 s | 1.21 GB |               1.20 GB |
|       4 |   44.05 s |             1.99x |               49.9% | 1.99x for 4x threads             |       91.60 s |          9.63 s | 1.47 GB |               1.46 GB |
|       8 |   40.45 s |             2.17x |               27.1% | 1.09x from `-t4` for 2x threads |       99.81 s |         39.19 s | 1.57 GB |               1.57 GB |
|      16 |   48.68 s |             1.80x |               11.3% | 0.83x from `-t8` for 2x threads |      108.46 s |        204.81 s | 1.69 GB |               1.69 GB |

Same-thread wall-time comparison:

| Threads | Git index-pack | This PR | gix speedup vs Git |
|--------:|---------------:|--------:|-------------------:|
|       1 |        87.85 s |  72.47 s |              1.21x |
|       4 |        44.05 s |  21.83 s |              2.02x |
|       8 |        40.45 s |  12.58 s |              3.22x |
|      16 |        48.68 s |   8.67 s |              5.61x |

gix SHA-256 results:

| Metric                | This PR, `-t1` | This PR, `-t4` | This PR, `-t8` | This PR, `-t16` |
|-----------------------|----------------:|----------------:|----------------:|-----------------:|
| Wall time             |         72.47 s |         21.83 s |         12.58 s |           8.67 s |
| Resolver time         |         70.31 s |         19.69 s |         10.43 s |           6.51 s |
| User CPU time         |         72.71 s |         81.31 s |         85.88 s |          97.04 s |
| Max RSS               |          5.18 GB |          5.29 GB |          5.39 GB |           5.61 GB |
| Peak memory footprint |          2.54 GB |          2.54 GB |          2.54 GB |           2.54 GB |

gix resolver scaling:

| Threads | Resolver time | Speedup vs `-t1` | Parallel efficiency | Incremental scaling              |
|--------:|--------------:|------------------:|--------------------:|----------------------------------|
|       1 |       70.31 s |             1.00x |              100.0% | —                                |
|       4 |       19.69 s |             3.57x |               89.3% | 3.57x for 4x threads             |
|       8 |       10.43 s |             6.74x |               84.3% | 1.89x from `-t4` for 2x threads |
|      16 |        6.51 s |            10.80x |               67.5% | 1.60x from `-t8` for 2x threads  |

SHA-1 versus SHA-256 resolver time on the identical compressed pack:

| Threads | SHA-1 resolver | SHA-256 resolver | SHA-256 speedup |
|--------:|---------------:|-----------------:|----------------:|
|       1 |       210.35 s |          70.31 s |           2.99x |
|       4 |        54.36 s |          19.69 s |           2.76x |
|       8 |        28.33 s |          10.43 s |           2.72x |
|      16 |        18.51 s |           6.51 s |           2.84x |

SHA-256 is 2.72x to 2.99x faster across the measured thread counts with identical work distribution and delta data, showing that the slow SHA-1 implementation, rather than the scheduler, dominates the absolute regression.

Commands:

```sh
/usr/bin/time -lp /Users/byron/dev/github.com/git/git.sha256-openssl/bin-wrappers/git index-pack --verify --object-format=sha256 --threads=1 /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256-pack.git/objects/pack/pack-sha256-linux.pack
/usr/bin/time -lp /Users/byron/dev/github.com/git/git.sha256-openssl/bin-wrappers/git index-pack --verify --object-format=sha256 --threads=4 /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256-pack.git/objects/pack/pack-sha256-linux.pack
/usr/bin/time -lp /Users/byron/dev/github.com/git/git.sha256-openssl/bin-wrappers/git index-pack --verify --object-format=sha256 --threads=8 /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256-pack.git/objects/pack/pack-sha256-linux.pack
/usr/bin/time -lp /Users/byron/dev/github.com/git/git.sha256-openssl/bin-wrappers/git index-pack --verify --object-format=sha256 --threads=16 /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256-pack.git/objects/pack/pack-sha256-linux.pack
/usr/bin/time -lp target/release/gix --object-hash sha256 -t1 -v free pack verify /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256-pack.git/objects/pack/pack-sha256-linux.idx
/usr/bin/time -lp target/release/gix --object-hash sha256 -t4 -v free pack verify /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256-pack.git/objects/pack/pack-sha256-linux.idx
/usr/bin/time -lp target/release/gix --object-hash sha256 -t8 -v free pack verify /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256-pack.git/objects/pack/pack-sha256-linux.idx
/usr/bin/time -lp target/release/gix --object-hash sha256 -t16 -v free pack verify /Users/byron/dev/git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux-sha256-pack.git/objects/pack/pack-sha256-linux.idx
```

## Validation

- `cargo test -p gix-pack`
- `cargo clippy -p gix-pack --all-targets --all-features -- -D warnings`
- `cargo check -p gix-pack --no-default-features --features sha1`
- `cargo check -p gix --no-default-features --features parallel,sha1`
- `cargo fmt --all -- --check`

The scheduling and bounded-live-base approach was informed by Git's `builtin/index-pack.c` at `cf5497b14c`; the implementation is independent and lock-free.

Fixes #2424.



