### PR TITLE
fix: an implicit boolean followed by whitespace is `true`, like in Git

### DIFF
--- a/gix-config/src/file/section/body.rs
+++ b/gix-config/src/file/section/body.rs
@@ -213,7 +213,11 @@ impl BodyData {
             // is included in the range
             let value_range = value_range.start..value_range.end + 1;
             let key_range = key_start..value_range.end;
-            (key_range, (value_range.start != key_start + 1).then_some(value_range))
+            let has_separator = self.0[key_start + 1..]
+                .iter()
+                .take_while(|e| matches!(e, Event::Whitespace(_) | Event::KeyValueSeparator))
+                .any(|e| matches!(e, Event::KeyValueSeparator));
+            (key_range, has_separator.then_some(value_range))
         })
     }
 

--- a/gix-config/tests/config/file/access/read_only.rs
+++ b/gix-config/tests/config/file/access/read_only.rs
@@ -496,6 +496,47 @@ fn overrides_with_implicit_booleans_work_in_single_section() {
 }
 
 #[test]
+fn implicit_booleans_may_be_followed_by_whitespace() -> crate::Result {
+    for config in [
+        "[a]\n\tb \n",
+        "[a]\n\tb\t\n",
+        "[a]\n\tb  \n",
+        "[a]\n\tb \t \n",
+        "[a]\n\tb ",
+        "[a]\n\tb \r\n",
+        "[a]\n\tb\n",
+    ] {
+        let file = File::try_from(config)?;
+        assert_eq!(
+            file.boolean("a.b"),
+            Ok(Some(true)),
+            "Git sees no separator in {config:?}, so the value is an implicit boolean and thus true"
+        );
+        assert_eq!(
+            file.string("a.b"),
+            None,
+            "implicit booleans have no value of their own, no matter the whitespace that follows them"
+        );
+    }
+
+    for config in ["[a]\n\tb =\n", "[a]\n\tb = \n", "[a]\n\tb=\"\"\n", "[a]\n\tb ="] {
+        let file = File::try_from(config)?;
+        assert_eq!(
+            file.boolean("a.b"),
+            Ok(Some(false)),
+            "a separator in {config:?} makes the value explicitly empty, and an empty value is false"
+        );
+        assert_eq!(
+            file.string("a.b"),
+            Some(bstring("")),
+            "an explicitly empty value is the empty string"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
 fn overrides_with_implicit_booleans_work_across_sections() {
     let config = r#"
         [a]

--- a/gix-config/tests/config/parse/error.rs
+++ b/gix-config/tests/config/parse/error.rs
@@ -51,4 +51,10 @@ fn to_string() {
         Events::from_str(input).unwrap_err().to_string(),
         "Got an unexpected token on line 1 while trying to parse a section header: '[core'"
     );
+    let input = "[a]\n\tb \u{8}\n";
+    assert_eq!(
+        Events::from_str(input).unwrap_err().to_string(),
+        "Got an unexpected token on line 2 while trying to parse a name: '\u{8}\n'",
+        "Git rejects backspace as trailing whitespace after an implicit boolean"
+    );
 }


### PR DESCRIPTION
Heads up before anything else, per the [agent impersonation policy](https://github.com/GitoxideLabs/gitoxide/blob/main/CONTRIBUTING.md): **an AI agent (Claude) is speaking through the `shuvamk` account** and wrote this description, the patch and the tests. The commit carries a `Co-authored-by` trailer for the same reason.

While differential-testing `gix-config` against `git config` I found that an implicit boolean stops being `true` as soon as a single space or tab follows the key.

### What's wrong (AI)

A key without `=` is an implicit boolean and reads as `true` — but only if nothing at all follows it on the line. One trailing space turns it into `false`.

Measured with `git 2.50.1 (Apple Git-155)` against `gix-config` at `b95db7ca8` (`main`). The gix columns are `gix_config::File::from_str(input)` followed by `.boolean("core.bare")` / `.string("core.bare")`:

| input | `git config --file f --bool core.bare` | `git config --file f --list` | `File::boolean` on `main` | `File::boolean` on this branch |
|---|---|---|---|---|
| `[core]\n\tbare \n` | `true` | `core.bare` | **`Ok(Some(false))`** | `Ok(Some(true))` |
| `[core]\n\tbare\t\n` | `true` | `core.bare` | **`Ok(Some(false))`** | `Ok(Some(true))` |
| `[core]\n\tbare  \n` | `true` | `core.bare` | **`Ok(Some(false))`** | `Ok(Some(true))` |
| `[core]\n\tbare \t \n` | `true` | `core.bare` | **`Ok(Some(false))`** | `Ok(Some(true))` |
| `[core]\n\tbare \r\n` | `true` | `core.bare` | **`Ok(Some(false))`** | `Ok(Some(true))` |
| `[core]\n\tbare ` (EOF) | `true` | `core.bare` | **`Ok(Some(false))`** | `Ok(Some(true))` |
| `[core]\n\tbare\n` (control) | `true` | `core.bare` | `Ok(Some(true))` | `Ok(Some(true))` |
| `[core]\n\tbare =\n` | `false` | `core.bare=` | `Ok(Some(false))` | `Ok(Some(false))` |
| `[core]\n\tbare = \n` | `false` | `core.bare=` | `Ok(Some(false))` | `Ok(Some(false))` |
| `[core]\n\tbare =` (EOF) | `false` | `core.bare=` | `Ok(Some(false))` | `Ok(Some(false))` |
| `[core]\n\tbare=""\n` | `false` | `core.bare=` | `Ok(Some(false))` | `Ok(Some(false))` |

`File::string` follows along: `Some("")` on `main` for the six affected rows, `None` on this branch, matching the control row.

It reaches porcelain. With `[core]\n\tfileMode \n` appended to the `config` of a repository created by `gix::init`, `Repository::filesystem_options()` goes through `boolean(self, "core.fileMode", …)` in `gix/src/config/cache/access.rs:268` and reports:

```
                     on main @ b95db7ca8                       on this branch
fileMode<space>      gix executable_bit = false                gix executable_bit = true
fileMode (control)   gix executable_bit = true                 gix executable_bit = true
```

with `git -C <repo> config --bool core.fileMode` printing `true` for both in either case. So on `main` a stray space after `fileMode` makes `gix` stop honouring the executable bit on a repository where Git still honours it.

Cause, in `gix-config/src/file/section/body.rs:216`:

```rust
(key_range, (value_range.start != key_start + 1).then_some(value_range))
```

`key_and_value_range_by_in()` decides implicit-vs-explicit by *adjacency* — whether the value event sits directly behind the `SectionValueName` event. But `key_value_pair()` in `gix-config/src/parse/from_bytes/mod.rs:277` emits a `Whitespace` event between the name and the synthetic empty `Value` when the key has trailing spaces or tabs:

```rust
dispatch(Event::SectionValueName(Span::new(backing, name)));

if let Ok(whitespace) = take_spaces1(i) {
    dispatch(Event::Whitespace(Span::new(backing, whitespace)));
}
```

so the value lands at `key_start + 2` and the pair looks explicit.

`git log -S 'value_range.start != key_start + 1'` puts the adjacency test in `08c50a47f`, *"fix: Properly handle boolean values such that `a` is true but `a=` is false. (#450)"*, which introduced the implicit/explicit distinction (`git blame` points one commit later, at `9e04685dd3` "thanks clippy", which only rewrote `.then(|| …)` to `.then_some(…)`). `git tag --contains 08c50a47f` makes `git-config v0.7.0` the first release with it. There is nothing about trailing whitespace in that commit, in `SHORTCOMINGS.md` or in `crate-status.md`, so this looks like an oversight rather than a decision — correct me if it was deliberate.

### What this does

Decides on the presence of a `KeyValueSeparator` between the name and the value instead of on adjacency, which is what the distinction is actually about:

```diff
-            (key_range, (value_range.start != key_start + 1).then_some(value_range))
+            let has_separator = self.0[key_start + 1..]
+                .iter()
+                .take_while(|e| matches!(e, Event::Whitespace(_) | Event::KeyValueSeparator))
+                .any(|e| matches!(e, Event::KeyValueSeparator));
+            (key_range, has_separator.then_some(value_range))
```

The `take_while` walks the run of events the parser and `MutableSection::push` can put between a name and its value — optional whitespace around an optional `=` — and stops at anything else.

The change is one-directional: a pair whose value is already adjacent to its name cannot have a separator between them, so nothing that was implicit becomes explicit.

Editing is untouched. Running five inputs through `File::to_string()`, `File::set_raw_value("core.bare", "yes")` and `MutableSection::remove("bare")` gives byte-identical results with and without the patch, because `set_inner()`'s implicit fallback range `key_range.end - 1..key_range.end` is the same slot the explicit branch would have used:

```
"[core]\n\tbare \n"    roundtrip="[core]\n\tbare \n"    set="[core]\n\tbare yes\n"    remove=Some("") -> "[core]\n"
"[core]\n\tbare\t\n"   roundtrip="[core]\n\tbare\t\n"   set="[core]\n\tbare\tyes\n"   remove=Some("") -> "[core]\n"
"[core]\n\tbare\n"     roundtrip="[core]\n\tbare\n"     set="[core]\n\tbareyes\n"     remove=Some("") -> "[core]\n"
"[core]\n\tbare =\n"   roundtrip="[core]\n\tbare =\n"   set="[core]\n\tbare =yes\n"   remove=Some("") -> "[core]\n"
"[core]\n\tbare = x\n" roundtrip="[core]\n\tbare = x\n" set="[core]\n\tbare = yes\n"  remove=Some("x") -> "[core]\n"
```

### Tests

`gix-config/tests/config/file/access/read_only.rs` gains `implicit_booleans_may_be_followed_by_whitespace`, which pins both directions: six no-separator inputs (space, tab, two spaces, space-tab-space, space before CRLF, space at EOF) plus the no-whitespace control must be `Ok(Some(true))` with `string() == None`, and four separator inputs (`b =`, `b = `, `b=""`, `b =` at EOF) must stay `Ok(Some(false))` with `string() == Some("")`. The eleven inputs are exactly the eleven rows of the table above, so every assertion has a `git config` measurement behind it.

**It fails before the change.** With the patch to `body.rs` reverted and the test kept, in a detached worktree:

```
running 1 test
test file::access::read_only::implicit_booleans_may_be_followed_by_whitespace ... FAILED

---- file::access::read_only::implicit_booleans_may_be_followed_by_whitespace stdout ----
thread '...' panicked at gix-config/tests/config/file/access/read_only.rs:510:9:
assertion `left == right` failed: Git sees no separator in "[a]\n\tb \n", so the value is an implicit boolean and thus true
  left: Ok(Some(false))
 right: Ok(Some(true))

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 258 filtered out
```

and with it restored:

```
running 1 test
test file::access::read_only::implicit_booleans_may_be_followed_by_whitespace ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 258 filtered out
```

No existing assertion was changed or removed — the `false` direction is additionally held by the pre-existing `get_value_for_all_provided_values`, `get_value_looks_up_all_sections_before_failing`, `single_section` and both `overrides_with_implicit_booleans_work_*` tests, and by the `implicit_boolean_key_keeps_no_separator` snapshots in `tests/config/format.rs` and `tests/config/parse/format.rs`.

### Alternative you might prefer

The other place to fix this is the parser: have `key_value_pair()` hold the trailing `Whitespace` event back until it knows whether a `=` follows, so the implicit case emits `SectionValueName` immediately followed by `Value` and the existing adjacency test keeps working. That keeps `body.rs` a one-liner, but it moves whitespace around in the event stream that `File::to_string()` and the `parse::Events` public API both expose, which felt like the riskier half of the two. Say the word and I'll switch.

### Where this still differs from Git, deliberately

I'd rather name these than imply the gap is closed. **This change is not confined to lines Git accepts** — most of what it moves is lines Git refuses to parse at all.

I swept a grid of `[core]\n\tbare<ws><sep?><ws><value><ws><terminator>` — 4476 unique inputs, built from 5 leading-whitespace runs × `=` present or absent × 4 post-separator whitespace runs × 11 values (empty, `true`, `false`, `x`, `""`, `"x"`, `; c`, `# c`, `0`, `a b`, `yes`) × 4 trailing-whitespace runs × 3 terminators (`\n`, EOF, `\r\n`) — through `git config --file f --bool core.bare` and through `File::boolean`/`File::string`/`File::to_string` on both `main` and this branch:

| | count |
|---|---|
| inputs swept | 4476 |
| inputs whose gix answer changes | 1284 |
| distinct `main` → branch transitions among them | 1 — `Ok(Some(false))`/`Some("")` → `Ok(Some(true))`/`None` |
| round-trip (`to_string() == input`) changes | 0 |
| inputs that start or stop being a parse error | 0 |
| **changed, and Git accepts the line** | **108** — branch matches `git --bool` on all 108; `main` matched on none |
| **changed, and Git rejects the line** (`fatal: bad config line 2`, rc 128) | **1176** — 840 of shape `key value` with no `=`, 336 of shape `key ; comment` / `key # comment` |

So 92% of what moves is input Git will not parse. `[core]\n\tbare true\n` is the representative case: Git says `fatal: bad config line 2`, `main` said `false`, this branch says `true`. That shape — a key and a value separated by whitespace instead of `=` — is a more plausible hand-edit typo than the comment shapes, and it is the bulk of the 1176.

Git offers no accepting answer to match on any of those 1176, so there is nothing to be "correct compared to Git" about; `gix-config` already parsed them and already produced an answer, and this change makes that answer consistent with the rest of the implicit-boolean handling (`[a]\n\tb; comment` already read as `true` on `main` — only the variants with a space before the comment marker read as `false`). I deliberately kept all of them out of the test: I cannot pin behaviour I cannot measure against Git. If you would rather `gix-config` reject a key followed by a bare word with no `=`, the way Git does, that is a bigger and separate change and I have not attempted it here.

The remaining, unrelated divergence: `git config --file f core.bare` prints an empty line and exits 0 for an implicit key, while `File::raw_value` returns `KeyMissing` and `File::string` returns `None`. That is the documented intent of #450 (*"`a` has no value as if it is not present, it's only available for booleans"*) and it already applied to `bare` with no trailing whitespace. This PR makes the trailing-whitespace case behave like the no-whitespace case; it does not touch that choice.

### What I ran

`just` and `cargo-nextest` aren't installed here, so these are the raw cargo invocations, on `rustc 1.95.0 (59807616e 2026-04-14)`:

| command | `main` @ `b95db7ca8` | this branch |
|---|---|---|
| `cargo test -p gix-config` (incl. doctests) | 391 passed, 0 failed | **392** passed, 0 failed |
| `cargo test --workspace` | rc=0 — 181 suites, 3666 passed, 0 failed, 22 ignored | rc=0 — 181 suites, **3667** passed, 0 failed, 22 ignored |
| `cargo test -p gix` | not measured | 413 passed across 8 suites, 0 failed |
| `cargo fmt --all -- --check` | clean | clean |
| `cargo clippy --workspace --all-targets -- -D warnings -A unknown-lints -A unfulfilled_lint_expectations` | not measured | rc=0, 0 warnings |
| `cargo clippy --workspace --all-targets -- -D warnings -A unknown-lints` | **rc=101**, see below | rc=101, same three errors |
| `cargo doc -p gix-config --no-deps --features sha1` | not measured | rc=0 |

`cargo clippy --workspace --all-targets -- -D warnings` *without* `-A unfulfilled_lint_expectations` is already red on clean `main` on this toolchain, with exactly three `this lint expectation is unfulfilled` errors at `gix-ref/src/lib.rs:90`, `:100` and `:120`. That is a rustc-version artefact of my local 1.95.0 against those `#[expect(dead_code, …)]` attributes, unrelated to this change, and I left it alone.

One more honest note: in one of three `cargo test --workspace` runs on this branch, three `gix-path` unit tests (`env::tests::system_prefix::exepath_*`) failed at `tempfile::tempdir().expect("can create new temporary directory")` with `No such file or directory`. They passed under `cargo test -p gix-path` and on both other full-suite runs. `gix-path` does not depend on `gix-config` (`cargo tree -p gix-path -e normal,build,dev` shows `gix-trace` and `gix-validate` only), so this cannot be reached from this change — but I could not reproduce it on demand and I would rather mention it than quietly report only the green runs.
