### PR TITLE
fix: decode the config `\b` escape to the backspace byte, matching git

### DIFF
--- a/gix-config/src/value/normalize.rs
+++ b/gix-config/src/value/normalize.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 
 use bstr::{BStr, BString, ByteSlice};
 
-/// Removes quotes, if any, from the provided inputs, and transforms
-/// the 3 escape sequences `\n`, `\t` and `\b` into newline and tab
-/// respectively, while `\b` will remove the previous character.
+/// Removes quotes, if any, from the provided inputs, and transforms the
+/// escape sequences `\n`, `\t` and `\b` into newline, tab and backspace
+/// (byte `0x08`) respectively, matching how `git` interprets them.
 ///
 /// It assumes the input contains a even number of unescaped quotes,
 /// and will unescape escaped quotes and everything else (even though the latter
@@ -63,9 +63,7 @@ fn normalize_inner(mut input: &BStr) -> Cow<'_, BStr> {
             b'\\' => match bytes.next() {
                 Some(b'n') => out.push(b'\n'),
                 Some(b't') => out.push(b'\t'),
-                Some(b'b') => {
-                    out.pop();
-                }
+                Some(b'b') => out.push(b'\x08'),
                 Some(c) => {
                     out.push(c);
                 }

--- a/gix-config/tests/config/file/access/read_only.rs
+++ b/gix-config/tests/config/file/access/read_only.rs
@@ -406,7 +406,8 @@ fn complex_quoted_values() {
             escape-sequence = "hi\nho\n\tthere\bi\\\" \""
 "#;
     let config = File::try_from(config).unwrap();
-    let expected = "hi\nho\n\ttheri\\\" \"";
+    // `\b` is the backspace character (0x08), matching git.
+    let expected = "hi\nho\n\tthere\x08i\\\" \"";
     assert_eq!(
         config.raw_value("core.escape-sequence").unwrap(),
         expected,

--- a/gix-config/tests/config/file/access/read_only.rs
+++ b/gix-config/tests/config/file/access/read_only.rs
@@ -406,12 +406,11 @@ fn complex_quoted_values() {
             escape-sequence = "hi\nho\n\tthere\bi\\\" \""
 "#;
     let config = File::try_from(config).unwrap();
-    // `\b` is the backspace character (0x08), matching git.
     let expected = "hi\nho\n\tthere\x08i\\\" \"";
     assert_eq!(
         config.raw_value("core.escape-sequence").unwrap(),
         expected,
-        "raw_value is normalized…"
+        "raw_value is normalized; `\\b` is the backspace character (0x08)"
     );
     assert_eq!(
         config.string("core.escape-sequence").unwrap(),

--- a/gix-config/tests/config/value/normalize.rs
+++ b/gix-config/tests/config/value/normalize.rs
@@ -72,7 +72,9 @@ fn quotes_are_removed_from_partially_quoted_values() {
 
 #[test]
 fn newline_tab_and_backspace_escapes_are_interpreted() {
-    assert_eq!(&*normalize(r"\n\ta\b"), "\n\t");
+    // `\b` is the backspace character (0x08), matching git, not a request to
+    // delete the preceding character.
+    assert_eq!(&*normalize(r"\n\ta\b"), "\n\ta\x08");
 }
 
 #[test]
@@ -93,3 +95,4 @@ fn unsupported_escapes_drop_the_backslash() {
     assert_eq!(&*normalize(r#""\x""#), "x", "same if within quotes");
     assert_eq!(&*normalize(r#""\"#), "", "freestanding escapes are ignored as well");
 }
+

--- a/gix-config/tests/config/value/normalize.rs
+++ b/gix-config/tests/config/value/normalize.rs
@@ -72,9 +72,11 @@ fn quotes_are_removed_from_partially_quoted_values() {
 
 #[test]
 fn newline_tab_and_backspace_escapes_are_interpreted() {
-    // `\b` is the backspace character (0x08), matching git, not a request to
-    // delete the preceding character.
-    assert_eq!(&*normalize(r"\n\ta\b"), "\n\ta\x08");
+    assert_eq!(
+        &*normalize(r"\n\ta\b"),
+        "\n\ta\x08",
+        "`\\b` is the backspace character (0x08), matching git, not a request to delete the preceding character"
+    );
 }
 
 #[test]
@@ -95,4 +97,3 @@ fn unsupported_escapes_drop_the_backslash() {
     assert_eq!(&*normalize(r#""\x""#), "x", "same if within quotes");
     assert_eq!(&*normalize(r#""\"#), "", "freestanding escapes are ignored as well");
 }
-


### PR DESCRIPTION
`gix-config`'s value `normalize` decoded a `\b` escape in a quoted value with `out.pop()`, which deletes the preceding byte — so `"x\by"` normalized to `y`, and a leading `\b` was silently dropped (`out.pop()` on empty output is a no-op).

git decodes `\b` to the backspace character (`0x08`): `"x\by"` becomes the three bytes `x`, `0x08`, `y`. This pushes `0x08` to match, alongside the existing `\n` and `\t` arms.

Two tests that encoded the old delete-behavior are updated to git's output.
