### PR TITLE
fix: respect filter driver configuration precedence

### DIFF
--- a/gix/src/filter.rs
+++ b/gix/src/filter.rs
@@ -289,31 +289,48 @@ impl Pipeline<'_> {
 
 /// Obtain a list of all configured driver, but ignore those in sections that we don't trust enough.
 fn extract_drivers(repo: &Repository) -> Result<Vec<gix_filter::Driver>, pipeline::options::Error> {
-    repo.config
+    let mut drivers = Vec::<gix_filter::Driver>::new();
+    for section in repo
+        .config
         .resolved
         .sections_by_name("filter")
         .into_iter()
         .flatten()
-        .filter(|s| repo.filter_config_section()(s.meta()))
-        .filter_map(|s| {
-            s.header().subsection_name().map(|name| {
-                Ok(gix_filter::Driver {
+        .filter(|section| repo.filter_config_section()(section.meta()))
+    {
+        let Some(name) = section.header().subsection_name() else {
+            continue;
+        };
+        let driver = match drivers.iter_mut().find(|driver| driver.name == name) {
+            Some(driver) => driver,
+            None => {
+                drivers.push(gix_filter::Driver {
                     name: name.to_owned(),
-                    clean: s.value("clean"),
-                    smudge: s.value("smudge"),
-                    process: s.value("process"),
-                    required: s
-                        .value("required")
-                        .map(|value| gix_config::Boolean::try_from(BStr::new(&value)))
-                        .transpose()
-                        .map_err(|err| pipeline::options::Error::Driver {
-                            name: name.to_owned(),
-                            source: err,
-                        })?
-                        .unwrap_or_default()
-                        .into(),
-                })
-            })
-        })
-        .collect::<Result<Vec<_>, pipeline::options::Error>>()
+                    clean: None,
+                    smudge: None,
+                    process: None,
+                    required: false,
+                });
+                drivers.last_mut().expect("the driver was just added")
+            }
+        };
+        if let Some(value) = section.value("clean") {
+            driver.clean = Some(value);
+        }
+        if let Some(value) = section.value("smudge") {
+            driver.smudge = Some(value);
+        }
+        if let Some(value) = section.value("process") {
+            driver.process = Some(value);
+        }
+        if let Some(value) = section.value("required") {
+            driver.required = gix_config::Boolean::try_from(BStr::new(&value))
+                .map_err(|source| pipeline::options::Error::Driver {
+                    name: name.to_owned(),
+                    source,
+                })?
+                .into();
+        }
+    }
+    Ok(drivers)
 }

--- a/gix/tests/gix/repository/filter.rs
+++ b/gix/tests/gix/repository/filter.rs
@@ -33,6 +33,31 @@ fn pipeline_in_repo_without_special_options() -> crate::Result {
 }
 
 #[test]
+fn repo_local_filter_driver_configuration_overrides_global_configuration() -> crate::Result {
+    let mut repo = named_repo("make_basic_repo.sh")?;
+    repo.config_snapshot_mut()
+        .append_config(
+            ["filter.lfs.clean=global-clean", "filter.lfs.smudge=global-smudge"],
+            gix_config::Source::User,
+        )?
+        .append_config(["filter.lfs.clean=local-clean"], gix_config::Source::Local)?;
+
+    let drivers = gix::filter::Pipeline::options(&repo)?.drivers;
+    assert_eq!(drivers.len(), 1, "configuration for the same driver is merged");
+    assert_eq!(
+        drivers[0].clean.as_deref().map(Vec::as_slice),
+        Some(b"local-clean".as_slice()),
+        "repository-local properties take precedence"
+    );
+    assert_eq!(
+        drivers[0].smudge.as_deref().map(Vec::as_slice),
+        Some(b"global-smudge".as_slice()),
+        "properties not overridden locally are inherited"
+    );
+    Ok(())
+}
+
+#[test]
 #[cfg(unix)]
 fn pipeline_worktree_file_to_object() -> crate::Result {
     let repo = named_repo("repo_with_untracked_files.sh")?;


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

> A filter driver config like  [filter "lfs"] in a global git config overrides a repo-local config, which is backwards from git.

## Fix

Merge repeated named filter-driver sections in configuration order. Later scopes replace only properties they define, so repository-local values override user-level values while untouched user-level properties remain inherited.

## Git baseline

Git aggregates named filter drivers property-by-property in `read_convert_config()` in `convert.c`; inspected at Git commit `cf5497b14c`.

## Validation

- `cargo test -p gix --test gix repository::filter`
- `cargo clippy -p gix --test gix -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `codex review --commit 5f732c1c9195991d76783f981082f1a8f1da2a72` (no actionable findings)