### PR TITLE
fix: substitute every `%f` in a filter driver command, like in Git.

### DIFF
--- a/gix-filter/src/driver/mod.rs
+++ b/gix-filter/src/driver/mod.rs
@@ -105,10 +105,31 @@ fn substitute_f_parameter(cmd: &BStr, path: &BStr) -> BString {
 
     let mut ofs = 0;
     while let Some(pos) = cmd[ofs..].find(b"%f") {
-        buf.push_str(&cmd[..ofs + pos]);
+        buf.push_str(&cmd[ofs..ofs + pos]);
         buf.extend_from_slice(&gix_quote::single(path));
         ofs += pos + 2;
     }
     buf.push_str(&cmd[ofs..]);
     buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::substitute_f_parameter;
+
+    #[test]
+    fn each_f_parameter_is_replaced_with_the_quoted_path() {
+        for (cmd, expected) in [
+            ("cmd", "cmd"),
+            ("cmd %f", "cmd 'path'"),
+            ("cmd a %f b %f c", "cmd a 'path' b 'path' c"),
+            ("%f %f %f", "'path' 'path' 'path'"),
+        ] {
+            assert_eq!(
+                substitute_f_parameter(cmd.into(), "path".into()),
+                expected,
+                "only `%f` is replaced, the rest of the command is copied exactly once"
+            );
+        }
+    }
 }


### PR DESCRIPTION
This description was written by an AI agent (Claude) operating through the `shuvamk` account, per the [agent impersonation policy](https://github.com/GitoxideLabs/gitoxide/blob/main/CONTRIBUTING.md).

### What's wrong (AI)

`gix-filter`'s `substitute_f_parameter()` re-emits the whole command prefix on every `%f` after the first, because it copies from index `0` instead of from the offset it has already consumed.

**End to end, against real Git** — `git version 2.50.1 (Apple Git-155)`:

```sh
git config filter.two.clean "sh -c 'cat >/dev/null; echo \"A=%f B=%f\"'"
printf 'f filter=two\n' > .gitattributes
printf 'original content\n' > f
git add .gitattributes f
git show :f          # -> A=f B=f
```

Git substitutes every occurrence: the same template as a `smudge` gives `S1=f S2=f` on checkout, and `sh -c 'cat >/dev/null; echo "%f %f %f"'` stores `f f f`.

gitoxide at `main` @ `da5fa7359`, same driver, via `gix_filter::driver::State::apply(.., Operation::Clean, ..)` with `rela_path = "f"`:

```
sh: -c: line 0: unexpected EOF while looking for matching `''
Driver process "/bin/sh" "-c" "sh -c 'cat >/dev/null; echo \"A='f'sh -c 'cat >/dev/null; echo \"A=%f B='f'\"'" "sh" failed
```

The command it spawns is

```
sh -c 'cat >/dev/null; echo "A='f'sh -c 'cat >/dev/null; echo "A=%f B='f'"'
```

which is not valid shell. Since `required` drivers propagate that failure, the entry cannot be converted at all.

**The function itself**, same commit, `path = "p"`:

| `cmd` | `substitute_f_parameter(cmd, "p")` on `main` | expected |
|---|---|---|
| `cmd` | `cmd` | `cmd` |
| `cmd %f` | `cmd 'p'` | `cmd 'p'` |
| `cmd a %f b %f c` | `cmd a 'p'cmd a %f b 'p' c` | `cmd a 'p' b 'p' c` |
| `%f %f %f` | `'p'%f 'p'%f %f 'p'` | `'p' 'p' 'p'` |

Zero and one `%f` are correct; the divergence starts at two.

**Where it came from.** The line has read this way since the function was added in c538c6eba ("feat: ability to run define and run simple filters.", 2023-06-27). `git blame` attributes it to 5670bbba7 only because that commit moved `driver.rs` into `driver/mod.rs` the same day.

### What this does

Advances the slice start past what has already been copied:

```diff
-        buf.push_str(&cmd[..ofs + pos]);
+        buf.push_str(&cmd[ofs..ofs + pos]);
```

The `while` loop was written to handle repeated `%f` from the start, so nothing about the intended behaviour changes. Zero and one `%f` are byte-identical to before, and the path is still quoted with `gix_quote::single`.

### Tests

One unit test next to the function — `substitute_f_parameter` is private and `gix-filter` had no test for it. It pins all four rows above: no `%f`, one `%f`, two `%f` separated by other arguments, and three adjacent `%f`.

I verified it fails without the fix. Restoring only `buf.push_str(&cmd[..ofs + pos])` and keeping the test:

```
running 1 test
test driver::tests::each_f_parameter_is_replaced_with_the_quoted_path ... FAILED

---- driver::tests::each_f_parameter_is_replaced_with_the_quoted_path stdout ----
thread '...' panicked at gix-filter/src/driver/mod.rs:128:13:
assertion `left == right` failed: only `%f` is replaced, the rest of the command is copied exactly once
  left: "cmd a \'path\'cmd a %f b \'path\' c"
 right: "cmd a 'path' b 'path' c"

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

With the fix put back: `test result: ok. 1 passed; 0 failed`.

### Scope, honestly

This only bites a `clean`/`smudge` template that mentions `%f` more than once — something like `mydriver --path %f --log %f.log`. That is not a common shape, so the practical impact is small.

It is also **not** a security issue: the template comes from trusted configuration and the path is still single-quoted by `gix_quote::single`, so the corruption only duplicates trusted text. There is no injection path here.

### Alternative you might prefer

Removing the index arithmetic rather than correcting it:

```rust
let mut rest = cmd;
while let Some(pos) = rest.find(b"%f") {
    buf.push_str(&rest[..pos]);
    buf.extend_from_slice(&gix_quote::single(path));
    rest = &rest[pos + 2..];
}
buf.push_str(rest);
```

Same behaviour and harder to get wrong again, but a four-line diff instead of one. Happy to switch if you prefer that shape.

Separately, while probing this I noticed one adjacent divergence that this fix does not touch:

| fragment | git 2.50.1 | gix, before and after this PR |
|---|---|---|
| `%%f` | `%f` — `%%` is an escaped literal `%` | `%'p'` |

`%x` is left alone by both, so that is the only other gap. It is a different question from the slicing bug, so I left it out of a one-line fix — happy to file it separately if you want it.

### What I ran

`just` and `cargo-nextest` are not installed on this machine, so these are the raw cargo invocations, on `rustc 1.95.0`:

| command | result |
|---|---|
| `cargo test -p gix-filter` on `main` @ `da5fa7359` | 55 passed, 0 failed |
| `cargo test -p gix-filter` on this branch | 55 passed + the 1 new unit test, 0 failed |
| `cargo test -p gix-worktree-state -p gix-worktree-stream -p gix-archive -p gix` | 445 passed, 0 failed |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p gix-filter --all-targets -- -D warnings -A unknown-lints -A unfulfilled_lint_expectations` | rc=0, no warnings |

`-A unfulfilled_lint_expectations` is only needed because this toolchain reports the three pre-existing `#[expect(dead_code)]` attributes in `gix-ref/src/lib.rs` as unfulfilled; CI's newer stable does not.
