### PR TITLE
fix: a trailing DOS EOF marker doesn't make a text file binary, like in Git.

### DIFF
--- a/gix-filter/src/eol/utils.rs
+++ b/gix-filter/src/eol/utils.rs
@@ -41,19 +41,21 @@ impl Stats {
     /// Gather statistics from the given `bytes`.
     ///
     /// Note that the entire buffer will be scanned.
+    ///
+    /// A trailing DOS end-of-file marker (`0x1a`) doesn't count towards [`non_printable`](Self::non_printable).
     pub fn from_bytes(bytes: &[u8]) -> Self {
-        let mut bytes = bytes.iter().peekable();
+        let mut iter = bytes.iter().peekable();
         let mut null = 0;
         let mut lone_cr = 0;
         let mut lone_lf = 0;
         let mut crlf = 0;
         let mut printable = 0;
         let mut non_printable = 0;
-        while let Some(b) = bytes.next() {
+        while let Some(b) = iter.next() {
             if *b == b'\r' {
-                match bytes.peek() {
+                match iter.peek() {
                     Some(n) if **n == b'\n' => {
-                        bytes.next();
+                        iter.next();
                         crlf += 1;
                     }
                     _ => lone_cr += 1,
@@ -78,6 +80,9 @@ impl Stats {
             } else {
                 printable += 1;
             }
+        }
+        if bytes.last() == Some(&0x1a) {
+            non_printable -= 1;
         }
 
         Self {

--- a/gix-filter/tests/filter/eol/convert_to_git.rs
+++ b/gix-filter/tests/filter/eol/convert_to_git.rs
@@ -61,6 +61,32 @@ fn detected_as_binary() -> crate::Result {
 }
 
 #[test]
+fn trailing_dos_eof_marker_is_not_detected_as_binary() -> crate::Result {
+    let mut buf = Vec::new();
+    let changed = eol::convert_to_git(
+        b"a\r\nb\r\n\x1a",
+        AttributesDigest::TextAuto,
+        &mut buf,
+        &mut no_object_in_index,
+        Default::default(),
+    )
+    .expect("no error");
+    assert!(changed, "the DOS EOF marker doesn't stand in the way of conversion");
+    assert_eq!(buf.as_bstr(), "a\nb\n\x1a");
+
+    let changed = eol::convert_to_git(
+        b"a\r\nb\r\n\x1a\x1a",
+        AttributesDigest::TextAuto,
+        &mut buf,
+        &mut no_object_in_index,
+        Default::default(),
+    )
+    .expect("no error");
+    assert!(!changed, "a second marker isn't discounted, so this is binary");
+    Ok(())
+}
+
+#[test]
 fn fast_conversion_by_stripping_cr() -> crate::Result {
     let mut buf = Vec::new();
     let changed = eol::convert_to_git(

--- a/gix-filter/tests/filter/eol/convert_to_worktree.rs
+++ b/gix-filter/tests/filter/eol/convert_to_worktree.rs
@@ -88,6 +88,28 @@ fn each_nl_is_replaced_with_crnl() -> crate::Result {
 }
 
 #[test]
+fn trailing_dos_eof_marker_is_not_detected_as_binary() -> crate::Result {
+    let mut buf = Vec::new();
+    let changed = eol::convert_to_worktree(
+        b"a\nb\n\x1a",
+        AttributesDigest::TextAutoCrlf,
+        &mut buf,
+        Default::default(),
+    )?;
+    assert!(changed, "the DOS EOF marker doesn't stand in the way of conversion");
+    assert_eq!(buf.as_bstr(), "a\r\nb\r\n\x1a");
+
+    let changed = eol::convert_to_worktree(
+        b"a\nb\n\x1a\x1a",
+        AttributesDigest::TextAutoCrlf,
+        &mut buf,
+        Default::default(),
+    )?;
+    assert!(!changed, "a second marker isn't discounted, so this is binary");
+    Ok(())
+}
+
+#[test]
 fn existing_crnl_are_not_replaced_for_safety_nor_are_lone_cr() -> crate::Result {
     let mut buf = Vec::new();
     let changed = eol::convert_to_worktree(

--- a/gix-filter/tests/filter/eol/mod.rs
+++ b/gix-filter/tests/filter/eol/mod.rs
@@ -18,6 +18,30 @@ mod stats {
             );
             assert!(stats.is_binary());
         }
+
+        #[test]
+        fn trailing_dos_eof_marker_is_not_counted_as_non_printable() {
+            let stats = eol::Stats::from_bytes(b"hello\r\n\x1a");
+            assert_eq!(
+                stats,
+                eol::Stats {
+                    null: 0,
+                    lone_cr: 0,
+                    lone_lf: 0,
+                    crlf: 1,
+                    printable: 5,
+                    non_printable: 0,
+                }
+            );
+            assert!(!stats.is_binary(), "text that ends with a DOS EOF marker is still text");
+
+            let stats = eol::Stats::from_bytes(b"hello\r\n\x1a\x1a");
+            assert_eq!(stats.non_printable, 1, "only the very last byte is discounted");
+            assert!(
+                stats.is_binary(),
+                "a marker anywhere else keeps counting as unprintable"
+            );
+        }
     }
 }
 

--- a/gix-filter/tests/filter/eol/mod.rs
+++ b/gix-filter/tests/filter/eol/mod.rs
@@ -33,7 +33,10 @@ mod stats {
                     non_printable: 0,
                 }
             );
-            assert!(!stats.is_binary(), "text that ends with a DOS EOF marker is still text");
+            assert!(
+                !stats.is_binary(),
+                "text that ends with a DOS EOF (\x1a) marker is still text"
+            );
 
             let stats = eol::Stats::from_bytes(b"hello\r\n\x1a\x1a");
             assert_eq!(stats.non_printable, 1, "only the very last byte is discounted");


### PR DESCRIPTION
*Per [CONTRIBUTING.md](https://github.com/GitoxideLabs/gitoxide/blob/main/CONTRIBUTING.md#prevent-agent-impersonation): this PR was authored by an AI agent (Claude) speaking through the `shuvamk` account. Everything below was executed, not inferred.*

### What's wrong (AI)

A text file that ends with a DOS end-of-file marker (Ctrl-Z, `0x1a`) is classified as **binary**, so under `text=auto` no EOL conversion happens in either direction.

Measured against `git version 2.50.1 (Apple Git-155)` and `gix` at `main` @ `da5fa7359`.

**To Git** — `.gitattributes` is `* text=auto`, `core.autocrlf=false`; git column is `git add -f f.txt && git cat-file blob :f.txt`, gix column is `eol::convert_to_git(.., AttributesDigest::TextAuto, ..)`:

| input | git | gix `main` | gix this PR |
|---|---|---|---|
| `hello\r\n` | `68656c6c6f0a` | `68656c6c6f0a` | `68656c6c6f0a` |
| **`hello\r\n\x1a`** | **`68656c6c6f0a1a`** | **`68656c6c6f0d0a1a`** | `68656c6c6f0a1a` |
| **`a\r\nb\r\n\x1a`** | **`610a620a1a`** | **`610d0a620d0a1a`** | `610a620a1a` |
| `hello\r\n\x1a\x1a` | unchanged | unchanged | unchanged |
| `hello\n\x1a` | unchanged | unchanged | unchanged |
| `\x1a` | `1a` | `1a` | `1a` |

**To worktree** — `.gitattributes` is `* text=auto eol=crlf`; the blob is written verbatim with `git hash-object -w --no-filters` and staged with `git update-index --add --cacheinfo`, then checked out; gix column is `eol::convert_to_worktree(.., AttributesDigest::TextAutoCrlf, ..)`:

| blob | git worktree | gix `main` | gix this PR |
|---|---|---|---|
| `hello\n` | `68656c6c6f0d0a` | `68656c6c6f0d0a` | `68656c6c6f0d0a` |
| **`hello\n\x1a`** | **`68656c6c6f0d0a1a`** | **`68656c6c6f0a1a`** | `68656c6c6f0d0a1a` |
| **`a\nb\n\x1a`** | **`610d0a620d0a1a`** | **`610a620a1a`** | `610d0a620d0a1a` |
| `hello\n\x1a\x1a` | unchanged | unchanged | unchanged |

End to end: a source repo with `.gitattributes` = `* text=auto eol=crlf` and a blob `x1.txt` = `hello\n\x1a`, cloned with both `git clone src git-clone` and `./target/debug/gix clone src gix-clone`, comparing the resulting worktree bytes (`x2.txt` = `hello\n` is the control):

```
# gix built from main @ da5fa7359
x1.txt    git=68656c6c6f0d0a1a     gix=68656c6c6f0a1a       DIFFER
x2.txt    git=68656c6c6f0d0a       gix=68656c6c6f0d0a       same

# gix built from this PR
x1.txt    git=68656c6c6f0d0a1a     gix=68656c6c6f0d0a1a     same
x2.txt    git=68656c6c6f0d0a       gix=68656c6c6f0d0a       same
```

Over **4722 generated buffers** (all strings of length 1–4 over `{a, CR, LF, NUL, 0x1a, TAB, DEL, 0x01}` plus longer realistic shapes), run through real `git` in both directions and through `gix-filter`:

| | to-git mismatches | to-worktree mismatches |
|---|---|---|
| `main` @ `da5fa7359` | 9 | 27 |
| this PR | **0** | **0** |

All 36 mismatching inputs on `main` end in `0x1a`.

### The cause

`Stats::from_bytes()` counts a trailing `0x1a` towards `non_printable`. `is_binary()` then trips on `(printable >> 7) < non_printable`, which for any file with fewer than 128 printable bytes means a single unprintable byte is enough. `convert_to_git()` returns early on `stats.is_binary()`, and `will_convert_lf_to_crlf()` does the same for `convert_to_worktree()`.

Git's `gather_stats()` in [`convert.c`](https://github.com/git/git/blob/v2.50.1/convert.c#L45-L88) discounts exactly this byte, as the last thing it does:

```c
	/* If file ends with EOF then don't count this EOF as non-printable. */
	if (size >= 1 && buf[size-1] == '\032')
		stats->nonprintable--;
```

Everything else in `gather_stats()` is already mirrored faithfully by `from_bytes()`; only this tail is missing. It has been missing since `e45fec966` ("feat: Add `eol::convert_to_git()`.", 2023-06-26).

### What this does

Discounts the trailing marker, exactly as Git does:

```rust
if bytes.last() == Some(&0x1a) {
    non_printable -= 1;
}
```

The only other change is the rename of the iterator binding from `bytes` to `iter`, so the slice is still reachable after the loop. It is a pure rename — no logic, signature or parameter change. `non_printable` cannot underflow, because a trailing `0x1a` is always counted by the loop first (`0x1a < 32` and it is not one of BS/HT/ESC/FF/NUL).

Only the very last byte is discounted, so `hello\r\n\x1a\x1a` stays binary here just as it does in Git.

### Tests

Three, all in `gix-filter/tests/filter/eol/`, each pinning both directions of the boundary (a single trailing marker converts, two markers stay binary):

- `stats::from_bytes::trailing_dos_eof_marker_is_not_counted_as_non_printable`
- `convert_to_git::trailing_dos_eof_marker_is_not_detected_as_binary`
- `convert_to_worktree::trailing_dos_eof_marker_is_not_detected_as_binary`

**All three fail without the change.** Reverting only `gix-filter/src/eol/utils.rs` in a throwaway worktree, keeping the tests:

```
---- eol::stats::from_bytes::trailing_dos_eof_marker_is_not_counted_as_non_printable stdout ----
assertion `left == right` failed
  left: Stats { null: 0, lone_cr: 0, lone_lf: 0, crlf: 1, printable: 5, non_printable: 1 }
 right: Stats { null: 0, lone_cr: 0, lone_lf: 0, crlf: 1, printable: 5, non_printable: 0 }

---- eol::convert_to_git::trailing_dos_eof_marker_is_not_detected_as_binary stdout ----
panicked at gix-filter/tests/filter/eol/convert_to_git.rs:74:5:
the DOS EOF marker doesn't stand in the way of conversion

---- eol::convert_to_worktree::trailing_dos_eof_marker_is_not_detected_as_binary stdout ----
panicked at gix-filter/tests/filter/eol/convert_to_worktree.rs:99:5:
the DOS EOF marker doesn't stand in the way of conversion

test result: FAILED. 13 passed; 3 failed; 0 ignored; 0 measured; 42 filtered out
```

Restoring the file: `test result: ok. 16 passed; 0 failed`.

No fixture is added, so no new archive.

### What I ran

`just` and `cargo-nextest` are not installed here, so these are the raw cargo invocations on `rustc 1.95.0`:

| command | `main` @ `da5fa7359` | this PR |
|---|---|---|
| `cargo test -p gix-filter` | 55 passed, 0 failed | **58 passed, 0 failed** |
| `cargo test --workspace --no-fail-fast` | rc=0, 181 suites, 3675 passed, 0 failed, 22 ignored | rc=0, 181 suites, **3678 passed**, 0 failed, 22 ignored |
| `cargo fmt --all -- --check` | clean | clean |
| `cargo clippy --workspace --all-targets -- -D warnings -A unknown-lints -A unfulfilled_lint_expectations` | rc=0 | rc=0 |
| `cargo doc -p gix-filter --features sha1 --no-deps` | — | ok |

Dropping `-A unfulfilled_lint_expectations` makes clean `main` fail too, with three `error: this lint expectation is unfulfilled` in `gix-ref/src/lib.rs` — a rustc-version artefact of running 1.95.0 rather than CI's `stable`, unrelated to this change. I measured it on `main` this run so the two columns are comparable.

### Alternative you might prefer

The adjustment could live in `is_binary()` instead, leaving `non_printable` a pure count of unprintable bytes. That needs either a new `Stats` field (`trailing_eof_marker: bool`, set by `from_bytes()`) or a buffer parameter on `is_binary()`, since `is_binary()` is reachable on a hand-built `Stats` where the bytes are long gone. I did not do it that way because `non_printable` is a **public field** whose meaning is Git's `stats->nonprintable`, and keeping the count raw would leave it disagreeing with Git for exactly the buffers this PR is about — but both variants are a few lines, so say the word and I will switch.

**The one observable consequence to flag:** because `non_printable` is public, any downstream consumer reading it directly (rather than going through `is_binary()`) will now see one less for a buffer ending in `0x1a`. Nothing in this workspace does — `git grep non_printable` finds only `eol/mod.rs`, `eol/utils.rs` and the `gix-filter` tests — but it is the one place the change is visible beyond the conversion decision.
