### PR TITLE
fix: harden URL authority and path parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,6 +2613,7 @@ dependencies = [
  "gix-utils",
  "percent-encoding",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "gix-command"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bstr",
  "gix-path",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bitflags 2.13.0",
  "bstr",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "bstr",
  "document-features",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "bstr",
  "gix-testtools",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "gix-transport"
-version = "0.58.0"
+version = "0.58.1"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2603,7 +2603,7 @@ version = "0.0.0"
 
 [[package]]
 name = "gix-url"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "assert_matches",
  "bstr",

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -51,7 +51,7 @@ serde = ["gix/serde", "dep:serde_json", "dep:serde", "bytesize/serde"]
 # deselect everything else (like "performance") as this should be controllable by the parent application.
 gix = { version = "^0.86.0", path = "../gix", default-features = false, features = ["merge", "blob-diff", "blame", "revision", "mailmap", "excludes", "attributes", "worktree-mutation", "credentials", "interrupt", "status", "dirwalk"] }
 gix-pack-for-configuration-only = { package = "gix-pack", version = "^0.73.0", path = "../gix-pack", default-features = false, features = ["pack-cache-lru-dynamic", "pack-cache-lru-static", "generate", "streaming-input"] }
-gix-transport-configuration-only = { package = "gix-transport", version = "^0.58.0", path = "../gix-transport", default-features = false }
+gix-transport-configuration-only = { package = "gix-transport", version = "^0.58.1", path = "../gix-transport", default-features = false }
 gix-archive-for-configuration-only = { package = "gix-archive", version = "^0.35.0", path = "../gix-archive", optional = true, features = ["tar", "tar_gz"] }
 gix-status = { version = "^0.33.0", path = "../gix-status" }
 gix-fsck = { version = "^0.24.0", path = "../gix-fsck" }
@@ -72,7 +72,7 @@ futures-io = { version = "0.3.32", optional = true }
 blocking = { version = "1.6.2", optional = true }
 
 # for 'organize' functionality
-gix-url = { version = "^0.37.0", path = "../gix-url", optional = true }
+gix-url = { version = "^0.37.1", path = "../gix-url", optional = true }
 jwalk = { version = "0.8.0", optional = true }
 
 # for 'hours'

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -33,7 +33,7 @@ zip = ["dep:rawzip", "dep:flate2"]
 [dependencies]
 gix-worktree-stream = { version = "^0.35.0", path = "../gix-worktree-stream" }
 gix-object = { version = "^0.63.0", path = "../gix-object" }
-gix-path = { version = "^0.12.3", path = "../gix-path", optional = true }
+gix-path = { version = "^0.12.4", path = "../gix-path", optional = true }
 gix-date = { version = "^0.15.6", path = "../gix-date" }
 
 flate2 = { version = "1.1.9", optional = true, default-features = false, features = ["zlib-rs"] }

--- a/gix-attributes/Cargo.toml
+++ b/gix-attributes/Cargo.toml
@@ -27,7 +27,7 @@ parallel = ["gix-features/parallel"]
 
 [dependencies]
 gix-features = { version = "^0.49.0", path = "../gix-features" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-quote = { version = "^0.7.2", path = "../gix-quote" }
 gix-glob = { version = "^0.27.0", path = "../gix-glob" }
 gix-trace = { version = "^0.1.21", path = "../gix-trace" }

--- a/gix-command/CHANGELOG.md
+++ b/gix-command/CHANGELOG.md
@@ -5,14 +5,111 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.9.2 (2026-08-03)
+
+### Bug Fixes
+
+ - <csr-id-85f10fcc96740eeb293b237d1300bf8aab428434/> use onfigured shell arguments in gix-command
+   <!-- agent -->
+   
+   Construct default shell invocations with gix_path::env::shell_command()
+   instead of rebuilding a Command from shell(). This preserves platform-specific
+   arguments, notably --posix for the Git for Windows bin/sh.exe shim, while
+   leaving caller-provided shells unchanged.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 3 commits contributed to the release.
+ - 69 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Merge pull request #2820 from GitoxideLabs/agent/fix-windows-shell-posix-mode ([`5a88ee7`](https://github.com/GitoxideLabs/gitoxide/commit/5a88ee740f6e81db550d75b9b94875d0cb71ed37))
+    - Use onfigured shell arguments in gix-command ([`85f10fc`](https://github.com/GitoxideLabs/gitoxide/commit/85f10fcc96740eeb293b237d1300bf8aab428434))
+    - Merge pull request #2618 from GitoxideLabs/report ([`f7d4f33`](https://github.com/GitoxideLabs/gitoxide/commit/f7d4f33b58503996ae90497b69ce4c3a757982ac))
+</details>
+
+## 0.9.1 (2026-05-26)
+
+### Bug Fixes
+
+ - <csr-id-8323858295164d23c25ebca52f6b9b01eeca885d/> Derive `$0` for `sh -c` from the shell's basename
+   `gix-command` invokes shells as `sh -c <script> <command_name> [args...]`,
+   where the `command_name` operand becomes `$0` inside the shell. Shells
+   use `$0` to prefix their own diagnostic messages (e.g.
+   `sh: line 1: <cmd>: command not found`), so the value should identify
+   the actually-running shell.
+   
+   Derive the value from the shell program itself, using the basename of
+   the path passed to `Command::new` for the shell:
+   
+     - With the default shell on Unix (`/bin/sh`), `$0` is `sh`.
+     - With the default shell on Windows (`sh.exe` from Git for Windows),
+       `$0` is `sh.exe`, matching the launched binary's actual name.
+     - With a customized `shell_program`, `$0` reflects the chosen shell
+       (e.g. `bash`, `zsh`), so its diagnostics correctly identify it.
+   
+   If the shell path has no extractable basename — `Path::file_name()`
+   returns `None` for degenerate input like an empty string or `/` — fall
+   back to `_`, the conventional placeholder for an unused `$0` used in
+   shell one-liners. This keeps the construction total without claiming a
+   specific shell name.
+   
+   Using the basename also avoids an MSYS2-specific surprise on Windows:
+   Cygwin/MSYS2 shells translate some command-line content received via
+   `lpCommandLine`, including full Windows paths, so a full shell path
+   passed as `$0` would come back from the shell as its translated form.
+   
+   This fixes #1842. (See #1840 and #1842 regarding some of these issues.)
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 13 commits contributed to the release over the course of 28 calendar days.
+ - 28 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Release gix-error v0.2.4, gix-date v0.15.4, gix-actor v0.41.1, gix-trace v0.1.20, gix-validate v0.11.2, gix-path v0.12.1, gix-utils v0.3.3, gix-features v0.48.1, gix-hash v0.25.1, gix-hashtable v0.15.1, gix-object v0.61.0, gix-glob v0.26.1, gix-quote v0.7.2, gix-attributes v0.33.1, gix-command v0.9.1, gix-packetline v0.21.4, gix-filter v0.31.0, gix-fs v0.21.2, gix-chunk v0.7.2, gix-commitgraph v0.37.1, gix-revwalk v0.32.0, gix-traverse v0.58.0, gix-worktree-stream v0.33.0, gix-archive v0.33.0, gix-bitmap v0.3.2, gix-tempfile v23.0.1, gix-lock v23.0.1, gix-index v0.52.0, gix-config-value v0.18.1, gix-pathspec v0.18.1, gix-ignore v0.21.1, gix-worktree v0.53.0, gix-imara-diff v0.2.2, gix-diff v0.64.0, gix-blame v0.14.0, gix-ref v0.64.0, gix-sec v0.14.1, gix-config v0.57.0, gix-prompt v0.15.1, gix-url v0.36.1, gix-credentials v0.38.1, gix-discover v0.52.0, gix-dir v0.26.0, gix-mailmap v0.33.1, gix-revision v0.46.0, gix-merge v0.17.0, gix-negotiate v0.32.0, gix-pack v0.71.0, gix-odb v0.81.0, gix-refspec v0.42.0, gix-shallow v0.12.1, gix-transport v0.57.1, gix-protocol v0.62.0, gix-status v0.31.0, gix-submodule v0.31.0, gix-worktree-state v0.31.0, gix v0.84.0, gix-fsck v0.22.0, gitoxide-core v0.58.0, gitoxide v0.54.0, safety bump 27 crates ([`10c58bb`](https://github.com/GitoxideLabs/gitoxide/commit/10c58bb56597d9335611da121aac21f9b09b6e5b))
+    - Merge pull request #2607 from SarthakB11/fix/issue-1842 ([`faecc23`](https://github.com/GitoxideLabs/gitoxide/commit/faecc2373d4b82f0856edbfa964280ab2134b8a5))
+    - Derive `$0` for `sh -c` from the shell's basename ([`8323858`](https://github.com/GitoxideLabs/gitoxide/commit/8323858295164d23c25ebca52f6b9b01eeca885d))
+    - Add tests for `$0` deriving from the actually-running shell ([`d62e33c`](https://github.com/GitoxideLabs/gitoxide/commit/d62e33c725d4a2a3415b9d31554d5fa39e0fed73))
+    - Pass sh (not --) as $0 to sh -c ([`6752a96`](https://github.com/GitoxideLabs/gitoxide/commit/6752a964b1e24bf79d1bda4e9cddd6e404646f2d))
+    - Merge pull request #2575 from SarthakB11/fix/issue-2316 ([`4743361`](https://github.com/GitoxideLabs/gitoxide/commit/4743361e69238245b77f5687620b20652e62a23c))
+    - Review ([`1980190`](https://github.com/GitoxideLabs/gitoxide/commit/19801900fdce7b7db3ab4da9866c44d7fea5598e))
+    - Document why each fixture archive is .gitignored ([`e3d5a04`](https://github.com/GitoxideLabs/gitoxide/commit/e3d5a0474574dbb546a61eefc91a03c2df72df74))
+    - Merge pull request #2568 from GitoxideLabs/dependabot/cargo/cargo-56d6b174d8 ([`ab2fee1`](https://github.com/GitoxideLabs/gitoxide/commit/ab2fee14651202fcb7b3d8178932090c73492014))
+    - Update crates to Rust 2024 edition ([`2cb17b2`](https://github.com/GitoxideLabs/gitoxide/commit/2cb17b2e7f6009693a55af907614f705a29d8c29))
+    - Remove rust_2018_idioms lint declarations ([`e10d5f6`](https://github.com/GitoxideLabs/gitoxide/commit/e10d5f662df2ee05f973a3167ad215a330ee74e1))
+    - Raise MSRV for hash dependency updates ([`3675a8d`](https://github.com/GitoxideLabs/gitoxide/commit/3675a8d61b17845a783bc27912a3f52ac273a4af))
+    - Merge pull request #2546 from GitoxideLabs/fix-2545 ([`adb8328`](https://github.com/GitoxideLabs/gitoxide/commit/adb8328952478c443ead5f5a8c6851928b377b37))
+</details>
+
 ## 0.9.0 (2026-04-28)
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 1 commit contributed to the release over the course of 2 calendar days.
- - 3 days passed between releases.
+ - 2 commits contributed to the release over the course of 2 calendar days.
+ - 4 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -23,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-error v0.2.3, gix-date v0.15.3, gix-actor v0.41.0, gix-path v0.12.0, gix-features v0.48.0, gix-hash v0.25.0, gix-hashtable v0.15.0, gix-object v0.60.0, gix-glob v0.26.0, gix-attributes v0.33.0, gix-command v0.9.0, gix-filter v0.30.0, gix-fs v0.21.0, gix-commitgraph v0.37.0, gix-revwalk v0.31.0, gix-traverse v0.57.0, gix-worktree-stream v0.32.0, gix-archive v0.32.0, gix-tempfile v23.0.0, gix-lock v23.0.0, gix-index v0.51.0, gix-config-value v0.18.0, gix-pathspec v0.18.0, gix-ignore v0.21.0, gix-worktree v0.52.0, gix-imara-diff v0.2.1, gix-diff v0.63.0, gix-blame v0.13.0, gix-ref v0.63.0, gix-sec v0.14.0, gix-config v0.56.0, gix-prompt v0.15.0, gix-url v0.36.0, gix-credentials v0.38.0, gix-discover v0.51.0, gix-dir v0.25.0, gix-mailmap v0.33.0, gix-revision v0.45.0, gix-merge v0.16.0, gix-negotiate v0.31.0, gix-pack v0.70.0, gix-odb v0.80.0, gix-refspec v0.41.0, gix-shallow v0.12.0, gix-transport v0.57.0, gix-protocol v0.61.0, gix-status v0.30.0, gix-submodule v0.30.0, gix-worktree-state v0.30.0, gix v0.83.0, gix-fsck v0.21.0, gitoxide-core v0.57.0, gitoxide v0.53.0, safety bump 48 crates ([`53f880c`](https://github.com/GitoxideLabs/gitoxide/commit/53f880c7604232c367870088176e42efd8a5b783))
     - Merge pull request #2540 from GitoxideLabs/reporting ([`4d5ba23`](https://github.com/GitoxideLabs/gitoxide/commit/4d5ba231685e8ff36195603c57193aa1cd21fa8e))
 </details>
 
@@ -37,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 9 commits contributed to the release.
+ - 61 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -134,7 +233,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release over the course of 3 calendar days.
- - 3 days passed between releases.
+ - 4 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -160,6 +259,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 11 commits contributed to the release.
+ - 72 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#2328](https://github.com/GitoxideLabs/gitoxide/issues/2328)
 
@@ -228,7 +328,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release over the course of 59 calendar days.
- - 59 days passed between releases.
+ - 60 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -280,6 +380,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -304,6 +405,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 9 commits contributed to the release.
+ - 21 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -335,25 +437,6 @@ A maintenance release without user-facing changes.
  - <csr-id-435984bffda225ee923aa2c9fdbbf730d7719f74/> add `Preprae::with_quoted_command()`
    That way it's possible to execute shell commands with spaces in their paths, for example.
 
-### Other
-
- - <csr-id-4e7306e9f995586069b388d1fe95d29b219f5610/> Revise and somewhat expand `Prepare` docs
-   This revises the `gix_command::Prepare` documentation, mainly for
-   clarity but also to add some information and cover or explain some
-   cases that were not (or not as fully) covered before.
-   
-   This builds on recent documentation changes, such as those in #1800.
-   
-   Less importantly, this also:
-   
-   - Wraps `Prepare` documentation comments to a more consistent
-     width, when doing so improved unrendered readability.
-   
-   - Made a trace message more precise, to avoid obscuring a subtlety
-     about the distinction between what we are looking for and what we
-     are adding, since that might occasionally relate to the reason
-     someone is examining trace messages.
-
 ### Bug Fixes (BREAKING)
 
  - <csr-id-667de433f2cd769323ec5534944a6eba01a8ae40/> rename `with_shell()` to `command_may_be_shell_script()`, add `with_shell()` to enforce using a shell.
@@ -368,6 +451,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 18 commits contributed to the release.
+ - 76 days passed between releases.
  - 4 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#1799](https://github.com/GitoxideLabs/gitoxide/issues/1799)
 
@@ -402,12 +486,6 @@ A maintenance release without user-facing changes.
 ## 0.4.1 (2025-01-18)
 
 <csr-id-17835bccb066bbc47cc137e8ec5d9fe7d5665af0/>
-
-### Chore
-
- - <csr-id-17835bccb066bbc47cc137e8ec5d9fe7d5665af0/> bump `rust-version` to 1.70
-   That way clippy will allow to use the fantastic `Option::is_some_and()`
-   and friends.
 
 ### Commit Statistics
 
@@ -482,6 +560,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
+ - 33 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -501,41 +580,6 @@ A maintenance release without user-facing changes.
 ## 0.3.10 (2024-10-22)
 
 <csr-id-64ff0a77062d35add1a2dd422bb61075647d1a36/>
-
-### Other
-
- - <csr-id-64ff0a77062d35add1a2dd422bb61075647d1a36/> Update gitoxide repository URLs
-   This updates `Byron/gitoxide` URLs to `GitoxideLabs/gitoxide` in:
-   
-   - Markdown documentation, except changelogs and other such files
-     where such changes should not be made.
-   
-   - Documentation comments (in .rs files).
-   
-   - Manifest (.toml) files, for the value of the `repository` key.
-   
-   - The comments appearing at the top of a sample hook that contains
-     a repository URL as an example.
-   
-   When making these changes, I also allowed my editor to remove
-   trailing whitespace in any lines in files already being edited
-   (since, in this case, there was no disadvantage to allowing this).
-   
-   The gitoxide repository URL changed when the repository was moved
-   into the recently created GitHub organization `GitoxideLabs`, as
-   detailed in #1406. Please note that, although I believe updating
-   the URLs to their new canonical values is useful, this is not
-   needed to fix any broken links, since `Byron/gitoxide` URLs
-   redirect (and hopefully will always redirect) to the coresponding
-   `GitoxideLabs/gitoxide` URLs.
-   
-   While this change should not break any URLs, some affected URLs
-   were already broken. This updates them, but they are still broken.
-   They will be fixed in a subsequent commit.
-   
-   This also does not update `Byron/gitoxide` URLs in test fixtures
-   or test cases, nor in the `Makefile`. (It may make sense to change
-   some of those too, but it is not really a documentation change.)
 
 ### Commit Statistics
 
@@ -633,6 +677,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
+ - 69 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -652,10 +697,6 @@ A maintenance release without user-facing changes.
 ## 0.3.6 (2024-03-14)
 
 <csr-id-39879af6eaf2bf4fe159a5c6371c98d516c4febe/>
-
-### Chore
-
- - <csr-id-39879af6eaf2bf4fe159a5c6371c98d516c4febe/> remove repetitive words
 
 ### Commit Statistics
 
@@ -710,7 +751,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release over the course of 12 calendar days.
- - 21 days passed between releases.
+ - 22 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#1284](https://github.com/GitoxideLabs/gitoxide/issues/1284)
 
@@ -770,7 +811,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release.
- - 20 days passed between releases.
+ - 21 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -792,20 +833,12 @@ A maintenance release without user-facing changes.
 
 <csr-id-3bd09ef120945a9669321ea856db4079a5dab930/>
 
-### Chore
-
- - <csr-id-3bd09ef120945a9669321ea856db4079a5dab930/> change `rust-version` manifest field back to 1.65.
-   They didn't actually need to be higher to work, and changing them
-   unecessarily can break downstream CI.
-   
-   Let's keep this value as low as possible, and only increase it when
-   more recent features are actually used.
-
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -825,17 +858,12 @@ A maintenance release without user-facing changes.
 
 <csr-id-aea89c3ad52f1a800abb620e9a4701bdf904ff7d/>
 
-### Chore
-
- - <csr-id-aea89c3ad52f1a800abb620e9a4701bdf904ff7d/> upgrade MSRV to v1.70
-   Our MSRV follows the one of `helix`, which in turn follows Firefox.
-
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
- - 22 days passed between releases.
+ - 23 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -889,6 +917,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 16 commits contributed to the release.
+ - 55 days passed between releases.
  - 4 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 2 unique issues were worked on: [#1103](https://github.com/GitoxideLabs/gitoxide/issues/1103), [#1129](https://github.com/GitoxideLabs/gitoxide/issues/1129)
 
@@ -950,16 +979,12 @@ A maintenance release without user-facing changes.
 
 <csr-id-229bd4899213f749a7cc124aa2b82a1368fba40f/>
 
-### Chore
-
- - <csr-id-229bd4899213f749a7cc124aa2b82a1368fba40f/> don't call crate 'WIP' in manifest anymore.
-
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release over the course of 18 calendar days.
- - 30 days passed between releases.
+ - 31 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1008,16 +1033,12 @@ A maintenance release without user-facing changes.
 
 <csr-id-7f7db9794c23b87c8ea50b7bcf38955c9d977624/>
 
-### Chore
-
- - <csr-id-7f7db9794c23b87c8ea50b7bcf38955c9d977624/> curtail `bstr` features to exactly what's needed.
-
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release over the course of 17 calendar days.
- - 26 days passed between releases.
+ - 27 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1044,7 +1065,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release over the course of 5 calendar days.
- - 15 days passed between releases.
+ - 16 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1070,6 +1091,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release over the course of 12 calendar days.
+ - 106 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1091,12 +1113,6 @@ A maintenance release without user-facing changes.
 
 ### Bug Fixes
 
- - <csr-id-e14dc7d475373d2c266e84ff8f1826c68a34ab92/> note that crates have been renamed from `git-*` to `gix-*`.
-   This also means that the `git-*` prefixed crates of the `gitoxide` project
-   are effectively unmaintained.
-   Use the crates with the `gix-*` prefix instead.
-   
-   If you were using `git-repository`, then `gix` is its substitute.
  - <csr-id-135d317065aae87af302beb6c26bb6ca8e30b6aa/> compatibility with `bstr` v1.3, use `*.as_bytes()` instead of `.as_ref()`.
    `as_ref()` relies on a known target type which isn't always present. However, once
    there is only one implementation, that's no problem, but when that changes compilation

--- a/gix-command/Cargo.toml
+++ b/gix-command/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-command"
-version = "0.9.1"
+version = "0.9.2"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project handling internal git command execution"
@@ -16,7 +16,7 @@ doctest = true
 
 [dependencies]
 gix-trace = { version = "^0.1.20", path = "../gix-trace" }
-gix-path = { version = "^0.12.1", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-quote = { version = "^0.7.2", path = "../gix-quote" }
 
 bstr = { version = "1.12.0", default-features = false, features = ["std", "unicode"] }

--- a/gix-config-value/CHANGELOG.md
+++ b/gix-config-value/CHANGELOG.md
@@ -5,13 +5,79 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.19.1 (2026-08-03)
+
+### Bug Fixes
+
+ - <csr-id-c78c2c91f5f4f25cd0b9fe3d40f641eb55445508/> also match the `reset` color case-insensitively
+ - <csr-id-8e5583686acf1fe66314aaec1fe122cc9d651491/> color names ignore case, and `bright` requires a standard color, like in Git.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 4 commits contributed to the release over the course of 11 calendar days.
+ - 11 days passed between releases.
+ - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Merge pull request #2863 from shuvamk/fix/color-name-case-and-bright-prefix ([`da5fa73`](https://github.com/GitoxideLabs/gitoxide/commit/da5fa735905c97b9454542bcaba848bcdeac760d))
+    - Also match the `reset` color case-insensitively ([`c78c2c9`](https://github.com/GitoxideLabs/gitoxide/commit/c78c2c91f5f4f25cd0b9fe3d40f641eb55445508))
+    - Color names ignore case, and `bright` requires a standard color, like in Git. ([`8e55836`](https://github.com/GitoxideLabs/gitoxide/commit/8e5583686acf1fe66314aaec1fe122cc9d651491))
+    - Merge pull request #2812 from GitoxideLabs/report-july ([`ae8845a`](https://github.com/GitoxideLabs/gitoxide/commit/ae8845a47c4c87e0996a119822106cf09036340b))
+</details>
+
+## 0.19.0 (2026-07-23)
+
+### New Features (BREAKING)
+
+ - <csr-id-020bbb694e0bf5305ea2759eeadba02930ac7480/> store configuration paths and parse values from strings
+   Remove the lifetime from gix_config_value::Path and store its bytes in a
+   BString. Path interpolation now returns an owned PathBuf, including for paths
+   that do not require expansion.
+   
+   Allow Boolean, Color, and Integer to parse UTF-8 string slices as well as
+   byte strings. Keep BStr as the canonical parser input and disambiguate BString
+   callers explicitly.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 6 commits contributed to the release.
+ - 58 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Release gix-trace v0.1.21, gix-validate v0.11.3, gix-path v0.12.3, gix-utils v0.3.5, gix-config-value v0.19.0, gix-prompt v0.16.0, gix-sec v0.14.2, gix-url v0.37.0, gix-credentials v0.39.0, safety bump 18 crates ([`f0ec710`](https://github.com/GitoxideLabs/gitoxide/commit/f0ec71076aa1cef3181b77946ee556a89c651b8e))
+    - Merge pull request #2722 from GitoxideLabs/reasons ([`c16b5a1`](https://github.com/GitoxideLabs/gitoxide/commit/c16b5a1892704b7c72a253bdd74a6848dd61032a))
+    - Replace lint allowances with expectations ([`43ff87a`](https://github.com/GitoxideLabs/gitoxide/commit/43ff87a73897b70313e3a58e7de82231be5b59ad))
+    - Merge pull request #2667 from GitoxideLabs/lifetime-free-config-parser ([`55b5158`](https://github.com/GitoxideLabs/gitoxide/commit/55b51580c2b018f9f35b4b865fe86a28a5c0ff84))
+    - Store configuration paths and parse values from strings ([`020bbb6`](https://github.com/GitoxideLabs/gitoxide/commit/020bbb694e0bf5305ea2759eeadba02930ac7480))
+    - Merge pull request #2618 from GitoxideLabs/report ([`f7d4f33`](https://github.com/GitoxideLabs/gitoxide/commit/f7d4f33b58503996ae90497b69ce4c3a757982ac))
+</details>
+
 ## 0.18.1 (2026-05-26)
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 5 commits contributed to the release over the course of 28 calendar days.
+ - 6 commits contributed to the release over the course of 28 calendar days.
  - 28 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -23,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-error v0.2.4, gix-date v0.15.4, gix-actor v0.41.1, gix-trace v0.1.20, gix-validate v0.11.2, gix-path v0.12.1, gix-utils v0.3.3, gix-features v0.48.1, gix-hash v0.25.1, gix-hashtable v0.15.1, gix-object v0.61.0, gix-glob v0.26.1, gix-quote v0.7.2, gix-attributes v0.33.1, gix-command v0.9.1, gix-packetline v0.21.4, gix-filter v0.31.0, gix-fs v0.21.2, gix-chunk v0.7.2, gix-commitgraph v0.37.1, gix-revwalk v0.32.0, gix-traverse v0.58.0, gix-worktree-stream v0.33.0, gix-archive v0.33.0, gix-bitmap v0.3.2, gix-tempfile v23.0.1, gix-lock v23.0.1, gix-index v0.52.0, gix-config-value v0.18.1, gix-pathspec v0.18.1, gix-ignore v0.21.1, gix-worktree v0.53.0, gix-imara-diff v0.2.2, gix-diff v0.64.0, gix-blame v0.14.0, gix-ref v0.64.0, gix-sec v0.14.1, gix-config v0.57.0, gix-prompt v0.15.1, gix-url v0.36.1, gix-credentials v0.38.1, gix-discover v0.52.0, gix-dir v0.26.0, gix-mailmap v0.33.1, gix-revision v0.46.0, gix-merge v0.17.0, gix-negotiate v0.32.0, gix-pack v0.71.0, gix-odb v0.81.0, gix-refspec v0.42.0, gix-shallow v0.12.1, gix-transport v0.57.1, gix-protocol v0.62.0, gix-status v0.31.0, gix-submodule v0.31.0, gix-worktree-state v0.31.0, gix v0.84.0, gix-fsck v0.22.0, gitoxide-core v0.58.0, gitoxide v0.54.0, safety bump 27 crates ([`10c58bb`](https://github.com/GitoxideLabs/gitoxide/commit/10c58bb56597d9335611da121aac21f9b09b6e5b))
     - Merge pull request #2568 from GitoxideLabs/dependabot/cargo/cargo-56d6b174d8 ([`ab2fee1`](https://github.com/GitoxideLabs/gitoxide/commit/ab2fee14651202fcb7b3d8178932090c73492014))
     - Update crates to Rust 2024 edition ([`2cb17b2`](https://github.com/GitoxideLabs/gitoxide/commit/2cb17b2e7f6009693a55af907614f705a29d8c29))
     - Remove rust_2018_idioms lint declarations ([`e10d5f6`](https://github.com/GitoxideLabs/gitoxide/commit/e10d5f662df2ee05f973a3167ad215a330ee74e1))
@@ -37,7 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 2 commits contributed to the release over the course of 2 calendar days.
- - 3 days passed between releases.
+ - 4 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -63,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 8 commits contributed to the release.
+ - 73 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -114,7 +182,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release over the course of 30 calendar days.
- - 30 days passed between releases.
+ - 31 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -142,6 +210,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release.
+ - 60 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -221,7 +290,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release over the course of 79 calendar days.
- - 79 days passed between releases.
+ - 80 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -246,6 +315,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -270,6 +340,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 9 commits contributed to the release.
+ - 21 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -300,6 +371,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 7 commits contributed to the release.
+ - 76 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -361,6 +433,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release.
+ - 33 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -465,6 +538,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 7 commits contributed to the release over the course of 32 calendar days.
+ - 131 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -553,7 +627,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 8 commits contributed to the release.
- - 20 days passed between releases.
+ - 21 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -583,6 +657,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -613,7 +688,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release over the course of 3 calendar days.
- - 22 days passed between releases.
+ - 23 days passed between releases.
  - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -641,6 +716,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 7 commits contributed to the release.
+ - 89 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -701,7 +777,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release over the course of 3 calendar days.
- - 30 days passed between releases.
+ - 31 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -754,7 +830,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release over the course of 17 calendar days.
- - 19 days passed between releases.
+ - 20 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -781,7 +857,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
- - 6 days passed between releases.
+ - 7 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -806,7 +882,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release over the course of 5 calendar days.
- - 15 days passed between releases.
+ - 16 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -861,6 +937,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -925,6 +1002,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 2 commits contributed to the release.
+ - 41 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 

--- a/gix-config-value/Cargo.toml
+++ b/gix-config-value/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-config-value"
-version = "0.19.0"
+version = "0.19.1"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project providing git-config value parsing"
@@ -19,7 +19,7 @@ doctest = true
 serde = ["dep:serde", "bstr/serde"]
 
 [dependencies]
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 
 thiserror = "2.0.18"
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }

--- a/gix-config/Cargo.toml
+++ b/gix-config/Cargo.toml
@@ -23,8 +23,8 @@ serde = ["dep:serde", "bstr/serde", "gix-sec/serde", "gix-ref/serde", "gix-glob/
 
 [dependencies]
 gix-features = { version = "^0.49.0", path = "../gix-features" }
-gix-config-value = { version = "^0.19.0", path = "../gix-config-value" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-config-value = { version = "^0.19.1", path = "../gix-config-value" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-sec = { version = "^0.14.2", path = "../gix-sec" }
 gix-ref = { version = "^0.66.0", path = "../gix-ref" }
 gix-glob = { version = "^0.27.0", path = "../gix-glob" }

--- a/gix-credentials/CHANGELOG.md
+++ b/gix-credentials/CHANGELOG.md
@@ -5,13 +5,169 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.39.1 (2026-08-03)
+
+### Bug Fixes
+
+ - <csr-id-e0655e29a49bbb1e028269c043b506988427da0e/> quote Git paths in credential helper shell commands
+   The problem was that it uses the exe-path unquoted in a script that it
+   had to create as it's one form of credential managers.
+ - <csr-id-85f10fcc96740eeb293b237d1300bf8aab428434/> use onfigured shell arguments in gix-command
+   <!-- agent -->
+   
+   Construct default shell invocations with gix_path::env::shell_command()
+   instead of rebuilding a Command from shell(). This preserves platform-specific
+   arguments, notably --posix for the Git for Windows bin/sh.exe shim, while
+   leaving caller-provided shells unchanged.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 6 commits contributed to the release over the course of 11 calendar days.
+ - 11 days passed between releases.
+ - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 1 unique issue was worked on: [#2844](https://github.com/GitoxideLabs/gitoxide/issues/2844)
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **[#2844](https://github.com/GitoxideLabs/gitoxide/issues/2844)**
+    - Quote Git paths in credential helper shell commands ([`e0655e2`](https://github.com/GitoxideLabs/gitoxide/commit/e0655e29a49bbb1e028269c043b506988427da0e))
+ * **Uncategorized**
+    - Verify credential helpers use decoded HTTP paths. ([`0334384`](https://github.com/GitoxideLabs/gitoxide/commit/033438491ef9c361ae50a4b82637e1cae9ef44a2))
+    - Merge pull request #2845 from GitoxideLabs/unqoted-sh-path ([`6c4619f`](https://github.com/GitoxideLabs/gitoxide/commit/6c4619f0cca713696c0bf8fd4585b9ca87c42a7c))
+    - Merge pull request #2820 from GitoxideLabs/agent/fix-windows-shell-posix-mode ([`5a88ee7`](https://github.com/GitoxideLabs/gitoxide/commit/5a88ee740f6e81db550d75b9b94875d0cb71ed37))
+    - Use onfigured shell arguments in gix-command ([`85f10fc`](https://github.com/GitoxideLabs/gitoxide/commit/85f10fcc96740eeb293b237d1300bf8aab428434))
+    - Merge pull request #2812 from GitoxideLabs/report-july ([`ae8845a`](https://github.com/GitoxideLabs/gitoxide/commit/ae8845a47c4c87e0996a119822106cf09036340b))
+</details>
+
+## 0.39.0 (2026-07-23)
+
+### Changed (BREAKING)
+
+ - <csr-id-582d7b56cc09cdafaa8db2fb34457f6970c39ce7/> adapt to lifetime-free configuration files in `gix-config`
+   Update repository configuration storage, snapshots, overrides, and caches
+   to use the self-contained `gix_config::File` representation. Configuration
+   can now move through repository initialization, cloning, and remote setup
+   without artificial input lifetimes or conversions to `'static`.
+   
+   - Return owned `BString`, `PathBuf`, `OsString`, and `FullName` values
+     from configuration-derived lookups.
+   - Simplify fallible optional access from `Option<Result<T, E>>` to
+     `Result<Option<T>, E>`, allowing errors to propagate naturally with
+     `?`.
+   - Accept common string and byte-string inputs through `AsBStr` in
+     configuration setters, converters, remote lookup, and remote saving.
+   - Remove widespread `Cow` construction, `into_owned()`, and redundant
+     cloning from configuration consumers.
+   - Preserve configuration-key context when converting owned values and
+     enriching validation errors.
+   
+   Adapt config-tree conversions for the new owned values and optional-result
+   shape, including booleans, integers, paths, URLs, refspecs, timeouts,
+   compression levels, and reference names.
+   
+   Return owned remote names, default remote names, branch tracking
+   references, and submodule paths so these results are independent of the
+   repository configuration borrow. Protocol feature values likewise use
+   owned strings.
+   
+   Update repository opening, initialization, cloning, remotes, filters,
+   status, submodules, and related tests to use the lifetime-free APIs.
+
+### New Features (BREAKING)
+
+ - <csr-id-020bbb694e0bf5305ea2759eeadba02930ac7480/> store configuration paths and parse values from strings
+   Remove the lifetime from gix_config_value::Path and store its bytes in a
+   BString. Path interpolation now returns an owned PathBuf, including for paths
+   that do not require expansion.
+   
+   Allow Boolean, Color, and Integer to parse UTF-8 string slices as well as
+   byte strings. Keep BStr as the canonical parser input and disambiguate BString
+   callers explicitly.
+ - <csr-id-ffa862d2c877e7ff9b0bdb6d368d5a5d63e29e71/> allow protocol protection to be configured
+
+### Bug Fixes (BREAKING)
+
+ - <csr-id-7d66c9fc1b8868919087329e517b77f142bacdae/> make `protect_protocol` part of `Context` so it's self-contained.
+   This returns many methods back to their original version, but it's still
+   a breaking change, but now once again less so.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 12 commits contributed to the release over the course of 8 calendar days.
+ - 8 days passed between releases.
+ - 4 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Release gix-trace v0.1.21, gix-validate v0.11.3, gix-path v0.12.3, gix-utils v0.3.5, gix-config-value v0.19.0, gix-prompt v0.16.0, gix-sec v0.14.2, gix-url v0.37.0, gix-credentials v0.39.0, safety bump 18 crates ([`f0ec710`](https://github.com/GitoxideLabs/gitoxide/commit/f0ec71076aa1cef3181b77946ee556a89c651b8e))
+    - Merge pull request #2734 from GitoxideLabs/url-parse-convenience ([`e7af50e`](https://github.com/GitoxideLabs/gitoxide/commit/e7af50ea6c686593ba627fcf79fdb228a1f29193))
+    - Adapt to changes in gix-url ([`271454b`](https://github.com/GitoxideLabs/gitoxide/commit/271454b5d544e2af2d17db454e72800dbc87acfe))
+    - Merge pull request #2722 from GitoxideLabs/reasons ([`c16b5a1`](https://github.com/GitoxideLabs/gitoxide/commit/c16b5a1892704b7c72a253bdd74a6848dd61032a))
+    - Replace lint allowances with expectations ([`43ff87a`](https://github.com/GitoxideLabs/gitoxide/commit/43ff87a73897b70313e3a58e7de82231be5b59ad))
+    - Merge pull request #2667 from GitoxideLabs/lifetime-free-config-parser ([`55b5158`](https://github.com/GitoxideLabs/gitoxide/commit/55b51580c2b018f9f35b4b865fe86a28a5c0ff84))
+    - Adapt to lifetime-free configuration files in `gix-config` ([`582d7b5`](https://github.com/GitoxideLabs/gitoxide/commit/582d7b56cc09cdafaa8db2fb34457f6970c39ce7))
+    - Store configuration paths and parse values from strings ([`020bbb6`](https://github.com/GitoxideLabs/gitoxide/commit/020bbb694e0bf5305ea2759eeadba02930ac7480))
+    - Merge pull request #2715 from GitoxideLabs/fixup-credentials ([`299d16b`](https://github.com/GitoxideLabs/gitoxide/commit/299d16b467d6ecbd74da71bc17d2b0b6cd62c109))
+    - Make `protect_protocol` part of `Context` so it's self-contained. ([`7d66c9f`](https://github.com/GitoxideLabs/gitoxide/commit/7d66c9fc1b8868919087329e517b77f142bacdae))
+    - Merge pull request #2714 from GitoxideLabs/fix-credentials-parsing ([`cf3053a`](https://github.com/GitoxideLabs/gitoxide/commit/cf3053a3c18e2de788cdaa9f41b5bd343bdc0091))
+    - Allow protocol protection to be configured ([`ffa862d`](https://github.com/GitoxideLabs/gitoxide/commit/ffa862d2c877e7ff9b0bdb6d368d5a5d63e29e71))
+</details>
+
+## 0.38.2 (2026-07-15)
+
+### Bug Fixes
+
+ - <csr-id-3a99e2572c281c9711fdee037eca79e8b3c5e858/> also reject carriage return when parsing credentials
+
+### Test
+
+ - <csr-id-a30d02fd95493947b4b93fd82a7d241fb6942069/> cover carriage returns in credential context values
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 6 commits contributed to the release.
+ - 50 days passed between releases.
+ - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Release gix-path v0.12.2, gix-error v0.2.5, gix-utils v0.3.4, gix-date v0.15.6, gix-url v0.36.2, gix-credentials v0.38.2 ([`27aec47`](https://github.com/GitoxideLabs/gitoxide/commit/27aec474c113cc885d44631b329454dc1ad0fed2))
+    - Cover carriage returns in credential context values ([`a30d02f`](https://github.com/GitoxideLabs/gitoxide/commit/a30d02fd95493947b4b93fd82a7d241fb6942069))
+    - Also reject carriage return when parsing credentials ([`3a99e25`](https://github.com/GitoxideLabs/gitoxide/commit/3a99e2572c281c9711fdee037eca79e8b3c5e858))
+    - Merge pull request #2686 from GitoxideLabs/try-redirect-re-auth ([`d8aeaac`](https://github.com/GitoxideLabs/gitoxide/commit/d8aeaac02e9e95315bc8b5bd2380e3465826e960))
+    - Adapt to changes in `gix-transport` ([`6a7a717`](https://github.com/GitoxideLabs/gitoxide/commit/6a7a71706d2d6691cd67837350c4859983978f38))
+    - Merge pull request #2618 from GitoxideLabs/report ([`f7d4f33`](https://github.com/GitoxideLabs/gitoxide/commit/f7d4f33b58503996ae90497b69ce4c3a757982ac))
+</details>
+
 ## 0.38.1 (2026-05-26)
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 8 commits contributed to the release over the course of 28 calendar days.
+ - 9 commits contributed to the release over the course of 28 calendar days.
  - 28 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -23,6 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-error v0.2.4, gix-date v0.15.4, gix-actor v0.41.1, gix-trace v0.1.20, gix-validate v0.11.2, gix-path v0.12.1, gix-utils v0.3.3, gix-features v0.48.1, gix-hash v0.25.1, gix-hashtable v0.15.1, gix-object v0.61.0, gix-glob v0.26.1, gix-quote v0.7.2, gix-attributes v0.33.1, gix-command v0.9.1, gix-packetline v0.21.4, gix-filter v0.31.0, gix-fs v0.21.2, gix-chunk v0.7.2, gix-commitgraph v0.37.1, gix-revwalk v0.32.0, gix-traverse v0.58.0, gix-worktree-stream v0.33.0, gix-archive v0.33.0, gix-bitmap v0.3.2, gix-tempfile v23.0.1, gix-lock v23.0.1, gix-index v0.52.0, gix-config-value v0.18.1, gix-pathspec v0.18.1, gix-ignore v0.21.1, gix-worktree v0.53.0, gix-imara-diff v0.2.2, gix-diff v0.64.0, gix-blame v0.14.0, gix-ref v0.64.0, gix-sec v0.14.1, gix-config v0.57.0, gix-prompt v0.15.1, gix-url v0.36.1, gix-credentials v0.38.1, gix-discover v0.52.0, gix-dir v0.26.0, gix-mailmap v0.33.1, gix-revision v0.46.0, gix-merge v0.17.0, gix-negotiate v0.32.0, gix-pack v0.71.0, gix-odb v0.81.0, gix-refspec v0.42.0, gix-shallow v0.12.1, gix-transport v0.57.1, gix-protocol v0.62.0, gix-status v0.31.0, gix-submodule v0.31.0, gix-worktree-state v0.31.0, gix v0.84.0, gix-fsck v0.22.0, gitoxide-core v0.58.0, gitoxide v0.54.0, safety bump 27 crates ([`10c58bb`](https://github.com/GitoxideLabs/gitoxide/commit/10c58bb56597d9335611da121aac21f9b09b6e5b))
     - Merge pull request #2607 from SarthakB11/fix/issue-1842 ([`faecc23`](https://github.com/GitoxideLabs/gitoxide/commit/faecc2373d4b82f0856edbfa964280ab2134b8a5))
     - Add tests for `$0` deriving from the actually-running shell ([`d62e33c`](https://github.com/GitoxideLabs/gitoxide/commit/d62e33c725d4a2a3415b9d31554d5fa39e0fed73))
     - Update downstream test assertions for sh $0 change ([`f6433ac`](https://github.com/GitoxideLabs/gitoxide/commit/f6433acf3ae34e2349dd970633ee428490aeff34))
@@ -40,7 +197,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 2 commits contributed to the release over the course of 2 calendar days.
- - 3 days passed between releases.
+ - 4 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -62,7 +219,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 8 commits contributed to the release over the course of 32 calendar days.
- - 32 days passed between releases.
+ - 33 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -90,6 +247,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release.
+ - 28 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -160,7 +318,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release over the course of 19 calendar days.
- - 19 days passed between releases.
+ - 20 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#2363](https://github.com/GitoxideLabs/gitoxide/issues/2363)
 
@@ -189,7 +347,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 8 commits contributed to the release over the course of 1 calendar day.
- - 1 day passed between releases.
+ - 2 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#2328](https://github.com/GitoxideLabs/gitoxide/issues/2328)
 
@@ -240,7 +398,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 1 commit contributed to the release.
- - 29 days passed between releases.
+ - 30 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -261,6 +419,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
+ - 30 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -357,7 +516,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 11 commits contributed to the release over the course of 79 calendar days.
- - 79 days passed between releases.
+ - 80 days passed between releases.
  - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#1998](https://github.com/GitoxideLabs/gitoxide/issues/1998)
 
@@ -389,6 +548,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -413,6 +573,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 7 commits contributed to the release.
+ - 21 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -441,6 +602,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 10 commits contributed to the release.
+ - 76 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -532,6 +694,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release.
+ - 33 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -637,7 +800,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
- - 1 day passed between releases.
+ - 2 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#1466](https://github.com/GitoxideLabs/gitoxide/issues/1466)
 
@@ -667,6 +830,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 13 commits contributed to the release.
+ - 131 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -753,7 +917,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release over the course of 4 calendar days.
- - 20 days passed between releases.
+ - 21 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -778,6 +942,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -802,7 +967,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
- - 22 days passed between releases.
+ - 23 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -839,6 +1004,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 14 commits contributed to the release.
+ - 55 days passed between releases.
  - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#1103](https://github.com/GitoxideLabs/gitoxide/issues/1103)
 
@@ -875,7 +1041,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 2 commits contributed to the release.
- - 17 days passed between releases.
+ - 18 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -953,7 +1119,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release over the course of 18 calendar days.
- - 30 days passed between releases.
+ - 31 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1009,7 +1175,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
- - 19 days passed between releases.
+ - 20 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1034,7 +1200,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
- - 6 days passed between releases.
+ - 7 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1059,7 +1225,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release over the course of 10 calendar days.
- - 15 days passed between releases.
+ - 16 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1116,6 +1282,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1148,6 +1315,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 7 commits contributed to the release.
+ - 47 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#814](https://github.com/GitoxideLabs/gitoxide/issues/814)
 
@@ -1237,7 +1405,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
- - 8 days passed between releases.
+ - 9 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 

--- a/gix-credentials/Cargo.toml
+++ b/gix-credentials/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-credentials"
-version = "0.39.0"
+version = "0.39.1"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project to interact with git credentials helpers"
@@ -20,11 +20,11 @@ serde = ["dep:serde", "bstr/serde", "gix-sec/serde"]
 
 [dependencies]
 gix-sec = { version = "^0.14.2", path = "../gix-sec" }
-gix-url = { version = "^0.37.0", path = "../gix-url" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-url = { version = "^0.37.1", path = "../gix-url" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-quote = { version = "^0.7.2", path = "../gix-quote" }
-gix-command = { version = "^0.9.1", path = "../gix-command" }
-gix-config-value = { version = "^0.19.0", path = "../gix-config-value" }
+gix-command = { version = "^0.9.2", path = "../gix-command" }
+gix-config-value = { version = "^0.19.1", path = "../gix-config-value" }
 gix-prompt = { version = "^0.16.0", path = "../gix-prompt" }
 gix-date = { version = "^0.15.6", path = "../gix-date" }
 gix-trace = { version = "^0.1.21", path = "../gix-trace" }

--- a/gix-credentials/tests/protocol/context.rs
+++ b/gix-credentials/tests/protocol/context.rs
@@ -74,6 +74,11 @@ mod destructure_url_in_place {
     }
 
     #[test]
+    fn http_path_is_decoded_when_used() {
+        assert_eq_parts("https://example.com/a%2Fb/", "https", None, "example.com", "a/b", true);
+    }
+
+    #[test]
     fn protocol_and_host_with_path_without_url_constructs_full_url() {
         let mut ctx = Context {
             protocol: Some("https".into()),

--- a/gix-diff/Cargo.toml
+++ b/gix-diff/Cargo.toml
@@ -59,8 +59,8 @@ gix-hash = { version = "^0.26.0", path = "../gix-hash" }
 gix-object = { version = "^0.63.0", path = "../gix-object" }
 gix-filter = { version = "^0.33.0", path = "../gix-filter", optional = true }
 gix-worktree = { version = "^0.55.0", path = "../gix-worktree", default-features = false, features = ["attributes"], optional = true }
-gix-command = { version = "^0.9.1", path = "../gix-command", optional = true }
-gix-path = { version = "^0.12.3", path = "../gix-path", optional = true }
+gix-command = { version = "^0.9.2", path = "../gix-command", optional = true }
+gix-path = { version = "^0.12.4", path = "../gix-path", optional = true }
 gix-fs = { version = "^0.22.0", path = "../gix-fs", optional = true }
 gix-tempfile = { version = "^24.0.0", path = "../gix-tempfile", optional = true }
 gix-trace = { version = "^0.1.21", path = "../gix-trace", optional = true }

--- a/gix-dir/Cargo.toml
+++ b/gix-dir/Cargo.toml
@@ -26,7 +26,7 @@ gix-trace = { version = "^0.1.21", path = "../gix-trace" }
 gix-index = { version = "^0.54.0", path = "../gix-index" }
 gix-discover = { version = "^0.54.0", path = "../gix-discover" }
 gix-fs = { version = "^0.22.0", path = "../gix-fs" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-pathspec = { version = "^0.19.0", path = "../gix-pathspec" }
 gix-worktree = { version = "^0.55.0", path = "../gix-worktree", default-features = false }
 gix-object = { version = "^0.63.0", path = "../gix-object" }

--- a/gix-discover/Cargo.toml
+++ b/gix-discover/Cargo.toml
@@ -22,7 +22,7 @@ sha256 = ["gix-ref/sha256"]
 
 [dependencies]
 gix-sec = { version = "^0.14.2", path = "../gix-sec" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-ref = { version = "^0.66.0", path = "../gix-ref" }
 gix-fs = { version = "^0.22.0", path = "../gix-fs" }
 

--- a/gix-filter/Cargo.toml
+++ b/gix-filter/Cargo.toml
@@ -43,10 +43,10 @@ test-helper = []
 gix-hash = { version = "^0.26.0", path = "../gix-hash" }
 gix-trace = { version = "^0.1.21", path = "../gix-trace" }
 gix-object = { version = "^0.63.0", path = "../gix-object" }
-gix-command = { version = "^0.9.1", path = "../gix-command" }
+gix-command = { version = "^0.9.2", path = "../gix-command" }
 gix-quote = { version = "^0.7.2", path = "../gix-quote" }
 gix-utils = { version = "^0.3.5", path = "../gix-utils" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-packetline = { version = "^0.22.0", path = "../gix-packetline", features = ["blocking-io"] }
 gix-attributes = { version = "^0.34.0", path = "../gix-attributes" }
 

--- a/gix-fs/Cargo.toml
+++ b/gix-fs/Cargo.toml
@@ -20,7 +20,7 @@ serde = ["dep:serde"]
 
 [dependencies]
 bstr = "1.12.0"
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-features = { version = "^0.49.0", path = "../gix-features", features = ["fs-read-dir"] }
 gix-utils = { version = "^0.3.5", path = "../gix-utils" }
 thiserror = "2.0.18"

--- a/gix-glob/Cargo.toml
+++ b/gix-glob/Cargo.toml
@@ -24,7 +24,7 @@ path = "./benches/wildmatch.rs"
 serde = ["dep:serde", "bstr/serde", "bitflags/serde"]
 
 [dependencies]
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-features = { version = "^0.49.0", path = "../gix-features" }
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 bitflags = "2"

--- a/gix-ignore/Cargo.toml
+++ b/gix-ignore/Cargo.toml
@@ -20,7 +20,7 @@ serde = ["dep:serde", "bstr/serde", "gix-glob/serde"]
 
 [dependencies]
 gix-glob = { version = "^0.27.0", path = "../gix-glob" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-trace = { version = "^0.1.21", path = "../gix-trace" }
 
 bstr = { version = "1.12.0", default-features = false, features = ["std", "unicode"] }

--- a/gix-merge/Cargo.toml
+++ b/gix-merge/Cargo.toml
@@ -28,8 +28,8 @@ gix-hash = { version = "^0.26.0", path = "../gix-hash" }
 gix-object = { version = "^0.63.0", path = "../gix-object" }
 gix-filter = { version = "^0.33.0", path = "../gix-filter" }
 gix-worktree = { version = "^0.55.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }
-gix-command = { version = "^0.9.1", path = "../gix-command" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-command = { version = "^0.9.2", path = "../gix-command" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-fs = { version = "^0.22.0", path = "../gix-fs" }
 gix-tempfile = { version = "^24.0.0", path = "../gix-tempfile" }
 gix-trace = { version = "^0.1.21", path = "../gix-trace" }

--- a/gix-odb/Cargo.toml
+++ b/gix-odb/Cargo.toml
@@ -30,7 +30,7 @@ gix-features = { version = "^0.49.0", path = "../gix-features", features = ["wal
 gix-zlib = { version = "^0.1.0", path = "../gix-zlib" }
 gix-hashtable = { version = "^0.16.0", path = "../gix-hashtable" }
 gix-hash = { version = "^0.26.0", path = "../gix-hash" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-quote = { version = "^0.7.2", path = "../gix-quote" }
 gix-object = { version = "^0.63.0", path = "../gix-object" }
 gix-pack = { version = "^0.73.0", path = "../gix-pack", default-features = false }

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -45,7 +45,7 @@ wasm = ["gix-diff?/wasm"]
 [dependencies]
 gix-features = { version = "^0.49.0", path = "../gix-features", features = ["crc32", "progress"] }
 gix-zlib = { version = "^0.1.0", path = "../gix-zlib" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-hash = { version = "^0.26.0", path = "../gix-hash" }
 gix-chunk = { version = "^0.7.3", path = "../gix-chunk" }
 gix-error = { version = "^0.2.5", path = "../gix-error" }

--- a/gix-path/CHANGELOG.md
+++ b/gix-path/CHANGELOG.md
@@ -5,13 +5,136 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.4 (2026-08-03)
+
+### Chore
+
+ - <csr-id-96efe08497c326eff2c710f92cd8b3ea2b87c3cb/> increase acceptable timeout for slow CI
+
+### New Features
+
+ - <csr-id-6560a5a871738979edc134d396fb53f67b7cb824/> add `normalize_saturating()`
+   That way, one can express another way with which Git handles worktrees.
+ - <csr-id-6125bc23c3655d6b9098e0da25ad6f653193c4be/> add `env::shell_command()` to get a Git shell.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 6 commits contributed to the release over the course of 11 calendar days.
+ - 11 days passed between releases.
+ - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Merge pull request #2841 from danielcadev/codex/fix-bare-git-work-tree-override ([`da71d06`](https://github.com/GitoxideLabs/gitoxide/commit/da71d065180674d6b45cd293fb576cba3ba0a238))
+    - Add `normalize_saturating()` ([`6560a5a`](https://github.com/GitoxideLabs/gitoxide/commit/6560a5a871738979edc134d396fb53f67b7cb824))
+    - Merge pull request #2820 from GitoxideLabs/agent/fix-windows-shell-posix-mode ([`5a88ee7`](https://github.com/GitoxideLabs/gitoxide/commit/5a88ee740f6e81db550d75b9b94875d0cb71ed37))
+    - Add `env::shell_command()` to get a Git shell. ([`6125bc2`](https://github.com/GitoxideLabs/gitoxide/commit/6125bc23c3655d6b9098e0da25ad6f653193c4be))
+    - Merge pull request #2812 from GitoxideLabs/report-july ([`ae8845a`](https://github.com/GitoxideLabs/gitoxide/commit/ae8845a47c4c87e0996a119822106cf09036340b))
+    - Increase acceptable timeout for slow CI ([`96efe08`](https://github.com/GitoxideLabs/gitoxide/commit/96efe08497c326eff2c710f92cd8b3ea2b87c3cb))
+</details>
+
+## 0.12.3 (2026-07-23)
+
+### New Features
+
+ - <csr-id-5e46d19acc5c1ae1525fa98c97bc43ab39ab8e52/> add `normalize_and_clean()`
+   While `normalize()` is optimised for keeping the look of paths the same,
+   the new function truly wants to normalize.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 6 commits contributed to the release over the course of 8 calendar days.
+ - 8 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Release gix-trace v0.1.21, gix-validate v0.11.3, gix-path v0.12.3, gix-utils v0.3.5, gix-config-value v0.19.0, gix-prompt v0.16.0, gix-sec v0.14.2, gix-url v0.37.0, gix-credentials v0.39.0, safety bump 18 crates ([`f0ec710`](https://github.com/GitoxideLabs/gitoxide/commit/f0ec71076aa1cef3181b77946ee556a89c651b8e))
+    - Merge pull request #2735 from GitoxideLabs/better-exclude-handling ([`02cb162`](https://github.com/GitoxideLabs/gitoxide/commit/02cb162e31fb7fed5f93d29c7447f68f690442df))
+    - Add `normalize_and_clean()` ([`5e46d19`](https://github.com/GitoxideLabs/gitoxide/commit/5e46d19acc5c1ae1525fa98c97bc43ab39ab8e52))
+    - Merge pull request #2722 from GitoxideLabs/reasons ([`c16b5a1`](https://github.com/GitoxideLabs/gitoxide/commit/c16b5a1892704b7c72a253bdd74a6848dd61032a))
+    - Replace lint allowances with expectations ([`43ff87a`](https://github.com/GitoxideLabs/gitoxide/commit/43ff87a73897b70313e3a58e7de82231be5b59ad))
+    - Merge pull request #2714 from GitoxideLabs/fix-credentials-parsing ([`cf3053a`](https://github.com/GitoxideLabs/gitoxide/commit/cf3053a3c18e2de788cdaa9f41b5bd343bdc0091))
+</details>
+
+## 0.12.2 (2026-07-15)
+
+### Bug Fixes
+
+ - <csr-id-82cdb47c7ac9853e48529b3d8341aa27e28b9df1/> local clones succeed even if git-upload-pack is not in PATH
+   Local clones spawn the service program, like git-upload-pack, by name and would
+   fail if it could not be found in PATH. This is common on Windows, where git can
+   be installed such that git itself is available but its subcommands are not, for
+   instance with scoop.
+   
+   Now, when spawning the service program for a local repository fails because it
+   cannot be found, find the same program in the directory that git --exec-path
+   reports - the location git itself uses to run its subcommands - and run it from
+   there. If it cannot be found there either, run the git binary that is always
+   findable with the service as its subcommand, which it can always dispatch.
+   
+   Remote transports are unaffected - they keep the standard invocation so servers
+   can provide their own implementations - and no shell is involved in any of this.
+   
+   The newly added gix_path::env::core_dir_program() provides the lookup and may
+   serve other Git-provided programs in the future.
+   
+   Git for Windows builds with SKIP_DASHED_BUILT_INS and thus does not provide
+   programs for builtin subcommands like git-upload-pack in its core directory.
+   The test now grounds itself in a listing of that directory instead, and the
+   documentation of core_dir_program() points out the difference - such programs
+   are still run through git itself thanks to the second fallback.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 8 commits contributed to the release.
+ - 50 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 1 unique issue was worked on: [#2313](https://github.com/GitoxideLabs/gitoxide/issues/2313)
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **[#2313](https://github.com/GitoxideLabs/gitoxide/issues/2313)**
+    - Local clones succeed even if git-upload-pack is not in PATH ([`82cdb47`](https://github.com/GitoxideLabs/gitoxide/commit/82cdb47c7ac9853e48529b3d8341aa27e28b9df1))
+ * **Uncategorized**
+    - Release gix-path v0.12.2, gix-error v0.2.5, gix-utils v0.3.4, gix-date v0.15.6, gix-url v0.36.2, gix-credentials v0.38.2 ([`27aec47`](https://github.com/GitoxideLabs/gitoxide/commit/27aec474c113cc885d44631b329454dc1ad0fed2))
+    - Merge pull request #2700 from ameyypawar/fix/2313-upload-pack-fallback ([`9884f48`](https://github.com/GitoxideLabs/gitoxide/commit/9884f48a957b9817b72d962224c80f22c5d0de49))
+    - Review ([`151a0af`](https://github.com/GitoxideLabs/gitoxide/commit/151a0af0468f0cf832b4f7e029041bfacf0b03f8))
+    - Merge pull request #2693 from Manishearth/relative-path-transparent ([`19bdf8a`](https://github.com/GitoxideLabs/gitoxide/commit/19bdf8a7d5aaf3b3b85b4add8936c05660f11a2a))
+    - Annotate RelativePath transmute types for clippy ([`7ef83ca`](https://github.com/GitoxideLabs/gitoxide/commit/7ef83ca42dad083d3391918bd994b234b8e42309))
+    - Actually mark RelativePath as transparent ([`d5f3723`](https://github.com/GitoxideLabs/gitoxide/commit/d5f3723ee958fae1098e1b7fbf55dd10c5a6e754))
+    - Merge pull request #2618 from GitoxideLabs/report ([`f7d4f33`](https://github.com/GitoxideLabs/gitoxide/commit/f7d4f33b58503996ae90497b69ce4c3a757982ac))
+</details>
+
 ## 0.12.1 (2026-05-26)
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 5 commits contributed to the release over the course of 28 calendar days.
+ - 6 commits contributed to the release over the course of 28 calendar days.
  - 28 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -23,6 +146,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-error v0.2.4, gix-date v0.15.4, gix-actor v0.41.1, gix-trace v0.1.20, gix-validate v0.11.2, gix-path v0.12.1, gix-utils v0.3.3, gix-features v0.48.1, gix-hash v0.25.1, gix-hashtable v0.15.1, gix-object v0.61.0, gix-glob v0.26.1, gix-quote v0.7.2, gix-attributes v0.33.1, gix-command v0.9.1, gix-packetline v0.21.4, gix-filter v0.31.0, gix-fs v0.21.2, gix-chunk v0.7.2, gix-commitgraph v0.37.1, gix-revwalk v0.32.0, gix-traverse v0.58.0, gix-worktree-stream v0.33.0, gix-archive v0.33.0, gix-bitmap v0.3.2, gix-tempfile v23.0.1, gix-lock v23.0.1, gix-index v0.52.0, gix-config-value v0.18.1, gix-pathspec v0.18.1, gix-ignore v0.21.1, gix-worktree v0.53.0, gix-imara-diff v0.2.2, gix-diff v0.64.0, gix-blame v0.14.0, gix-ref v0.64.0, gix-sec v0.14.1, gix-config v0.57.0, gix-prompt v0.15.1, gix-url v0.36.1, gix-credentials v0.38.1, gix-discover v0.52.0, gix-dir v0.26.0, gix-mailmap v0.33.1, gix-revision v0.46.0, gix-merge v0.17.0, gix-negotiate v0.32.0, gix-pack v0.71.0, gix-odb v0.81.0, gix-refspec v0.42.0, gix-shallow v0.12.1, gix-transport v0.57.1, gix-protocol v0.62.0, gix-status v0.31.0, gix-submodule v0.31.0, gix-worktree-state v0.31.0, gix v0.84.0, gix-fsck v0.22.0, gitoxide-core v0.58.0, gitoxide v0.54.0, safety bump 27 crates ([`10c58bb`](https://github.com/GitoxideLabs/gitoxide/commit/10c58bb56597d9335611da121aac21f9b09b6e5b))
     - Merge pull request #2568 from GitoxideLabs/dependabot/cargo/cargo-56d6b174d8 ([`ab2fee1`](https://github.com/GitoxideLabs/gitoxide/commit/ab2fee14651202fcb7b3d8178932090c73492014))
     - Update crates to Rust 2024 edition ([`2cb17b2`](https://github.com/GitoxideLabs/gitoxide/commit/2cb17b2e7f6009693a55af907614f705a29d8c29))
     - Remove rust_2018_idioms lint declarations ([`e10d5f6`](https://github.com/GitoxideLabs/gitoxide/commit/e10d5f662df2ee05f973a3167ad215a330ee74e1))
@@ -50,7 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release over the course of 2 calendar days.
- - 3 days passed between releases.
+ - 4 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -113,6 +237,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
+ - 40 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -160,7 +285,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 1 commit contributed to the release.
- - 60 days passed between releases.
+ - 61 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -185,6 +310,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
+ - 31 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#2234](https://github.com/GitoxideLabs/gitoxide/issues/2234)
 
@@ -444,7 +570,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 40 commits contributed to the release over the course of 79 calendar days.
- - 79 days passed between releases.
+ - 80 days passed between releases.
  - 6 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -533,7 +659,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release over the course of 65 calendar days.
- - 65 days passed between releases.
+ - 66 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#2074](https://github.com/GitoxideLabs/gitoxide/issues/2074)
 
@@ -593,6 +719,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -621,6 +748,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 13 commits contributed to the release.
+ - 21 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -820,6 +948,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 26 commits contributed to the release.
+ - 76 days passed between releases.
  - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -923,6 +1052,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release.
+ - 33 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1098,7 +1228,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 57 commits contributed to the release.
- - 14 days passed between releases.
+ - 15 days passed between releases.
  - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1218,7 +1348,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 36 commits contributed to the release.
- - 23 days passed between releases.
+ - 24 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1280,6 +1410,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 5 commits contributed to the release over the course of 3 calendar days.
+ - 102 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1404,7 +1535,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 7 commits contributed to the release over the course of 4 calendar days.
- - 20 days passed between releases.
+ - 21 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1433,6 +1564,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
+ - 1 day passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1458,7 +1590,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
- - 22 days passed between releases.
+ - 23 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1488,6 +1620,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release.
+ - 89 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#1103](https://github.com/GitoxideLabs/gitoxide/issues/1103)
 
@@ -1552,7 +1685,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release over the course of 12 calendar days.
- - 30 days passed between releases.
+ - 31 days passed between releases.
  - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1606,7 +1739,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
- - 6 days passed between releases.
+ - 7 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1636,7 +1769,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 8 commits contributed to the release over the course of 10 calendar days.
- - 15 days passed between releases.
+ - 16 days passed between releases.
  - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1700,6 +1833,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
+ - 1 day passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1778,6 +1912,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
+ - 38 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 

--- a/gix-path/Cargo.toml
+++ b/gix-path/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-path"
-version = "0.12.3"
+version = "0.12.4"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dealing paths and their conversions"

--- a/gix-pathspec/Cargo.toml
+++ b/gix-pathspec/Cargo.toml
@@ -20,9 +20,9 @@ parallel = ["gix-attributes/parallel"]
 
 [dependencies]
 gix-glob = { version = "^0.27.0", path = "../gix-glob" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-attributes = { version = "^0.34.0", path = "../gix-attributes" }
-gix-config-value = { version = "^0.19.0", path = "../gix-config-value" }
+gix-config-value = { version = "^0.19.1", path = "../gix-config-value" }
 
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 bitflags = "2"

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -75,7 +75,7 @@ required-features = ["async-client"]
 gix-features = { version = "^0.49.0", path = "../gix-features", features = [
     "progress",
 ] }
-gix-transport = { version = "^0.58.0", path = "../gix-transport" }
+gix-transport = { version = "^0.58.1", path = "../gix-transport" }
 gix-hash = { version = "^0.26.0", path = "../gix-hash" }
 gix-shallow = { version = "^0.13.0", path = "../gix-shallow" }
 gix-date = { version = "^0.15.6", path = "../gix-date" }
@@ -86,7 +86,7 @@ gix-trace = { version = "^0.1.21", path = "../gix-trace", optional = true }
 gix-negotiate = { version = "^0.34.0", path = "../gix-negotiate", optional = true }
 gix-object = { version = "^0.63.0", path = "../gix-object", optional = true }
 gix-revwalk = { version = "^0.34.0", path = "../gix-revwalk", optional = true }
-gix-credentials = { version = "^0.39.0", path = "../gix-credentials", optional = true }
+gix-credentials = { version = "^0.39.1", path = "../gix-credentials", optional = true }
 gix-refspec = { version = "^0.44.0", path = "../gix-refspec", optional = true }
 gix-lock = { version = "^24.0.0", path = "../gix-lock", optional = true }
 

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -28,7 +28,7 @@ parallel = ["gix-features/parallel"]
 [dependencies]
 gix-features = { version = "^0.49.0", path = "../gix-features", features = ["walkdir"] }
 gix-fs = { version = "^0.22.0", path = "../gix-fs" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-hash = { version = "^0.26.0", path = "../gix-hash" }
 gix-object = { version = "^0.63.0", path = "../gix-object" }
 gix-utils = { version = "^0.3.5", path = "../gix-utils" }

--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -29,7 +29,7 @@ gix-index = { version = "^0.54.0", path = "../gix-index" }
 gix-fs = { version = "^0.22.0", path = "../gix-fs" }
 gix-hash = { version = "^0.26.0", path = "../gix-hash" }
 gix-object = { version = "^0.63.0", path = "../gix-object" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-features = { version = "^0.49.0", path = "../gix-features", features = ["progress"] }
 gix-filter = { version = "^0.33.0", path = "../gix-filter" }
 gix-worktree = { version = "^0.55.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }

--- a/gix-submodule/Cargo.toml
+++ b/gix-submodule/Cargo.toml
@@ -24,8 +24,8 @@ sha256 = ["gix-refspec/sha256"]
 gix-pathspec = { version = "^0.19.0", path = "../gix-pathspec" }
 gix-refspec = { version = "^0.44.0", path = "../gix-refspec" }
 gix-config = { version = "^0.59.0", path = "../gix-config" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
-gix-url = { version = "^0.37.0", path = "../gix-url" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
+gix-url = { version = "^0.37.1", path = "../gix-url" }
 
 bstr = { version = "1.12.0", default-features = false }
 thiserror = "2.0.18"

--- a/gix-transport/CHANGELOG.md
+++ b/gix-transport/CHANGELOG.md
@@ -5,7 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.58.1 (2026-08-03)
+
+### Bug Fixes
+
+ - <csr-id-60850df267f902ef6b65e8211e6d40aeb45e1970/> preserve encoded HTTP paths across redirects.
+   <!-- agent -->
+   Resolve relative curl redirects against the original request URL spelling
+   so percent-encoded separators remain data instead of changing path segment
+   structure.
+ - <csr-id-156b53de2b7d93087aceee623965110a19750d37/> terminate URL authorities at query and fragment delimiters.
+   <!-- agent -->
+   gix-url treated everything before the first slash as the authority, so a
+   query or fragment could change the parsed host and make gix-transport retain
+   an identity across an actual authority change.
+   
+   End the authority at slash, query, or fragment delimiters, and cover both the
+   parser result and redirect identity decision. This addresses
+   GHSA-jrcm-326h-gpp8 without changing how the remainder is stored in the path.
+   
+   Git baseline: git url-parse at da5fa735905c97b9454542bcaba848bcdeac760d
+   reports the host before either delimiter.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 3 commits contributed to the release over the course of 11 calendar days.
+ - 11 days passed between releases.
+ - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Preserve encoded HTTP paths across redirects. ([`60850df`](https://github.com/GitoxideLabs/gitoxide/commit/60850df267f902ef6b65e8211e6d40aeb45e1970))
+    - Terminate URL authorities at query and fragment delimiters. ([`156b53d`](https://github.com/GitoxideLabs/gitoxide/commit/156b53de2b7d93087aceee623965110a19750d37))
+    - Merge pull request #2812 from GitoxideLabs/report-july ([`ae8845a`](https://github.com/GitoxideLabs/gitoxide/commit/ae8845a47c4c87e0996a119822106cf09036340b))
+</details>
+
+## 0.58.0 (2026-07-23)
 
 ### New Features
 
@@ -44,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 20 commits contributed to the release.
+ - 22 commits contributed to the release.
  - 31 days passed between releases.
  - 4 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#2685](https://github.com/GitoxideLabs/gitoxide/issues/2685)
@@ -58,6 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * **[#2685](https://github.com/GitoxideLabs/gitoxide/issues/2685)**
     - Re-authenticate smart HTTP redirects ([`ac26491`](https://github.com/GitoxideLabs/gitoxide/commit/ac264913e55fa10b2237820ef5ee61aeb50467c7))
  * **Uncategorized**
+    - Release gix-actor v0.41.2, gix-features v0.49.0, gix-hash v0.26.0, gix-hashtable v0.16.0, gix-object v0.63.0, gix-glob v0.27.0, gix-attributes v0.34.0, gix-packetline v0.22.0, gix-filter v0.33.0, gix-fs v0.22.0, gix-chunk v0.7.3, gix-commitgraph v0.38.0, gix-revwalk v0.34.0, gix-traverse v0.60.0, gix-worktree-stream v0.35.0, gix-archive v0.35.0, gix-bitmap v0.3.3, gix-tempfile v24.0.0, gix-lock v24.0.0, gix-index v0.54.0, gix-pathspec v0.19.0, gix-ignore v0.22.0, gix-worktree v0.55.0, gix-imara-diff v0.2.4, gix-diff v0.66.0, gix-blame v0.16.0, gix-ref v0.66.0, gix-config v0.59.0, gix-discover v0.54.0, gix-dir v0.28.0, gix-mailmap v0.33.2, gix-revision v0.48.0, gix-merge v0.19.0, gix-negotiate v0.34.0, gix-zlib v0.1.0, gix-pack v0.73.0, gix-odb v0.83.0, gix-refspec v0.44.0, gix-shallow v0.13.0, gix-transport v0.58.0, gix-protocol v0.64.0, gix-status v0.33.0, gix-submodule v0.33.0, gix-worktree-state v0.33.0, gix v0.86.0, gix-fsck v0.24.0, gitoxide-core v0.60.0, gix-tix v0.1.0, gitoxide v0.56.0, safety bump 40 crates ([`842bc44`](https://github.com/GitoxideLabs/gitoxide/commit/842bc447e3aeacf5d9d36f7f8a01068eda4b7999))
+    - Update changelogs prior to release ([`cb6ec7d`](https://github.com/GitoxideLabs/gitoxide/commit/cb6ec7dce283943d811b1600b577f586d7a13e1f))
     - Release gix-trace v0.1.21, gix-validate v0.11.3, gix-path v0.12.3, gix-utils v0.3.5, gix-config-value v0.19.0, gix-prompt v0.16.0, gix-sec v0.14.2, gix-url v0.37.0, gix-credentials v0.39.0, safety bump 18 crates ([`f0ec710`](https://github.com/GitoxideLabs/gitoxide/commit/f0ec71076aa1cef3181b77946ee556a89c651b8e))
     - Merge pull request #2734 from GitoxideLabs/url-parse-convenience ([`e7af50e`](https://github.com/GitoxideLabs/gitoxide/commit/e7af50ea6c686593ba627fcf79fdb228a1f29193))
     - Adapt to changes in gix-url ([`271454b`](https://github.com/GitoxideLabs/gitoxide/commit/271454b5d544e2af2d17db454e72800dbc87acfe))

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-transport"
-version = "0.58.0"
+version = "0.58.1"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project dedicated to implementing the git transport layer"
@@ -91,13 +91,13 @@ path = "tests/async-transport.rs"
 required-features = ["async-client"]
 
 [dependencies]
-gix-command = { version = "^0.9.1", path = "../gix-command" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-command = { version = "^0.9.2", path = "../gix-command" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-features = { version = "^0.49.0", path = "../gix-features" }
-gix-url = { version = "^0.37.0", path = "../gix-url" }
+gix-url = { version = "^0.37.1", path = "../gix-url" }
 gix-sec = { version = "^0.14.2", path = "../gix-sec" }
 gix-packetline = { version = "^0.22.0", path = "../gix-packetline" }
-gix-credentials = { version = "^0.39.0", path = "../gix-credentials", optional = true }
+gix-credentials = { version = "^0.39.1", path = "../gix-credentials", optional = true }
 gix-quote = { version = "^0.7.2", path = "../gix-quote" }
 
 serde = { version = "1.0.114", optional = true, default-features = false, features = [

--- a/gix-transport/src/client/blocking_io/http/curl/remote.rs
+++ b/gix-transport/src/client/blocking_io/http/curl/remote.rs
@@ -153,7 +153,7 @@ fn absolute_location(request_url: &str, location: &str) -> Option<String> {
         out.push(':');
         out.push_str(&port.to_string());
     }
-    let request_path = request_url.path.to_str().ok()?;
+    let request_path = request_url.original_path().to_str().ok()?;
     out.push_str(&resolve_location_path(request_path, location));
     Some(out)
 }
@@ -664,6 +664,30 @@ mod absolute_location_tests {
             absolute_location(REQUEST_URL, "?service=git-receive-pack"),
             Some("http://example.com:8080/original/repo/info/refs?service=git-receive-pack".to_owned()),
             "query-only Location values replace the query while preserving the current request path"
+        );
+    }
+
+    #[test]
+    fn keeps_percent_encoded_separators_in_relative_locations() {
+        assert_eq!(
+            absolute_location(
+                "http://example.com/a%2Fb/info/refs?service=git-upload-pack",
+                "../objects/info/packs"
+            ),
+            Some("http://example.com/a%2Fb/objects/info/packs".to_owned()),
+            "relative redirects resolve against the encoded request path"
+        );
+    }
+
+    #[test]
+    fn keeps_percent_encoded_non_separators_in_relative_locations() {
+        assert_eq!(
+            absolute_location(
+                "http://example.com/a%20b/info/refs?service=git-upload-pack",
+                "../objects/info/packs"
+            ),
+            Some("http://example.com/a%20b/objects/info/packs".to_owned()),
+            "relative redirects use the original encoded request path"
         );
     }
 }

--- a/gix-transport/src/client/blocking_io/http/redirect.rs
+++ b/gix-transport/src/client/blocking_io/http/redirect.rs
@@ -185,6 +185,15 @@ mod tests {
             !can_reuse_identity("https://original:444/b", "http://original/a"),
             "upgrading the scheme does not allow changing the port"
         );
+        for delimiter in ['?', '#'] {
+            assert!(
+                !can_reuse_identity(
+                    &format!("https://redirected.org{delimiter}@original/b"),
+                    "https://original/a"
+                ),
+                "an authority terminated by {delimiter} must not reuse another host's identity"
+            );
+        }
     }
 
     #[test]

--- a/gix-url/CHANGELOG.md
+++ b/gix-url/CHANGELOG.md
@@ -5,13 +5,181 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.37.1 (2026-08-03)
+
+### New Features
+
+ - <csr-id-57a13cfe401669edbf71ab110eb89b607b42a30f/> add `Url::original_path()`
+   <!-- agent -->
+   Retain the original spelling of every percent-escaped parsed path and expose
+   it through Url::original_path(). Fall back to the decoded public path after
+   construction or mutation so consumers can use one read-only accessor safely.
+
+### Bug Fixes
+
+ - <csr-id-4b62822bf56f8eff8886ed39c00ba1177db615a3/> match Git URL parsing edge cases.
+   <!-- agent -->
+   Expand the URL baseline with Git-observed authority, port, IPv6, file, and
+   percent-encoding forms. Match Git’s scheme-specific delimiters and permissive
+   SSH authority behavior, retain escaped paths across serialization, and align
+   public docs with the actual parsing and serialization contracts.
+ - <csr-id-5c01fc9cfc01bee0a7396c0660071f4bc1cb99da/> accept scoped IPv6 URL literals.
+   <!-- agent -->
+   Validate RFC 6874 IPv6 addresses and zone identifiers separately, decode scoped
+   hosts for SSH invocation, and restore bracketed percent-encoded form during URL
+   serialization. Add the scoped form to the Git-generated compatibility baseline.
+ - <csr-id-7ea6c37981e9c0b732f0b97cabad38deb6a6a919/> keep parsed HTTP paths decoded.
+   <!-- agent -->
+   Retain the encoded HTTP path privately for lossless request serialization while
+   exposing the fully decoded public path used by credential consumers. Migrate legacy
+   serde values and extend the Git-derived credential baseline with reserved escapes.
+ - <csr-id-93c5398e1d9050cab30c21bffe4780d14b7ea2fc/> measure URL authorities after the scheme separator.
+   <!-- agent -->
+   Count only bytes after :// when a URL has no path, so the documented 1024-byte
+   authority limit accepts exactly 1024 bytes and still rejects 1025.
+ - <csr-id-97dce26f31f91077827d3a4caca0a5af536ad845/> validate URL schemes and percent escapes.
+   <!-- agent -->
+   Apply RFC 3986 grammar before decoding: schemes must begin with an ASCII letter
+   and every percent sign must introduce two hexadecimal digits. This prevents
+   malformed inputs from being accepted and rewritten during serialization.
+ - <csr-id-23559057b1ad6db03714f16aa7ba9bde041f55c8/> preserve percent-encoded URL path delimiters.
+   <!-- agent -->
+   Parse URL components before decoding reserved octets so encoded slashes,
+   queries, fragments, and other RFC 3986 delimiters cannot become structure. Keep
+   valid escapes intact during HTTP URL serialization, including nested percent
+   escapes.
+ - <csr-id-79b4c613de30da93108ca948e36d732920dc91e6/> reject malformed URL authorities.
+   <!-- agent -->
+   Fail closed when GHSA-jrcm-326h-gpp8 redirect authority checks receive syntax
+   that RFC 3986 and HTTP clients interpret differently. Reject backslashes,
+   non-ASCII reg-names, malformed ports, malformed IPv6 literals, and unbracketed
+   IPv6 before host identity is trusted.
+ - <csr-id-156b53de2b7d93087aceee623965110a19750d37/> terminate URL authorities at query and fragment delimiters.
+   <!-- agent -->
+   gix-url treated everything before the first slash as the authority, so a
+   query or fragment could change the parsed host and make gix-transport retain
+   an identity across an actual authority change.
+   
+   End the authority at slash, query, or fragment delimiters, and cover both the
+   parser result and redirect identity decision. This addresses
+   GHSA-jrcm-326h-gpp8 without changing how the remainder is stored in the path.
+   
+   Git baseline: git url-parse at da5fa735905c97b9454542bcaba848bcdeac760d
+   reports the host before either delimiter.
+ - <csr-id-4a6834de50298d3e23beab3a529f70cb72323c27/> preserve colons in URL usernames
+   <!-- agent -->
+   
+   Percent-decoded colons in usernames were serialized literally, causing the
+   parser to reinterpret the suffix as a password. The regression test shows
+   that an HTTP username containing a colon did not survive serialization and
+   reparsing.
+   
+   Encode colons specifically in the username while retaining the existing
+   userinfo encoding for passwords, where colons are data.
+   
+   Git baseline: credential.c at a23bace963d508bd96983cc637131392d3face18
+   uses the first literal colon as the user/password boundary and percent-decodes
+   the resulting fields.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 13 commits contributed to the release over the course of 11 calendar days.
+ - 11 days passed between releases.
+ - 10 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 1 unique issue was worked on: [#2827](https://github.com/GitoxideLabs/gitoxide/issues/2827)
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **[#2827](https://github.com/GitoxideLabs/gitoxide/issues/2827)**
+    - Preserve colons in URL usernames ([`4a6834d`](https://github.com/GitoxideLabs/gitoxide/commit/4a6834de50298d3e23beab3a529f70cb72323c27))
+ * **Uncategorized**
+    - Review ([`84826ba`](https://github.com/GitoxideLabs/gitoxide/commit/84826baab4d6311ec502da18597931cc3a3fa404))
+    - Add `Url::original_path()` ([`57a13cf`](https://github.com/GitoxideLabs/gitoxide/commit/57a13cfe401669edbf71ab110eb89b607b42a30f))
+    - Match Git URL parsing edge cases. ([`4b62822`](https://github.com/GitoxideLabs/gitoxide/commit/4b62822bf56f8eff8886ed39c00ba1177db615a3))
+    - Accept scoped IPv6 URL literals. ([`5c01fc9`](https://github.com/GitoxideLabs/gitoxide/commit/5c01fc9cfc01bee0a7396c0660071f4bc1cb99da))
+    - Keep parsed HTTP paths decoded. ([`7ea6c37`](https://github.com/GitoxideLabs/gitoxide/commit/7ea6c37981e9c0b732f0b97cabad38deb6a6a919))
+    - Measure URL authorities after the scheme separator. ([`93c5398`](https://github.com/GitoxideLabs/gitoxide/commit/93c5398e1d9050cab30c21bffe4780d14b7ea2fc))
+    - Validate URL schemes and percent escapes. ([`97dce26`](https://github.com/GitoxideLabs/gitoxide/commit/97dce26f31f91077827d3a4caca0a5af536ad845))
+    - Preserve percent-encoded URL path delimiters. ([`2355905`](https://github.com/GitoxideLabs/gitoxide/commit/23559057b1ad6db03714f16aa7ba9bde041f55c8))
+    - Reject malformed URL authorities. ([`79b4c61`](https://github.com/GitoxideLabs/gitoxide/commit/79b4c613de30da93108ca948e36d732920dc91e6))
+    - Terminate URL authorities at query and fragment delimiters. ([`156b53d`](https://github.com/GitoxideLabs/gitoxide/commit/156b53de2b7d93087aceee623965110a19750d37))
+    - Merge pull request #2828 from GitoxideLabs/user-colon-tobstring ([`45ec08d`](https://github.com/GitoxideLabs/gitoxide/commit/45ec08d150f81894d945b5163bf84fd7e284ef41))
+    - Merge pull request #2812 from GitoxideLabs/report-july ([`ae8845a`](https://github.com/GitoxideLabs/gitoxide/commit/ae8845a47c4c87e0996a119822106cf09036340b))
+</details>
+
+## 0.37.0 (2026-07-23)
+
+### New Features (BREAKING)
+
+ - <csr-id-8bc70058ca6e94cc04c0e4db4140a883b0719e7e/> more convenient calling of `parse()`.
+   Possibly breaking, as calling code might now be ambiguous until fixed.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 6 commits contributed to the release over the course of 8 calendar days.
+ - 8 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Release gix-trace v0.1.21, gix-validate v0.11.3, gix-path v0.12.3, gix-utils v0.3.5, gix-config-value v0.19.0, gix-prompt v0.16.0, gix-sec v0.14.2, gix-url v0.37.0, gix-credentials v0.39.0, safety bump 18 crates ([`f0ec710`](https://github.com/GitoxideLabs/gitoxide/commit/f0ec71076aa1cef3181b77946ee556a89c651b8e))
+    - Merge pull request #2734 from GitoxideLabs/url-parse-convenience ([`e7af50e`](https://github.com/GitoxideLabs/gitoxide/commit/e7af50ea6c686593ba627fcf79fdb228a1f29193))
+    - More convenient calling of `parse()`. ([`8bc7005`](https://github.com/GitoxideLabs/gitoxide/commit/8bc70058ca6e94cc04c0e4db4140a883b0719e7e))
+    - Merge pull request #2722 from GitoxideLabs/reasons ([`c16b5a1`](https://github.com/GitoxideLabs/gitoxide/commit/c16b5a1892704b7c72a253bdd74a6848dd61032a))
+    - Replace lint allowances with expectations ([`43ff87a`](https://github.com/GitoxideLabs/gitoxide/commit/43ff87a73897b70313e3a58e7de82231be5b59ad))
+    - Merge pull request #2714 from GitoxideLabs/fix-credentials-parsing ([`cf3053a`](https://github.com/GitoxideLabs/gitoxide/commit/cf3053a3c18e2de788cdaa9f41b5bd343bdc0091))
+</details>
+
+## 0.36.2 (2026-07-15)
+
+### Other
+
+ - <csr-id-5d318ad7c70107f0ca5626b6083da89701acd47b/> Document lossy SCP-like SSH URL canonicalization
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 4 commits contributed to the release.
+ - 50 days passed between releases.
+ - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
+ - 1 unique issue was worked on: [#2467](https://github.com/GitoxideLabs/gitoxide/issues/2467)
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **[#2467](https://github.com/GitoxideLabs/gitoxide/issues/2467)**
+    - Document lossy SCP-like SSH URL canonicalization ([`5d318ad`](https://github.com/GitoxideLabs/gitoxide/commit/5d318ad7c70107f0ca5626b6083da89701acd47b))
+ * **Uncategorized**
+    - Release gix-path v0.12.2, gix-error v0.2.5, gix-utils v0.3.4, gix-date v0.15.6, gix-url v0.36.2, gix-credentials v0.38.2 ([`27aec47`](https://github.com/GitoxideLabs/gitoxide/commit/27aec474c113cc885d44631b329454dc1ad0fed2))
+    - Merge pull request #2681 from GitoxideLabs/lossy-url-conversion ([`b893e01`](https://github.com/GitoxideLabs/gitoxide/commit/b893e014d1c94152d60970caa4b699b2a5dceb11))
+    - Merge pull request #2618 from GitoxideLabs/report ([`f7d4f33`](https://github.com/GitoxideLabs/gitoxide/commit/f7d4f33b58503996ae90497b69ce4c3a757982ac))
+</details>
+
 ## 0.36.1 (2026-05-26)
 
 ### Commit Statistics
 
 <csr-read-only-do-not-edit/>
 
- - 8 commits contributed to the release over the course of 28 calendar days.
+ - 9 commits contributed to the release over the course of 28 calendar days.
  - 28 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -23,6 +191,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-error v0.2.4, gix-date v0.15.4, gix-actor v0.41.1, gix-trace v0.1.20, gix-validate v0.11.2, gix-path v0.12.1, gix-utils v0.3.3, gix-features v0.48.1, gix-hash v0.25.1, gix-hashtable v0.15.1, gix-object v0.61.0, gix-glob v0.26.1, gix-quote v0.7.2, gix-attributes v0.33.1, gix-command v0.9.1, gix-packetline v0.21.4, gix-filter v0.31.0, gix-fs v0.21.2, gix-chunk v0.7.2, gix-commitgraph v0.37.1, gix-revwalk v0.32.0, gix-traverse v0.58.0, gix-worktree-stream v0.33.0, gix-archive v0.33.0, gix-bitmap v0.3.2, gix-tempfile v23.0.1, gix-lock v23.0.1, gix-index v0.52.0, gix-config-value v0.18.1, gix-pathspec v0.18.1, gix-ignore v0.21.1, gix-worktree v0.53.0, gix-imara-diff v0.2.2, gix-diff v0.64.0, gix-blame v0.14.0, gix-ref v0.64.0, gix-sec v0.14.1, gix-config v0.57.0, gix-prompt v0.15.1, gix-url v0.36.1, gix-credentials v0.38.1, gix-discover v0.52.0, gix-dir v0.26.0, gix-mailmap v0.33.1, gix-revision v0.46.0, gix-merge v0.17.0, gix-negotiate v0.32.0, gix-pack v0.71.0, gix-odb v0.81.0, gix-refspec v0.42.0, gix-shallow v0.12.1, gix-transport v0.57.1, gix-protocol v0.62.0, gix-status v0.31.0, gix-submodule v0.31.0, gix-worktree-state v0.31.0, gix v0.84.0, gix-fsck v0.22.0, gitoxide-core v0.58.0, gitoxide v0.54.0, safety bump 27 crates ([`10c58bb`](https://github.com/GitoxideLabs/gitoxide/commit/10c58bb56597d9335611da121aac21f9b09b6e5b))
     - Merge pull request #2575 from SarthakB11/fix/issue-2316 ([`4743361`](https://github.com/GitoxideLabs/gitoxide/commit/4743361e69238245b77f5687620b20652e62a23c))
     - Review ([`1980190`](https://github.com/GitoxideLabs/gitoxide/commit/19801900fdce7b7db3ab4da9866c44d7fea5598e))
     - Document why each fixture archive is .gitignored ([`e3d5a04`](https://github.com/GitoxideLabs/gitoxide/commit/e3d5a0474574dbb546a61eefc91a03c2df72df74))
@@ -40,7 +209,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 2 commits contributed to the release over the course of 2 calendar days.
- - 3 days passed between releases.
+ - 4 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -66,6 +235,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release.
+ - 61 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -156,7 +326,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 15 commits contributed to the release over the course of 30 calendar days.
- - 30 days passed between releases.
+ - 31 days passed between releases.
  - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 2 unique issues were worked on: [#2355](https://github.com/GitoxideLabs/gitoxide/issues/2355), [#2363](https://github.com/GitoxideLabs/gitoxide/issues/2363)
 
@@ -197,7 +367,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 9 commits contributed to the release over the course of 20 calendar days.
- - 29 days passed between releases.
+ - 30 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -231,6 +401,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release.
+ - 30 days passed between releases.
  - 2 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -326,7 +497,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 8 commits contributed to the release over the course of 79 calendar days.
- - 79 days passed between releases.
+ - 80 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#2056](https://github.com/GitoxideLabs/gitoxide/issues/2056)
 
@@ -355,6 +526,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -379,6 +551,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 15 commits contributed to the release.
+ - 21 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#1962](https://github.com/GitoxideLabs/gitoxide/issues/1962)
 
@@ -416,6 +589,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 10 commits contributed to the release.
+ - 76 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -510,6 +684,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 8 commits contributed to the release.
+ - 33 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -692,6 +867,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 14 commits contributed to the release.
+ - 30 days passed between releases.
  - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -785,7 +961,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 8 commits contributed to the release over the course of 17 calendar days.
- - 20 days passed between releases.
+ - 21 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -815,6 +991,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
+ - 1 day passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -840,7 +1017,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 13 commits contributed to the release over the course of 19 calendar days.
- - 22 days passed between releases.
+ - 23 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -880,6 +1057,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 16 commits contributed to the release.
+ - 53 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 2 unique issues were worked on: [#1082](https://github.com/GitoxideLabs/gitoxide/issues/1082), [#1119](https://github.com/GitoxideLabs/gitoxide/issues/1119)
 
@@ -921,7 +1099,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 4 commits contributed to the release.
- - 1 day passed between releases.
+ - 2 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#1063](https://github.com/GitoxideLabs/gitoxide/issues/1063)
 
@@ -967,7 +1145,7 @@ open a new issue to help us making Gitoxide even more correct.
 <csr-read-only-do-not-edit/>
 
  - 19 commits contributed to the release over the course of 17 calendar days.
- - 17 days passed between releases.
+ - 18 days passed between releases.
  - 3 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1116,7 +1294,7 @@ open a new issue to help us making Gitoxide even more correct.
 <csr-read-only-do-not-edit/>
 
  - 28 commits contributed to the release over the course of 17 calendar days.
- - 30 days passed between releases.
+ - 31 days passed between releases.
  - 5 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1194,7 +1372,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
- - 19 days passed between releases.
+ - 20 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1219,7 +1397,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
- - 6 days passed between releases.
+ - 7 days passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1244,7 +1422,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release over the course of 10 calendar days.
- - 15 days passed between releases.
+ - 16 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1301,6 +1479,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 3 commits contributed to the release.
+ - 1 day passed between releases.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -1333,6 +1512,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 7 commits contributed to the release.
+ - 47 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 1 unique issue was worked on: [#814](https://github.com/GitoxideLabs/gitoxide/issues/814)
 
@@ -1422,7 +1602,7 @@ A maintenance release without user-facing changes.
 <csr-read-only-do-not-edit/>
 
  - 6 commits contributed to the release over the course of 2 calendar days.
- - 8 days passed between releases.
+ - 9 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-url"
-version = "0.37.0"
+version = "0.37.1"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing parsing and serialization of gix-url"
@@ -19,7 +19,7 @@ doctest = true
 serde = ["dep:serde", "bstr/serde"]
 
 [dependencies]
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-utils = { version = "^0.3.5", path = "../gix-utils", features = ["bstr"] }
 
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["std", "derive"] }

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -32,6 +32,7 @@ document-features = { version = "0.2.0", optional = true }
 [dev-dependencies]
 assert_matches = "1.5.0"
 gix-testtools = { path = "../tests/tools" }
+serde_json = "1.0.150"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gix-url/src/expand_path.rs
+++ b/gix-url/src/expand_path.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use bstr::{BStr, BString, ByteSlice};
 
-/// Whether a repository is resolving for the current user, or the given one.
+/// The user whose home directory a repository path refers to.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ForUser {
@@ -43,8 +43,10 @@ fn path_segments(path: &BStr) -> Option<impl Iterator<Item = &[u8]>> {
 /// Parse user information from the given `path`, returning `(possible user information, adjusted input path)`.
 ///
 /// Supported formats for user extraction are…
-/// * `~/repopath` - the currently logged in user's home.
-/// * `~user/repopath` - the repository in the given user's home.
+/// * `/~/repopath` - the currently logged-in user's home, returning `/repopath`.
+/// * `/~user/repopath` - the named user's home, returning `/repopath`.
+///
+/// Paths without a leading slash or home marker are returned unchanged without user information.
 pub fn parse(path: &BStr) -> Result<(Option<ForUser>, BString), Error> {
     Ok(path_segments(path)
         .and_then(|mut iter| {
@@ -71,7 +73,9 @@ pub fn parse(path: &BStr) -> Result<(Option<ForUser>, BString), Error> {
         .unwrap_or_else(|| (None, path.into())))
 }
 
-/// Expand `path` for use in a shell and return the expanded path.
+/// Convert a leading URL-style `/~/` or `/~user/` path into shell-style `~/` or `~user/` syntax.
+///
+/// Other paths are returned unchanged.
 pub fn for_shell(path: BString) -> BString {
     use bstr::ByteVec;
     match parse(path.as_slice().as_bstr()) {
@@ -91,9 +95,13 @@ pub fn for_shell(path: BString) -> BString {
     }
 }
 
-/// Expand `path` for the given `user`, which can be obtained by [`parse()`], resolving them with `home_for_user(&user)`.
+/// Expand `path` for the given `user`, which can be obtained with [`parse()`], resolving the home directory with
+/// `home_for_user(&user)`.
 ///
-/// For the common case consider using [`expand_path()]` instead.
+/// When `user` is present, `path` must be the slash-prefixed adjusted path returned by [`parse()`]; it is joined below
+/// the resolved home directory. With no user, `path` is returned as a platform path without home expansion.
+///
+/// For the common case consider using [`crate::expand_path()`] instead.
 pub fn with(
     user: Option<&ForUser>,
     path: &BStr,

--- a/gix-url/src/impls.rs
+++ b/gix-url/src/impls.rs
@@ -14,6 +14,7 @@ impl Default for Url {
             host: None,
             port: None,
             path: bstr::BString::default(),
+            path_with_percent_escapes: None,
         }
     }
 }

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -39,25 +39,28 @@ const HTTP_PATH_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CON
     .add(b'{')
     .add(b'}');
 
-///
+/// User-home expansion for repository paths.
 pub mod expand_path;
 
 mod scheme;
 pub use scheme::Scheme;
 mod impls;
 
-///
+/// Parsing errors and input classifications.
 pub mod parse;
 
 /// Minimal URL parser to replace the `url` crate dependency
 mod simple_url;
 
-/// Parse the given `bytes` as a [git url](Url).
+/// Parse a Git remote location from `input`.
 ///
-/// # Note
+/// This accepts standard URLs, SCP-like SSH locations, and local paths. URL and SCP-like inputs must be UTF-8;
+/// local paths retain arbitrary bytes.
 ///
-/// We cannot and should never have to deal with UTF-16 encoded windows strings, so bytes input is acceptable.
-/// For file-paths, we don't expect UTF8 encoding either.
+/// # Deviation
+///
+/// Unlike Git, this rejects textual and overflowing ports in SSH and Git URLs. Git treats such port text as part of
+/// the hostname, which hides the malformed port and causes a less useful hostname-resolution error later.
 pub fn parse(input: impl AsBStr) -> Result<Url, parse::Error> {
     use parse::InputScheme;
     let input = input.as_bstr();
@@ -71,8 +74,8 @@ pub fn parse(input: impl AsBStr) -> Result<Url, parse::Error> {
     }
 }
 
-/// Expand `path` for the given `user`, which can be obtained by [`parse()`], resolving the home directories
-/// of `user` automatically.
+/// Expand `path` for the given `user`, which can be obtained from [`expand_path::parse()`], resolving the home
+/// directory automatically.
 ///
 /// If more precise control of the resolution mechanism is needed, then use the [expand_path::with()] function.
 pub fn expand_path(user: Option<&expand_path::ForUser>, path: &BStr) -> Result<PathBuf, expand_path::Error> {
@@ -111,26 +114,23 @@ pub enum ArgumentSafety<'a> {
 ///
 /// # Mutability Warning
 ///
-/// Due to the mutability of this type, it's possible that the URL serializes to something invalid
-/// when fields are modified directly. URLs should always be parsed to this type from string or byte
-/// parameters, but never be accepted as an instance of this type and then reconstructed, to maintain
-/// validity guarantees.
+/// Public fields can be modified into combinations that do not serialize or parse. Use [`parse()`] or
+/// [`Url::from_parts()`] at trust boundaries; do not assume an accepted `Url` remains valid without revalidation.
 ///
 /// # Serialization
 ///
 /// This type does not implement `Into<String>`, `From<Url> for String` because URLs
 /// can contain non-UTF-8 sequences in the path component when parsed from raw bytes.
-/// Use [to_bstring()](Url::to_bstring()) for lossless serialization, or use the [`Display`](std::fmt::Display)
-/// trait for a UTF-8 representation that redacts passwords for safe logging.
+/// Use [to_bstring()](Url::to_bstring()) for complete serialization, including non-UTF-8 path bytes, or use the
+/// [`Display`](std::fmt::Display) trait for a UTF-8 representation that redacts passwords for safe logging.
 ///
 /// When the `serde` feature is enabled, this type implements `serde::Serialize` and `serde::Deserialize`,
 /// which will serialize *all* fields, including the password.
 ///
 /// # Security Warning
 ///
-/// URLs may contain passwords and using standard [formatting](std::fmt::Display) will redact
-/// such password, whereas [lossless serialization](Url::to_bstring()) will contain all parts of the
-/// URL.
+/// URLs may contain passwords and using standard [formatting](std::fmt::Display) will redact such passwords,
+/// whereas [`Url::to_bstring()`] includes all URL parts.
 /// **Beware that some URLs still print secrets if they use them outside of the designated password fields.**
 ///
 /// Also note that URLs that fail to parse are typically stored in [the resulting error](parse::Error) type
@@ -148,29 +148,40 @@ pub struct Url {
     /// The password associated with a user.
     ///
     /// Stored in decoded form: percent-encoded characters are decoded during parsing.
-    /// Re-encoded during canonical serialization. Cannot be serialized in alternative form (will panic in debug builds).
+    /// Re-encoded during canonical serialization. Its presence makes serialization use canonical rather than alternative
+    /// form because SCP-like and local-path syntax cannot represent a password.
     pub password: Option<String>,
-    /// The host to which to connect. Localhost is implied if `None`.
+    /// The host to which to connect, or `None` for locations without a host, such as local paths.
     ///
-    /// IPv6 addresses are stored *without* brackets for SSH schemes, but *with* brackets for other schemes.
-    /// Brackets are automatically added during serialization when needed (e.g., when a port is specified with an IPv6 host).
+    /// Brackets are stripped from parsed SSH hosts and otherwise preserved as parsed. Serialization adds brackets to
+    /// unbracketed colon-containing hosts when needed to disambiguate a port or scoped IPv6 address.
+    /// DNS-like ASCII hosts are lowercased. Non-HTTP hosts are percent-decoded for Git compatibility, while HTTP and
+    /// HTTPS host escapes remain encoded.
     pub host: Option<String>,
-    /// When serializing, use the alternative forms as it was parsed as such.
+    /// Request alternative serialization, generally because the location was parsed in that form.
     ///
     /// Alternative forms include SCP-like syntax (`user@host:path`) and bare file paths.
-    /// When `true`, password and port cannot be serialized (will panic in debug builds).
+    /// It is used only for SSH or file locations without a password or port; otherwise serialization uses canonical URL form.
     pub serialize_alternative_form: bool,
-    /// The port to use when connecting to a host. If `None`, standard ports depending on `scheme` will be used.
+    /// The explicit port, if parsed or assigned.
+    ///
+    /// Git accepts port zero in SSH and Git URLs, so this field may contain `0`. Textual and overflowing ports are
+    /// rejected unlike Git; see the deviation documented on [`parse()`]. Use [`Self::port_or_default()`] to obtain a
+    /// scheme default when this is `None`.
     pub port: Option<u16>,
     /// The path portion of the URL, usually the location of the git repository.
     ///
-    /// Paths are stored in decoded form: percent-encoded characters are decoded during parsing
-    /// and re-encoded during canonical serialization (e.g., `%20` becomes a space in this field).
+    /// Percent-encoded characters are decoded during parsing (e.g., `%20` becomes a space in this field). An unchanged
+    /// parsed path may retain its original encoded spelling for serialization. Constructed or modified HTTP paths are
+    /// percent-encoded during canonical serialization; other schemes write the path bytes as stored.
     ///
     /// Path normalization during parsing:
     /// - SSH/Git schemes: Leading `/~` is stripped (e.g., `/~repo` becomes `~repo`)
     /// - SSH/Git schemes: Empty paths are rejected as errors
     /// - HTTP/HTTPS schemes: Empty paths are normalized to `/`
+    ///
+    /// This type has no separate query or fragment fields. For HTTP and HTTPS, `?`, `#`, and everything after them are
+    /// stored in this field. For other URL schemes, Git treats `?` and `#` before the first slash as authority text.
     ///
     /// During serialization, SSH/Git URLs prepend `/` to paths not starting with `/`.
     ///
@@ -179,7 +190,8 @@ pub struct Url {
     /// URLs allow paths to start with `-` which makes it possible to mask command-line arguments as path which then leads to
     /// the invocation of programs from an attacker controlled URL. See <https://secure.phabricator.com/T12961> for details.
     ///
-    /// If this value is ever going to be passed to a command-line application, call [Self::path_argument_safe()] instead.
+    /// For a slash-prefixed path that will be passed intact to a command-line application, call
+    /// [`Self::path_argument_safe()`]. Other path forms require validation appropriate to how they will be passed.
     pub path: BString,
     /// The original parsed path when it contains percent escapes for reserved URL characters.
     ///
@@ -257,7 +269,16 @@ fn encode_legacy_http_path(path: &[u8]) -> BString {
 
 /// Instantiation
 impl Url {
-    /// Create a new instance from the given parts, including a password, which will be validated by parsing them back.
+    /// Create an instance from the given parts and validate it by serializing and parsing it back.
+    ///
+    /// For HTTP and HTTPS, `path` is decoded data: literal percent signs are encoded during serialization, and an empty
+    /// path is normalized to `/`. Other schemes interpret `path` according to their serialized syntax.
+    /// `serialize_alternative_form` merely requests alternative form; passwords, ports, and unsupported schemes force
+    /// canonical URL serialization.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the supplied parts cannot be serialized before validation, such as a user without a host.
     pub fn from_parts(
         scheme: Scheme,
         user: Option<String>,
@@ -312,10 +333,10 @@ impl Url {
 
 /// Builder
 impl Url {
-    /// Enable alternate serialization for this url, e.g. `file:///path` becomes `/path`.
+    /// Request alternative serialization, e.g. `file:///path` becomes `/path`.
     ///
-    /// This is automatically set correctly for parsed URLs, but can be set here for urls
-    /// created by constructor.
+    /// Parsed URLs set this automatically. Alternative form is used only for SSH or file locations without a password
+    /// or port; all other values serialize in canonical URL form.
     ///
     /// Setting `use_alternate_form` to `false` forces canonical serialization. For SCP-like SSH URLs this
     /// can be lossy: `user@host:path/repo` and `user@host:/path/repo` both serialize as
@@ -326,8 +347,9 @@ impl Url {
         self
     }
 
-    /// Turn a file url like `file://relative` into `file:///root/relative`, hence it assures the url's path component is absolute,
-    /// using `current_dir` if needed to achieve that.
+    /// Resolve the path of a file location against `current_dir` and normalize it in place.
+    ///
+    /// Other schemes are unchanged.
     pub fn canonicalize(&mut self, current_dir: &std::path::Path) -> Result<(), gix_path::realpath::Error> {
         if self.scheme == Scheme::File {
             let path = gix_path::from_bstr(Cow::Borrowed(self.path.as_ref()));
@@ -354,7 +376,7 @@ impl Url {
 
     /// Classify the username of this URL by whether it is safe to pass as a command-line argument.
     ///
-    /// Use this method instead of [Self::user()] if the host is going to be passed to a command-line application.
+    /// Use this method instead of [Self::user()] if the username is going to be passed to a command-line application.
     /// If the unsafe and absent cases need not be distinguished, [Self::user_argument_safe()] may also be used.
     pub fn user_as_argument(&self) -> ArgumentSafety<'_> {
         match self.user() {
@@ -366,7 +388,7 @@ impl Url {
 
     /// Return the username of this URL if present *and* if it can't be mistaken for a command-line argument.
     ///
-    /// Use this method or [Self::user_as_argument()] instead of [Self::user()] if the host is going to be
+    /// Use this method or [Self::user_as_argument()] instead of [Self::user()] if the username is going to be
     /// passed to a command-line application. Prefer [Self::user_as_argument()] unless the unsafe and absent
     /// cases need not be distinguished from each other.
     pub fn user_argument_safe(&self) -> Option<&str> {
@@ -418,14 +440,13 @@ impl Url {
         }
     }
 
-    /// Return the path of this URL *if* it can't be mistaken for a command-line argument.
-    /// Note that it always begins with a slash, which is ignored for this comparison.
+    /// Return a slash-prefixed path if the bytes after the slash can't be mistaken for a command-line argument.
     ///
-    /// Use this method instead of accessing [Self::path] directly if the path is going to be passed to a
-    /// command-line application, unless it is certain that the leading `/` will always be included.
+    /// The leading slash must be present and must be passed to the command. Empty and non-slash-prefixed paths return
+    /// `None`; validate those according to how they will be passed.
     pub fn path_argument_safe(&self) -> Option<&BStr> {
         self.path
-            .get(1..)
+            .strip_prefix(b"/")
             .and_then(|truncated| (!looks_like_command_line_option(truncated)).then_some(self.path.as_ref()))
     }
 
@@ -456,8 +477,9 @@ fn looks_like_command_line_option(b: &[u8]) -> bool {
 
 /// Transformation
 impl Url {
-    /// Turn a file URL like `file://relative` into `file:///root/relative`, hence it assures the URL's path component is absolute, using
-    /// `current_dir` if necessary.
+    /// Return a clone whose file path is resolved against `current_dir` and normalized.
+    ///
+    /// Other schemes are returned unchanged.
     pub fn canonicalized(&self, current_dir: &std::path::Path) -> Result<Self, gix_path::realpath::Error> {
         let mut res = self.clone();
         res.canonicalize(current_dir)?;
@@ -467,7 +489,11 @@ impl Url {
 
 /// Serialization
 impl Url {
-    /// Write this URL losslessly to `out`, ready to be parsed again.
+    /// Write all URL components, including the password, to `out` in a form suitable for parsing again.
+    ///
+    /// Parsed escapes for reserved path characters retain their spelling while [`Self::path`] is unchanged, but other escaping and
+    /// canonicalization can change the original input spelling. Invalid combinations created through public field
+    /// mutation may return an error.
     pub fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
         // Since alternative form doesn't employ any escape syntax, password and
         // port number cannot be encoded.
@@ -566,22 +592,20 @@ impl Url {
         if matches!(self.scheme, Scheme::Ssh | Scheme::Git) && !self.path.starts_with(b"/") {
             out.write_all(b"/")?;
         }
-        if matches!(self.scheme, Scheme::Http | Scheme::Https) {
+        if let Some(encoded) = self
+            .path_with_percent_escapes
+            .as_ref()
+            .filter(|encoded| percent_encoding::percent_decode(encoded).eq(self.path.iter().copied()))
+        {
+            out.write_all(encoded)?;
+        } else if matches!(self.scheme, Scheme::Http | Scheme::Https) {
             // We intentionally do not encode '?' and '#': ParsedUrl keeps them in `path`,
             // and encoding would change routed endpoints for already parsed URLs.
-            if let Some(encoded) = self
-                .path_with_percent_escapes
-                .as_ref()
-                .filter(|encoded| percent_encoding::percent_decode(encoded).eq(self.path.iter().copied()))
-            {
-                out.write_all(encoded)?;
-            } else {
-                write!(
-                    out,
-                    "{}",
-                    percent_encoding::percent_encode(&self.path, HTTP_PATH_ENCODE_SET)
-                )?;
-            }
+            write!(
+                out,
+                "{}",
+                percent_encoding::percent_encode(&self.path, HTTP_PATH_ENCODE_SET)
+            )?;
         } else {
             out.write_all(&self.path)?;
         }
@@ -633,7 +657,14 @@ impl Url {
         Ok(())
     }
 
-    /// Transform ourselves into a binary string, losslessly, or fail if the URL is malformed due to host or user parts being incorrect.
+    /// Serialize all URL components, including the password, into a binary string.
+    ///
+    /// Parsed escapes for reserved path characters retain their spelling while [Self::path] is unchanged, but other escaping and
+    /// canonicalization can change the original input spelling.
+    ///
+    /// # Panics
+    ///
+    /// Panics if public field mutation created a structure that cannot be serialized, such as a user without a host.
     pub fn to_bstring(&self) -> BString {
         let mut buf = Vec::with_capacity(
             (5 + 3)

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -522,10 +522,21 @@ impl Url {
             percent_encoding::utf8_percent_encode(s, encode_set).into()
         }
 
+        fn write_host(out: &mut dyn std::io::Write, host: &str, bracket: bool) -> std::io::Result<()> {
+            if bracket {
+                out.write_all(b"[")?;
+                out.write_all(host.replace('%', "%25").as_bytes())?;
+                out.write_all(b"]")
+            } else {
+                out.write_all(host.as_bytes())
+            }
+        }
+
         out.write_all(self.scheme.as_str().as_bytes())?;
         out.write_all(b"://")?;
 
-        let needs_brackets = self.port.is_some() && self.host_needs_brackets();
+        let needs_brackets = self.host_needs_brackets()
+            && (self.port.is_some() || self.host.as_ref().is_some_and(|host| host.contains('%')));
 
         match (&self.user, &self.host) {
             (Some(user), Some(host)) => {
@@ -535,22 +546,10 @@ impl Url {
                     out.write_all(percent_encode(password, false).as_bytes())?;
                 }
                 out.write_all(b"@")?;
-                if needs_brackets {
-                    out.write_all(b"[")?;
-                }
-                out.write_all(host.as_bytes())?;
-                if needs_brackets {
-                    out.write_all(b"]")?;
-                }
+                write_host(out, host, needs_brackets)?;
             }
             (None, Some(host)) => {
-                if needs_brackets {
-                    out.write_all(b"[")?;
-                }
-                out.write_all(host.as_bytes())?;
-                if needs_brackets {
-                    out.write_all(b"]")?;
-                }
+                write_host(out, host, needs_brackets)?;
             }
             (None, None) => {}
             (Some(_user), None) => {

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -171,6 +171,12 @@ pub struct Url {
     ///
     /// If this value is ever going to be passed to a command-line application, call [Self::path_argument_safe()] instead.
     pub path: BString,
+    /// The parsed path when it contains preserved percent escapes for reserved URL characters.
+    ///
+    /// This lets serialization distinguish preserved escapes from literal percent text in [`Self::path`]. Escapes are
+    /// reused only while both paths match; constructing or mutating the public path causes percent signs to be encoded.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub(crate) path_with_percent_escapes: Option<BString>,
 }
 
 /// Instantiation
@@ -185,18 +191,29 @@ impl Url {
         path: BString,
         serialize_alternative_form: bool,
     ) -> Result<Self, parse::Error> {
-        parse(
+        let is_http = matches!(scheme, Scheme::Http | Scheme::Https);
+        let mut parsed = parse(
             Url {
                 scheme,
                 user,
                 password,
                 host,
                 port,
-                path,
+                path: path.clone(),
                 serialize_alternative_form,
+                path_with_percent_escapes: None,
             }
             .to_bstring(),
-        )
+        )?;
+        if is_http {
+            // Preserve the caller's path as decoded data, except for an empty path normalized to `/` above. In
+            // particular, percent escapes supplied through `from_parts()` are literal text and must be encoded.
+            if !path.is_empty() {
+                parsed.path = path;
+            }
+            parsed.path_with_percent_escapes = None;
+        }
+        Ok(parsed)
     }
 }
 
@@ -486,10 +503,34 @@ impl Url {
                 .add(b'`')
                 .add(b'{')
                 .add(b'}');
+
+            let preserve_percent_escapes = self.path_with_percent_escapes.as_ref() == Some(&self.path);
+            let mut start = 0;
+            if preserve_percent_escapes {
+                let mut pos = start;
+                while pos + 2 < self.path.len() {
+                    if self.path[pos] == b'%'
+                        && self.path[pos + 1].is_ascii_hexdigit()
+                        && self.path[pos + 2].is_ascii_hexdigit()
+                    {
+                        write!(
+                            out,
+                            "{}",
+                            percent_encoding::percent_encode(&self.path[start..pos], PATH_ENCODE_SET)
+                        )?;
+                        let unchanged_percent_encoded_triplet = &self.path[pos..pos + 3];
+                        out.write_all(unchanged_percent_encoded_triplet)?;
+                        pos += 3;
+                        start = pos;
+                    } else {
+                        pos += 1;
+                    }
+                }
+            };
             write!(
                 out,
                 "{}",
-                percent_encoding::percent_encode(self.path.as_ref(), PATH_ENCODE_SET)
+                percent_encoding::percent_encode(&self.path[start..], PATH_ENCODE_SET)
             )?;
         } else {
             out.write_all(&self.path)?;
@@ -598,6 +639,7 @@ pub mod testing {
                 port,
                 path,
                 serialize_alternative_form,
+                path_with_percent_escapes: None,
             }
         }
     }

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -29,6 +29,16 @@ use std::{borrow::Cow, path::PathBuf};
 use bstr::{BStr, BString};
 use gix_utils::AsBStr;
 
+const HTTP_PATH_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'%')
+    .add(b'<')
+    .add(b'>')
+    .add(b'`')
+    .add(b'{')
+    .add(b'}');
+
 ///
 pub mod expand_path;
 
@@ -126,7 +136,7 @@ pub enum ArgumentSafety<'a> {
 /// Also note that URLs that fail to parse are typically stored in [the resulting error](parse::Error) type
 /// and printed in full using its display implementation.
 #[derive(PartialEq, Eq, Debug, Hash, Ord, PartialOrd, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Url {
     /// The URL scheme.
     pub scheme: Scheme,
@@ -171,12 +181,78 @@ pub struct Url {
     ///
     /// If this value is ever going to be passed to a command-line application, call [Self::path_argument_safe()] instead.
     pub path: BString,
-    /// The parsed path when it contains preserved percent escapes for reserved URL characters.
+    /// The original parsed path when it contains percent escapes for reserved URL characters.
     ///
-    /// This lets serialization distinguish preserved escapes from literal percent text in [`Self::path`]. Escapes are
-    /// reused only while both paths match; constructing or mutating the public path causes percent signs to be encoded.
+    /// This lets serialization retain the encoded spelling while [`Self::path`] remains decoded. It is reused only
+    /// while decoding it still produces the public path; constructing or mutating the public path encodes percent signs.
     #[cfg_attr(feature = "serde", serde(default))]
     pub(crate) path_with_percent_escapes: Option<BString>,
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Url {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct Fields {
+            scheme: Scheme,
+            user: Option<String>,
+            password: Option<String>,
+            host: Option<String>,
+            serialize_alternative_form: bool,
+            port: Option<u16>,
+            path: BString,
+            #[serde(default)]
+            path_with_percent_escapes: Option<BString>,
+        }
+
+        let mut fields = Fields::deserialize(deserializer)?;
+        if fields.path_with_percent_escapes.as_ref() == Some(&fields.path) {
+            fields.path_with_percent_escapes = Some(encode_legacy_http_path(&fields.path));
+            fields.path = percent_encoding::percent_decode(&fields.path)
+                .collect::<Vec<_>>()
+                .into();
+        }
+        Ok(Url {
+            scheme: fields.scheme,
+            user: fields.user,
+            password: fields.password,
+            host: fields.host,
+            serialize_alternative_form: fields.serialize_alternative_form,
+            port: fields.port,
+            path: fields.path,
+            path_with_percent_escapes: fields.path_with_percent_escapes,
+        })
+    }
+}
+
+#[cfg(feature = "serde")]
+fn encode_legacy_http_path(path: &[u8]) -> BString {
+    let mut out = Vec::with_capacity(path.len());
+    let mut start = 0;
+    let mut pos = 0;
+    while pos + 2 < path.len() {
+        if path[pos] == b'%' && path[pos + 1].is_ascii_hexdigit() && path[pos + 2].is_ascii_hexdigit() {
+            out.extend(
+                percent_encoding::percent_encode(&path[start..pos], HTTP_PATH_ENCODE_SET)
+                    .to_string()
+                    .bytes(),
+            );
+            out.extend_from_slice(&path[pos..pos + 3]);
+            pos += 3;
+            start = pos;
+        } else {
+            pos += 1;
+        }
+    }
+    out.extend(
+        percent_encoding::percent_encode(&path[start..], HTTP_PATH_ENCODE_SET)
+            .to_string()
+            .bytes(),
+    );
+    out.into()
 }
 
 /// Instantiation
@@ -494,44 +570,19 @@ impl Url {
         if matches!(self.scheme, Scheme::Http | Scheme::Https) {
             // We intentionally do not encode '?' and '#': ParsedUrl keeps them in `path`,
             // and encoding would change routed endpoints for already parsed URLs.
-            const PATH_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
-                .add(b' ')
-                .add(b'"')
-                .add(b'%')
-                .add(b'<')
-                .add(b'>')
-                .add(b'`')
-                .add(b'{')
-                .add(b'}');
-
-            let preserve_percent_escapes = self.path_with_percent_escapes.as_ref() == Some(&self.path);
-            let mut start = 0;
-            if preserve_percent_escapes {
-                let mut pos = start;
-                while pos + 2 < self.path.len() {
-                    if self.path[pos] == b'%'
-                        && self.path[pos + 1].is_ascii_hexdigit()
-                        && self.path[pos + 2].is_ascii_hexdigit()
-                    {
-                        write!(
-                            out,
-                            "{}",
-                            percent_encoding::percent_encode(&self.path[start..pos], PATH_ENCODE_SET)
-                        )?;
-                        let unchanged_percent_encoded_triplet = &self.path[pos..pos + 3];
-                        out.write_all(unchanged_percent_encoded_triplet)?;
-                        pos += 3;
-                        start = pos;
-                    } else {
-                        pos += 1;
-                    }
-                }
-            };
-            write!(
-                out,
-                "{}",
-                percent_encoding::percent_encode(&self.path[start..], PATH_ENCODE_SET)
-            )?;
+            if let Some(encoded) = self
+                .path_with_percent_escapes
+                .as_ref()
+                .filter(|encoded| percent_encoding::percent_decode(encoded).eq(self.path.iter().copied()))
+            {
+                out.write_all(encoded)?;
+            } else {
+                write!(
+                    out,
+                    "{}",
+                    percent_encoding::percent_encode(&self.path, HTTP_PATH_ENCODE_SET)
+                )?;
+            }
         } else {
             out.write_all(&self.path)?;
         }
@@ -607,6 +658,29 @@ impl Url {
 }
 
 /// This module contains extensions to the [Url] struct which are only intended to be used
+#[cfg(all(test, feature = "serde"))]
+mod serde_tests {
+    #[test]
+    fn legacy_encoded_public_path_is_migrated() -> gix_testtools::Result {
+        for (input, legacy_path, decoded_path) in [
+            ("https://example.com/a%2Fb", "/a%2Fb", "/a/b"),
+            ("https://example.com/%20%25", "/ %25", "/ %"),
+        ] {
+            let mut legacy = crate::parse(input)?;
+            legacy.path = legacy_path.into();
+            legacy.path_with_percent_escapes = Some(legacy_path.into());
+
+            let migrated: crate::Url = serde_json::from_slice(&serde_json::to_vec(&legacy)?)?;
+            assert_eq!(
+                migrated.path, decoded_path,
+                "the public path is upgraded to decoded form"
+            );
+            assert_eq!(migrated.to_bstring(), input, "the encoded spelling remains lossless");
+        }
+        Ok(())
+    }
+}
+
 /// for testing code. Do not use this module in production! For all intents and purposes, the APIs of
 /// all functions and types exposed by this module are considered unstable and are allowed to break
 /// even in patch releases!

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -560,13 +560,15 @@ impl Url {
             percent_encoding::utf8_percent_encode(s, encode_set).into()
         }
 
-        fn write_host(out: &mut dyn std::io::Write, host: &str, bracket: bool) -> std::io::Result<()> {
+        fn write_host(out: &mut dyn std::io::Write, host: &str, bracket: bool, scheme: &Scheme) -> std::io::Result<()> {
             if bracket {
                 out.write_all(b"[")?;
                 out.write_all(host.replace('%', "%25").as_bytes())?;
                 out.write_all(b"]")
-            } else {
+            } else if matches!(scheme, Scheme::File | Scheme::Http | Scheme::Https) {
                 out.write_all(host.as_bytes())
+            } else {
+                out.write_all(percent_encode(host, host.parse::<std::net::Ipv6Addr>().is_err()).as_bytes())
             }
         }
 
@@ -584,10 +586,10 @@ impl Url {
                     out.write_all(percent_encode(password, false).as_bytes())?;
                 }
                 out.write_all(b"@")?;
-                write_host(out, host, needs_brackets)?;
+                write_host(out, host, needs_brackets, &self.scheme)?;
             }
             (None, Some(host)) => {
-                write_host(out, host, needs_brackets)?;
+                write_host(out, host, needs_brackets, &self.scheme)?;
             }
             (None, None) => {}
             (Some(_user), None) => {

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -193,7 +193,7 @@ pub struct Url {
     /// For a slash-prefixed path that will be passed intact to a command-line application, call
     /// [`Self::path_argument_safe()`]. Other path forms require validation appropriate to how they will be passed.
     pub path: BString,
-    /// The original parsed path when it contains percent escapes for reserved URL characters.
+    /// The original parsed path when it contains percent escapes.
     ///
     /// This lets serialization retain the encoded spelling while [`Self::path`] remains decoded. It is reused only
     /// while decoding it still produces the public path; constructing or mutating the public path encodes percent signs.
@@ -440,6 +440,18 @@ impl Url {
         }
     }
 
+    fn path_with_percent_escapes(&self) -> Option<&BStr> {
+        let encoded = self.path_with_percent_escapes.as_ref()?;
+        percent_encoding::percent_decode(encoded)
+            .eq(self.path.iter().copied())
+            .then_some(encoded.as_ref())
+    }
+
+    /// Return the original percent-escaped path if [Self::path] wasn't changed in the meantime, or [`Self::path`] otherwise.
+    pub fn original_path(&self) -> &BStr {
+        self.path_with_percent_escapes().unwrap_or(self.path.as_ref())
+    }
+
     /// Return a slash-prefixed path if the bytes after the slash can't be mistaken for a command-line argument.
     ///
     /// The leading slash must be present and must be passed to the command. Empty and non-slash-prefixed paths return
@@ -491,9 +503,9 @@ impl Url {
 impl Url {
     /// Write all URL components, including the password, to `out` in a form suitable for parsing again.
     ///
-    /// Parsed escapes for reserved path characters retain their spelling while [`Self::path`] is unchanged, but other escaping and
-    /// canonicalization can change the original input spelling. Invalid combinations created through public field
-    /// mutation may return an error.
+    /// Parsed escapes for reserved path characters retain their spelling while [`Self::path`] is unchanged, but other
+    /// escaping and canonicalization can change the original input spelling. Invalid combinations created through
+    /// public field mutation may return an error.
     pub fn write_to(&self, out: &mut dyn std::io::Write) -> std::io::Result<()> {
         // Since alternative form doesn't employ any escape syntax, password and
         // port number cannot be encoded.
@@ -592,11 +604,7 @@ impl Url {
         if matches!(self.scheme, Scheme::Ssh | Scheme::Git) && !self.path.starts_with(b"/") {
             out.write_all(b"/")?;
         }
-        if let Some(encoded) = self
-            .path_with_percent_escapes
-            .as_ref()
-            .filter(|encoded| percent_encoding::percent_decode(encoded).eq(self.path.iter().copied()))
-        {
+        if let Some(encoded) = self.path_with_percent_escapes() {
             out.write_all(encoded)?;
         } else if matches!(self.scheme, Scheme::Http | Scheme::Https) {
             // We intentionally do not encode '?' and '#': ParsedUrl keeps them in `path`,
@@ -659,8 +667,8 @@ impl Url {
 
     /// Serialize all URL components, including the password, into a binary string.
     ///
-    /// Parsed escapes for reserved path characters retain their spelling while [Self::path] is unchanged, but other escaping and
-    /// canonicalization can change the original input spelling.
+    /// Parsed escapes for reserved path characters retain their spelling while [`Self::path`] is unchanged, but other
+    /// escaping and canonicalization can change the original input spelling.
     ///
     /// # Panics
     ///

--- a/gix-url/src/parse.rs
+++ b/gix-url/src/parse.rs
@@ -169,7 +169,7 @@ pub(crate) fn url(input: &BStr, protocol_end: usize) -> Result<crate::Url, Error
     } else {
         url.host
     };
-    let path_with_percent_escapes = url.path_has_percent_escapes.then(|| path.clone());
+    let path_with_percent_escapes = url.path_with_percent_escapes.map(Into::into);
     Ok(crate::Url {
         serialize_alternative_form: false,
         path_with_percent_escapes,

--- a/gix-url/src/parse.rs
+++ b/gix-url/src/parse.rs
@@ -168,8 +168,10 @@ pub(crate) fn url(input: &BStr, protocol_end: usize) -> Result<crate::Url, Error
     } else {
         url.host
     };
+    let path_with_percent_escapes = url.path_has_percent_escapes.then(|| path.clone());
     Ok(crate::Url {
         serialize_alternative_form: false,
+        path_with_percent_escapes,
         scheme,
         user,
         password,
@@ -228,6 +230,7 @@ pub(crate) fn scp(input: &BStr, colon: usize) -> Result<crate::Url, Error> {
 
     Ok(crate::Url {
         serialize_alternative_form: true,
+        path_with_percent_escapes: None,
         scheme: Scheme::from(url.scheme.as_str()),
         user,
         password,
@@ -305,6 +308,7 @@ pub(crate) fn local(input: &BStr) -> Result<crate::Url, Error> {
 
     Ok(crate::Url {
         serialize_alternative_form: true,
+        path_with_percent_escapes: None,
         scheme: Scheme::File,
         password: None,
         user: None,

--- a/gix-url/src/parse.rs
+++ b/gix-url/src/parse.rs
@@ -205,7 +205,8 @@ pub(crate) fn scp(input: &BStr, colon: usize) -> Result<crate::Url, Error> {
     // should never differ in any other way (ssh URLs should not contain a query or fragment part).
     // To avoid the various off-by-one errors caused by the `/` characters, we keep using the path
     // determined above and can therefore skip parsing it here as well.
-    let url_string = format!("ssh://{host}");
+    // In SCP-like syntax `%` is literal host data, but the synthesized URL parser treats it as an escape introducer.
+    let url_string = format!("ssh://{}", host.replace('%', "%25"));
     let url = crate::simple_url::ParsedUrl::parse(&url_string).map_err(|source| Error::Url {
         url: input.to_owned(),
         kind: UrlKind::Scp,

--- a/gix-url/src/parse.rs
+++ b/gix-url/src/parse.rs
@@ -150,10 +150,16 @@ pub(crate) fn url(input: &BStr, protocol_end: usize) -> Result<crate::Url, Error
             if let Some(h2) = h.strip_prefix('[') {
                 if let Some(inner) = h2.strip_suffix("]:") {
                     // "[::1]:" → "::1"
-                    h = inner.to_string();
+                    h = percent_encoding::percent_decode_str(inner)
+                        .decode_utf8()
+                        .expect("bracketed hosts were validated during parsing")
+                        .into_owned();
                 } else if let Some(inner) = h2.strip_suffix(']') {
                     // "[::1]" → "::1"
-                    h = inner.to_string();
+                    h = percent_encoding::percent_decode_str(inner)
+                        .decode_utf8()
+                        .expect("bracketed hosts were validated during parsing")
+                        .into_owned();
                 }
             } else {
                 // Non-bracketed host: strip a single trailing colon

--- a/gix-url/src/parse.rs
+++ b/gix-url/src/parse.rs
@@ -105,7 +105,7 @@ pub(crate) fn url(input: &BStr, protocol_end: usize) -> Result<crate::Url, Error
         .iter()
         .filter(|b| !b.is_ascii_whitespace())
         .skip_while(|b| **b == b'/' || **b == b'\\')
-        .position(|b| *b == b'/')
+        .position(|b| matches!(*b, b'/' | b'?' | b'#'))
         .unwrap_or(input.len() - protocol_end);
     if bytes_to_path > MAX_LEN || protocol_end > MAX_LEN {
         return Err(Error::TooLong {

--- a/gix-url/src/parse.rs
+++ b/gix-url/src/parse.rs
@@ -35,14 +35,14 @@ impl From<Infallible> for Error {
     }
 }
 
-///
+/// The syntax used to interpret an input location.
 #[derive(Debug, Clone, Copy)]
 pub enum UrlKind {
-    ///
+    /// A URL containing a `scheme://` separator.
     Url,
-    ///
+    /// An SCP-like SSH location such as `user@host:path`.
     Scp,
-    ///
+    /// A local filesystem path.
     Local,
 }
 
@@ -102,11 +102,15 @@ pub(crate) fn find_scheme(input: &BStr) -> InputScheme {
 pub(crate) fn url(input: &BStr, protocol_end: usize) -> Result<crate::Url, Error> {
     const MAX_LEN: usize = 1024;
     let input_after_protocol = &input[protocol_end + "://".len()..];
+    let is_http = {
+        let scheme = &input[..protocol_end];
+        scheme.eq_ignore_ascii_case(b"http") || scheme.eq_ignore_ascii_case(b"https")
+    };
     let bytes_to_path = input_after_protocol
         .iter()
         .filter(|b| !b.is_ascii_whitespace())
         .skip_while(|b| **b == b'/' || **b == b'\\')
-        .position(|b| matches!(*b, b'/' | b'?' | b'#'))
+        .position(|b| *b == b'/' || is_http && matches!(*b, b'?' | b'#'))
         .unwrap_or(input_after_protocol.len());
     if bytes_to_path > MAX_LEN || protocol_end > MAX_LEN {
         return Err(Error::TooLong {
@@ -150,16 +154,10 @@ pub(crate) fn url(input: &BStr, protocol_end: usize) -> Result<crate::Url, Error
             if let Some(h2) = h.strip_prefix('[') {
                 if let Some(inner) = h2.strip_suffix("]:") {
                     // "[::1]:" → "::1"
-                    h = percent_encoding::percent_decode_str(inner)
-                        .decode_utf8()
-                        .expect("bracketed hosts were validated during parsing")
-                        .into_owned();
+                    h = inner.to_owned();
                 } else if let Some(inner) = h2.strip_suffix(']') {
                     // "[::1]" → "::1"
-                    h = percent_encoding::percent_decode_str(inner)
-                        .decode_utf8()
-                        .expect("bracketed hosts were validated during parsing")
-                        .into_owned();
+                    h = inner.to_owned();
                 }
             } else {
                 // Non-bracketed host: strip a single trailing colon

--- a/gix-url/src/parse.rs
+++ b/gix-url/src/parse.rs
@@ -101,12 +101,13 @@ pub(crate) fn find_scheme(input: &BStr) -> InputScheme {
 
 pub(crate) fn url(input: &BStr, protocol_end: usize) -> Result<crate::Url, Error> {
     const MAX_LEN: usize = 1024;
-    let bytes_to_path = input[protocol_end + "://".len()..]
+    let input_after_protocol = &input[protocol_end + "://".len()..];
+    let bytes_to_path = input_after_protocol
         .iter()
         .filter(|b| !b.is_ascii_whitespace())
         .skip_while(|b| **b == b'/' || **b == b'\\')
         .position(|b| matches!(*b, b'/' | b'?' | b'#'))
-        .unwrap_or(input.len() - protocol_end);
+        .unwrap_or(input_after_protocol.len());
     if bytes_to_path > MAX_LEN || protocol_end > MAX_LEN {
         return Err(Error::TooLong {
             truncated_url: input[..(protocol_end + "://".len() + MAX_LEN).min(input.len())].into(),

--- a/gix-url/src/scheme.rs
+++ b/gix-url/src/scheme.rs
@@ -35,7 +35,9 @@ impl<'a> From<&'a str> for Scheme {
 }
 
 impl Scheme {
-    /// Return ourselves parseable name.
+    /// Return the canonical textual name of this scheme.
+    ///
+    /// Legacy `ssh+git` and `git+ssh` inputs are represented as [`Scheme::Ssh`] and therefore return `ssh`.
     pub fn as_str(&self) -> &str {
         use Scheme::*;
         match self {

--- a/gix-url/src/simple_url.rs
+++ b/gix-url/src/simple_url.rs
@@ -10,7 +10,7 @@ pub(crate) struct ParsedUrl {
     pub host: Option<String>,     // Owned to allow normalization to lowercase
     pub port: Option<u16>,
     pub path: String, // Owned to allow percent-decoding
-    /// The original path when it contains escaped reserved characters, allowing lossless serialization.
+    /// The original path when it contains percent escapes, allowing lossless serialization.
     pub path_with_percent_escapes: Option<String>,
 }
 
@@ -57,24 +57,9 @@ fn percent_decode(s: &str) -> Result<String, UrlParseError> {
         .map_err(|_| UrlParseError::InvalidDomainCharacter)
 }
 
-/// Decode percent-encoded path bytes and retain the original spelling if it contains escaped reserved characters.
+/// Decode percent-encoded path bytes and retain the original spelling if it contains escapes.
 fn percent_decode_path(s: &str) -> Result<(String, Option<String>), UrlParseError> {
-    let input = s.as_bytes();
-    let mut has_percent_escapes = false;
-    let mut pos = 0;
-    while pos < input.len() {
-        if input[pos] == b'%' {
-            if let Some(value) = s.get(pos + 1..pos + 3).and_then(|hex| u8::from_str_radix(hex, 16).ok()) {
-                if value == b'%' || b":/?#[]@!$&'()*+,;=".contains(&value) {
-                    has_percent_escapes = true;
-                }
-                pos += 3;
-                continue;
-            }
-        }
-        pos += 1;
-    }
-    percent_decode(s).map(|path| (path, has_percent_escapes.then(|| s.to_owned())))
+    percent_decode(s).map(|path| (path, s.contains('%').then(|| s.to_owned())))
 }
 
 /// Validate and normalize the contents of a bracketed IPv6 host literal.

--- a/gix-url/src/simple_url.rs
+++ b/gix-url/src/simple_url.rs
@@ -33,6 +33,21 @@ fn is_valid_scheme_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.'
 }
 
+fn has_valid_percent_encoding(input: &str) -> bool {
+    let mut bytes = input.bytes();
+    while let Some(byte) = bytes.next() {
+        if byte == b'%'
+            && !matches!(
+                (bytes.next(), bytes.next()),
+                (Some(a), Some(b)) if a.is_ascii_hexdigit() && b.is_ascii_hexdigit()
+            )
+        {
+            return false;
+        }
+    }
+    true
+}
+
 /// Decode a percent-encoded string, returning an error if the result is not valid UTF-8.
 /// Returns the original string if it contains no percent-encoding.
 fn percent_decode(s: &str) -> Result<String, UrlParseError> {
@@ -80,7 +95,7 @@ impl ParsedUrl {
     /// Expected format: scheme://[user[:password]@]host[:port]/path
     pub(crate) fn parse(input: &str) -> Result<Self, UrlParseError> {
         // Validate that the entire URL doesn't contain any whitespace (per RFC 3986)
-        if input.chars().any(char::is_whitespace) {
+        if input.chars().any(char::is_whitespace) || !has_valid_percent_encoding(input) {
             return Err(UrlParseError::InvalidDomainCharacter);
         }
 
@@ -99,7 +114,9 @@ impl ParsedUrl {
         }
 
         // Validate scheme characters (check original before lowercase conversion)
-        if !scheme_str.chars().all(is_valid_scheme_char) {
+        if !scheme_str.as_bytes().first().is_some_and(u8::is_ascii_alphabetic)
+            || !scheme_str.chars().all(is_valid_scheme_char)
+        {
             return Err(UrlParseError::RelativeUrlWithoutBase);
         }
 
@@ -378,6 +395,24 @@ mod tests {
         let url = ParsedUrl::parse("ssh://jörg:passwörd@example.com/repo").expect("valid UTF-8 user information");
         assert_eq!(url.username, "jörg", "the username is preserved");
         assert_eq!(url.password.as_deref(), Some("passwörd"), "the password is preserved");
+    }
+
+    #[test]
+    fn malformed_schemes_and_percent_escapes_are_rejected() {
+        for url in [
+            "1http://example.com/",
+            "http://example.com/%",
+            "http://example.com/%2",
+            "http://example.com/%zz",
+            "http://user%zz@example.com/",
+            "http://example%zz.com/",
+        ] {
+            assert!(ParsedUrl::parse(url).is_err(), "invalid URL {url:?} must be rejected");
+        }
+        assert!(
+            ParsedUrl::parse("http://example.com/%2f").is_ok(),
+            "hex escapes are valid"
+        );
     }
 
     #[test]

--- a/gix-url/src/simple_url.rs
+++ b/gix-url/src/simple_url.rs
@@ -10,8 +10,8 @@ pub(crate) struct ParsedUrl {
     pub host: Option<String>,     // Owned to allow normalization to lowercase
     pub port: Option<u16>,
     pub path: String, // Owned to allow percent-decoding
-    /// Whether `path` retains percent escapes for reserved URL characters, allowing lossless serialization.
-    pub path_has_percent_escapes: bool,
+    /// The original path when it contains escaped reserved characters, allowing lossless serialization.
+    pub path_with_percent_escapes: Option<String>,
 }
 
 /// Minimal parse error type to replace url::ParseError
@@ -57,37 +57,24 @@ fn percent_decode(s: &str) -> Result<String, UrlParseError> {
         .map_err(|_| UrlParseError::InvalidDomainCharacter)
 }
 
-/// Decode percent-encoded path bytes, unlike [`percent_decode`] preserving escapes for reserved URL characters.
-/// This keeps escaped delimiters from changing the path's structure and lets an unchanged parsed path be serialized
-/// losslessly, while still exposing decoded non-reserved characters.
-/// The boolean indicates whether the returned path still contains such escapes.
-fn percent_decode_path(s: &str) -> Result<(String, bool), UrlParseError> {
+/// Decode percent-encoded path bytes and retain the original spelling if it contains escaped reserved characters.
+fn percent_decode_path(s: &str) -> Result<(String, Option<String>), UrlParseError> {
     let input = s.as_bytes();
-    let mut out = Vec::with_capacity(input.len());
     let mut has_percent_escapes = false;
     let mut pos = 0;
     while pos < input.len() {
         if input[pos] == b'%' {
-            if let Some(value) = s
-                .get(pos + 1..pos + 3)
-                .and_then(|hex| u8::from_str_radix(hex, 16).ok())
-            {
+            if let Some(value) = s.get(pos + 1..pos + 3).and_then(|hex| u8::from_str_radix(hex, 16).ok()) {
                 if value == b'%' || b":/?#[]@!$&'()*+,;=".contains(&value) {
-                    out.extend_from_slice(&input[pos..pos + 3]);
                     has_percent_escapes = true;
-                } else {
-                    out.push(value);
                 }
                 pos += 3;
                 continue;
             }
         }
-        out.push(input[pos]);
         pos += 1;
     }
-    String::from_utf8(out)
-        .map(|path| (path, has_percent_escapes))
-        .map_err(|_| UrlParseError::InvalidDomainCharacter)
+    percent_decode(s).map(|path| (path, has_percent_escapes.then(|| s.to_owned())))
 }
 
 impl ParsedUrl {
@@ -126,15 +113,15 @@ impl ParsedUrl {
         if authority.contains('\\') {
             return Err(UrlParseError::InvalidDomainCharacter);
         }
-        let (path, path_has_percent_escapes) = if path_start < after_scheme.len() {
+        let (path, path_with_percent_escapes) = if path_start < after_scheme.len() {
             if matches!(scheme.as_str(), "http" | "https") {
                 percent_decode_path(&after_scheme[path_start..])?
             } else {
-                (percent_decode(&after_scheme[path_start..])?, false)
+                (percent_decode(&after_scheme[path_start..])?, None)
             }
         } else {
             // No path specified - leave empty (caller can default to / if needed)
-            (String::new(), false)
+            (String::new(), None)
         };
 
         let allow_unbracketed_ipv6 = matches!(scheme.as_str(), "git" | "ssh" | "git+ssh" | "ssh+git");
@@ -181,7 +168,7 @@ impl ParsedUrl {
             host,
             port,
             path,
-            path_has_percent_escapes,
+            path_with_percent_escapes,
         })
     }
 

--- a/gix-url/src/simple_url.rs
+++ b/gix-url/src/simple_url.rs
@@ -10,6 +10,8 @@ pub(crate) struct ParsedUrl {
     pub host: Option<String>,     // Owned to allow normalization to lowercase
     pub port: Option<u16>,
     pub path: String, // Owned to allow percent-decoding
+    /// Whether `path` retains percent escapes for reserved URL characters, allowing lossless serialization.
+    pub path_has_percent_escapes: bool,
 }
 
 /// Minimal parse error type to replace url::ParseError
@@ -37,6 +39,39 @@ fn percent_decode(s: &str) -> Result<String, UrlParseError> {
     percent_decode_str(s)
         .decode_utf8()
         .map(std::borrow::Cow::into_owned)
+        .map_err(|_| UrlParseError::InvalidDomainCharacter)
+}
+
+/// Decode percent-encoded path bytes, unlike [`percent_decode`] preserving escapes for reserved URL characters.
+/// This keeps escaped delimiters from changing the path's structure and lets an unchanged parsed path be serialized
+/// losslessly, while still exposing decoded non-reserved characters.
+/// The boolean indicates whether the returned path still contains such escapes.
+fn percent_decode_path(s: &str) -> Result<(String, bool), UrlParseError> {
+    let input = s.as_bytes();
+    let mut out = Vec::with_capacity(input.len());
+    let mut has_percent_escapes = false;
+    let mut pos = 0;
+    while pos < input.len() {
+        if input[pos] == b'%' {
+            if let Some(value) = s
+                .get(pos + 1..pos + 3)
+                .and_then(|hex| u8::from_str_radix(hex, 16).ok())
+            {
+                if value == b'%' || b":/?#[]@!$&'()*+,;=".contains(&value) {
+                    out.extend_from_slice(&input[pos..pos + 3]);
+                    has_percent_escapes = true;
+                } else {
+                    out.push(value);
+                }
+                pos += 3;
+                continue;
+            }
+        }
+        out.push(input[pos]);
+        pos += 1;
+    }
+    String::from_utf8(out)
+        .map(|path| (path, has_percent_escapes))
         .map_err(|_| UrlParseError::InvalidDomainCharacter)
 }
 
@@ -74,11 +109,15 @@ impl ParsedUrl {
         if authority.contains('\\') {
             return Err(UrlParseError::InvalidDomainCharacter);
         }
-        let path = if path_start < after_scheme.len() {
-            percent_decode(&after_scheme[path_start..])?
+        let (path, path_has_percent_escapes) = if path_start < after_scheme.len() {
+            if matches!(scheme.as_str(), "http" | "https") {
+                percent_decode_path(&after_scheme[path_start..])?
+            } else {
+                (percent_decode(&after_scheme[path_start..])?, false)
+            }
         } else {
             // No path specified - leave empty (caller can default to / if needed)
-            String::new()
+            (String::new(), false)
         };
 
         let allow_unbracketed_ipv6 = matches!(scheme.as_str(), "git" | "ssh" | "git+ssh" | "ssh+git");
@@ -125,6 +164,7 @@ impl ParsedUrl {
             host,
             port,
             path,
+            path_has_percent_escapes,
         })
     }
 

--- a/gix-url/src/simple_url.rs
+++ b/gix-url/src/simple_url.rs
@@ -77,6 +77,43 @@ fn percent_decode_path(s: &str) -> Result<(String, Option<String>), UrlParseErro
     percent_decode(s).map(|path| (path, has_percent_escapes.then(|| s.to_owned())))
 }
 
+/// Validate and normalize the contents of a bracketed IPv6 host literal.
+///
+/// The IPv6 address is lowercased. An optional zone identifier must be introduced by the URI-encoded `%25`
+/// delimiter and contain only unreserved or percent-encoded characters; its spelling is otherwise preserved.
+/// Brackets are not part of the input or output.
+///
+/// Examples:
+/// - `2001:DB8::1` becomes `2001:db8::1`.
+/// - `fe80::1%25Eth0` remains `fe80::1%25Eth0`.
+/// - `fe80::1%25` and `not-ip` are rejected with `None`.
+fn normalize_ipv6_literal(host: &str) -> Option<String> {
+    let Some((address, zone)) = host.split_once("%25") else {
+        return host
+            .parse::<std::net::Ipv6Addr>()
+            .is_ok()
+            .then(|| host.to_ascii_lowercase());
+    };
+    if address.parse::<std::net::Ipv6Addr>().is_err() || zone.is_empty() || percent_decode(zone).is_err() {
+        return None;
+    }
+    let mut pos = 0;
+    let bytes = zone.as_bytes();
+    while pos < bytes.len() {
+        if bytes[pos].is_ascii_alphanumeric() || matches!(bytes[pos], b'-' | b'.' | b'_' | b'~') {
+            pos += 1;
+        } else if bytes[pos] == b'%'
+            && bytes.get(pos + 1).is_some_and(u8::is_ascii_hexdigit)
+            && bytes.get(pos + 2).is_some_and(u8::is_ascii_hexdigit)
+        {
+            pos += 3;
+        } else {
+            return None;
+        }
+    }
+    Some(format!("{}%25{zone}", address.to_ascii_lowercase()))
+}
+
 impl ParsedUrl {
     /// Parse a URL string into its components.
     /// Expected format: scheme://[user[:password]@]host[:port]/path
@@ -183,29 +220,23 @@ impl ParsedUrl {
         // Handle IPv6 addresses: [::1] or [::1]:port
         if host_port.starts_with('[') {
             if let Some(bracket_end) = host_port.find(']') {
-                if host_port[1..bracket_end].parse::<std::net::Ipv6Addr>().is_err() {
-                    return Err(UrlParseError::InvalidDomainCharacter);
-                }
+                let host =
+                    normalize_ipv6_literal(&host_port[1..bracket_end]).ok_or(UrlParseError::InvalidDomainCharacter)?;
                 let remaining = &host_port[bracket_end + 1..];
 
                 if remaining.is_empty() {
-                    // IPv6 addresses are case-insensitive, normalize to lowercase
-                    let host = Some(host_port[..=bracket_end].to_ascii_lowercase());
-                    return Ok((host, None));
+                    return Ok((Some(format!("[{host}]")), None));
                 } else if let Some(port_str) = remaining.strip_prefix(':') {
                     if port_str.is_empty() {
                         // Empty port like "[::1]:" - preserve the trailing colon for Git compatibility
-                        let host = Some(host_port.to_ascii_lowercase());
-                        return Ok((host, None));
+                        return Ok((Some(format!("[{host}]:")), None));
                     }
                     let port = port_str.parse::<u16>().map_err(|_| UrlParseError::InvalidPort)?;
                     // Validate port is in valid range (1-65535, port 0 is invalid)
                     if port == 0 {
                         return Err(UrlParseError::InvalidPort);
                     }
-                    // IPv6 addresses are case-insensitive, normalize to lowercase
-                    let host = Some(host_port[..=bracket_end].to_ascii_lowercase());
-                    return Ok((host, Some(port)));
+                    return Ok((Some(format!("[{host}]")), Some(port)));
                 } else {
                     return Err(UrlParseError::InvalidDomainCharacter);
                 }
@@ -370,6 +401,11 @@ mod tests {
             ("http://example.com:abc/", "non-numeric ports must be rejected"),
             ("http://foo:bar:baz/", "unbracketed colons must be rejected"),
             ("http://[not-ip]/", "bracketed hosts must be valid IPv6 addresses"),
+            ("ssh://[fe80::1%25]/repo", "IPv6 zone identifiers must not be empty"),
+            (
+                "ssh://[fe80::1%25eth!0]/repo",
+                "IPv6 zone identifiers contain only unreserved or percent-encoded characters",
+            ),
             ("http://bücher.example/", "non-ASCII hostnames must be rejected"),
             ("http://::1/", "unbracketed IPv6 addresses must be rejected for HTTP"),
         ] {

--- a/gix-url/src/simple_url.rs
+++ b/gix-url/src/simple_url.rs
@@ -144,24 +144,26 @@ impl ParsedUrl {
             return Err(UrlParseError::RelativeUrlWithoutBase);
         }
 
-        // Find the end of the authority.
-        let path_start = after_scheme.find(['/', '?', '#']).unwrap_or(after_scheme.len());
+        // Git treats query and fragment delimiters as authority text outside HTTP URLs.
+        let path_start = if matches!(scheme.as_str(), "http" | "https") {
+            after_scheme.find(['/', '?', '#'])
+        } else {
+            after_scheme.find('/')
+        }
+        .unwrap_or(after_scheme.len());
         let authority = &after_scheme[..path_start];
         if authority.contains('\\') {
             return Err(UrlParseError::InvalidDomainCharacter);
         }
         let (path, path_with_percent_escapes) = if path_start < after_scheme.len() {
-            if matches!(scheme.as_str(), "http" | "https") {
-                percent_decode_path(&after_scheme[path_start..])?
-            } else {
-                (percent_decode(&after_scheme[path_start..])?, None)
-            }
+            percent_decode_path(&after_scheme[path_start..])?
         } else {
             // No path specified - leave empty (caller can default to / if needed)
             (String::new(), None)
         };
 
         let allow_unbracketed_ipv6 = matches!(scheme.as_str(), "git" | "ssh" | "git+ssh" | "ssh+git");
+        let strict_authority = matches!(scheme.as_str(), "http" | "https");
 
         // Parse authority: [user[:password]@]host[:port]
         let (username, password, host, port) = if let Some((user_info, host_port)) = authority.rsplit_once('@') {
@@ -179,7 +181,7 @@ impl ParsedUrl {
                 (percent_decode(user_info)?, None)
             };
 
-            let (h, p) = Self::parse_host_port(host_port, allow_unbracketed_ipv6)?;
+            let (h, p) = Self::parse_host_port(host_port, allow_unbracketed_ipv6, strict_authority)?;
             // If we have user info, we must have a host
             if h.is_none() {
                 return Err(UrlParseError::InvalidDomainCharacter);
@@ -187,7 +189,7 @@ impl ParsedUrl {
             (user, pass, h, p)
         } else {
             // No user info
-            let (h, p) = Self::parse_host_port(authority, allow_unbracketed_ipv6)?;
+            let (h, p) = Self::parse_host_port(authority, allow_unbracketed_ipv6, strict_authority)?;
             (String::new(), None, h, p)
         };
 
@@ -209,9 +211,11 @@ impl ParsedUrl {
         })
     }
 
+    /// `strict_authority` is set for HTTP/HTTPS.
     fn parse_host_port(
         host_port: &str,
         allow_unbracketed_ipv6: bool,
+        strict_authority: bool,
     ) -> Result<(Option<String>, Option<u16>), UrlParseError> {
         if host_port.is_empty() {
             return Ok((None, None));
@@ -220,8 +224,13 @@ impl ParsedUrl {
         // Handle IPv6 addresses: [::1] or [::1]:port
         if host_port.starts_with('[') {
             if let Some(bracket_end) = host_port.find(']') {
-                let host =
-                    normalize_ipv6_literal(&host_port[1..bracket_end]).ok_or(UrlParseError::InvalidDomainCharacter)?;
+                let inner = &host_port[1..bracket_end];
+                let host = match normalize_ipv6_literal(inner) {
+                    Some(host) if !strict_authority => percent_decode(&host)?,
+                    Some(host) => host,
+                    None if !strict_authority => percent_decode(inner)?,
+                    None => return Err(UrlParseError::InvalidDomainCharacter),
+                };
                 let remaining = &host_port[bracket_end + 1..];
 
                 if remaining.is_empty() {
@@ -231,9 +240,11 @@ impl ParsedUrl {
                         // Empty port like "[::1]:" - preserve the trailing colon for Git compatibility
                         return Ok((Some(format!("[{host}]:")), None));
                     }
+                    if !port_str.bytes().all(|b| b.is_ascii_digit()) {
+                        return Err(UrlParseError::InvalidPort);
+                    }
                     let port = port_str.parse::<u16>().map_err(|_| UrlParseError::InvalidPort)?;
-                    // Validate port is in valid range (1-65535, port 0 is invalid)
-                    if port == 0 {
+                    if port == 0 && strict_authority {
                         return Err(UrlParseError::InvalidPort);
                     }
                     return Ok((Some(format!("[{host}]")), Some(port)));
@@ -257,29 +268,46 @@ impl ParsedUrl {
         // Handle regular host:port. Unbracketed colons cannot be part of a host.
         if let Some((before_last_colon, after_last_colon)) = host_port.rsplit_once(':') {
             if before_last_colon.is_empty() || before_last_colon.contains(':') {
-                return Err(UrlParseError::InvalidDomainCharacter);
+                return if strict_authority {
+                    Err(UrlParseError::InvalidDomainCharacter)
+                } else {
+                    Ok((Some(Self::normalize_git_hostname(host_port)?), None))
+                };
             }
             if after_last_colon.is_empty() {
                 // Empty port like "host:" - store host with trailing colon for Git compatibility.
-                let mut host = Self::normalize_hostname(before_last_colon)?;
+                let mut host = if strict_authority {
+                    Self::normalize_http_hostname(before_last_colon)?
+                } else {
+                    Self::normalize_git_hostname(before_last_colon)?
+                };
                 host.push(':');
                 return Ok((Some(host), None));
             }
             if !after_last_colon.chars().all(|c| c.is_ascii_digit()) {
                 return Err(UrlParseError::InvalidPort);
             }
-            let host = Self::normalize_hostname(before_last_colon)?;
+            let host = if strict_authority {
+                Self::normalize_http_hostname(before_last_colon)?
+            } else {
+                Self::normalize_git_hostname(before_last_colon)?
+            };
             let port = after_last_colon
                 .parse::<u16>()
                 .map_err(|_| UrlParseError::InvalidPort)?;
-            if port == 0 {
+            if port == 0 && strict_authority {
                 return Err(UrlParseError::InvalidPort);
             }
             return Ok((Some(host), Some(port)));
         }
 
         // No port, just host.
-        Ok((Some(Self::normalize_hostname(host_port)?), None))
+        let host = if strict_authority {
+            Self::normalize_http_hostname(host_port)?
+        } else {
+            Self::normalize_git_hostname(host_port)?
+        };
+        Ok((Some(host), None))
     }
 
     fn is_normalizable_hostname(host: &str) -> bool {
@@ -289,7 +317,7 @@ impl ParsedUrl {
 
     /// Validate a hostname and normalize DNS-like ASCII hostnames to lowercase.
     /// Hostnames containing other permitted URL characters retain their original case.
-    fn normalize_hostname(host: &str) -> Result<String, UrlParseError> {
+    fn normalize_http_hostname(host: &str) -> Result<String, UrlParseError> {
         if !host.bytes().all(|c| {
             c.is_ascii_alphanumeric()
                 || matches!(
@@ -317,6 +345,19 @@ impl ParsedUrl {
             host.to_ascii_lowercase()
         } else {
             host.to_owned()
+        })
+    }
+
+    /// Decode percent escapes before normalizing DNS-like hostnames for Git-compatible, non-HTTP authorities.
+    ///
+    /// This is separate from [`Self::normalize_http_hostname`] because Git passes the decoded host to transports, whereas
+    /// HTTP and HTTPS retain escaped host spelling and apply stricter hostname validation.
+    fn normalize_git_hostname(host: &str) -> Result<String, UrlParseError> {
+        let host = percent_decode(host)?;
+        Ok(if Self::is_normalizable_hostname(&host) {
+            host.to_ascii_lowercase()
+        } else {
+            host
         })
     }
 }
@@ -401,9 +442,9 @@ mod tests {
             ("http://example.com:abc/", "non-numeric ports must be rejected"),
             ("http://foo:bar:baz/", "unbracketed colons must be rejected"),
             ("http://[not-ip]/", "bracketed hosts must be valid IPv6 addresses"),
-            ("ssh://[fe80::1%25]/repo", "IPv6 zone identifiers must not be empty"),
+            ("http://[fe80::1%25]/repo", "IPv6 zone identifiers must not be empty"),
             (
-                "ssh://[fe80::1%25eth!0]/repo",
+                "http://[fe80::1%25eth!0]/repo",
                 "IPv6 zone identifiers contain only unreserved or percent-encoded characters",
             ),
             ("http://bücher.example/", "non-ASCII hostnames must be rejected"),

--- a/gix-url/src/simple_url.rs
+++ b/gix-url/src/simple_url.rs
@@ -71,12 +71,17 @@ impl ParsedUrl {
         // Find the end of the authority.
         let path_start = after_scheme.find(['/', '?', '#']).unwrap_or(after_scheme.len());
         let authority = &after_scheme[..path_start];
+        if authority.contains('\\') {
+            return Err(UrlParseError::InvalidDomainCharacter);
+        }
         let path = if path_start < after_scheme.len() {
             percent_decode(&after_scheme[path_start..])?
         } else {
             // No path specified - leave empty (caller can default to / if needed)
             String::new()
         };
+
+        let allow_unbracketed_ipv6 = matches!(scheme.as_str(), "git" | "ssh" | "git+ssh" | "ssh+git");
 
         // Parse authority: [user[:password]@]host[:port]
         let (username, password, host, port) = if let Some((user_info, host_port)) = authority.rsplit_once('@') {
@@ -94,7 +99,7 @@ impl ParsedUrl {
                 (percent_decode(user_info)?, None)
             };
 
-            let (h, p) = Self::parse_host_port(host_port)?;
+            let (h, p) = Self::parse_host_port(host_port, allow_unbracketed_ipv6)?;
             // If we have user info, we must have a host
             if h.is_none() {
                 return Err(UrlParseError::InvalidDomainCharacter);
@@ -102,7 +107,7 @@ impl ParsedUrl {
             (user, pass, h, p)
         } else {
             // No user info
-            let (h, p) = Self::parse_host_port(authority)?;
+            let (h, p) = Self::parse_host_port(authority, allow_unbracketed_ipv6)?;
             (String::new(), None, h, p)
         };
 
@@ -123,7 +128,10 @@ impl ParsedUrl {
         })
     }
 
-    fn parse_host_port(host_port: &str) -> Result<(Option<String>, Option<u16>), UrlParseError> {
+    fn parse_host_port(
+        host_port: &str,
+        allow_unbracketed_ipv6: bool,
+    ) -> Result<(Option<String>, Option<u16>), UrlParseError> {
         if host_port.is_empty() {
             return Ok((None, None));
         }
@@ -131,6 +139,9 @@ impl ParsedUrl {
         // Handle IPv6 addresses: [::1] or [::1]:port
         if host_port.starts_with('[') {
             if let Some(bracket_end) = host_port.find(']') {
+                if host_port[1..bracket_end].parse::<std::net::Ipv6Addr>().is_err() {
+                    return Err(UrlParseError::InvalidDomainCharacter);
+                }
                 let remaining = &host_port[bracket_end + 1..];
 
                 if remaining.is_empty() {
@@ -159,67 +170,79 @@ impl ParsedUrl {
             }
         }
 
-        // Handle regular host:port
-        // Use rfind to find the last colon
-        if let Some((before_last_colon, after_last_colon)) = host_port.rsplit_once(':') {
-            // Check if this looks like a port (all digits after colon)
-            // But avoid treating IPv6 addresses as host:port
-            // IPv6 addresses have colons in the part before the last colon (e.g., "::1" has "::" before the last ":")
-            let has_colon_before_last = before_last_colon.contains(':');
-            let is_all_digits_after =
-                !after_last_colon.is_empty() && after_last_colon.chars().all(|c| c.is_ascii_digit());
-
-            // Treat as port separator only if:
-            // 1. There's no colon before the last colon (normal host:port)
-            // 2. OR it's explicitly empty (host: with trailing colon)
-            if !has_colon_before_last {
-                if after_last_colon.is_empty() {
-                    // Empty port like "host:" - store host with trailing colon
-                    // This is needed for Git compatibility where "host:" != "host"
-                    return Ok((Some(Self::normalize_hostname(host_port)?), None));
-                } else if is_all_digits_after {
-                    let host = Self::normalize_hostname(before_last_colon)?;
-                    let port = after_last_colon
-                        .parse::<u16>()
-                        .map_err(|_| UrlParseError::InvalidPort)?;
-                    // Validate port is in valid range (1-65535, port 0 is invalid)
-                    if port == 0 {
-                        return Err(UrlParseError::InvalidPort);
-                    }
-                    return Ok((Some(host), Some(port)));
-                }
-            }
+        if allow_unbracketed_ipv6
+            && (host_port.parse::<std::net::Ipv6Addr>().is_ok()
+                || host_port
+                    .strip_suffix(':')
+                    .is_some_and(|host| host.parse::<std::net::Ipv6Addr>().is_ok()))
+        {
+            return Ok((Some(host_port.to_ascii_lowercase()), None));
         }
 
-        // No port, just host (including bare IPv6 addresses)
+        // Handle regular host:port. Unbracketed colons cannot be part of a host.
+        if let Some((before_last_colon, after_last_colon)) = host_port.rsplit_once(':') {
+            if before_last_colon.is_empty() || before_last_colon.contains(':') {
+                return Err(UrlParseError::InvalidDomainCharacter);
+            }
+            if after_last_colon.is_empty() {
+                // Empty port like "host:" - store host with trailing colon for Git compatibility.
+                let mut host = Self::normalize_hostname(before_last_colon)?;
+                host.push(':');
+                return Ok((Some(host), None));
+            }
+            if !after_last_colon.chars().all(|c| c.is_ascii_digit()) {
+                return Err(UrlParseError::InvalidPort);
+            }
+            let host = Self::normalize_hostname(before_last_colon)?;
+            let port = after_last_colon
+                .parse::<u16>()
+                .map_err(|_| UrlParseError::InvalidPort)?;
+            if port == 0 {
+                return Err(UrlParseError::InvalidPort);
+            }
+            return Ok((Some(host), Some(port)));
+        }
+
+        // No port, just host.
         Ok((Some(Self::normalize_hostname(host_port)?), None))
     }
 
-    /// Check if a string looks like a valid DNS hostname (for normalization purposes)
-    /// Valid DNS names contain only alphanumeric, hyphens, dots, underscores, and wildcards
     fn is_normalizable_hostname(host: &str) -> bool {
-        // Allow alphanumeric, -, ., _, and * (for patterns)
-        host.chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '*'))
+        host.bytes()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, b'-' | b'.' | b'_' | b'*'))
     }
 
-    /// Validate and possibly normalize a hostname
-    /// Valid DNS hostnames are normalized to lowercase
-    /// Hostnames containing ? or whitespace characters are rejected with an error
+    /// Validate a hostname and normalize DNS-like ASCII hostnames to lowercase.
+    /// Hostnames containing other permitted URL characters retain their original case.
     fn normalize_hostname(host: &str) -> Result<String, UrlParseError> {
-        // Reject invalid characters: ?, space, tab, newline, etc.
-        // These characters are forbidden in URLs per RFC 3986
-        if host.chars().any(|c| c == '?' || c.is_whitespace()) {
+        if !host.bytes().all(|c| {
+            c.is_ascii_alphanumeric()
+                || matches!(
+                    c,
+                    b'-' | b'.'
+                        | b'_'
+                        | b'~'
+                        | b'!'
+                        | b'$'
+                        | b'&'
+                        | b'\''
+                        | b'('
+                        | b')'
+                        | b'*'
+                        | b'+'
+                        | b','
+                        | b';'
+                        | b'='
+                        | b'%'
+                )
+        }) {
             return Err(UrlParseError::InvalidDomainCharacter);
         }
-
-        // Only normalize if it looks like a valid DNS hostname
-        // Preserve case for security checks if it contains special characters
-        if Self::is_normalizable_hostname(host) {
-            Ok(host.to_ascii_lowercase())
+        Ok(if Self::is_normalizable_hostname(host) {
+            host.to_ascii_lowercase()
         } else {
-            Ok(host.to_owned())
-        }
+            host.to_owned()
+        })
     }
 }
 
@@ -281,6 +304,40 @@ mod tests {
         assert_eq!(url.host.as_deref(), Some("[::1]"));
         assert_eq!(url.port, Some(8080));
         assert_eq!(url.path, "/path");
+    }
+
+    #[test]
+    fn git_schemes_allow_unbracketed_ipv6() {
+        for scheme in ["git", "ssh", "git+ssh", "ssh+git"] {
+            let url = ParsedUrl::parse(&format!("{scheme}://user@::1/repo"))
+                .expect("Git schemes allow unbracketed IPv6 hosts");
+            assert_eq!(url.host.as_deref(), Some("::1"), "the IPv6 address is the host");
+            assert_eq!(url.path, "/repo", "the path remains separate from the IPv6 host");
+        }
+    }
+
+    #[test]
+    fn malformed_authorities_are_rejected() {
+        for (url, message) in [
+            (
+                r"http://redirected.example\@original.example/repo",
+                "backslashes in the authority must be rejected",
+            ),
+            ("http://example.com:abc/", "non-numeric ports must be rejected"),
+            ("http://foo:bar:baz/", "unbracketed colons must be rejected"),
+            ("http://[not-ip]/", "bracketed hosts must be valid IPv6 addresses"),
+            ("http://bücher.example/", "non-ASCII hostnames must be rejected"),
+            ("http://::1/", "unbracketed IPv6 addresses must be rejected for HTTP"),
+        ] {
+            assert!(ParsedUrl::parse(url).is_err(), "{message}");
+        }
+    }
+
+    #[test]
+    fn utf8_user_information_is_accepted() {
+        let url = ParsedUrl::parse("ssh://jörg:passwörd@example.com/repo").expect("valid UTF-8 user information");
+        assert_eq!(url.username, "jörg", "the username is preserved");
+        assert_eq!(url.password.as_deref(), Some("passwörd"), "the password is preserved");
     }
 
     #[test]

--- a/gix-url/src/simple_url.rs
+++ b/gix-url/src/simple_url.rs
@@ -68,8 +68,8 @@ impl ParsedUrl {
             return Err(UrlParseError::RelativeUrlWithoutBase);
         }
 
-        // Find path start (first '/' after scheme)
-        let path_start = after_scheme.find('/').unwrap_or(after_scheme.len());
+        // Find the end of the authority.
+        let path_start = after_scheme.find(['/', '?', '#']).unwrap_or(after_scheme.len());
         let authority = &after_scheme[..path_start];
         let path = if path_start < after_scheme.len() {
             percent_decode(&after_scheme[path_start..])?

--- a/gix-url/tests/fixtures/make_baseline.sh
+++ b/gix-url/tests/fixtures/make_baseline.sh
@@ -13,6 +13,12 @@ credential_urls=(
   "https://example.com/%3Fquery"
   "https://example.com/%23fragment"
   "https://example.com/%252F"
+  "https://host?@redirected/repo"
+  "https://host#@redirected/repo"
+  "https://example.com/a%20b"
+  "https://example.com/caf%C3%A9"
+  "https://[2001:db8::1]:8443/repo"
+  "https://example.com/%2f%3f%23%25"
 )
 
 # The contents and structure of this loop are an adaption
@@ -59,6 +65,40 @@ done
 tests_windows+=("file://c:/repo")
 tests_windows+=("c:repo")
 tests+=("ssh://[fe80::1%25Eth0]/repo")
+tests+=(
+  "ssh://host?@redirected/repo"
+  "ssh://host#@redirected/repo"
+  "ssh://host%2ename/repo"
+  "git://host%2ename/repo"
+  "ssh://host:0/repo"
+  "ssh://foo:bar:baz/repo"
+  "ssh://[not-ip]/repo"
+  "file://::1/repo"
+  "ssh://host:1/repo"
+  "ssh://host:65535/repo"
+  "ssh://user@[2001:db8::1]:2222/repo"
+  "ssh://user@2001:db8::1/repo"
+  "ssh://::1/repo"
+  "git://::1/repo"
+  "ssh://host/a%2Fb"
+  "ssh://host/%3Fquery"
+  "ssh://host/%23fragment"
+  "ssh://host/%252F"
+  "git://host/a%2Fb"
+)
+tests_unix+=(
+  "file:///repo"
+  "file://host/repo"
+  "file://localhost/repo"
+  "file://[::1]/repo"
+  "file://x:/repo"
+)
+tests_windows+=(
+  "file:///repo"
+  "file://host/repo"
+  "file://localhost/repo"
+  "file://[::1]/repo"
+)
 
 tests_unix+=("${tests[@]}")
 tests_windows+=("${tests[@]}")

--- a/gix-url/tests/fixtures/make_baseline.sh
+++ b/gix-url/tests/fixtures/make_baseline.sh
@@ -58,6 +58,7 @@ done
 # These two test cases are from git's test suite as well.
 tests_windows+=("file://c:/repo")
 tests_windows+=("c:repo")
+tests+=("ssh://[fe80::1%25Eth0]/repo")
 
 tests_unix+=("${tests[@]}")
 tests_windows+=("${tests[@]}")

--- a/gix-url/tests/fixtures/make_baseline.sh
+++ b/gix-url/tests/fixtures/make_baseline.sh
@@ -55,7 +55,7 @@ for path in "repo" "re:po" "re/po"; do
     tests+=("./$protocol:$host/~$path")
   done
   # SCP like urls
-  for host in "user@name@host" "user_name@host" "host" "[::1]"; do
+  for host in "user@name@host" "user_name@host" "host" "[::1]" "[fe80::1%Eth0]"; do
     tests+=("$host:$path")
     tests+=("$host:/~$path")
   done

--- a/gix-url/tests/fixtures/make_baseline.sh
+++ b/gix-url/tests/fixtures/make_baseline.sh
@@ -7,6 +7,13 @@ tests=()
 tests_unix=()
 # urls only intended for testing on Windows
 tests_windows=()
+# HTTP URLs whose decoded paths are obtained through Git's credential plumbing.
+credential_urls=(
+  "https://example.com/a%2Fb/"
+  "https://example.com/%3Fquery"
+  "https://example.com/%23fragment"
+  "https://example.com/%252F"
+)
 
 # The contents and structure of this loop are an adaption
 # from git's own test suite (t/t5500-fetch-pack.sh).
@@ -71,5 +78,19 @@ do
   echo ";" # there are no `;` in the tested urls
   git -C temp-repo fetch-pack --diag-url "$url"
 done >git-baseline.windows
+
+# `fetch-pack --diag-url` doesn't support HTTP, so use Git's credential parser as the baseline oracle.
+for url in "${credential_urls[@]}"
+do
+  block=$(
+    echo ";"
+    echo "Diag: url=$url"
+    printf 'url=%s\n\n' "$url" |
+      git -c credential.useHttpPath=true \
+        -c 'credential.helper=!f() { echo username=baseline; echo password=baseline; }; f' credential fill |
+      sed -n 's/^protocol=/Diag: protocol=/p; s/^host=/Diag: hostandport=/p; s/^path=/Diag: path=/p'
+  )
+  printf '%s\n' "$block" | tee -a git-baseline.unix >>git-baseline.windows
+done
 
 rm -rf temp-repo

--- a/gix-url/tests/url/access.rs
+++ b/gix-url/tests/url/access.rs
@@ -160,6 +160,15 @@ fn path_argument_safety() -> crate::Result {
     assert_eq!(url.path, "/-oProxyCommand=open$IFS-aCalculator");
     assert_eq!(url.path_argument_safe(), None, "An unsafe path is blocked");
 
+    for input in ["foo:path", "foo:-option"] {
+        let url = gix_url::parse(input)?;
+        assert_eq!(
+            url.path_argument_safe(),
+            None,
+            "relative paths need validation at their command-line use site"
+        );
+    }
+
     Ok(())
 }
 

--- a/gix-url/tests/url/baseline.rs
+++ b/gix-url/tests/url/baseline.rs
@@ -6,6 +6,10 @@ fn parse_and_compare_baseline_urls() {
     let mut failed = 0;
     let mut expected_failures = 0;
     let total = baseline::URLS.len();
+    assert_ne!(
+        total, 0,
+        "baseline must contain expectations (425 at this time just FYI)"
+    );
 
     for (url, expected) in baseline::URLS.iter() {
         if baseline::is_expected_failure_on_windows(url) {
@@ -101,7 +105,9 @@ fn assert_urls_equal(expected: &baseline::GitDiagUrl<'_>, actual: &gix_url::Url)
     }
 
     if matches!(actual.scheme, gix_url::Scheme::Http | gix_url::Scheme::Https) {
-        assert_eq!(actual.path.trim_with(|b| b == '/'), expected.path.unwrap_or_default());
+        let path = actual.path.strip_prefix(b"/").unwrap_or(&actual.path);
+        let path = path.strip_suffix(b"/").unwrap_or(path);
+        assert_eq!(path, expected.path.unwrap_or_default());
     } else {
         assert_eq!(actual.path, expected.path.unwrap_or_default());
     }

--- a/gix-url/tests/url/baseline.rs
+++ b/gix-url/tests/url/baseline.rs
@@ -8,7 +8,7 @@ fn parse_and_compare_baseline_urls() {
     let total = baseline::URLS.len();
     assert_ne!(
         total, 0,
-        "baseline must contain expectations (425 at this time just FYI)"
+        "baseline must contain expectations (431 on Unix at this time just FYI)"
     );
 
     for (url, expected) in baseline::URLS.iter() {
@@ -158,12 +158,14 @@ mod baseline {
         out
     });
 
-    /// Known failures on Windows for IPv6 file URLs with paths.
-    /// On Windows, these URLs fail to parse the path component correctly.
+    /// Known failures caused by Windows-specific `file://` host and path interpretation.
     pub fn is_expected_failure_on_windows(url: &BStr) -> bool {
         #[cfg(windows)]
         {
             const EXPECTED_FAILURES: &[&str] = &[
+                "file://host/repo",
+                "file://localhost/repo",
+                "file://[::1]/repo",
                 "file://User@[::1]/repo",
                 "file://User@[::1]/~repo",
                 "file://User@[::1]/re:po",

--- a/gix-url/tests/url/baseline.rs
+++ b/gix-url/tests/url/baseline.rs
@@ -100,7 +100,11 @@ fn assert_urls_equal(expected: &baseline::GitDiagUrl<'_>, actual: &gix_url::Url)
         }
     }
 
-    assert_eq!(actual.path, expected.path.unwrap_or_default());
+    if matches!(actual.scheme, gix_url::Scheme::Http | gix_url::Scheme::Https) {
+        assert_eq!(actual.path.trim_with(|b| b == '/'), expected.path.unwrap_or_default());
+    } else {
+        assert_eq!(actual.path, expected.path.unwrap_or_default());
+    }
 }
 
 #[expect(clippy::module_inception)]

--- a/gix-url/tests/url/parse/http.rs
+++ b/gix-url/tests/url/parse/http.rs
@@ -198,3 +198,25 @@ fn query_and_fragment_delimiters_in_path_roundtrip() -> crate::Result {
     )?;
     Ok(())
 }
+
+#[test]
+fn query_and_fragment_delimiters_end_the_authority() -> crate::Result {
+    for input in ["https://host?@redirected/repo", "https://host#@redirected/repo"] {
+        let url = gix_url::parse(input)?;
+        assert_eq!(url.host(), Some("host"), "the authority ends at the delimiter");
+        assert_eq!(
+            &url.path,
+            &input["https://host".len()..],
+            "the remainder is kept in the path"
+        );
+    }
+    for delimiter in ['?', '#'] {
+        let input = format!("https://host{delimiter}{}", "x".repeat(1025));
+        assert_eq!(
+            gix_url::parse(input)?.host(),
+            Some("host"),
+            "the remainder does not count toward the authority length"
+        );
+    }
+    Ok(())
+}

--- a/gix-url/tests/url/parse/http.rs
+++ b/gix-url/tests/url/parse/http.rs
@@ -293,3 +293,19 @@ fn query_and_fragment_delimiters_end_the_authority() -> crate::Result {
     }
     Ok(())
 }
+
+#[test]
+fn authority_length_limit_excludes_the_scheme_separator() -> crate::Result {
+    let at_limit = format!("https://{}", "a".repeat(1024));
+    assert_eq!(
+        gix_url::parse(&at_limit)?.host().map(str::len),
+        Some(1024),
+        "the full authority limit is accepted"
+    );
+    let over_limit = format!("https://{}", "a".repeat(1025));
+    assert!(
+        matches!(gix_url::parse(over_limit), Err(gix_url::parse::Error::TooLong { .. })),
+        "one byte beyond the authority limit is rejected"
+    );
+    Ok(())
+}

--- a/gix-url/tests/url/parse/http.rs
+++ b/gix-url/tests/url/parse/http.rs
@@ -171,17 +171,90 @@ fn percent_encoded_international_path() -> crate::Result {
 }
 
 #[test]
+fn reserved_percent_encoded_path_octets_remain_encoded() -> crate::Result {
+    for (input, message) in [
+        ("https://example.com/a%2Fb", "an encoded slash remains path data"),
+        (
+            "https://example.com/%3Fquery",
+            "an encoded question mark does not start a query",
+        ),
+        (
+            "https://example.com/%23fragment",
+            "an encoded hash does not start a fragment",
+        ),
+        (
+            "https://example.com/%252F",
+            "an encoded percent sign remains lossless",
+        ),
+    ] {
+        let url = gix_url::parse(input)?;
+        assert_eq!(url.to_bstring(), input, "{message}");
+        assert!(url.path.contains(&b'%'), "{message}");
+    }
+    Ok(())
+}
+
+#[test]
+fn literal_percent_escape_text_from_parts_is_encoded() -> crate::Result {
+    let url = gix_url::Url::from_parts(
+        Scheme::Https,
+        None,
+        None,
+        Some("example.com".into()),
+        None,
+        "/foo%2Fbar".into(),
+        false,
+    )?;
+    assert_eq!(url.path, "/foo%2Fbar", "the decoded path remains unchanged");
+    assert_eq!(
+        url.to_bstring(),
+        "https://example.com/foo%252Fbar",
+        "literal percent text is encoded"
+    );
+    let empty = gix_url::Url::from_parts(
+        Scheme::Https,
+        None,
+        None,
+        Some("example.com".into()),
+        None,
+        "".into(),
+        false,
+    )?;
+    assert_eq!(empty.path, "/", "an empty HTTP path is normalized");
+    assert_eq!(empty.to_bstring(), "https://example.com/");
+
+    let mut parsed = gix_url::parse("https://example.com/a%2Fb")?;
+    parsed.path = "/literal%2Ftext".into();
+    assert_eq!(
+        parsed.to_bstring(),
+        "https://example.com/literal%252Ftext",
+        "mutating a parsed path invalidates preserved escapes"
+    );
+    Ok(())
+}
+
+#[test]
 fn percent_encoded_path_roundtrips_in_lossless_serialization() -> crate::Result {
-    for (input, expected_host, expected_path) in [
-        ("https://%20@%40.example.org/%20%25", "%40.example.org", "/ %"),
-        ("https://%20@%40.example.org/%20%25/%20%25", "%40.example.org", "/ %/ %"),
+    for (input, message, expected_host, expected_path) in [
+        (
+            "https://%20@%40.example.org/%20%25",
+            "a single percent-encoded path segment roundtrips losslessly",
+            "%40.example.org",
+            "/ %25",
+        ),
+        (
+            "https://%20@%40.example.org/%20%25/%20%25",
+            "multiple percent-encoded path segments roundtrip losslessly",
+            "%40.example.org",
+            "/ %25/ %25",
+        ),
     ] {
         let url = gix_url::parse(input)?;
         let serialized = url.to_bstring();
-        assert_eq!(serialized, input);
-        assert_eq!(url.host(), Some(expected_host));
-        assert_eq!(url.path, expected_path);
-        assert_eq!(gix_url::parse(&serialized)?, url);
+        assert_eq!(serialized, input, "{message}");
+        assert_eq!(url.host(), Some(expected_host), "{message}");
+        assert_eq!(url.path, expected_path, "{message}");
+        assert_eq!(gix_url::parse(&serialized)?, url, "{message}");
     }
     Ok(())
 }

--- a/gix-url/tests/url/parse/http.rs
+++ b/gix-url/tests/url/parse/http.rs
@@ -160,6 +160,11 @@ fn https_with_ipv6_user_and_port() -> crate::Result {
 fn percent_encoded_path() -> crate::Result {
     let url = gix_url::parse("https://example.com/path/with%20spaces/file")?;
     assert_eq!(url.path, "/path/with spaces/file", "paths are now decoded");
+    assert_eq!(
+        url.original_path(),
+        "/path/with%20spaces/file",
+        "the encoded request path remains available"
+    );
     Ok(())
 }
 
@@ -167,6 +172,42 @@ fn percent_encoded_path() -> crate::Result {
 fn percent_encoded_international_path() -> crate::Result {
     let url = gix_url::parse("https://example.com/caf%C3%A9")?;
     assert_eq!(url.path, "/café", "international characters are decoded in path");
+    Ok(())
+}
+
+#[test]
+fn original_path_preserves_exact_spelling() -> crate::Result {
+    for (input, decoded_path, original_path, message) in [
+        (
+            "https://example.com/plain",
+            "/plain",
+            "/plain",
+            "a path without escapes falls back to the decoded path",
+        ),
+        (
+            "https://example.com/%41",
+            "/A",
+            "/%41",
+            "an unreserved escape retains its spelling",
+        ),
+        (
+            "https://example.com/%2f",
+            "//",
+            "/%2f",
+            "lowercase escape digits retain their case",
+        ),
+        (
+            "https://example.com/caf%C3%A9",
+            "/café",
+            "/caf%C3%A9",
+            "a multi-byte escape retains its complete spelling",
+        ),
+    ] {
+        let url = gix_url::parse(input)?;
+        assert_eq!(url.path, decoded_path, "the public path is decoded: {message}");
+        assert_eq!(url.original_path(), original_path, "{message}");
+        assert_eq!(url.to_bstring(), input, "serialization remains lossless: {message}");
+    }
     Ok(())
 }
 
@@ -232,6 +273,11 @@ fn literal_percent_escape_text_from_parts_is_encoded() -> crate::Result {
 
     let mut parsed = gix_url::parse("https://example.com/a%2Fb")?;
     parsed.path = "/literal%2Ftext".into();
+    assert_eq!(
+        parsed.original_path(),
+        "/literal%2Ftext",
+        "mutating the path invalidates its encoded spelling"
+    );
     assert_eq!(
         parsed.to_bstring(),
         "https://example.com/literal%252Ftext",

--- a/gix-url/tests/url/parse/http.rs
+++ b/gix-url/tests/url/parse/http.rs
@@ -171,25 +171,32 @@ fn percent_encoded_international_path() -> crate::Result {
 }
 
 #[test]
-fn reserved_percent_encoded_path_octets_remain_encoded() -> crate::Result {
-    for (input, message) in [
-        ("https://example.com/a%2Fb", "an encoded slash remains path data"),
+fn reserved_percent_encoded_path_octets_remain_lossless() -> crate::Result {
+    for (input, expected_path, message) in [
+        (
+            "https://example.com/a%2Fb",
+            "/a/b",
+            "an encoded slash remains path data",
+        ),
         (
             "https://example.com/%3Fquery",
+            "/?query",
             "an encoded question mark does not start a query",
         ),
         (
             "https://example.com/%23fragment",
+            "/#fragment",
             "an encoded hash does not start a fragment",
         ),
         (
             "https://example.com/%252F",
+            "/%2F",
             "an encoded percent sign remains lossless",
         ),
     ] {
         let url = gix_url::parse(input)?;
         assert_eq!(url.to_bstring(), input, "{message}");
-        assert!(url.path.contains(&b'%'), "{message}");
+        assert_eq!(url.path, expected_path, "the public path is decoded: {message}");
     }
     Ok(())
 }
@@ -240,13 +247,13 @@ fn percent_encoded_path_roundtrips_in_lossless_serialization() -> crate::Result 
             "https://%20@%40.example.org/%20%25",
             "a single percent-encoded path segment roundtrips losslessly",
             "%40.example.org",
-            "/ %25",
+            "/ %",
         ),
         (
             "https://%20@%40.example.org/%20%25/%20%25",
             "multiple percent-encoded path segments roundtrip losslessly",
             "%40.example.org",
-            "/ %25/ %25",
+            "/ %/ %",
         ),
     ] {
         let url = gix_url::parse(input)?;

--- a/gix-url/tests/url/parse/http.rs
+++ b/gix-url/tests/url/parse/http.rs
@@ -173,8 +173,8 @@ fn percent_encoded_international_path() -> crate::Result {
 #[test]
 fn percent_encoded_path_roundtrips_in_lossless_serialization() -> crate::Result {
     for (input, expected_host, expected_path) in [
-        ("https://%20@%40:example.org/%20%25", "%40:example.org", "/ %"),
-        ("https://%20@%40:example.org/%20%25/%20%25", "%40:example.org", "/ %/ %"),
+        ("https://%20@%40.example.org/%20%25", "%40.example.org", "/ %"),
+        ("https://%20@%40.example.org/%20%25/%20%25", "%40.example.org", "/ %/ %"),
     ] {
         let url = gix_url::parse(input)?;
         let serialized = url.to_bstring();

--- a/gix-url/tests/url/parse/invalid.rs
+++ b/gix-url/tests/url/parse/invalid.rs
@@ -41,23 +41,33 @@ fn missing_port_despite_indication() {
 }
 
 #[test]
-fn port_zero_is_invalid() {
-    assert_matches!(parse("ssh://host.xz:0/path"), Err(Url { .. }));
+fn port_zero_is_accepted_for_git_compatibility() {
+    for input in [
+        "ssh://host.xz:0/path",
+        "ssh://[::1]:0/path",
+        "git://host.xz:0/path",
+        "git://[::1]:0/path",
+    ] {
+        let url = parse(input).expect("Git accepts port zero");
+        assert_eq!(url.port, Some(0), "port zero is retained: {input}");
+    }
 }
 
 #[test]
-fn port_too_large() {
-    assert_matches!(parse("ssh://host.xz:65536/path"), Err(Url { .. }));
-    assert_matches!(parse("ssh://host.xz:99999/path"), Err(Url { .. }));
-}
-
-#[test]
-fn invalid_port_format() {
-    assert_matches!(
-        parse("ssh://host.xz:abc/path"),
-        Err(Url { .. }),
-        "non-numeric ports must be rejected"
-    );
+fn textual_and_overflowing_ssh_and_git_ports_are_rejected_despite_git() {
+    for input in [
+        "ssh://host.xz:abc/path",
+        "git://host.xz:abc/path",
+        "ssh://host.xz:65536/path",
+        "ssh://host.xz:99999/path",
+        "git://host.xz:65536/path",
+    ] {
+        assert_matches!(
+            parse(input),
+            Err(Url { .. }),
+            "invalid ports are diagnosed instead of being treated as host text: {input}"
+        );
+    }
 }
 
 #[test]

--- a/gix-url/tests/url/parse/invalid.rs
+++ b/gix-url/tests/url/parse/invalid.rs
@@ -53,13 +53,11 @@ fn port_too_large() {
 
 #[test]
 fn invalid_port_format() {
-    let url = parse("ssh://host.xz:abc/path").expect("non-numeric port is treated as part of host");
-    assert_eq!(
-        url.host(),
-        Some("host.xz:abc"),
-        "port parse failure makes it part of hostname"
+    assert_matches!(
+        parse("ssh://host.xz:abc/path"),
+        Err(Url { .. }),
+        "non-numeric ports must be rejected"
     );
-    assert_eq!(url.port, None);
 }
 
 #[test]

--- a/gix-url/tests/url/parse/ssh.rs
+++ b/gix-url/tests/url/parse/ssh.rs
@@ -306,6 +306,13 @@ fn ipv6_full_address() -> crate::Result {
 }
 
 #[test]
+fn percent_encoded_path_delimiters_are_decoded() -> crate::Result {
+    let url = gix_url::parse("ssh://example.com/a%2Fb")?;
+    assert_eq!(url.path, "/a/b", "Git decodes reserved escapes in SSH repository paths");
+    Ok(())
+}
+
+#[test]
 fn ipv6_address_scp_like() -> crate::Result {
     let url = assert_url("[::1]:repo", url_alternate(Scheme::Ssh, None, "::1", None, b"repo"))?;
     assert_eq!(url.host(), Some("::1"), "SCP-like format with IPv6");

--- a/gix-url/tests/url/parse/ssh.rs
+++ b/gix-url/tests/url/parse/ssh.rs
@@ -320,6 +320,20 @@ fn scoped_ipv6_address() -> crate::Result {
 }
 
 #[test]
+fn scp_like_scoped_ipv6_address_uses_a_raw_zone_separator() -> crate::Result {
+    let input = "[fe80::1%Eth0]:repo";
+    let url = gix_url::parse(input)?;
+    assert_eq!(url.host(), Some("fe80::1%Eth0"), "the raw percent sign is host data");
+    assert_eq!(
+        url.to_bstring(),
+        input,
+        "alternative serialization retains the raw separator"
+    );
+    assert_eq!(gix_url::parse(url.to_bstring())?, url, "the alternative form reparses");
+    Ok(())
+}
+
+#[test]
 fn scoped_ipv6_address_with_empty_port() -> crate::Result {
     let url = gix_url::parse("ssh://[fe80::1%25Eth0]:/repo")?;
     assert_eq!(
@@ -345,6 +359,32 @@ fn bracketed_host_is_percent_decoded_once() -> crate::Result {
         "an escape produced by decoding must not be decoded again"
     );
     assert_eq!(url.path, "/00%85]://", "the path is decoded once as well");
+    Ok(())
+}
+
+#[test]
+fn escaped_authority_delimiters_remain_host_data() -> crate::Result {
+    for (input, expected_host) in [
+        ("ssh://host%3A123/repo", "host:123"),
+        ("ssh://host%2Fname/repo", "host/name"),
+    ] {
+        let url = gix_url::parse(input)?;
+        assert_eq!(
+            url.host(),
+            Some(expected_host),
+            "the escaped delimiter is host data: {input}"
+        );
+        assert_eq!(
+            url.to_bstring(),
+            input,
+            "serialization re-escapes the delimiter: {input}"
+        );
+        assert_eq!(
+            gix_url::parse(url.to_bstring())?,
+            url,
+            "the URL reparses unchanged: {input}"
+        );
+    }
     Ok(())
 }
 

--- a/gix-url/tests/url/parse/ssh.rs
+++ b/gix-url/tests/url/parse/ssh.rs
@@ -349,9 +349,26 @@ fn bracketed_host_is_percent_decoded_once() -> crate::Result {
 }
 
 #[test]
-fn percent_encoded_path_delimiters_are_decoded() -> crate::Result {
-    let url = gix_url::parse("ssh://example.com/a%2Fb")?;
-    assert_eq!(url.path, "/a/b", "Git decodes reserved escapes in SSH repository paths");
+fn percent_encoded_paths_are_decoded_and_the_original_is_retained() -> crate::Result {
+    for (input, decoded_path, original_path, message) in [
+        (
+            "ssh://example.com/a%2Fb",
+            "/a/b",
+            "/a%2Fb",
+            "Git decodes reserved escapes in SSH repository paths",
+        ),
+        (
+            "ssh://example.com/a%20b",
+            "/a b",
+            "/a%20b",
+            "original paths are available independently of the URL scheme",
+        ),
+    ] {
+        let url = gix_url::parse(input)?;
+        assert_eq!(url.path, decoded_path, "{message}");
+        assert_eq!(url.original_path(), original_path, "{message}");
+        assert_eq!(url.to_bstring(), input, "serialization remains lossless: {message}");
+    }
     Ok(())
 }
 

--- a/gix-url/tests/url/parse/ssh.rs
+++ b/gix-url/tests/url/parse/ssh.rs
@@ -337,6 +337,18 @@ fn scoped_ipv6_address_with_empty_port() -> crate::Result {
 }
 
 #[test]
+fn bracketed_host_is_percent_decoded_once() -> crate::Result {
+    let url = gix_url::parse("SSh://[::81ssssssssssssssssssssssssssssssssssssss%2585]:/00%2585]://")?;
+    assert_eq!(
+        url.host(),
+        Some("::81ssssssssssssssssssssssssssssssssssssss%85"),
+        "an escape produced by decoding must not be decoded again"
+    );
+    assert_eq!(url.path, "/00%85]://", "the path is decoded once as well");
+    Ok(())
+}
+
+#[test]
 fn percent_encoded_path_delimiters_are_decoded() -> crate::Result {
     let url = gix_url::parse("ssh://example.com/a%2Fb")?;
     assert_eq!(url.path, "/a/b", "Git decodes reserved escapes in SSH repository paths");

--- a/gix-url/tests/url/parse/ssh.rs
+++ b/gix-url/tests/url/parse/ssh.rs
@@ -306,6 +306,37 @@ fn ipv6_full_address() -> crate::Result {
 }
 
 #[test]
+fn scoped_ipv6_address() -> crate::Result {
+    let input = "ssh://[fe80::1%25Eth0]/repo";
+    let url = gix_url::parse(input)?;
+    assert_eq!(
+        url.host(),
+        Some("fe80::1%Eth0"),
+        "the zone identifier is decoded for SSH"
+    );
+    assert_eq!(url.to_bstring(), input, "the URI spelling remains encoded");
+    assert_eq!(gix_url::parse(url.to_bstring())?, url, "the scoped address roundtrips");
+    Ok(())
+}
+
+#[test]
+fn scoped_ipv6_address_with_empty_port() -> crate::Result {
+    let url = gix_url::parse("ssh://[fe80::1%25Eth0]:/repo")?;
+    assert_eq!(
+        url.host(),
+        Some("fe80::1%Eth0"),
+        "the bracketed host with an empty port is decoded"
+    );
+    assert_eq!(url.port, None, "an empty port is not represented");
+    assert_eq!(
+        url.to_bstring(),
+        "ssh://[fe80::1%25Eth0]/repo",
+        "serialization omits the empty port"
+    );
+    Ok(())
+}
+
+#[test]
 fn percent_encoded_path_delimiters_are_decoded() -> crate::Result {
     let url = gix_url::parse("ssh://example.com/a%2Fb")?;
     assert_eq!(url.path, "/a/b", "Git decodes reserved escapes in SSH repository paths");

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -27,7 +27,7 @@ gix-worktree = { version = "^0.55.0", path = "../gix-worktree", default-features
 gix-index = { version = "^0.54.0", path = "../gix-index" }
 gix-fs = { version = "^0.22.0", path = "../gix-fs" }
 gix-object = { version = "^0.63.0", path = "../gix-object" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-features = { version = "^0.49.0", path = "../gix-features" }
 gix-filter = { version = "^0.33.0", path = "../gix-filter" }
 

--- a/gix-worktree-stream/Cargo.toml
+++ b/gix-worktree-stream/Cargo.toml
@@ -28,7 +28,7 @@ gix-attributes = { version = "^0.34.0", path = "../gix-attributes", features = [
 gix-filter = { version = "^0.33.0", path = "../gix-filter" }
 gix-traverse = { version = "^0.60.0", path = "../gix-traverse" }
 gix-fs = { version = "^0.22.0", path = "../gix-fs" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 
 gix-error = { version = "^0.2.5", path = "../gix-error" }
 parking_lot = "0.12.4"

--- a/gix-worktree/Cargo.toml
+++ b/gix-worktree/Cargo.toml
@@ -33,7 +33,7 @@ gix-fs = { version = "^0.22.0", path = "../gix-fs" }
 gix-hash = { version = "^0.26.0", path = "../gix-hash" }
 gix-object = { version = "^0.63.0", path = "../gix-object" }
 gix-glob = { version = "^0.27.0", path = "../gix-glob" }
-gix-path = { version = "^0.12.3", path = "../gix-path" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
 gix-attributes = { version = "^0.34.0", path = "../gix-attributes", optional = true }
 gix-validate = { version = "^0.11.3", path = "../gix-validate", optional = true }
 gix-ignore = { version = "^0.22.0", path = "../gix-ignore" }

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -358,8 +358,8 @@ gix-revision = { version = "^0.48.0", path = "../gix-revision", default-features
 gix-revwalk = { version = "^0.34.0", path = "../gix-revwalk" }
 gix-negotiate = { version = "^0.34.0", path = "../gix-negotiate", optional = true }
 
-gix-path = { version = "^0.12.3", path = "../gix-path" }
-gix-url = { version = "^0.37.0", path = "../gix-url" }
+gix-path = { version = "^0.12.4", path = "../gix-path" }
+gix-url = { version = "^0.37.1", path = "../gix-url" }
 gix-traverse = { version = "^0.60.0", path = "../gix-traverse" }
 gix-diff = { version = "^0.66.0", path = "../gix-diff", default-features = false }
 gix-merge = { version = "^0.19.0", path = "../gix-merge", default-features = false, optional = true }
@@ -371,7 +371,7 @@ gix-features = { version = "^0.49.0", path = "../gix-features", features = [
 gix-trace = { version = "^0.1.21", path = "../gix-trace" }
 
 gix-glob = { version = "^0.27.0", path = "../gix-glob" }
-gix-credentials = { version = "^0.39.0", path = "../gix-credentials", optional = true }
+gix-credentials = { version = "^0.39.1", path = "../gix-credentials", optional = true }
 gix-prompt = { version = "^0.16.0", path = "../gix-prompt", optional = true }
 gix-index = { version = "^0.54.0", path = "../gix-index", optional = true }
 gix-attributes = { version = "^0.34.0", path = "../gix-attributes", optional = true }
@@ -385,7 +385,7 @@ gix-submodule = { version = "^0.33.0", path = "../gix-submodule", optional = tru
 gix-status = { version = "^0.33.0", path = "../gix-status", optional = true, features = [
     "worktree-rewrites",
 ] }
-gix-command = { version = "^0.9.1", path = "../gix-command", optional = true }
+gix-command = { version = "^0.9.2", path = "../gix-command", optional = true }
 
 gix-worktree-stream = { version = "^0.35.0", path = "../gix-worktree-stream", optional = true }
 gix-archive = { version = "^0.35.0", path = "../gix-archive", default-features = false, optional = true }
@@ -393,7 +393,7 @@ gix-blame = { version = "^0.16.0", path = "../gix-blame", optional = true }
 
 # For communication with remotes
 gix-protocol = { version = "^0.64.0", path = "../gix-protocol" }
-gix-transport = { version = "^0.58.0", path = "../gix-transport", optional = true }
+gix-transport = { version = "^0.58.1", path = "../gix-transport", optional = true }
 
 # Just to get the progress-tree feature
 prodash = { version = "31.0.0", optional = true, features = ["progress-tree"] }


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew
- [x] compare against Git (are we too strict now?) - done as part of the auto-review, and locally with baseline extensions
- [x] patch release for `gix-url`

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- Terminate URL authorities at `/`, `?`, or `#` consistently.
- Reject malformed authorities, schemes, ports, IP literals, and percent escapes before security comparisons.
- Preserve percent-encoded HTTP path delimiters without changing Git-compatible SSH path decoding.
- Apply the 1024-byte authority limit only after the scheme separator.

## Advisory

https://github.com/GitoxideLabs/gitoxide/security/advisories/GHSA-jrcm-326h-gpp8

GHSA-jrcm-326h-gpp8 is a draft security advisory. This PR intentionally omits reproduction and exploit details.

### Advisory summary

- Severity: High
- Affected packages: `gix-url <= 0.32.0`; `gix-transport <= 0.49.0`
- Patched versions: not assigned
- CVE: not assigned

## Git baseline

Git `da5fa735905c97b9454542bcaba848bcdeac760d` reports the host before query and fragment delimiters and decodes reserved escapes in SSH repository paths.

## Validation

- `cargo test -p gix-url`
- `cargo test -p gix-transport --lib --features http-client`
- `cargo clippy -p gix-url --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- One Codex review per final commit hash; all actionable findings addressed