### PR TITLE
fix: validate delta base sizes during entry decoding

### DIFF
--- a/gix-pack/src/data/file/decode/entry.rs
+++ b/gix-pack/src/data/file/decode/entry.rs
@@ -306,6 +306,10 @@ where
         let total_delta_data_size: usize = total_delta_data_size.try_into().map_err(|_| Error::OutOfMemory)?;
 
         let chain_len = chain.len();
+        let actual_base_size = match base_buffer_size {
+            Some(size) => size,
+            None => self.decoded_object_size(cursor.decompressed_size)?,
+        };
         let (first_buffer_end, second_buffer_end) = {
             let delta_start = base_buffer_size.unwrap_or(0);
 
@@ -321,6 +325,7 @@ where
             let mut instructions = &mut out[delta_range.clone()];
             let mut relative_delta_start = 0;
             let mut biggest_result_size = 0;
+            let mut expected_base_size = actual_base_size;
             for (delta_idx, delta) in chain.iter_mut().rev().enumerate() {
                 let (consumed_from_data_offset, consumed_out) = self.decompress_complete_entry_from_data_offset(
                     delta.data_offset,
@@ -335,13 +340,20 @@ where
                 let current_delta = &instructions[..consumed_out];
                 let (base_size, offset) = delta::decode_header_size(current_delta)?;
                 let mut bytes_consumed_by_header = offset;
-                biggest_result_size = biggest_result_size.max(base_size);
                 delta.base_size = self.decoded_object_size(base_size)?;
+                if delta.base_size != expected_base_size {
+                    return Err(delta::apply::Error::Corrupt {
+                        message: "delta base size does not match base object size",
+                    }
+                    .into());
+                }
+                biggest_result_size = biggest_result_size.max(base_size);
 
                 let (result_size, offset) = delta::decode_header_size(&current_delta[offset..])?;
                 bytes_consumed_by_header += offset;
                 biggest_result_size = biggest_result_size.max(result_size);
                 delta.result_size = self.decoded_object_size(result_size)?;
+                expected_base_size = delta.result_size;
 
                 // the absolute location into the instructions buffer, so we keep track of the end point of the last
                 delta.data.start = relative_delta_start + bytes_consumed_by_header;

--- a/gix-pack/tests/pack/malformed.rs
+++ b/gix-pack/tests/pack/malformed.rs
@@ -135,6 +135,30 @@ fn empty_plain_object_is_accepted() -> crate::Result {
 }
 
 #[test]
+fn delta_with_mismatched_base_size_is_rejected_before_allocating_work_buffers() -> crate::Result {
+    let declared_base_size = 1_000_000;
+    let mut delta = encode_delta_size(declared_base_size);
+    delta.extend([1, 0x90, 1]);
+    let pack_data = ref_delta_pack(&delta)?;
+    let pack = data::File::from_data(pack_data, PathBuf::from("malformed.pack"), gix_hash::Kind::Sha1)?;
+    let entry = pack.entry(12)?;
+    let mut out = Vec::new();
+    let mut inflate = gix_zlib::Inflate::default();
+
+    let res = pack.decode_entry(entry, &mut out, &mut inflate, &resolve_external_blob, &mut cache::Never);
+
+    assert_err_message(
+        res,
+        "Corrupt delta data: delta base size does not match base object size",
+    );
+    assert!(
+        out.capacity() < declared_base_size as usize,
+        "the invalid declared base size must not determine work-buffer capacity"
+    );
+    Ok(())
+}
+
+#[test]
 fn in_pack_delta_base_with_mismatched_declared_size_is_rejected() -> crate::Result {
     let (pack_data, delta_offset) = ofs_delta_pack_with_mismatched_base_size()?;
     let pack = data::File::from_data(
@@ -150,7 +174,7 @@ fn in_pack_delta_base_with_mismatched_declared_size_is_rejected() -> crate::Resu
 
     assert_err_message(
         res,
-        "Pack entry is truncated: pack entry decompressed size does not match entry header",
+        "Corrupt delta data: delta base size does not match base object size",
     );
     Ok(())
 }


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

Reject delta instruction streams whose declared base size differs from the resolved base object, including mismatches between links in a delta chain.

Fixes #2868

## Git reference

Git patch_delta() validates the decoded source size against the actual source buffer size before applying instructions. Reference checkout: cf5497b14c5a.

## Validation

- cargo test -p gix-pack
- cargo clippy -p gix-pack --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- Codex commit review: no findings