### PR TITLE
Add feature gates to doc tests so they compile with `--no-default-features`

### DIFF
--- a/gix/src/object/commit.rs
+++ b/gix/src/object/commit.rs
@@ -147,6 +147,7 @@ impl<'repo> Commit<'repo> {
     /// let commit = repo.head_commit()?;
     /// let parent_ids: Vec<_> = commit.parent_ids().collect();
     ///
+    /// #[cfg(feature = "revision")]
     /// assert_eq!(parent_ids, vec![repo.rev_parse_single("HEAD~1")?]);
     /// # Ok(()) }
     /// ```

--- a/gix/src/repository/reference.rs
+++ b/gix/src/repository/reference.rs
@@ -243,8 +243,11 @@ impl crate::Repository {
     /// assert_eq!(head.decode()?.message, "c2\n");
     /// assert_eq!(repo.head_tree_id()?, head.tree_id()?);
     ///
-    /// let previous = repo.rev_parse_single("HEAD^")?;
-    /// assert_ne!(previous, head.id);
+    /// #[cfg(feature = "revision")]
+    /// {
+    ///     let previous = repo.rev_parse_single("HEAD^")?;
+    ///     assert_ne!(previous, head.id);
+    /// }
     /// # Ok(()) }
     /// ```
     pub fn head_commit(&self) -> Result<crate::Commit<'_>, reference::head_commit::Error> {

--- a/justfile
+++ b/justfile
@@ -233,6 +233,8 @@ doc-tests:
     cargo test --workspace --doc --no-fail-fast
     # `cargo nextest` doesn't run doctests, so cover feature-gated examples explicitly here.
     cargo test -p gix-packetline --doc --features blocking-io --no-fail-fast
+    cargo test -p gix --doc --no-default-features --no-fail-fast
+    cargo test -p gix --doc --no-default-features --features revision --no-fail-fast
 
 # These tests aren't run by default as they are flaky (even locally)
 unit-tests-flaky:


### PR DESCRIPTION
This is a very small fix for two doctests that were calling `Repository::rev_parse_single` which is gated behind `revision` and not available with `--no-default-features --features sha256`. Feel free to close this PR if this is not supposed to be changed.