### PR TITLE
Add small SHA-256 acceptance test

### DIFF
--- a/gix-odb/tests/fixtures/generated-archives/.gitignore
+++ b/gix-odb/tests/fixtures/generated-archives/.gitignore
@@ -5,18 +5,18 @@
 # `make_alternates_odb.sh` writes `$PWD/object_source/.git/objects` into
 # `.git/objects/info/alternates`; the absolute path is host-specific.
 make_alternates_odb.tar
-# The fixuture is 2MB in size, so let's not track it (like its SHA-1 sibling)
+# The fixture is 2MB in size, so let's not track it (like its SHA-1 sibling).
 make_alternates_odb_sha256.tar
 # Fixture deliberately uses loose objects; whether commits remain loose vs. get
 # packed depends on installation-wide Git auto-gc/repack behavior, so the
 # layout is regenerated per run.
 repo_with_loose_objects.tar
 repo_with_loose_objects_sha256.tar
-# The fixuture is 2MB in size, so let's not track it (like its SHA-1 sibling)
+# The fixture is 2MB in size, so let's not track it (like its SHA-1 sibling).
 make_repo_multi_index_sha256.tar
-# The fixuture is 2MB in size, so let's not track it (like its SHA-1 sibling)
+# The fixture is 2MB in size, so let's not track it (like its SHA-1 sibling).
 make_replaced_history_sha256.tar
-# The fixuture is 2MB in size, so let's not track it (like its SHA-1 sibling)
+# The fixture is 2MB in size, so let's not track it (like its SHA-1 sibling).
 make_repo_multi_index_no_sha256.tar
-# The fixuture is 2MB in size, so let's not track it (like its SHA-1 sibling)
+# The fixture is 2MB in size, so let's not track it (like its SHA-1 sibling).
 make_repo_multi_index_without-multi-index_sha256.tar


### PR DESCRIPTION
This PR is based on this assessment of the current state (as of 2026-08-04) of SHA-256 support, produced by GPT-5.5:

```
Summary

The old plan is now out of date in a positive way: the biggest `gix` library blockers listed there—SHA-256-only `gix` compile, protocol `object-format=sha256`, and clone hash mismatch
handling—appear fixed.

The remaining risk is mostly in two areas:

1. *CLI/gitoxide-core SHA-1-shaped assumptions*, especially the query DB and index/list/archive/diff/remote sentinels.
2. *Insufficient explicit acceptance coverage* proving that SHA-256 object hash flows through create/open/clone/fetch/storage/refs/index/worktree end-to-end.

So I’d say: *`gix` is close, but I would not declare the whole gitoxide stack SHA-256-ready until the `gitoxide-core` SHA-1 assumptions are fixed or excluded, and the end-to-end SHA-256
acceptance suite is made mandatory*.
```

This PR is an attempt at starting to add the acceptance coverage mentioned above. If you agree this is useful, I can extend it with more test cases; if you disagree, feel free to close the PR. 😀 (In that case, I would create a separate PR and just update the plan.)