### PR TITLE
fix(features): `in_parallel_with_slice` appends a whole `periodic()` interval to every call

### DIFF
--- a/gix-features/src/parallel/in_parallel.rs
+++ b/gix-features/src/parallel/in_parallel.rs
@@ -176,18 +176,22 @@ where
     })
 }
 
-/// An experiment to have fine-grained per-item parallelization with built-in aggregation via thread state.
-/// This is only good for operations where near-random access isn't detrimental, so it's not usually great
-/// for file-io as it won't make use of sorted inputs well.
-/// Note that `periodic` is not guaranteed to be called in case other threads come up first and finish too fast.
-/// `consume(&mut item, &mut stat, &Scope, &threads_available, &should_interrupt)` is called for performing the actual computation.
-/// Note that `threads_available` should be decremented to start a thread that can steal your own work (as stored in `item`),
-/// which allows callees to implement their own work-stealing in case the work is distributed unevenly.
-/// Work stealing should only start after having processed at least one item to give all threads naturally operating on the slice
-/// some time to start. Starting threads while slice-workers are still starting up would lead to over-allocation of threads,
-/// which is why the number of threads left may turn negative. Once threads are started and stopped, be sure to adjust
-/// the thread-count accordingly.
-// TODO: better docs
+/// Process mutable `input` items concurrently and return one finalized value per worker, in worker order.
+///
+/// Workers claim individual items, so processing order is unspecified. This suits independent work with no
+/// locality requirements; workloads such as file I/O may benefit more from processing sorted chunks instead.
+///
+/// * `thread_limit` selects the worker count. `None` or `Some(0)` uses all available logical cores.
+/// * `new_thread_state(worker_index)` creates the state passed to that worker's `consume` calls.
+/// * `consume(item, state, threads_left, should_interrupt)` processes one item. Setting `should_interrupt`
+///   stops workers after their current item. The first error does the same and is returned.
+/// * `periodic` runs on a watcher thread. `Some(duration)` schedules its next call after that duration;
+///   `None` requests an interruption. It may never run if the workers finish first.
+/// * `state_to_rval` converts each worker's state after it stops successfully, including after interruption.
+///
+/// `threads_left` tracks capacity for nested work. A consumer may reserve capacity with `fetch_sub` before
+/// spawning work and must release it with `fetch_add` afterward. Do this only after consuming an item, as the
+/// slice workers may still be starting and can temporarily make the counter negative.
 pub fn in_parallel_with_slice<I, S, R, E>(
     input: &mut [I],
     thread_limit: Option<usize>,
@@ -229,12 +233,12 @@ where
                             // watch. It needs no mutex, because an `unpark` that arrives
                             // before the `park_timeout` is remembered by the park token.
                             Some(duration) => {
-                                let deadline = std::time::Instant::now() + duration;
+                                let start = std::time::Instant::now();
                                 loop {
                                     if stop_everything.load(Ordering::Relaxed) {
                                         break;
                                     }
-                                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                                    let remaining = duration.saturating_sub(start.elapsed());
                                     if remaining.is_zero() {
                                         break;
                                     }

--- a/gix-features/src/parallel/in_parallel.rs
+++ b/gix-features/src/parallel/in_parallel.rs
@@ -210,7 +210,7 @@ where
 
     std::thread::scope({
         move |s| {
-            std::thread::Builder::new()
+            let watcher = std::thread::Builder::new()
                 .name("gitoxide.in_parallel_with_slice.watch-interrupts".into())
                 .spawn_scoped(s, {
                     move || loop {
@@ -219,7 +219,28 @@ where
                         }
 
                         match periodic() {
-                            Some(duration) => std::thread::sleep(duration),
+                            // Park rather than sleep. `stop_everything` is only set once
+                            // every worker has been joined, and this thread lives in the
+                            // same `std::thread::scope`, so a plain `sleep` is *appended*
+                            // to the call: the scope cannot return until this thread wakes
+                            // on its own. Parking keeps the requested interval exactly (a
+                            // spurious wake-up re-parks for the remainder) while letting
+                            // the joiner end the wait as soon as there is nothing left to
+                            // watch. It needs no mutex, because an `unpark` that arrives
+                            // before the `park_timeout` is remembered by the park token.
+                            Some(duration) => {
+                                let deadline = std::time::Instant::now() + duration;
+                                loop {
+                                    if stop_everything.load(Ordering::Relaxed) {
+                                        break;
+                                    }
+                                    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                                    if remaining.is_zero() {
+                                        break;
+                                    }
+                                    std::thread::park_timeout(remaining);
+                                }
+                            }
                             None => {
                                 stop_everything.store(true, Ordering::Relaxed);
                                 break;
@@ -228,6 +249,7 @@ where
                     }
                 })
                 .expect("valid name");
+            let watcher = watcher.thread().clone();
 
             let input_len = input.len();
             struct Input<I>(*mut I)
@@ -295,18 +317,26 @@ where
                     Ok(Err((err, is_cause))) => {
                         // is-cause is race-free, and must be set on the first error.
                         if is_cause {
+                            // The failing consumer already set `stop_everything`; end the
+                            // watcher's current interval so an error is not held open for
+                            // one whole `periodic()`.
+                            watcher.unpark();
                             return Err(err);
                         }
                     }
                     Err(err) => {
                         // a panic happened, stop the world gracefully (even though we panic later)
                         stop_everything.store(true, Ordering::Relaxed);
+                        watcher.unpark();
                         std::panic::resume_unwind(err);
                     }
                 }
             }
 
             stop_everything.store(true, Ordering::Relaxed);
+            // Nothing left to watch. Without this the scope blocks until the watcher's own
+            // timer expires, adding a whole `periodic()` interval to every call.
+            watcher.unpark();
             Ok(results)
         }
     })

--- a/gix-features/src/parallel/serial.rs
+++ b/gix-features/src/parallel/serial.rs
@@ -87,10 +87,12 @@ mod not_parallel {
         }
     }
 
-    /// An experiment to have fine-grained per-item parallelization with built-in aggregation via thread state.
-    /// This is only good for operations where near-random access isn't detrimental, so it's not usually great
-    /// for file-io as it won't make use of sorted inputs well.
-    // TODO: better docs
+    /// Process mutable `input` items and return the finalized worker state.
+    ///
+    /// This is the single-threaded counterpart of the parallel implementation: `thread_limit` is ignored,
+    /// `new_thread_state` receives worker index `0`, and `consume` receives a zero `threads_left` counter.
+    /// After each item, `periodic` is called; `None` stops processing successfully, while its duration is ignored.
+    /// An error from `consume` stops processing and is returned without calling `state_to_rval`.
     pub fn in_parallel_with_slice<I, S, R, E>(
         input: &mut [I],
         _thread_limit: Option<usize>,

--- a/gix-features/tests/parallel/in_parallel_with_slice.rs
+++ b/gix-features/tests/parallel/in_parallel_with_slice.rs
@@ -32,6 +32,26 @@ mod threaded {
     use super::parallel;
 
     #[test]
+    fn periodic_duration_does_not_have_to_fit_in_an_instant() {
+        let watcher_and_worker = &Barrier::new(2);
+        parallel::in_parallel_with_slice(
+            &mut [()],
+            Some(1),
+            |_| (),
+            |_item, _state, _threads_left, _should_interrupt| {
+                watcher_and_worker.wait();
+                Ok::<_, ()>(())
+            },
+            || {
+                watcher_and_worker.wait();
+                Some(std::time::Duration::MAX)
+            },
+            std::convert::identity,
+        )
+        .expect("an effectively infinite polling interval can still be interrupted");
+    }
+
+    #[test]
     fn the_error_that_caused_the_stop_is_returned_even_if_other_threads_fail_on_interrupt() {
         // Regression test for the race behind issue #2701: a thread that observes the stop
         // signal and bails out with a reactive error (like `Interrupted`) must not mask the


### PR DESCRIPTION
## The problem

`parallel::in_parallel_with_slice` spawns an interrupt-watching thread whose body is:

```rust
move || loop {
    if stop_everything.load(Ordering::Relaxed) { break; }
    match periodic() {
        Some(duration) => std::thread::sleep(duration),
        None => { stop_everything.store(true, Ordering::Relaxed); break; }
    }
}
```

`stop_everything` is set at the **end** of the enclosing `std::thread::scope`, after every worker has been joined:

```rust
for thread in threads { … }          // all workers joined here

stop_everything.store(true, Ordering::Relaxed);
Ok(results)
```

The watcher is inside that same scope, so `std::thread::scope` cannot return until it wakes on its own. **The sleep is therefore appended to the call, not overlapped with it** — `in_parallel_with_slice` cannot return in less than one `periodic()` interval however little work it was given, and the whole of that interval is dead time: every worker has finished and every result is collected.

## What it costs on `main` today

Two callers, both in `gitoxide-core`, and **both pass 100 ms**:

* `gitoxide-core/src/repository/odb.rs:248` — `|| Some(std::time::Duration::from_millis(100))`. Note this closure never returns `None`, so `stop_everything` is only ever set by the join loop, which means the full 100 ms is added to every `gix odb` run that reaches it, unconditionally.
* `gitoxide-core/src/corpus/engine.rs:213` — `|| (!gix::interrupt::is_triggered()).then(|| Duration::from_millis(100))`.

## Where I actually hit it, and a correction

I found this through `index-pack`, and I should be straight about the version that applies to, because it is **not** `main`.

**Published `gix-pack` 0.73.0 — the latest release on crates.io — drives this function from `Tree::traverse` at a 50 ms interval**, and `Tree::traverse` is unconditional in `index::File::write_data_iter_to_stream`. So every `index-pack` on the current release pays 50 ms. On `main` that is already gone: the delta traversal has been rewritten to `resolve::all` and no longer calls `in_parallel_with_slice` at all. I did not know that when I started measuring and only found it while checking my own claim against `main` — so please read the numbers below as characterising **0.73.0**, not the branch this PR targets.

That does not make the defect stale, and it is why I am still opening the PR: the function is unchanged on `main`, its two remaining callers pay 100 ms each, and a fix here is what makes the released line safe for anyone still on it.

The measurement, against published `gix-pack` 0.73.0, which asks for 50 ms:

```rust
// gix-pack/src/cache/delta/traverse/mod.rs
|| (!should_interrupt.load(Ordering::Relaxed)).then(|| std::time::Duration::from_millis(50)),
```

Measured on Linux 6.x / x86-64, release, an 8-object 490-byte pack (a five-file commit: five blobs, two trees, one commit):

| | before | after |
|---|---:|---:|
| min of 101 calls | **50.22 ms** | **2.99 ms** |
| p10 | 50.25 ms | 5.11 ms |
| p50 | 50.32 ms | 10.98 ms |
| max | 55.01 ms | 43.08 ms |
| samples below 45 ms | **0 / 100** | 100 / 100 |
| process CPU (`getrusage`, all threads) | 3.0–5.2 ms | 3.2–5.4 ms |

`strace -f -c -e trace=clock_nanosleep` over one call: exactly **one** `clock_nanosleep(CLOCK_MONOTONIC, {tv_nsec=50000000})` before, and **none** after.

The flatness of the before-column is the point. Those 101 samples were taken on a 32-core box at load average 317; the spread is 50.22–55.01 ms because the sleep dominates everything the machine is doing. The after-column's spread *is* that load, now visible. **Process CPU is unchanged: nothing was made faster, a wait was removed.**

## The change

Park instead of sleeping, and unpark once there is nothing left to watch.

Three things worth calling out, since they are why this shape rather than a smaller one:

* **The inner loop preserves the interval exactly.** `park_timeout` may return spuriously; re-parking for the *remaining* time means a spurious wake-up cannot shorten the polling cadence `periodic()` asked for, so a caller that does real work in `periodic` is unaffected.
* **No mutex, and no race.** A thread's park token is remembered: an `unpark` that lands before the `park_timeout` makes that `park_timeout` return immediately. There is no window in which the joiner signals and the watcher then sleeps anyway.
* **The error and panic arms need it too.** Without `unpark` there, a failing traversal holds its error open for one whole interval before the scope can return.

`cargo test -p gix-features --features parallel` passes, including `the_error_of_a_consumer_that_set_the_stop_flag_itself_is_still_the_cause` and `the_error_that_caused_the_stop_is_returned_even_if_other_threads_fail_on_interrupt`, which are the two that exercise the arms the `unpark` calls were added to. `cargo fmt --check` is clean.

## Why not just lower the interval

For the 0.73.0 case that removes the floor too, and I'd argue against it: 50 ms (or `gitoxide-core`'s 100 ms) is a perfectly good latency for noticing a Ctrl-C, and an interval small enough to hide this would wake a thread ten or a hundred times a second to poll one atomic. The interval is not the defect; an uninterruptible wait is.

## Environment

- `gix-features` 0.49.0 (`parallel` on), published `gix-pack` 0.73.0
- Linux 6.x, x86-64, 32 cores
- observed through `gix_pack::Bundle::write_to_directory`; the code under change is
  unchanged between 0.49.0 and `main`, so the patch applies to `main` as-is

No signature change, no new dependency, no behaviour change other than not waiting.
