### PR TITLE
fix: reject Git's reserved 'builtin_' attribute namespace in attribute files

### DIFF
--- a/gix-attributes/tests/attributes/parse.rs
+++ b/gix-attributes/tests/attributes/parse.rs
@@ -256,6 +256,46 @@ fn attribute_names_must_not_be_empty() {
         ),
         "the unspecified prefix needs one as well"
     );
+    assert!(
+        gix_attributes::NameRef::try_from(bstr::BStr::new(b"")).is_err(),
+        "names can't be created empty either, which `attr_name_valid()` rejects via `namelen <= 0`"
+    );
+}
+
+#[test]
+fn attribute_names_must_not_use_the_reserved_builtin_prefix() {
+    assert!(
+        matches!(
+            try_line(r"p builtin_objectmode"),
+            Err(parse::Error::AttributeName { line_number: 1, .. })
+        ),
+        "Git reserves 'builtin_' for built-in attributes and drops lines that assign to it"
+    );
+    assert!(lenient_lines(r"p builtin_objectmode").is_empty());
+    assert!(
+        matches!(
+            try_line(r"p -builtin_objectmode"),
+            Err(parse::Error::AttributeName { line_number: 1, .. })
+        ),
+        "the prefix is checked after '-' and '!' are stripped, just like in `parse_attr()`"
+    );
+    assert!(
+        matches!(
+            try_line(r"[attr]builtin_macro -text"),
+            Err(parse::Error::MacroName { line_number: 1, .. })
+        ),
+        "macro names are checked against the reserved namespace as well"
+    );
+    assert_eq!(
+        line(r"p builtin"),
+        (pattern("p", Mode::NO_SUB_DIR, None), vec![set("builtin")], 1),
+        "only the exact 'builtin_' prefix is reserved"
+    );
+    assert_eq!(
+        line(r"p x_builtin_y"),
+        (pattern("p", Mode::NO_SUB_DIR, None), vec![set("x_builtin_y")], 1),
+        "and only at the beginning of the name"
+    );
 }
 
 #[test]

--- a/gix-attributes/tests/attributes/parse.rs
+++ b/gix-attributes/tests/attributes/parse.rs
@@ -289,29 +289,13 @@ fn attribute_names_must_not_use_the_reserved_builtin_prefix() {
     assert_eq!(
         line(r"p builtin"),
         (pattern("p", Mode::NO_SUB_DIR, None), vec![set("builtin")], 1),
-        "only the exact 'builtin_' prefix is reserved"
+        "only the exact 'builtin_' prefix is reserved…"
     );
     assert_eq!(
         line(r"p x_builtin_y"),
         (pattern("p", Mode::NO_SUB_DIR, None), vec![set("x_builtin_y")], 1),
-        "and only at the beginning of the name"
+        "…and only at the beginning of the name"
     );
-}
-
-#[test]
-fn the_builtin_namespace_is_reserved_in_attribute_files() {
-    assert!(matches!(
-        try_line("p builtin_custom valid"),
-        Err(parse::Error::AttributeName { line_number: 1, .. })
-    ));
-    assert!(
-        lenient_lines("p builtin_custom valid").is_empty(),
-        "one reserved name invalidates the entire line"
-    );
-    assert!(matches!(
-        try_line("[attr]builtin_custom valid"),
-        Err(parse::Error::MacroName { line_number: 1, .. })
-    ));
 }
 
 #[test]


### PR DESCRIPTION
Git reserves `builtin_` for built-in attributes and drops any attribute-file line that assigns to it. gitoxide applied those lines.

```
$ echo '* builtin_objectmode=100644 mytext' > .gitattributes
$ git check-attr -a foo.txt
builtin_objectmode is not a valid attribute name: .gitattributes:1
```

There is no output — Git drops the whole line, so `mytext` is lost with it. gitoxide set both attributes. The namespace is occupied, so this isn't hypothetical: `git check-attr builtin_objectmode foo.txt` reports `100644`.

From `attr.c`:

```c
/*
 * Attribute name cannot begin with "builtin_" which
 * is a reserved namespace for built in attributes values.
 */
static int attr_name_reserved(const char *name)
```

It's applied in `parse_attr()` and `parse_attr_line()`, and deliberately not in `git_attr_internal()` — which is why `:(attr:builtin_objectmode=100644)` still works and matches files. This mirrors that split: `Iter::new()` is unchanged, since that's the path `gix-pathspec` uses, and only attribute-file parsing rejects the namespace. There's a test in `gix-pathspec` pinning that, because I got it wrong first and nothing in the suite caught it.

Two smaller things surfaced on the way:

- `name.rs` and `parse.rs` held two copies of the name validation that had drifted apart. `parse.rs` rejected empty names, `name.rs` didn't, so `NameRef::try_from("")` returned `Ok(NameRef(""))` even though the type documents itself as holding "a validated attribute name". Deduplicated, keeping the empty check — Git's `attr_name_valid()` rejects `namelen <= 0`.
- The error messages said "has non-ascii characters or starts with '-'", which was never the full rule.

Checked against git 2.52.0 by diffing `check-attr` and `ls-files` output against the parser: 12 attribute-file inputs and 5 pathspecs, covering `-`/`!` prefixes, macro names, macro bodies, and `builtin_` appearing in values and in patterns. All agree.

On semver: this tightens two public behaviours — attribute-file parsing, and `NameRef::try_from` on empty input. Happy to retitle as `change!:` if you'd rather.

Adjacent gaps I left alone: Git caps attribute lines at 2048 bytes (`ATTR_MAX_LINE_LENGTH`) and attribute files at 100MB, treats a bare `[attr]` as a pattern rather than a macro, and rejects `:(attr:-foo=bar)` where gix-pathspec accepts it and drops the value. Happy to take any of those separately.

---

Written with AI assistance (Claude Code); I've reviewed and verified the change and everything stated above.