### PR TITLE
fix: parse !$ ignore lines as negations unless precious files are enabled

### DIFF
--- a/gix-ignore/src/parse.rs
+++ b/gix-ignore/src/parse.rs
@@ -39,7 +39,11 @@ impl Iterator for Lines<'_> {
                 (crate::Kind::Precious, false)
             } else {
                 let second = line.get(1);
-                if first == b'!' && second == Some(&b'$') {
+                // Negating a precious entry is contradictory, but that's only true while `$` means
+                // precious. Without that support `$` is an ordinary character, and Git parses
+                // `!$foo` as a negation of the literal `$foo` - dropping it would make the
+                // backward-compatible mode reject a valid line.
+                if self.support_precious && first == b'!' && second == Some(&b'$') {
                     gix_trace::error!(
                         "Line {} starts with !$ which is not allowed ('{}')",
                         self.line_no,

--- a/gix-ignore/tests/fixtures/ignore/precious.txt
+++ b/gix-ignore/tests/fixtures/ignore/precious.txt
@@ -5,7 +5,7 @@ $*.html
 
 !foo.html
 
-# this isn't allowed and ignored
+# not allowed with precious support, but a plain negation without it
 !$foo.html
 
 # but this is a literal !/* that is precious

--- a/gix-ignore/tests/ignore/parse.rs
+++ b/gix-ignore/tests/ignore/parse.rs
@@ -25,8 +25,11 @@ fn precious() {
             pat("$starts-with-dollar", Mode::NO_SUB_DIR, 2),
             pat("$*.html", Mode::NO_SUB_DIR, 4),
             pat("foo.html", Mode::NO_SUB_DIR | Mode::NEGATIVE, 6),
+            pat("$foo.html", Mode::NO_SUB_DIR | Mode::NEGATIVE, 9),
             pat("$!/*", Mode::empty(), 12),
-        ]
+        ],
+        "without precious support `$` is an ordinary character, so `!$foo.html` is the plain \
+         negation that Git sees - only the precious mode has a reason to reject it"
     );
 }
 


### PR DESCRIPTION
`.gitignore` lines starting with `!$` are dropped entirely, even when precious-file support is off. Git parses them as an ordinary negation.

```
$ printf '*.html\n!$foo.html\n' > .gitignore
$ git check-ignore --no-index -v -- '$foo.html'
.gitignore:2:!$foo.html	$foo.html
```

Git un-ignores `$foo.html`; gitoxide discards the line, so it stays ignored.

## Why it looks intentional

Precious files landed in 890efd591 with `$` handled unconditionally — every `$` prefix meant precious, so `!$` genuinely was contradictory. 828e9035a later made the parser stateful and gated that branch:

```diff
-            let (kind, can_negate) = if first == b'$' {
+            let (kind, can_negate) = if self.support_precious && first == b'$' {
```

The `!$` check in the `else` branch just below kept its unconditional form. This applies the same gate to it. The fixture comment predates the flag; the `support_precious: false` expectation added in 828e9035a carried the drop over. Both are updated to match.

## Git baseline

With `support_precious: false` — the default, and the mode `Lines::new` documents as the backward-compatible one — `$` carries no meaning, so `!$foo` is just a negation of a file literally named `$foo`. `$houdini`, the flag doc's own example, is the kind of directory people do ignore and un-ignore.

I found this by reading `gix-ignore/src/parse.rs` and confirmed it against `git check-ignore` with targeted `$` / `\$` / `!$` cases. Separately, a differential sweep of 3,079 (pattern, path) pairs against git 2.52.0 — character classes, POSIX classes, malformed classes, escapes, trailing-whitespace rules, `**` forms — found no other exclude or wildmatch divergence.

Precious mode is unchanged: `!$` is still rejected there, and the `support_precious: true` expectation in `precious()` is untouched.

## Validation

- `cargo test` — gix-ignore 12, gix-glob 40, gix-dir 79, gix-worktree 10, gix-status 31
- `cargo clippy -p gix-ignore --all-targets`, `cargo fmt --check`
- differential re-run after the change, now including the `$` forms: 1,770 pairs, zero divergences

---

Written with AI assistance (Claude Code); I've reviewed and verified the change and everything above.