### PR TITLE
fix: reject a lone '@' as a reference name, like Git does

### DIFF
--- a/gix-refspec/tests/refspec/parse/invalid.rs
+++ b/gix-refspec/tests/refspec/parse/invalid.rs
@@ -24,6 +24,19 @@ fn whitespace() {
 }
 
 #[test]
+fn destination_cannot_be_a_lone_at_sign() {
+    for op in [Operation::Fetch, Operation::Push] {
+        assert!(
+            matches!(
+                try_parse("HEAD:@", op).expect_err("a lone '@' is not a valid destination"),
+                Error::ReferenceName(gix_validate::reference::name::Error::Reserved { name }) if name == "@"
+            ),
+            "{op:?} validates refspec destinations"
+        );
+    }
+}
+
+#[test]
 fn complex_patterns_with_more_than_one_asterisk() {
     // For one-sided refspecs, complex patterns are now allowed
     for op in [Operation::Fetch, Operation::Push] {

--- a/gix-validate/src/reference.rs
+++ b/gix-validate/src/reference.rs
@@ -123,13 +123,23 @@ enum Mode {
 }
 
 fn validate(path: &BStr, mode: Mode) -> Result<Option<BString>, name::Error> {
-    let out = crate::tag::name_inner(
+    let mut out = crate::tag::name_inner(
         path,
         match mode {
             Mode::Complete | Mode::Partial => crate::tag::Mode::Validate,
             Mode::PartialSanitize => crate::tag::Mode::Sanitize,
         },
     )?;
+    // `@` alone is shorthand for `HEAD` in revision syntax, so Git refuses it as a reference name -
+    // see `check_or_sanitize_refname()` in `refs.c`, which `check_refname_format()` delegates to.
+    // Git substitutes `-` when sanitizing it, which is what we do here too. Note that `@` stays
+    // valid as a component, which is why `refs/heads/@` and a tag named `@` are both fine.
+    if out.as_ref().map_or(path, |b| b.as_bstr()) == "@" {
+        match out.as_mut() {
+            Some(out) => out[0] = b'-',
+            None => return Err(name::Error::Reserved { name: path.into() }),
+        }
+    }
     if let Mode::Complete = mode {
         let input = out.as_ref().map_or(path, |b| b.as_bstr());
         let saw_slash = input.find_byte(b'/').is_some();

--- a/gix-validate/src/reference.rs
+++ b/gix-validate/src/reference.rs
@@ -130,9 +130,8 @@ fn validate(path: &BStr, mode: Mode) -> Result<Option<BString>, name::Error> {
             Mode::PartialSanitize => crate::tag::Mode::Sanitize,
         },
     )?;
-    // `@` alone is shorthand for `HEAD` in revision syntax, so Git refuses it as a reference name -
-    // see `check_or_sanitize_refname()` in `refs.c`, which `check_refname_format()` delegates to.
-    // Git substitutes `-` when sanitizing it, which is what we do here too. Note that `@` stays
+    // `@` alone is shorthand for `HEAD` in revspecs, so Git refuses it as a reference name.
+    // Git substitutes it with `-` when sanitizing it, which is what we do here too. Note that `@` stays
     // valid as a component, which is why `refs/heads/@` and a tag named `@` are both fine.
     if out.as_ref().map_or(path, |b| b.as_bstr()) == "@" {
         match out.as_mut() {

--- a/gix-validate/src/tag.rs
+++ b/gix-validate/src/tag.rs
@@ -66,6 +66,10 @@ pub(crate) enum Mode {
     Validate,
 }
 
+/// Validate or sanitize `input` according to `mode`.
+///
+/// Validation returns `Ok(None)` when `input` is valid, while sanitization returns the rebuilt name
+/// in `Ok(Some(_))` even if it is identical to `input`. An error means validation failed.
 pub(crate) fn name_inner(input: &BStr, mode: Mode) -> Result<Option<BString>, name::Error> {
     let mut out: Option<BString> =
         matches!(mode, Mode::Sanitize).then(|| BString::from(Vec::with_capacity(input.len())));

--- a/gix-validate/tests/validate/reference.rs
+++ b/gix-validate/tests/validate/reference.rs
@@ -73,6 +73,12 @@ mod name_partial {
         mktests!(chinese_utf8_san, "heads/你好吗".as_bytes(), "heads/你好吗");
         mktest!(parentheses_special_case_upload_pack, b"(null)");
         mktests!(parentheses_special_case_upload_pack_san, b"(null)", "(null)");
+        mktest!(an_at_sign_within_a_component, b"refs/heads/@");
+        mktests!(an_at_sign_within_a_component_san, b"refs/heads/@", "refs/heads/@");
+        mktest!(an_at_sign_as_its_own_component, b"@/x");
+        mktests!(an_at_sign_as_its_own_component_san, b"@/x", "@/x");
+        mktest!(an_at_sign_beside_other_characters, b"@@");
+        mktests!(an_at_sign_beside_other_characters_san, b"@@", "@@");
     }
 
     mod invalid {
@@ -93,6 +99,13 @@ mod name_partial {
 
         mktest!(refs_path_double_dot, b"refs/../somewhere", RefError::StartsWithDot);
         mktests!(refs_path_double_dot_san, b"refs/../somewhere", "refs/-/somewhere");
+        mktest!(a_lone_at_sign, b"@", RefError::Reserved { .. });
+        mktests!(a_lone_at_sign_san, b"@", "-");
+        // Sanitizing strips slashes first, so these collapse to a lone `@` and must be replaced
+        // as well - otherwise the output wouldn't pass `name_partial()`.
+        mktests!(a_lone_at_sign_leading_slash_san, b"/@", "-");
+        mktests!(a_lone_at_sign_trailing_slash_san, b"@/", "-");
+        mktests!(a_lone_at_sign_surrounded_by_slashes_san, b"//@//", "-");
         mktest!(
             refs_path_name_starts_with_dot,
             b".refs/somewhere",
@@ -289,6 +302,7 @@ mod name {
             b"refs/./still-inside-but-not-cool",
             "refs/-/still-inside-but-not-cool"
         );
+        mktest!(a_lone_at_sign, b"@", RefError::Reserved { .. });
         mktest!(capitalized_name_without_path, b"Main", RefError::SomeLowercase);
         mktests!(capitalized_name_without_path_san, b"Main", "Main");
         mktest!(lowercase_name_without_path, b"main", RefError::SomeLowercase);

--- a/gix-validate/tests/validate/reference.rs
+++ b/gix-validate/tests/validate/reference.rs
@@ -233,6 +233,9 @@ mod name {
         mktests!(all_uppercase_with_underscore_san, b"NEW_HEAD", "NEW_HEAD");
         mktest!(chinese_utf8, "refs/heads/你好吗".as_bytes());
         mktests!(chinese_utf8_san, "refs/heads/你好吗".as_bytes(), "refs/heads/你好吗");
+        mktest!(an_at_sign_within_a_component, b"refs/heads/@");
+        mktest!(an_at_sign_as_its_own_component, b"@/x");
+        mktest!(an_at_sign_beside_other_characters, b"refs/heads/@@");
         mktest!(dot_in_directory_component, b"this./totally./works");
         mktests!(
             dot_in_directory_component_san,

--- a/gix-validate/tests/validate/tag.rs
+++ b/gix-validate/tests/validate/tag.rs
@@ -22,7 +22,9 @@ mod name {
             };
         }
         mktest!(an_at_sign, b"@");
-        mktests!(an_at_sign_san, b"@", "@");
+        // `mktests!` sanitizes as a *reference* name, where a lone `@` means `HEAD` and is refused,
+        // so it has to be replaced. As a tag name it stays valid - `refs/tags/@` is a legal ref.
+        mktests!(an_at_sign_san, b"@", "-");
         mktest!(chinese_utf8, "你好吗".as_bytes());
         mktests!(chinese_utf8_san, "你好吗".as_bytes(), "你好吗");
         mktest!(non_text, "😅🙌".as_bytes());


### PR DESCRIPTION
Created by Claude Code on behalf of Amey, who reviewed it before submitting. Everything below this line is the agent's writing, not his.

----

## Summary

- Reject a reference name consisting solely of `@`, which Git refuses because `@` is shorthand for `HEAD`.
- Replace it with `-` when sanitizing, which is what Git's sanitizer does.
- Leave `@` valid as a component, so `refs/heads/@` and a tag named `@` are unaffected.

## Git baseline

`check_or_sanitize_refname()` in `refs.c`, which `check_refname_format()` delegates to, rejects the name outright and substitutes `-` in its sanitizing path. `git check-ref-format` refuses `@` under every flag combination — plain, `--allow-onelevel`, `--refspec-pattern`, both together, and `--normalize` — while accepting `refs/heads/@`, `refs/tags/@`, `@/x` and `@@`.

The visible consequence was in refspec destinations:

```
$ git push origin "HEAD:@"
fatal: invalid refspec 'HEAD:@'
```

where `gix_refspec::parse("HEAD:@", Push)` returned `Ok(dst = "@")`. Sources were already right, since `parse()` rewrites a bare `@` source to `HEAD`, but destinations reach `reference::name_partial()` directly.

Two public behaviours change as a result: `name_partial_or_sanitize("@")` now yields `"-"` rather than `"@"`, and `name("@")` reports `Reserved` where it previously reported `SomeLowercase`. No caller in the workspace observes either.

## Validation

A differential sweep of 1,030 reference names against git 2.52.0 — every byte `0x01`–`0xFF` embedded in a component and as a whole component, plus `.lock` placement, slash density, dot placement and `@{` forms — found `@` to be the only divergence, and none remaining afterwards. Two shapes lie outside what the oracle can express: names containing NUL, and names beginning with `-`, which `git check-ref-format` will not accept as an argument.

- `cargo test` — gix-validate 326, gix-ref 179, gix-refspec 76, gix-revision 112, gix-object 148, gix-url 144, gix-worktree 10, gix 417
- `cargo clippy -p gix-validate --all-targets`
- `cargo fmt --check`