### PR TITLE
change!: fall back to the raw text when ansi-c unquoting fails

### DIFF
--- a/gix-attributes/src/parse.rs
+++ b/gix-attributes/src/parse.rs
@@ -120,8 +120,6 @@ fn parse_line(line: &BStr, line_number: usize) -> Option<Result<(Kind, Iter<'_>,
         return None;
     }
 
-    // Broken quoting, like a pattern that never closes its quote, falls back to the raw text -
-    // `parse_attr_line()` in Git's `attr.c` reaches its unquoted branch the same way.
     let unquoted = line
         .starts_with(b"\"")
         .then(|| gix_quote::ansi_c::undo(line).ok())

--- a/gix-attributes/src/parse.rs
+++ b/gix-attributes/src/parse.rs
@@ -26,8 +26,6 @@ mod error {
         AttributeName { line_number: usize, attribute: BString },
         #[error("Macro in line {line_number} has an invalid name: {macro_name}")]
         MacroName { line_number: usize, macro_name: BString },
-        #[error("Could not unquote attributes line")]
-        Unquote(#[from] gix_quote::ansi_c::undo::Error),
     }
 }
 pub use error::Error;
@@ -122,16 +120,18 @@ fn parse_line(line: &BStr, line_number: usize) -> Option<Result<(Kind, Iter<'_>,
         return None;
     }
 
-    let (line, attrs): (Cow<'_, _>, _) = if line.starts_with(b"\"") {
-        let (unquoted, consumed) = match gix_quote::ansi_c::undo(line) {
-            Ok(res) => res,
-            Err(err) => return Some(Err(err.into())),
-        };
-        (unquoted, &line[consumed..])
-    } else {
-        line.find_byteset(BLANKS)
+    // Broken quoting, like a pattern that never closes its quote, falls back to the raw text -
+    // `parse_attr_line()` in Git's `attr.c` reaches its unquoted branch the same way.
+    let unquoted = line
+        .starts_with(b"\"")
+        .then(|| gix_quote::ansi_c::undo(line).ok())
+        .flatten();
+    let (line, attrs): (Cow<'_, _>, _) = match unquoted {
+        Some((unquoted, consumed)) => (unquoted, &line[consumed..]),
+        None => line
+            .find_byteset(BLANKS)
             .map(|pos| (line[..pos].as_bstr().into(), line[pos..].as_bstr()))
-            .unwrap_or((line.into(), [].as_bstr()))
+            .unwrap_or((line.into(), [].as_bstr())),
     };
 
     let kind_res = match line.strip_prefix(b"[attr]").filter(|name| !name.is_empty()) {

--- a/gix-attributes/tests/attributes/parse.rs
+++ b/gix-attributes/tests/attributes/parse.rs
@@ -115,9 +115,23 @@ fn exclamation_marks_must_be_escaped_or_error_unlike_gitignore() {
 }
 
 #[test]
-fn invalid_escapes_in_quotes_are_an_error() {
-    assert!(matches!(try_line(r#""\!hello""#), Err(parse::Error::Unquote(_))));
-    assert!(lenient_lines(r#""\!hello""#).is_empty());
+fn broken_quoting_falls_back_to_the_raw_text() {
+    assert_eq!(
+        line(r#""\!hello""#),
+        (pattern(r#""\!hello""#, Mode::NO_SUB_DIR, Some(1)), vec![], 1),
+        "an invalid escape leaves the quotes in place, so the leading `!` no longer negates, \
+         and the backslash goes on to escape it for the matcher"
+    );
+    assert_eq!(
+        line(r#""abc"#),
+        (pattern(r#""abc"#, Mode::NO_SUB_DIR, None), vec![], 1),
+        "so does a quote that is never closed"
+    );
+    assert_eq!(
+        line(r#""abc def"#),
+        (pattern(r#""abc"#, Mode::NO_SUB_DIR, None), vec![set("def")], 1),
+        "the raw text is then split on blanks like any unquoted pattern"
+    );
 }
 
 #[test]

--- a/gix-odb/src/alternate/mod.rs
+++ b/gix-odb/src/alternate/mod.rs
@@ -22,6 +22,7 @@ use gix_path::realpath::MAX_SYMLINKS;
 
 ///
 pub mod parse;
+pub use parse::function::parse;
 
 /// Returned by [`resolve()`]
 #[derive(thiserror::Error, Debug)]
@@ -67,7 +68,7 @@ pub fn resolve(objects_directory: PathBuf, current_dir: &std::path::Path) -> Res
         seen.push((dir_canonicalized, parent_idx));
         match fs::read(dir.join("info").join("alternates")) {
             Ok(input) => {
-                for path in parse::content(&input)?.into_iter().rev() {
+                for path in parse(&input)?.into_iter().rev() {
                     dirs.push((Some(idx), objects_directory.join(path)));
                 }
             }

--- a/gix-odb/src/alternate/parse.rs
+++ b/gix-odb/src/alternate/parse.rs
@@ -10,22 +10,34 @@ pub enum Error {
     PathConversion(Vec<u8>),
 }
 
-pub(crate) fn content(input: &[u8]) -> Result<Vec<PathBuf>, Error> {
+pub(crate) fn content(mut input: &[u8]) -> Result<Vec<PathBuf>, Error> {
     let mut out = Vec::new();
-    for line in input.split(|b| *b == b'\n') {
-        let line = line.as_bstr();
-        if line.is_empty() || line.starts_with(b"#") {
+    while !input.is_empty() {
+        let entry = input.as_bstr();
+        let end_of_line = || entry.find_byte(b'\n').unwrap_or(entry.len());
+        let (path, consumed) = if entry.starts_with(b"#") {
+            (None, end_of_line())
+        } else {
+            // Like Git, try unquoting before treating a newline as the next separator.
+            match entry.starts_with(b"\"").then(|| gix_quote::ansi_c::undo(entry)) {
+                Some(Ok((unquoted, consumed))) => (Some(unquoted), consumed),
+                _ => {
+                    let consumed = end_of_line();
+                    (Some(Cow::Borrowed(entry[..consumed].as_bstr())), consumed)
+                }
+            }
+        };
+        let original = &entry[..consumed];
+        let maybe_nl = usize::from(consumed < input.len());
+        input = &input[consumed + maybe_nl..];
+
+        let Some(path) = path.filter(|path| !path.is_empty()) else {
             continue;
-        }
+        };
         out.push(
-            // Broken quoting, like an entry that doesn't end with a quote, falls back to the raw
-            // line - a case that Git's alternates parsing in `odb.c` calls out in its own comment.
-            gix_path::try_from_bstr(match line.starts_with(b"\"").then(|| gix_quote::ansi_c::undo(line)) {
-                Some(Ok((unquoted, _consumed))) => unquoted,
-                _ => Cow::Borrowed(line),
-            })
-            .map_err(|_| Error::PathConversion(line.to_vec()))?
-            .into_owned(),
+            gix_path::try_from_bstr(path)
+                .map_err(|_| Error::PathConversion(original.to_vec()))?
+                .into_owned(),
         );
     }
     Ok(out)
@@ -41,7 +53,7 @@ mod tests {
         assert_eq!(
             content(br#""unterminated"#).expect("no path conversion issue"),
             vec![PathBuf::from(r#""unterminated"#)],
-            "broken quoting falls back to the raw line, like Git's alternates parsing does"
+            "broken quoting falls back to the raw line"
         );
     }
 
@@ -49,8 +61,16 @@ mod tests {
     fn a_properly_quoted_path_is_unquoted() {
         assert_eq!(
             content(br#""quoted\tpath""#).expect("no path conversion issue"),
-            vec![PathBuf::from("quoted\tpath")],
-            "…while quoting that is intact still decodes its escapes"
+            vec![PathBuf::from("quoted\tpath")]
+        );
+    }
+
+    #[test]
+    fn a_quoted_path_may_contain_the_line_separator() {
+        assert_eq!(
+            content(b"\"quoted\npath\"\nnext").expect("no path conversion issue"),
+            vec![PathBuf::from("quoted\npath"), PathBuf::from("next")],
+            "Git looks for a closing quote before treating a newline as the next separator"
         );
     }
 }

--- a/gix-odb/src/alternate/parse.rs
+++ b/gix-odb/src/alternate/parse.rs
@@ -8,8 +8,6 @@ use gix_object::bstr::ByteSlice;
 pub enum Error {
     #[error("Could not obtain an object path for the alternate directory '{}'", String::from_utf8_lossy(.0))]
     PathConversion(Vec<u8>),
-    #[error("Could not unquote alternate path")]
-    Unquote(#[from] gix_quote::ansi_c::undo::Error),
 }
 
 pub(crate) fn content(input: &[u8]) -> Result<Vec<PathBuf>, Error> {
@@ -20,10 +18,11 @@ pub(crate) fn content(input: &[u8]) -> Result<Vec<PathBuf>, Error> {
             continue;
         }
         out.push(
-            gix_path::try_from_bstr(if line.starts_with(b"\"") {
-                gix_quote::ansi_c::undo(line)?.0
-            } else {
-                Cow::Borrowed(line)
+            // Broken quoting, like an entry that doesn't end with a quote, falls back to the raw
+            // line - a case that Git's alternates parsing in `odb.c` calls out in its own comment.
+            gix_path::try_from_bstr(match line.starts_with(b"\"").then(|| gix_quote::ansi_c::undo(line)) {
+                Some(Ok((unquoted, _consumed))) => unquoted,
+                _ => Cow::Borrowed(line),
             })
             .map_err(|_| Error::PathConversion(line.to_vec()))?
             .into_owned(),

--- a/gix-odb/src/alternate/parse.rs
+++ b/gix-odb/src/alternate/parse.rs
@@ -1,7 +1,3 @@
-use std::{borrow::Cow, path::PathBuf};
-
-use gix_object::bstr::ByteSlice;
-
 /// Returned as part of [`crate::alternate::Error::Parse`]
 #[derive(thiserror::Error, Debug)]
 #[expect(missing_docs)]
@@ -10,67 +6,46 @@ pub enum Error {
     PathConversion(Vec<u8>),
 }
 
-pub(crate) fn content(mut input: &[u8]) -> Result<Vec<PathBuf>, Error> {
-    let mut out = Vec::new();
-    while !input.is_empty() {
-        let entry = input.as_bstr();
-        let end_of_line = || entry.find_byte(b'\n').unwrap_or(entry.len());
-        let (path, consumed) = if entry.starts_with(b"#") {
-            (None, end_of_line())
-        } else {
-            // Like Git, try unquoting before treating a newline as the next separator.
-            match entry.starts_with(b"\"").then(|| gix_quote::ansi_c::undo(entry)) {
-                Some(Ok((unquoted, consumed))) => (Some(unquoted), consumed),
-                _ => {
-                    let consumed = end_of_line();
-                    (Some(Cow::Borrowed(entry[..consumed].as_bstr())), consumed)
+pub(super) mod function {
+    use super::Error;
+    use std::{borrow::Cow, path::PathBuf};
+
+    use gix_object::bstr::ByteSlice;
+
+    /// Parse the raw contents of an `objects/info/alternates` file from `input` into paths.
+    ///
+    /// Empty entries and comments are ignored. Entries beginning with `"` use Git's C-style quoting,
+    /// which permits literal newlines in paths. Invalid quoting falls back to the raw entry.
+    pub fn parse(mut input: &[u8]) -> Result<Vec<PathBuf>, Error> {
+        let mut out = Vec::new();
+        while !input.is_empty() {
+            let entry = input.as_bstr();
+            let end_of_line = || entry.find_byte(b'\n').unwrap_or(entry.len());
+            let (path, consumed) = if entry.starts_with(b"#") {
+                (None, end_of_line())
+            } else {
+                // Like Git, try unquoting before treating a newline as the next separator.
+                match entry.starts_with(b"\"").then(|| gix_quote::ansi_c::undo(entry)) {
+                    Some(Ok((unquoted, consumed))) => (Some(unquoted), consumed),
+                    _ => {
+                        let consumed = end_of_line();
+                        (Some(Cow::Borrowed(entry[..consumed].as_bstr())), consumed)
+                    }
                 }
-            }
-        };
-        let original = &entry[..consumed];
-        let maybe_nl = usize::from(consumed < input.len());
-        input = &input[consumed + maybe_nl..];
+            };
+            let original = &entry[..consumed];
+            let maybe_nl = usize::from(consumed < input.len());
+            input = &input[consumed + maybe_nl..];
 
-        let Some(path) = path.filter(|path| !path.is_empty()) else {
-            continue;
-        };
-        out.push(
-            gix_path::try_from_bstr(path)
-                .map_err(|_| Error::PathConversion(original.to_vec()))?
-                .into_owned(),
-        );
-    }
-    Ok(out)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::content;
-    use std::path::PathBuf;
-
-    #[test]
-    fn a_quote_that_is_never_closed_is_used_as_a_literal_path() {
-        assert_eq!(
-            content(br#""unterminated"#).expect("no path conversion issue"),
-            vec![PathBuf::from(r#""unterminated"#)],
-            "broken quoting falls back to the raw line"
-        );
-    }
-
-    #[test]
-    fn a_properly_quoted_path_is_unquoted() {
-        assert_eq!(
-            content(br#""quoted\tpath""#).expect("no path conversion issue"),
-            vec![PathBuf::from("quoted\tpath")]
-        );
-    }
-
-    #[test]
-    fn a_quoted_path_may_contain_the_line_separator() {
-        assert_eq!(
-            content(b"\"quoted\npath\"\nnext").expect("no path conversion issue"),
-            vec![PathBuf::from("quoted\npath"), PathBuf::from("next")],
-            "Git looks for a closing quote before treating a newline as the next separator"
-        );
+            let Some(path) = path.filter(|path| !path.is_empty()) else {
+                continue;
+            };
+            out.push(
+                gix_path::try_from_bstr(path)
+                    .map_err(|_| Error::PathConversion(original.to_vec()))?
+                    .into_owned(),
+            );
+        }
+        Ok(out)
     }
 }

--- a/gix-odb/src/alternate/parse.rs
+++ b/gix-odb/src/alternate/parse.rs
@@ -30,3 +30,27 @@ pub(crate) fn content(input: &[u8]) -> Result<Vec<PathBuf>, Error> {
     }
     Ok(out)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::content;
+    use std::path::PathBuf;
+
+    #[test]
+    fn a_quote_that_is_never_closed_is_used_as_a_literal_path() {
+        assert_eq!(
+            content(br#""unterminated"#).expect("no path conversion issue"),
+            vec![PathBuf::from(r#""unterminated"#)],
+            "broken quoting falls back to the raw line, like Git's alternates parsing does"
+        );
+    }
+
+    #[test]
+    fn a_properly_quoted_path_is_unquoted() {
+        assert_eq!(
+            content(br#""quoted\tpath""#).expect("no path conversion issue"),
+            vec![PathBuf::from("quoted\tpath")],
+            "…while quoting that is intact still decodes its escapes"
+        );
+    }
+}

--- a/gix-odb/tests/odb/alternate.rs
+++ b/gix-odb/tests/odb/alternate.rs
@@ -5,6 +5,37 @@ use std::{
 
 use gix_odb::alternate;
 
+mod parse {
+    use std::path::PathBuf;
+
+    use gix_odb::alternate;
+
+    #[test]
+    fn a_quote_that_is_never_closed_is_used_as_a_literal_path() {
+        assert_eq!(
+            alternate::parse(br#""unterminated"#).expect("no path conversion issue"),
+            vec![PathBuf::from(r#""unterminated"#)],
+            "broken quoting falls back to the raw line"
+        );
+    }
+
+    #[test]
+    fn a_properly_quoted_path_is_unquoted() {
+        assert_eq!(
+            alternate::parse(br#""quoted\tpath""#).expect("no path conversion issue"),
+            vec![PathBuf::from("quoted\tpath")]
+        );
+    }
+
+    #[test]
+    fn a_quoted_path_may_contain_the_line_separator() {
+        assert_eq!(
+            alternate::parse(b"\"quoted\npath\"\nnext").expect("no path conversion issue"),
+            vec![PathBuf::from("quoted\npath"), PathBuf::from("next")],
+            "Git looks for a closing quote before treating a newline as the next separator"
+        );
+    }
+}
 pub fn alternate(
     objects_at: impl Into<PathBuf>,
     objects_to: impl Into<PathBuf>,

--- a/gix-odb/tests/odb/alternate.rs
+++ b/gix-odb/tests/odb/alternate.rs
@@ -149,26 +149,6 @@ fn single_link_with_comment_before_path_and_ansi_c_escape() -> crate::Result {
 }
 
 #[test]
-fn a_quote_that_is_never_closed_is_used_as_a_literal_path() -> crate::Result {
-    let tmp = gix_testtools::tempfile::TempDir::new()?;
-    // The entry is relative so that it can start with the quote that is never closed.
-    let (from, to) = alternate_with_content(
-        tmp.path().join("a"),
-        tmp.path().join("a").join("\"unterminated"),
-        br#""unterminated"#.to_vec(),
-        None,
-    )?;
-
-    let alternates = alternate::resolve(from, &std::env::current_dir()?)?;
-    assert_eq!(
-        alternates,
-        vec![to],
-        "broken quoting falls back to the raw line, like Git's alternates parsing does"
-    );
-    Ok(())
-}
-
-#[test]
 fn no_alternate_in_first_objects_dir() -> crate::Result {
     let tmp = gix_testtools::tempfile::TempDir::new()?;
     assert!(alternate::resolve(tmp.path().to_owned(), &std::env::current_dir()?)?.is_empty());

--- a/gix-odb/tests/odb/alternate.rs
+++ b/gix-odb/tests/odb/alternate.rs
@@ -149,6 +149,26 @@ fn single_link_with_comment_before_path_and_ansi_c_escape() -> crate::Result {
 }
 
 #[test]
+fn a_quote_that_is_never_closed_is_used_as_a_literal_path() -> crate::Result {
+    let tmp = gix_testtools::tempfile::TempDir::new()?;
+    // The entry is relative so that it can start with the quote that is never closed.
+    let (from, to) = alternate_with_content(
+        tmp.path().join("a"),
+        tmp.path().join("a").join("\"unterminated"),
+        br#""unterminated"#.to_vec(),
+        None,
+    )?;
+
+    let alternates = alternate::resolve(from, &std::env::current_dir()?)?;
+    assert_eq!(
+        alternates,
+        vec![to],
+        "broken quoting falls back to the raw line, like Git's alternates parsing does"
+    );
+    Ok(())
+}
+
+#[test]
 fn no_alternate_in_first_objects_dir() -> crate::Result {
     let tmp = gix_testtools::tempfile::TempDir::new()?;
     assert!(alternate::resolve(tmp.path().to_owned(), &std::env::current_dir()?)?.is_empty());

--- a/gix-quote/src/ansi_c.rs
+++ b/gix-quote/src/ansi_c.rs
@@ -15,10 +15,7 @@ use gix_error::{ErrorExt, OptionExt, ResultExt, ValidationError};
 /// quotation, otherwise a new unquoted string will always be allocated.
 /// The amount of consumed bytes allow to pass strings that start with a quote, and skip all quoted text for additional processing
 ///
-/// A quote that is never closed is an error, just as in Git's `unquote_c_style()`. Note that Git's
-/// callers differ in how they respond to that: some abort, while those reading attributes and
-/// alternates fall back to using the raw, still-quoted text.
-///
+/// A quote that is never closed is an error.
 /// See [the tests][tests] for quotation examples.
 ///
 /// [tests]: https://github.com/GitoxideLabs/gitoxide/blob/64872690e60efdd9267d517f4d9971eecd3b875c/gix-quote/tests/quote.rs#L57-L74
@@ -97,8 +94,6 @@ pub fn undo(input: &BStr) -> Result<(Cow<'_, BStr>, usize), undo::Error> {
                 }
             }
             None => {
-                // Running out of input before the closing quote is an error in Git's
-                // `unquote_c_style()` as well.
                 return Err(
                     ValidationError::new_with_input("Missing closing quote in quoted string", original).raise(),
                 );

--- a/gix-quote/src/ansi_c.rs
+++ b/gix-quote/src/ansi_c.rs
@@ -15,6 +15,10 @@ use gix_error::{ErrorExt, OptionExt, ResultExt, ValidationError};
 /// quotation, otherwise a new unquoted string will always be allocated.
 /// The amount of consumed bytes allow to pass strings that start with a quote, and skip all quoted text for additional processing
 ///
+/// A quote that is never closed is an error, just as in Git's `unquote_c_style()`. Note that Git's
+/// callers differ in how they respond to that: some abort, while those reading attributes and
+/// alternates fall back to using the raw, still-quoted text.
+///
 /// See [the tests][tests] for quotation examples.
 ///
 /// [tests]: https://github.com/GitoxideLabs/gitoxide/blob/64872690e60efdd9267d517f4d9971eecd3b875c/gix-quote/tests/quote.rs#L57-L74
@@ -93,9 +97,11 @@ pub fn undo(input: &BStr) -> Result<(Cow<'_, BStr>, usize), undo::Error> {
                 }
             }
             None => {
-                out.extend_from_slice(input);
-                consumed += input.len();
-                break;
+                // Running out of input before the closing quote is an error in Git's
+                // `unquote_c_style()` as well.
+                return Err(
+                    ValidationError::new_with_input("Missing closing quote in quoted string", original).raise(),
+                );
             }
         }
     }

--- a/gix-quote/tests/quote.rs
+++ b/gix-quote/tests/quote.rs
@@ -82,6 +82,16 @@ mod ansi_c {
         }
 
         #[test]
+        fn a_quote_that_is_never_closed_is_an_error() {
+            for unterminated in [r#"""#, r#""abc"#, r#""abc def"#, r#""abc\"#, r#""\""#] {
+                assert!(
+                    ansi_c::undo(unterminated.into()).is_err(),
+                    "{unterminated:?} should not parse, just like in `unquote_c_style()`"
+                );
+            }
+        }
+
+        #[test]
         fn fuzzed() {
             for invalid in ["\"\\", "\"Q\u{2}QT\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\0\0\\"] {
                 assert!(ansi_c::undo(invalid.into()).is_err());

--- a/gix-quote/tests/quote.rs
+++ b/gix-quote/tests/quote.rs
@@ -86,7 +86,7 @@ mod ansi_c {
             for unterminated in [r#"""#, r#""abc"#, r#""abc def"#, r#""abc\"#, r#""\""#] {
                 assert!(
                     ansi_c::undo(unterminated.into()).is_err(),
-                    "{unterminated:?} should not parse, just like in `unquote_c_style()`"
+                    "{unterminated:?} should not parse"
                 );
             }
         }


### PR DESCRIPTION
Created by Claude Code on behalf of Amey, who reviewed it before submitting. Everything below this line is the agent's writing, not his.

----

## Summary

- `ansi_c::undo()` now fails when a quote is never closed, instead of returning the rest of the input as if it had been unquoted.
- Attributes and alternates fall back to the raw, still-quoted text when unquoting fails, which is what Git does at both of those call sites.
- For attributes this also covers invalid escapes, which previously discarded the whole line.
- The two `Error::Unquote` variants become unreachable and are removed.

## Git baseline

`unquote_c_style()` in `quote.c` has no branch for running out of input: `strcspn(quoted, "\"\\")` stops at the terminating NUL, and the `switch (*quoted++)` that follows reaches `default: goto error`, returning -1. `undo()` instead treated a missing closing quote as success, so `"abc` unquoted to `abc` and reported all 4 bytes as consumed. A lone `"` already errored, so the two cases disagreed with each other.

Both callers in this workspace are places where Git recovers rather than aborts:

```c
/* parse_attr_line(), attr.c */
if (*cp == '"' && !unquote_c_style(&pattern, name, &states)) {
	name = pattern.buf;
	namelen = pattern.len;
} else {
	namelen = strcspn(name, blank);
	states = name + namelen;
}
```

The alternates parser in `odb.c` says so outright — "Broken quoting (e.g., an entry that doesn't end with a quote) falls back to the unquoted case below". (That function is `parse_alt_odb_entry()` in 2.52.0 and `parse_alternates()` on `master`, so it is referred to by file here rather than by name.)

Measured with `git check-attr`, where the pattern is inferred from the file each line matches:

| `.gitattributes` line | unquote | Git's pattern | matches |
|---|---|---|---|
| `"abc` | fails, unterminated | raw `"abc` | `"abc` |
| `"\!hello"` | fails, invalid escape | raw, and `\!` then escapes the `!` | `"!hello"` |
| `"ab\qcd"` | fails, invalid escape | raw | `"abqcd"` |
| `"ab\tcd"` | succeeds | `ab<TAB>cd` | `ab<TAB>cd` |

The second row is why the invalid-escape case is included: `gix-attributes` turned it into an error for the whole line, while Git keeps the pattern and the leading `!` never negates, because after the fallback the token still begins with a quote. Both implementations fall back before testing for the `[attr]` prefix, so `"[attr]x` stays a pattern on either side.

This does not extend to every unquoting site in Git — `git checkout-index --stdin` aborts with `fatal: line is badly quoted` on the same input — so the doc on `undo()` says callers differ rather than claiming a universal rule.

## Validation

A differential sweep of 28 quoting shapes, taking Git's own answer via `git check-attr` rather than an expectation, goes from 12 divergences to 1. The harness was first run against an unmodified build to confirm it could detect the divergences at all, and corrected once when it scored dropped lines as agreement.

The remaining row is `"\\"`, a pattern consisting of a single backslash. Both implementations produce that same pattern — the probe output is byte-identical before and after — and neither matches any file with it, so the oracle has no filename that can demonstrate agreement. It is a limit of matching-based comparison, not a divergence.

To show the refactor in `parse_line()` changes nothing it should not, 26 lines whose quoting succeeds or never begins were run through the old and new parsers: pattern text, mode, `first_wildcard_pos`, line number and every attribute assignment are byte-for-byte identical. The only behavioural difference is the failure path.

Reverting the `gix-quote` arm alone makes all three new tests fail.

- `cargo test` — gix-quote 17, gix-attributes 39, gix-odb 73, gix-pathspec 65, gix-dir 79, gix-worktree 10, gix-glob 40, gix 417
- `cargo fmt --check` — gix-quote, gix-attributes, gix-odb

`gix-ignore` is deliberately untouched: Git does not ansi-c unquote exclude patterns, so `"quoted.txt"` there ignores a file literally named `"quoted.txt"`, and this crate already agrees.

## Notes

The change is split as `DEVELOPMENT.md` asks, with the breaking change to `gix-quote` first and the two adaptations second.

It is confined to parsing. `alternate::resolve()` still applies its own handling to whatever path comes out, which is unchanged here.

One interaction worth flagging: #2847 hand-writes `Display`, `Error::source` and `From` impls for the `Unquote` variant in *both* `gix-attributes` and `gix-odb`, and carries a `TODO(review)` on the `gix-odb` one about it wrapping an `Exn` that does not implement `std::error::Error`. Removing the variants makes those impls, and that question, unnecessary. Whichever lands first, the other side is a deletion rather than a conflict of intent.

As for how the arm came to look like this: it was written before `undo()` reported consumed bytes, and a052d7967 added that feature a couple of hours later in the same PR by extending this arm with `consumed += input.len()` — treating the unterminated remainder as consumed, rather than asking whether reaching the end should have succeeded at all.
