### PR TITLE
Use `GIX_TEST_FIXTURE_HASH` for `gix-archive` tests

### DIFF
--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -48,11 +48,11 @@ document-features = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 gix-testtools = { path = "../tests/tools" }
-gix-odb = { path = "../gix-odb" }
+gix-odb = { path = "../gix-odb", features = ["sha1", "sha256"] }
 gix-worktree = { path = "../gix-worktree", default-features = false, features = [
     "attributes",
 ] }
-gix-hash = { path = "../gix-hash", features = ["sha1"] }
+gix-hash = { path = "../gix-hash", features = ["sha1", "sha256"] }
 gix-attributes = { path = "../gix-attributes" }
 gix-object = { path = "../gix-object" }
 gix-filter = { path = "../gix-filter" }

--- a/gix-archive/tests/archive.rs
+++ b/gix-archive/tests/archive.rs
@@ -1,6 +1,48 @@
-/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+static SHA1_TO_SHA256_HASHES: std::sync::LazyLock<std::collections::HashMap<&str, &str>> =
+    std::sync::LazyLock::new(|| {
+        [
+            (
+                "45c160c35c17ad264b96431cceb9793160396e99",
+                "e34ae8e2c517230c6c613202a955b5f2095567830de5c3bb7081d72f1af393dd",
+            ),
+            (
+                "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
+                "96c18f0297e38d01f4b2dacddea4259aea6b2961eb0822bd2c0c3f6029030045",
+            ),
+            (
+                "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+                "eb337bcee2061c5313c9a1392116b6c76039e9e30d71467ae359b36277e17dc7",
+            ),
+            (
+                "ab4a98190cf776b43cb0fe57cef231fb93fd07e6",
+                "cf84f9ae227fa5c481dacd97f6d6506de727dabd30377c6907f623ef1192637a",
+            ),
+            (
+                "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                "473a0f4c3be8a93681a267e3b1e9a7dcda1185436fe141f7749120a303721813",
+            ),
+            (
+                "0000000000000000000000000000000000000000",
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            ),
+        ]
+        .into()
+    });
+
+/// Convert a hexadecimal SHA-1 hash or the corresponding SHA-256 hash into an `ObjectId` or
+/// _panic_.
 fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
-    gix_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+    match gix_testtools::object_hash() {
+        gix_hash::Kind::Sha1 => gix_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex"),
+        gix_hash::Kind::Sha256 => gix_hash::ObjectId::from_hex(
+            SHA1_TO_SHA256_HASHES
+                .get(hex)
+                .unwrap_or_else(|| panic!("SHA-1 {hex} wasn't mapped to SHA-256 yet"))
+                .as_bytes(),
+        )
+        .expect("64 bytes hex"),
+        _ => unimplemented!(),
+    }
 }
 
 mod from_tree {
@@ -15,15 +57,22 @@ mod from_tree {
 
     use crate::hex_to_id;
 
-    #[cfg(target_pointer_width = "64")]
-    const EXPECTED_BUFFER_LENGTH: usize = 551;
-    #[cfg(target_pointer_width = "32")]
-    const EXPECTED_BUFFER_LENGTH: usize = 479;
-
     #[test]
     fn basic_usage_internal() -> gix_testtools::Result {
         basic_usage(gix_archive::Format::InternalTransientNonPersistable, |buf| {
-            assert_eq!(buf.len(), EXPECTED_BUFFER_LENGTH);
+            #[cfg(target_pointer_width = "64")]
+            let expected_buffer_length = match gix_testtools::object_hash() {
+                gix_hash::Kind::Sha1 => 551,
+                gix_hash::Kind::Sha256 => 659,
+                _ => unimplemented!(),
+            };
+            #[cfg(target_pointer_width = "32")]
+            let expected_buffer_length = match gix_testtools::object_hash() {
+                gix_hash::Kind::Sha1 => 479,
+                gix_hash::Kind::Sha256 => todo!("let the test fail on CI and add the value here"),
+                _ => unimplemented!(),
+            };
+            assert_eq!(buf.len(), expected_buffer_length);
 
             let mut stream = gix_worktree_stream::Stream::from_read(std::io::Cursor::new(buf));
             let mut paths_and_modes = Vec::new();
@@ -292,7 +341,14 @@ mod from_tree {
             let hex = std::fs::read(dir.join("head.hex"))?;
             gix_hash::ObjectId::from_hex(hex.trim())?
         };
-        let odb = gix_odb::at(dir.join(".git").join("objects"))?;
+        let odb = gix_odb::at_opts(
+            dir.join(".git").join("objects"),
+            Vec::new(),
+            gix_odb::store::init::Options {
+                object_hash: gix_testtools::object_hash(),
+                ..Default::default()
+            },
+        )?;
 
         let mut collection = Default::default();
         let mut buf = Default::default();

--- a/gix-archive/tests/fixtures/generated-archives/.gitignore
+++ b/gix-archive/tests/fixtures/generated-archives/.gitignore
@@ -3,3 +3,4 @@
 # extracted on every supported platform (notably Windows). The script is re-run
 # on the test host instead.
 basic.tar
+basic_sha256.tar

--- a/justfile
+++ b/justfile
@@ -158,10 +158,15 @@ unit-tests:
     cargo nextest run -p gix-attributes --features serde --no-fail-fast
     cargo nextest run -p gix-testtools --no-fail-fast
     cargo nextest run -p gix-testtools --features xz --no-fail-fast
-    cargo nextest run -p gix-archive --no-default-features --features sha1 --no-fail-fast
-    cargo nextest run -p gix-archive --no-default-features --features sha1,tar --no-fail-fast
-    cargo nextest run -p gix-archive --no-default-features --features sha1,tar_gz --no-fail-fast
-    cargo nextest run -p gix-archive --no-default-features --features sha1,zip --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-archive --no-default-features --features sha1 --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-archive --no-default-features --features sha1,tar --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-archive --no-default-features --features sha1,tar_gz --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-archive --no-default-features --features sha1,zip --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-archive --features sha256 --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-archive --no-default-features --features sha256 --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-archive --no-default-features --features sha256,tar --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-archive --no-default-features --features sha256,tar_gz --no-fail-fast
+    env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-archive --no-default-features --features sha256,zip --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-diff --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-diff --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-status --no-fail-fast


### PR DESCRIPTION
This PR makes `gix-archive` tests run with `GIX_TEST_FIXTURE_HASH=sha256`.

The changes are pretty straightforward, but there’s one thing I’m not sure about: `justfile` has 5 new `cargo nextest` entries in this initial version. If you feel this is unwarranted, feel free to remove those that are not needed.

In this PR, I tried to follow the patterns used in 3bca1a1.

Some of the code changes, in particular the exact SHA-1 to SHA-256 mappings, were drafted by GPT-5.5.