### PR TITLE
feat: honor `GIT_INDEX_FILE` via `gitoxide.core.indexFile`

### DIFF
--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -67,12 +67,9 @@ extras = [
     "interrupt",
     "status",
     "dirwalk",
-    "blame"
+    "blame",
+    "merge"
 ]
-
-## A collection of features that need a larger MSRV, and thus are disabled by default.
-## * `blob-merge` should be in extras, but needs `tree-editor` for convenience.
-need-more-recent-msrv = ["merge", "tree-editor"]
 
 ## Various progress-related features that improve the look of progress message units.
 comfort = [
@@ -133,9 +130,6 @@ worktree-mutation = ["attributes", "dep:gix-worktree-state"]
 excludes = ["dep:gix-ignore", "dep:gix-worktree", "index"]
 
 ## Provide facilities to edit trees conveniently.
-##
-## Not that currently, this requires [Rust 1.75](https://caniuse.rs/features/return_position_impl_trait_in_trait).
-## This feature toggle is likely going away then.
 tree-editor = []
 
 ## Query attributes and excludes. Enables access to pathspecs, worktree checkouts, filter-pipelines and submodules.
@@ -420,9 +414,8 @@ parking_lot = { version = "0.12.4", optional = true }
 document-features = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
-# For additional features that aren't enabled by default due to MSRV
 gix = { path = ".", default-features = false, features = [
-    "need-more-recent-msrv", "tree-error", "sha1", "sha256"
+    "merge", "tree-error", "sha1", "sha256"
 ] }
 gix-hash = { version = "^0.26.0", path = "../gix-hash" }
 pretty_assertions = "1.4.0"
@@ -441,7 +434,6 @@ features = [
     "max-performance",
     "blocking-network-client",
     "blocking-http-transport-curl",
-    "need-more-recent-msrv",
     "serde",
 ]
 

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -129,9 +129,6 @@ worktree-mutation = ["attributes", "dep:gix-worktree-state"]
 ## Retrieve a worktree stack for querying exclude information
 excludes = ["dep:gix-ignore", "dep:gix-worktree", "index"]
 
-## Provide facilities to edit trees conveniently.
-tree-editor = []
-
 ## Query attributes and excludes. Enables access to pathspecs, worktree checkouts, filter-pipelines and submodules.
 attributes = [
     "excludes",
@@ -158,7 +155,7 @@ revparse-regex = ["regex", "revision"]
 blob-diff = ["gix-diff/blob", "attributes"]
 
 ## Add functions to specifically merge files, using the standard three-way merge that git offers.
-merge = ["tree-editor", "blob-diff", "dep:gix-merge", "attributes"]
+merge = ["blob-diff", "dep:gix-merge", "attributes"]
 
 ## Add blame command similar to `git blame`.
 blame = ["dep:gix-blame", "blob-diff"]

--- a/gix/src/config/cache/access.rs
+++ b/gix/src/config/cache/access.rs
@@ -288,7 +288,6 @@ impl Cache {
         })
     }
 
-    #[cfg(any(feature = "index", feature = "tree-editor"))]
     pub(crate) fn protect_options(&self) -> Result<gix_validate::path::component::Options, config::boolean::Error> {
         const IS_WINDOWS: bool = cfg!(windows);
         const IS_MACOS: bool = cfg!(target_os = "macos");

--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -41,6 +41,7 @@ impl Cache {
         lenient_config: bool,
         api_config_overrides: &[BString],
         cli_config_overrides: &[BString],
+        use_repository_local_environment: bool,
     ) -> Result<Self, Error> {
         let config = load(
             Some(git_dir_config),
@@ -55,6 +56,7 @@ impl Cache {
             lenient_config,
             api_config_overrides,
             cli_config_overrides,
+            use_repository_local_environment,
         )?;
 
         let hex_len = util::parse_core_abbrev(&config, object_hash).with_leniency(lenient_config)?;
@@ -234,6 +236,7 @@ pub(crate) fn load(
     lenient: bool,
     api_config_overrides: &[BString],
     cli_config_overrides: &[BString],
+    use_repository_local_environment: bool,
 ) -> Result<gix_config::File, Error> {
     let options = gix_config::file::init::Options {
         includes: if use_includes {
@@ -313,7 +316,14 @@ pub(crate) fn load(
             },
         )?;
     }
-    apply_environment_overrides(&mut globals, *git_prefix, http_transport, identity, objects)?;
+    apply_environment_overrides(
+        &mut globals,
+        *git_prefix,
+        http_transport,
+        identity,
+        objects,
+        use_repository_local_environment,
+    )?;
     if let Some(local_meta) = local_meta {
         globals.set_meta(local_meta);
     }
@@ -365,6 +375,7 @@ fn apply_environment_overrides(
     http_transport: Permission,
     identity: Permission,
     objects: Permission,
+    use_repository_local_environment: bool,
 ) -> Result<(), Error> {
     fn env(key: &'static dyn config::tree::Key) -> &'static str {
         key.the_environment_override()
@@ -380,7 +391,11 @@ fn apply_environment_overrides(
         (
             "core",
             None,
-            git_prefix,
+            if use_repository_local_environment {
+                git_prefix
+            } else {
+                Permission::Deny
+            },
             &[{
                 let key = &Core::WORKTREE;
                 (env(key), key.name)
@@ -499,25 +514,43 @@ fn apply_environment_overrides(
         (
             "gitoxide",
             Some("core"),
-            git_prefix,
+            if use_repository_local_environment {
+                git_prefix
+            } else {
+                Permission::Deny
+            },
             &[
                 {
                     let key = &gitoxide::Core::SHALLOW_FILE;
                     (env(key), key.name)
                 },
                 {
-                    let key = &gitoxide::Core::INDEX_FILE;
-                    (env(key), key.name)
-                },
-                {
                     let key = &gitoxide::Core::REFS_NAMESPACE;
                     (env(key), key.name)
                 },
-                {
-                    let key = &gitoxide::Core::EXTERNAL_COMMAND_STDERR;
-                    (env(key), key.name)
-                },
             ],
+        ),
+        (
+            "gitoxide",
+            Some("core"),
+            if use_repository_local_environment {
+                git_prefix
+            } else {
+                Permission::Deny
+            },
+            &[{
+                let key = &gitoxide::Core::INDEX_FILE;
+                (env(key), key.name)
+            }],
+        ),
+        (
+            "gitoxide",
+            Some("core"),
+            git_prefix,
+            &[{
+                let key = &gitoxide::Core::EXTERNAL_COMMAND_STDERR;
+                (env(key), key.name)
+            }],
         ),
         (
             "gitoxide",

--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -506,6 +506,10 @@ fn apply_environment_overrides(
                     (env(key), key.name)
                 },
                 {
+                    let key = &gitoxide::Core::INDEX_FILE;
+                    (env(key), key.name)
+                },
+                {
                     let key = &gitoxide::Core::REFS_NAMESPACE;
                     (env(key), key.name)
                 },

--- a/gix/src/config/tree/sections/gitoxide.rs
+++ b/gix/src/config/tree/sections/gitoxide.rs
@@ -121,6 +121,13 @@ mod subsections {
                 "relative file paths will always be made relative to the git-common-dir, whereas `git` keeps them as is.",
             );
 
+        /// The `gitoxide.core.indexFile` key.
+        pub const INDEX_FILE: keys::Path = keys::Path::new_path("indexFile", &Gitoxide::CORE)
+            .with_environment_override("GIT_INDEX_FILE")
+            .with_deviation(
+                "relative file paths are relative to the current working directory when the repository was opened, whereas `git` resolves them each time. An empty value is treated as unset.",
+            );
+
         /// The `gitoxide.core.filterProcessDelay` key (default `true`).
         ///
         /// It controls whether or not long running filter driver processes can use the 'delay' capability.
@@ -153,6 +160,7 @@ mod subsections {
                 &Self::USE_NSEC,
                 &Self::USE_STDEV,
                 &Self::SHALLOW_FILE,
+                &Self::INDEX_FILE,
                 &Self::PROTECT_WINDOWS,
                 &Self::FILTER_PROCESS_DELAY,
                 &Self::EXTERNAL_COMMAND_STDERR,

--- a/gix/src/config/tree/sections/gitoxide.rs
+++ b/gix/src/config/tree/sections/gitoxide.rs
@@ -83,6 +83,8 @@ mod subsections {
 
     /// The `gitoxide.allow.protocolFromUser` key.
     pub type RefsNamespace = keys::Any<super::validate::RefsNamespace>;
+    /// A path to an alternate index file.
+    pub type IndexFile = keys::Any<super::validate::NonEmptyPath>;
 
     impl RefsNamespace {
         /// Derive the negotiation algorithm identified by `name`, case-sensitively.
@@ -121,11 +123,15 @@ mod subsections {
                 "relative file paths will always be made relative to the git-common-dir, whereas `git` keeps them as is.",
             );
 
-        /// The `gitoxide.core.indexFile` key.
-        pub const INDEX_FILE: keys::Path = keys::Path::new_path("indexFile", &Gitoxide::CORE)
+        /// The `gitoxide.core.indexFile` key, which selects an alternate index file.
+        ///
+        /// `GIT_INDEX_FILE` is mapped to this key when environment overrides are enabled and takes precedence over
+        /// configured values. An empty value is invalid.
+        pub const INDEX_FILE: IndexFile =
+            keys::Any::new_with_validate("indexFile", &Gitoxide::CORE, super::validate::NonEmptyPath)
             .with_environment_override("GIT_INDEX_FILE")
             .with_deviation(
-                "relative file paths are relative to the current working directory when the repository was opened, whereas `git` resolves them each time. An empty value is treated as unset.",
+                "relative file paths are resolved against the current working directory captured when the repository was opened, whereas Git retains them and thus resolves them against the process's current directory on each use.",
             );
 
         /// The `gitoxide.core.filterProcessDelay` key (default `true`).
@@ -577,6 +583,7 @@ mod subsections {
 pub use subsections::{Allow, Author, Commit, Committer, Core, Credentials, Http, Https, Objects, Pathspec, Ssh, User};
 
 pub mod validate {
+    use gix_error::ValidationError;
     use std::error::Error;
 
     use crate::{bstr::BStr, config::tree::keys::Validate};
@@ -597,6 +604,17 @@ pub mod validate {
     impl Validate for RefsNamespace {
         fn validate(&self, value: &BStr) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
             super::Core::REFS_NAMESPACE.try_into_refs_namespace(value)?;
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct NonEmptyPath;
+    impl Validate for NonEmptyPath {
+        fn validate(&self, value: &BStr) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+            if value.is_empty() {
+                return Err(ValidationError::new("index file path must not be empty").into());
+            }
             Ok(())
         }
     }

--- a/gix/src/discover.rs
+++ b/gix/src/discover.rs
@@ -55,11 +55,23 @@ impl ThreadSafeRepository {
     }
 
     /// Try to open a git repository directly from the environment, which reads `GIT_DIR`
-    /// if it is set. If unset, discover upwards from `directory` until one is found,
-    /// while applying `options` with overrides from the environment which includes:
+    /// if it is set. Once selected, the repository also honors these primary environment
+    /// overrides if permitted by its options:
+    ///
+    /// - `GIT_WORK_TREE`
+    /// - `GIT_INDEX_FILE`
+    /// - `GIT_SHALLOW_FILE`
+    /// - `GIT_NAMESPACE`
+    ///
+    /// If `GIT_DIR` is unset, discover upwards from `directory` until one is found,
+    /// while applying `options` with discovery overrides from the environment which includes:
     ///
     /// - `GIT_DISCOVERY_ACROSS_FILESYSTEM`
     /// - `GIT_CEILING_DIRECTORIES`
+    ///
+    /// This is particularly useful for hooks, as Git exports repository-local environment variables
+    /// to them. Honoring these variables preserves the repository and worktree context established by
+    /// Git, including temporary overrides, instead of relying only on discovery from `directory`.
     ///
     /// Finally, use the `trust_map` to determine which of our own repository options to use
     /// based on the trust level of the effective repository directory.

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -449,6 +449,7 @@ pub fn config(git_dir: Option<&std::path::Path>, options: &open::Options) -> Res
         options.lenient_config,
         &options.api_config_overrides,
         &options.cli_config_overrides,
+        options.use_repository_local_environment,
     )
 }
 

--- a/gix/src/object/tree/editor.rs
+++ b/gix/src/object/tree/editor.rs
@@ -75,7 +75,6 @@ impl<'repo> super::Editor<'repo> {
 }
 
 /// Tree editing
-#[cfg(feature = "tree-editor")]
 impl<'repo> crate::Tree<'repo> {
     /// Start editing a new tree based on this one.
     #[doc(alias = "treebuilder", alias = "git2")]

--- a/gix/src/object/tree/mod.rs
+++ b/gix/src/object/tree/mod.rs
@@ -7,7 +7,6 @@ use gix_object::{FindExt, TreeRefIter, bstr::BStr, tree::next_entry};
 use crate::{Id, ObjectDetached, Repository, Tree, object::find};
 
 /// All state needed to conveniently edit a tree, using only [update-or-insert](Editor::upsert()) and [removals](Editor::remove()).
-#[cfg(feature = "tree-editor")]
 #[derive(Clone)]
 pub struct Editor<'repo> {
     pub(crate) inner: gix_object::tree::Editor<'repo>,
@@ -204,7 +203,6 @@ impl<'repo> Tree<'repo> {
 }
 
 ///
-#[cfg(feature = "tree-editor")]
 pub mod editor;
 
 ///

--- a/gix/src/open/mod.rs
+++ b/gix/src/open/mod.rs
@@ -35,8 +35,16 @@ pub struct Options {
     pub(crate) bail_if_untrusted: bool,
     pub(crate) api_config_overrides: Vec<BString>,
     pub(crate) cli_config_overrides: Vec<BString>,
+    /// Whether repository-local environment variables like `GIT_WORK_TREE` and `GIT_INDEX_FILE` may be applied.
+    /// This is disabled when reusing these options to enter another repository.
+    pub(crate) use_repository_local_environment: bool,
+    /// Whether to treat the input path as a git directory without first trying `<path>/.git`.
+    /// This only controls how the current call's input is interpreted, so it is reset after path resolution.
+    /// Retaining it would make later submodule or worktree opens that clone these options skip their normal
+    /// `<path>/.git` lookup as well.
     pub(crate) open_path_as_is: bool,
-    /// Internal to pass an already obtained CWD on to where it may also be used. This avoids the CWD being queried more than once per repo.
+    /// Internal to pass an already obtained CWD on to where it may also be used.
+    /// This avoids the CWD being queried more than once per repo.
     pub(crate) current_dir: Option<PathBuf>,
 }
 

--- a/gix/src/open/options.rs
+++ b/gix/src/open/options.rs
@@ -16,6 +16,7 @@ impl Default for Options {
             open_path_as_is: false,
             api_config_overrides: Vec::new(),
             cli_config_overrides: Vec::new(),
+            use_repository_local_environment: true,
             current_dir: None,
         }
     }
@@ -153,6 +154,14 @@ impl Options {
 }
 
 impl Options {
+    /// Prevent repository-local environment overrides from being inherited when opening another repository.
+    ///
+    /// To be used when opening a nested repository, like worktrees or submodules.
+    pub(crate) fn without_repository_environment_overrides(mut self) -> Self {
+        self.use_repository_local_environment = false;
+        self
+    }
+
     pub(crate) fn current_dir_or_empty(&self) -> &std::path::Path {
         self.current_dir.as_deref().unwrap_or(std::path::Path::new(""))
     }
@@ -172,6 +181,7 @@ impl gix_sec::trust::DefaultForLevel for Options {
                 open_path_as_is: false,
                 api_config_overrides: Vec::new(),
                 cli_config_overrides: Vec::new(),
+                use_repository_local_environment: true,
                 current_dir: None,
             },
             gix_sec::Trust::Reduced => Options {
@@ -185,6 +195,7 @@ impl gix_sec::trust::DefaultForLevel for Options {
                 lossy_config: false,
                 api_config_overrides: Vec::new(),
                 cli_config_overrides: Vec::new(),
+                use_repository_local_environment: true,
                 current_dir: None,
             },
         }

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -180,6 +180,7 @@ impl ThreadSafeRepository {
                 },
             ref api_config_overrides,
             ref cli_config_overrides,
+            use_repository_local_environment,
             ref mut current_dir,
         } = options;
         let git_dir_trust = git_dir_trust.as_mut().expect("trust must be determined by now");
@@ -254,8 +255,8 @@ impl ThreadSafeRepository {
             lenient_config,
             api_config_overrides,
             cli_config_overrides,
+            use_repository_local_environment,
         )?;
-
         // Git's precedence is: GIT_WORK_TREE, core.bare, core.worktree, inferred worktree.
         let configured_worktree = config
             .resolved
@@ -408,6 +409,22 @@ impl ThreadSafeRepository {
             config.resolved = resolved.into();
         }
 
+        let index_path = match config
+            .resolved
+            .string_filter(gitoxide::Core::INDEX_FILE, &mut filter_config_section)
+        {
+            Some(value) => {
+                gitoxide::Core::INDEX_FILE.validate(value.as_bstr()).map_err(|_| {
+                    config::Error::ConfigTypedString(config::key::GenericErrorWithValue::from_value(
+                        &gitoxide::Core::INDEX_FILE,
+                        value.clone(),
+                    ))
+                })?;
+                gix_path::from_bstr(value).into_owned()
+            }
+            None => git_dir.join("index"),
+        };
+
         refs.write_reflog = config::cache::util::reflog_or_default(config.reflog, worktree_dir.is_some());
         refs.namespace.clone_from(&config.refs_namespace);
         let prefix = replacement_objects_refs_prefix(&config.resolved, lenient_config, filter_config_section)?;
@@ -477,6 +494,7 @@ impl ThreadSafeRepository {
             common_dir,
             refs,
             work_tree: worktree_dir,
+            index_path,
             config,
             // used when spawning new repositories off this one when following worktrees
             linked_worktree_options: options,

--- a/gix/src/repository/config/mod.rs
+++ b/gix/src/repository/config/mod.rs
@@ -31,6 +31,11 @@ impl crate::Repository {
     /// Note that changes to the configuration are in-memory only and are observed only this instance
     /// of the [`Repository`](crate::Repository). Use [`reload()`](Self::reload()) to discard them and
     /// refresh the snapshot from disk.
+    ///
+    /// Values used to locate repository files are fixed when the repository is opened and aren't reapplied by
+    /// committing changes here. This includes `core.worktree` and `gitoxide.core.indexFile`; `GIT_DIR` likewise
+    /// cannot retarget an existing repository. Reload after changing persisted configuration or open another
+    /// repository to change these locations.
     pub fn config_snapshot_mut(&mut self) -> config::SnapshotMut<'_> {
         let config = self.config.resolved.as_ref().clone();
         config::SnapshotMut {

--- a/gix/src/repository/impls.rs
+++ b/gix/src/repository/impls.rs
@@ -9,6 +9,7 @@ impl Clone for crate::Repository {
             self.refs.clone(),
             self.objects.clone(),
             self.work_tree.clone(),
+            self.index_path.clone(),
             self.common_dir.clone(),
             self.config.clone(),
             self.options.clone(),
@@ -39,9 +40,12 @@ impl std::fmt::Debug for crate::Repository {
 
 impl PartialEq<crate::Repository> for crate::Repository {
     fn eq(&self, other: &crate::Repository) -> bool {
-        self.git_dir().canonicalize().ok() == other.git_dir().canonicalize().ok()
-            && self.work_tree.as_deref().and_then(|wt| wt.canonicalize().ok())
-                == other.work_tree.as_deref().and_then(|wt| wt.canonicalize().ok())
+        let realpath = |repo: &crate::Repository, path| {
+            gix_path::realpath_opts(path, repo.current_dir(), gix_path::realpath::MAX_SYMLINKS).ok()
+        };
+        realpath(self, self.git_dir()) == realpath(other, other.git_dir())
+            && self.work_tree.as_deref().and_then(|path| realpath(self, path))
+                == other.work_tree.as_deref().and_then(|path| realpath(other, path))
     }
 }
 
@@ -51,6 +55,7 @@ impl From<&crate::ThreadSafeRepository> for crate::Repository {
             repo.refs.clone(),
             gix_odb::memory::Proxy::from(gix_odb::Cache::from(repo.objects.to_handle())).with_write_passthrough(),
             repo.work_tree.clone(),
+            repo.index_path.clone(),
             repo.common_dir.clone(),
             repo.config.clone(),
             repo.linked_worktree_options.clone(),
@@ -69,6 +74,7 @@ impl From<crate::ThreadSafeRepository> for crate::Repository {
             repo.refs,
             gix_odb::memory::Proxy::from(gix_odb::Cache::from(repo.objects.to_handle())).with_write_passthrough(),
             repo.work_tree,
+            repo.index_path,
             repo.common_dir,
             repo.config,
             repo.linked_worktree_options,
@@ -87,6 +93,7 @@ impl From<crate::Repository> for crate::ThreadSafeRepository {
             refs: r.refs,
             objects: r.objects.into_inner().store(),
             work_tree: r.work_tree,
+            index_path: r.index_path,
             common_dir: r.common_dir,
             config: r.config,
             linked_worktree_options: r.options,

--- a/gix/src/repository/index.rs
+++ b/gix/src/repository/index.rs
@@ -211,7 +211,7 @@ impl crate::Repository {
                     source: err,
                 }
             })?,
-            self.git_dir().join("index"),
+            self.index_path(),
         ))
     }
 }

--- a/gix/src/repository/init.rs
+++ b/gix/src/repository/init.rs
@@ -6,6 +6,7 @@ impl crate::Repository {
         refs: crate::RefStore,
         mut objects: crate::OdbHandle,
         work_tree: Option<std::path::PathBuf>,
+        index_path: std::path::PathBuf,
         common_dir: Option<std::path::PathBuf>,
         config: crate::config::Cache,
         linked_worktree_options: crate::open::Options,
@@ -17,6 +18,7 @@ impl crate::Repository {
         crate::Repository {
             bufs: Some(RefCell::new(Vec::with_capacity(4))),
             work_tree,
+            index_path,
             common_dir,
             objects,
             refs,
@@ -37,7 +39,7 @@ impl crate::Repository {
 
     /// Reopen this repository in place using the stored open options.
     /// Use this to forcefully refresh Git configuration, drop caches, and release system resources
-    /// for opened object database resources.
+    /// for opened object database resources (if this is the last instance to a repository).
     ///
     /// This discards in-memory-only configuration edits and any other transient repository state that is recreated
     /// during opening.

--- a/gix/src/repository/location.rs
+++ b/gix/src/repository/location.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::bstr::BStr;
+use crate::{bstr::BStr, config::tree::gitoxide};
 
 impl crate::Repository {
     /// Return the path to the repository itself, containing objects, references, configuration, and more.
@@ -38,7 +38,15 @@ impl crate::Repository {
 
     /// Return the path to the worktree index file, which may or may not exist.
     pub fn index_path(&self) -> PathBuf {
-        self.git_dir().join("index")
+        match self
+            .config
+            .resolved
+            .string_filter(gitoxide::Core::INDEX_FILE, &mut self.filter_config_section())
+            .filter(|path| !path.is_empty())
+        {
+            Some(path) => self.current_dir().join(gix_path::from_bstr(path)),
+            None => self.git_dir().join("index"),
+        }
     }
 
     /// The path to the `.gitmodules` file in the worktree, if a worktree is available.

--- a/gix/src/repository/location.rs
+++ b/gix/src/repository/location.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{bstr::BStr, config::tree::gitoxide};
+use crate::bstr::BStr;
 
 impl crate::Repository {
     /// Return the path to the repository itself, containing objects, references, configuration, and more.
@@ -37,16 +37,12 @@ impl crate::Repository {
     }
 
     /// Return the path to the worktree index file, which may or may not exist.
+    ///
+    /// It may have been overridden with
+    /// [gitoxide.core.indexFile][crate::config::tree::gitoxide::Core::INDEX_FILE].
+    /// The path is selected when the repository is opened and only re-evaluated by [`reload()`](Self::reload()).
     pub fn index_path(&self) -> PathBuf {
-        match self
-            .config
-            .resolved
-            .string_filter(gitoxide::Core::INDEX_FILE, &mut self.filter_config_section())
-            .filter(|path| !path.is_empty())
-        {
-            Some(path) => self.current_dir().join(gix_path::from_bstr(path)),
-            None => self.git_dir().join("index"),
-        }
+        self.index_path.clone()
     }
 
     /// The path to the `.gitmodules` file in the worktree, if a worktree is available.

--- a/gix/src/repository/mod.rs
+++ b/gix/src/repository/mod.rs
@@ -324,7 +324,6 @@ pub mod diff_resource_cache {
 }
 
 ///
-#[cfg(feature = "tree-editor")]
 pub mod edit_tree {
     /// The error returned by [Repository::edit_tree()](crate::Repository::edit_tree).
     #[derive(Debug, thiserror::Error)]

--- a/gix/src/repository/object.rs
+++ b/gix/src/repository/object.rs
@@ -14,7 +14,6 @@ use crate::repository::{new_commit, new_commit_as};
 use crate::{Blob, Commit, Id, Object, Reference, Tag, Tree, commit, ext::ObjectIdExt, object, tag};
 
 /// Tree editing
-#[cfg(feature = "tree-editor")]
 impl crate::Repository {
     /// Return an editor for adjusting the tree at `id`.
     ///

--- a/gix/src/repository/worktree.rs
+++ b/gix/src/repository/worktree.rs
@@ -48,7 +48,11 @@ impl crate::Repository {
         reason = "will be removed once `gix-error` is used consistently"
     )]
     pub fn main_repo(&self) -> Result<crate::Repository, crate::open::Error> {
-        crate::ThreadSafeRepository::open_opts(self.common_dir(), self.options.clone()).map(Into::into)
+        let options = match (self.kind(), self.options.clone()) {
+            (crate::repository::Kind::LinkedWorkTree, opts) => opts.without_repository_environment_overrides(),
+            (_, opts) => opts,
+        };
+        crate::ThreadSafeRepository::open_opts(self.common_dir(), options).map(Into::into)
     }
 
     /// Return the currently set worktree if there is one, acting as platform providing a validated worktree base path.

--- a/gix/src/submodule/mod.rs
+++ b/gix/src/submodule/mod.rs
@@ -311,7 +311,12 @@ impl Submodule<'_> {
     /// The repository can also be used to learn about the submodule `HEAD`, i.e. where its working tree is at,
     /// which may differ compared to the superproject's index or `HEAD` commit.
     pub fn open(&self) -> Result<Option<Repository>, open::Error> {
-        let mut options = self.state.repo.options.clone();
+        let mut options = self
+            .state
+            .repo
+            .options
+            .clone()
+            .without_repository_environment_overrides();
         options.git_dir_trust = None;
         match crate::open_opts(self.git_dir_try_old_form()?, options) {
             Ok(mut repo) => {

--- a/gix/src/types.rs
+++ b/gix/src/types.rs
@@ -162,7 +162,10 @@ pub struct Repository {
     /// A way to access objects.
     pub objects: crate::OdbHandle,
 
+    /// The worktree selected when the repository was opened, or `None` for a bare repository.
     pub(crate) work_tree: Option<PathBuf>,
+    /// The index selected when the repository was opened, including any `gitoxide.core.indexFile` override.
+    pub(crate) index_path: PathBuf,
     /// The path to the resolved common directory if this is a linked worktree repository or it is otherwise set.
     pub(crate) common_dir: Option<PathBuf>,
     /// A free-list of reusable object backing buffers
@@ -202,6 +205,8 @@ pub struct ThreadSafeRepository {
     pub objects: gix_features::threading::OwnShared<gix_odb::Store>,
     /// The path to the worktree at which to find checked out files
     pub work_tree: Option<PathBuf>,
+    /// The path to the index selected when the repository was opened.
+    pub(crate) index_path: PathBuf,
     /// The path to the common directory if this is a linked worktree repository or it is otherwise set.
     pub common_dir: Option<PathBuf>,
     pub(crate) config: crate::config::Cache,

--- a/gix/src/worktree/proxy.rs
+++ b/gix/src/worktree/proxy.rs
@@ -91,7 +91,8 @@ impl Proxy<'_> {
     /// a lot of information if work tree access is avoided.
     pub fn into_repo_with_possibly_inaccessible_worktree(self) -> Result<Repository, crate::open::Error> {
         let base = self.base().ok();
-        let repo = ThreadSafeRepository::open_from_paths(self.git_dir, base, self.parent.options.clone())?;
+        let options = self.parent.options.clone().without_repository_environment_overrides();
+        let repo = ThreadSafeRepository::open_from_paths(self.git_dir, base, options)?;
         Ok(repo.into())
     }
 
@@ -104,7 +105,8 @@ impl Proxy<'_> {
         if !base.is_dir() {
             return Err(into_repo::Error::MissingWorktree { base });
         }
-        let repo = ThreadSafeRepository::open_from_paths(self.git_dir, base.into(), self.parent.options.clone())?;
+        let options = self.parent.options.clone().without_repository_environment_overrides();
+        let repo = ThreadSafeRepository::open_from_paths(self.git_dir, base.into(), options)?;
         Ok(repo.into())
     }
 }

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -167,6 +167,7 @@ mod with_overrides {
             .set("GIT_ICASE_PATHSPECS", "pathspecs-icase")
             .set("GIT_TERMINAL_PROMPT", "42")
             .set("GIT_SHALLOW_FILE", "shallow-file-env")
+            .set("GIT_INDEX_FILE", "index-file-env")
             .set("GIT_NAMESPACE", "namespace-env")
             .set("GIT_EXTERNAL_DIFF", "external-diff-env");
         let mut opts = gix::open::Options::isolated()
@@ -181,6 +182,7 @@ mod with_overrides {
                 "gitoxide.ssh.commandWithoutShellFallback=ssh-command-fallback-cli",
                 "gitoxide.http.proxyAuthMethod=proxy-auth-method-cli",
                 "gitoxide.core.shallowFile=shallow-file-cli",
+                "gitoxide.core.indexFile=index-file-cli",
                 "gitoxide.core.refsNamespace=namespace-cli",
             ])
             .config_overrides([
@@ -194,6 +196,7 @@ mod with_overrides {
                 "gitoxide.ssh.commandWithoutShellFallback=ssh-command-fallback-api",
                 "gitoxide.http.proxyAuthMethod=proxy-auth-method-api",
                 "gitoxide.core.shallowFile=shallow-file-api",
+                "gitoxide.core.indexFile=index-file-api",
                 "gitoxide.core.refsNamespace=namespace-api",
             ]);
         opts.permissions.env.git_prefix = Permission::Allow;
@@ -210,6 +213,10 @@ mod with_overrides {
         assert_eq!(
             config.strings("gitoxide.core.shallowFile").expect("at least one value"),
             ["shallow-file-cli", "shallow-file-api", "shallow-file-env"]
+        );
+        assert_eq!(
+            config.strings("gitoxide.core.indexFile").expect("at least one value"),
+            ["index-file-cli", "index-file-api", "index-file-env"]
         );
         assert_eq!(
             config
@@ -501,6 +508,159 @@ fn git_worktree_absolute_over_root_overrides_bare() -> gix_testtools::Result {
         repo.workdir(),
         Some(worktree.path()),
         "an absolute path with `..` beyond the root resolves to the configured worktree"
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn git_index_file_overrides_the_index_in_the_git_dir() -> gix_testtools::Result {
+    let repository = gix_testtools::scripted_fixture_writable("make_basic_repo.sh")?;
+    let index_file = repository.path().join(".git").join("temporary-index");
+    let _env = gix_testtools::Env::new()
+        .unset("GIT_DIR")
+        .set("GIT_INDEX_FILE", index_file.to_string_lossy());
+
+    let repo = gix::discover_opts(repository.path(), Default::default(), gix::open::Options::isolated())?;
+    assert_eq!(
+        repo.index_path(),
+        repo.git_dir().join("index"),
+        "without environment overrides the index in the git-dir is used even though one is set"
+    );
+    #[cfg(feature = "index")]
+    {
+        assert_eq!(
+            repo.index()?.entries().len(),
+            1,
+            "the index in the git-dir has an entry, so it is distinguishable from the override"
+        );
+    }
+
+    let repo = discover_with_environment_overrides_isolated(repository.path())?;
+
+    assert_eq!(
+        repo.index_path(),
+        index_file,
+        "GIT_INDEX_FILE replaces the index in the git-dir just like it does in Git"
+    );
+
+    #[cfg(feature = "index")]
+    {
+        gix::index::File::from_state(gix::index::State::new(repo.object_hash()), index_file)
+            .write(Default::default())?;
+        assert!(
+            repo.index()?.entries().is_empty(),
+            "the override is read, not the index in the git-dir"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn git_index_file_relative_paths_use_the_cwd_when_opening() -> gix_testtools::Result {
+    let repository = gix_testtools::scripted_fixture_writable("make_basic_repo.sh")?;
+    let _cwd = gix_testtools::set_current_dir(repository.path())?;
+    let _env = gix_testtools::Env::new()
+        .unset("GIT_DIR")
+        .set("GIT_INDEX_FILE", "temporary-index");
+
+    let repo = discover_with_environment_overrides_isolated(repository.path())?;
+
+    assert_eq!(
+        repo.index_path(),
+        repo.current_dir().join("temporary-index"),
+        "relative paths start at the captured CWD, which is where Git invokes hooks"
+    );
+    assert_ne!(
+        repo.index_path(),
+        repo.git_dir().join("temporary-index"),
+        "they are notably not relative to the git-dir"
+    );
+
+    #[cfg(feature = "index")]
+    {
+        gix::index::File::from_state(gix::index::State::new(repo.object_hash()), repo.index_path())
+            .write(Default::default())?;
+        assert!(
+            repo.index()?.entries().is_empty(),
+            "the relative path is resolved and read"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[cfg(feature = "index")]
+fn git_index_file_missing_yields_no_index() -> gix_testtools::Result {
+    let repository = gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?;
+    let index_file = repository.join(".git").join("missing");
+    let _env = gix_testtools::Env::new()
+        .unset("GIT_DIR")
+        .set("GIT_INDEX_FILE", index_file.to_string_lossy());
+
+    let repo = discover_with_environment_overrides_isolated(&repository)?;
+
+    assert!(
+        repo.git_dir().join("index").is_file(),
+        "the index in the git-dir exists and would be found without the override"
+    );
+    assert!(
+        repo.try_index()?.is_none(),
+        "a missing file reports no index instead of falling back to the git-dir"
+    );
+    assert!(
+        repo.index_or_empty()?.entries().is_empty(),
+        "and the usual empty-index semantics apply"
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn git_index_file_empty_is_treated_as_unset() -> gix_testtools::Result {
+    let repository = gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?;
+    let _env = gix_testtools::Env::new().unset("GIT_DIR").set("GIT_INDEX_FILE", "");
+
+    let repo = discover_with_environment_overrides_isolated(&repository)?;
+
+    assert_eq!(
+        repo.index_path(),
+        repo.git_dir().join("index"),
+        "an empty value would otherwise resolve to the current directory itself"
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[cfg(feature = "index")]
+fn git_index_file_receives_writes_while_the_git_dir_index_is_locked() -> gix_testtools::Result {
+    let repository = gix_testtools::scripted_fixture_writable("make_basic_repo.sh")?;
+    let index_file = repository.path().join(".git").join("temporary-index");
+    let _env = gix_testtools::Env::new()
+        .unset("GIT_DIR")
+        .set("GIT_INDEX_FILE", index_file.to_string_lossy());
+
+    let repo = discover_with_environment_overrides_isolated(repository.path())?;
+    let git_dir_index = repo.git_dir().join("index");
+    let git_dir_index_before = std::fs::read(&git_dir_index)?;
+
+    // `git commit <paths>` holds this lock for the duration of the commit, hooks included.
+    std::fs::write(repo.git_dir().join("index.lock"), [])?;
+
+    let mut index = (**repo.index_or_empty()?).clone();
+    index.write(Default::default())?;
+
+    assert!(
+        index_file.is_file(),
+        "the write lands on the override, so the lock in the git-dir isn't contended"
+    );
+    assert_eq!(
+        std::fs::read(&git_dir_index)?,
+        git_dir_index_before,
+        "and the index in the git-dir is left untouched"
     );
     Ok(())
 }

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -514,45 +514,181 @@ fn git_worktree_absolute_over_root_overrides_bare() -> gix_testtools::Result {
 
 #[test]
 #[serial]
-fn git_index_file_overrides_the_index_in_the_git_dir() -> gix_testtools::Result {
-    let repository = gix_testtools::scripted_fixture_writable("make_basic_repo.sh")?;
-    let index_file = repository.path().join(".git").join("temporary-index");
-    let _env = gix_testtools::Env::new()
-        .unset("GIT_DIR")
-        .set("GIT_INDEX_FILE", index_file.to_string_lossy());
-
-    let repo = gix::discover_opts(repository.path(), Default::default(), gix::open::Options::isolated())?;
-    assert_eq!(
-        repo.index_path(),
-        repo.git_dir().join("index"),
-        "without environment overrides the index in the git-dir is used even though one is set"
-    );
-    #[cfg(feature = "index")]
-    {
+fn repository_transitions_do_not_inherit_repository_environment_overrides() -> gix_testtools::Result {
+    fn assert_paths(
+        repo: &Repository,
+        git_dir: &Path,
+        worktree: &Path,
+        index: &Path,
+        context: &str,
+    ) -> gix_testtools::Result {
         assert_eq!(
-            repo.index()?.entries().len(),
-            1,
-            "the index in the git-dir has an entry, so it is distinguishable from the override"
+            gix_path::realpath(repo.git_dir())?,
+            gix_path::realpath(git_dir)?,
+            "{context}: git directory"
         );
+        assert_eq!(
+            repo.workdir().map(gix_path::realpath).transpose()?,
+            Some(gix_path::realpath(worktree)?),
+            "{context}: worktree"
+        );
+        assert_eq!(
+            gix_path::realpath(repo.index_path())?,
+            gix_path::realpath(index)?,
+            "{context}: index"
+        );
+        Ok(())
     }
 
-    let repo = discover_with_environment_overrides_isolated(repository.path())?;
+    let fixture = gix_testtools::scripted_fixture_read_only_needs_archive("make_worktree_relative_linking.sh")?;
+    let main = std::fs::canonicalize(fixture.join("main"))?;
+    let main_git_dir = main.join(".git");
+    let main_index_file = main.join(".git/index");
+    let git_dir_override = main_git_dir.clone();
+    let worktree_override = fixture.to_owned();
+    let index_override = main.join(".git/temporary-index");
+    let _env = gix_testtools::Env::new()
+        .set("GIT_DIR", git_dir_override.to_string_lossy())
+        .set("GIT_WORK_TREE", worktree_override.to_string_lossy())
+        .set("GIT_INDEX_FILE", index_override.to_string_lossy());
+    let mut options = gix::open::Options::isolated();
+    options.permissions.env.git_prefix = Permission::Allow;
 
+    let mut main_repo = discover_with_environment_overrides_isolated(fixture.join("linked"))?;
+    assert_paths(
+        &main_repo,
+        &git_dir_override,
+        &worktree_override,
+        &index_override,
+        "the initial open uses all overrides",
+    )?;
+    main_repo.reload()?;
+    assert_paths(
+        &main_repo,
+        &git_dir_override,
+        &worktree_override,
+        &index_override,
+        "reloading the initial repository keeps all overrides",
+    )?;
+    let mut reopened_main_repo = main_repo.main_repo()?;
+    assert_paths(
+        &reopened_main_repo,
+        &git_dir_override,
+        &worktree_override,
+        &index_override,
+        "remaining in the main repository keeps all overrides",
+    )?;
+    reopened_main_repo.reload()?;
+    assert_paths(
+        &reopened_main_repo,
+        &git_dir_override,
+        &worktree_override,
+        &index_override,
+        "reloading the reopened main repository keeps all overrides",
+    )?;
+
+    let proxy = main_repo.worktrees()?.into_iter().next().expect("one linked worktree");
+    let expected_linked_worktree = proxy.base()?;
+    let expected_linked_git_dir = proxy.git_dir();
+    let expected_linked_index = proxy.git_dir().join("index");
+    let mut linked_repo_from_proxy = proxy.clone().into_repo()?;
+    assert_paths(
+        &linked_repo_from_proxy,
+        expected_linked_git_dir,
+        &expected_linked_worktree,
+        &expected_linked_index,
+        "opening a linked worktree uses its own repository paths",
+    )?;
+    linked_repo_from_proxy.reload()?;
+    assert_paths(
+        &linked_repo_from_proxy,
+        expected_linked_git_dir,
+        &expected_linked_worktree,
+        &expected_linked_index,
+        "reloading keeps the linked worktree repository paths",
+    )?;
+    let mut linked_repo_from_permissive_proxy = proxy.clone().into_repo_with_possibly_inaccessible_worktree()?;
+    assert_paths(
+        &linked_repo_from_permissive_proxy,
+        expected_linked_git_dir,
+        &expected_linked_worktree,
+        &expected_linked_index,
+        "the permissive proxy open also uses the linked worktree repository paths",
+    )?;
+    linked_repo_from_permissive_proxy.reload()?;
+    assert_paths(
+        &linked_repo_from_permissive_proxy,
+        expected_linked_git_dir,
+        &expected_linked_worktree,
+        &expected_linked_index,
+        "reloading the permissively opened repository keeps the linked worktree repository paths",
+    )?;
+
+    let mut linked_repo = gix::open_opts(proxy.base()?, options)?;
+    assert_paths(
+        &linked_repo,
+        expected_linked_git_dir,
+        &worktree_override,
+        &index_override,
+        "a direct open still uses repository environment overrides",
+    )?;
+    linked_repo.reload()?;
+    assert_paths(
+        &linked_repo,
+        expected_linked_git_dir,
+        &worktree_override,
+        &index_override,
+        "reloading a directly opened worktree keeps repository environment overrides",
+    )?;
+    let mut main_repo_from_linked = linked_repo.main_repo()?;
+    assert_paths(
+        &main_repo_from_linked,
+        &main_git_dir,
+        &main,
+        &main_index_file,
+        "returning to the main repository uses its own repository paths",
+    )?;
+    main_repo_from_linked.reload()?;
+    assert_paths(
+        &main_repo_from_linked,
+        &main_git_dir,
+        &main,
+        &main_index_file,
+        "reloading the main repository preserves its own repository paths",
+    )?;
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[cfg(feature = "attributes")]
+fn git_index_file_override_is_not_inherited_by_opened_submodules() -> gix_testtools::Result {
+    let fixture = gix_testtools::scripted_fixture_read_only("make_submodules.sh")?;
+    let superproject = std::fs::canonicalize(fixture.join("with-submodules"))?;
+    let index_file = superproject.join(".git/index");
+    let _env = gix_testtools::Env::new().set("GIT_INDEX_FILE", index_file.to_string_lossy());
+    let mut options = gix::open::Options::isolated();
+    options.permissions.env.git_prefix = Permission::Allow;
+    let repo = gix::open_opts(superproject, options)?;
+    assert_eq!(repo.index_path(), index_file, "the superproject uses the override");
+
+    let submodule = repo
+        .submodules()?
+        .expect("modules present")
+        .next()
+        .expect("one submodule");
+    let mut submodule = submodule.open()?.expect("initialized submodule");
     assert_eq!(
-        repo.index_path(),
-        index_file,
-        "GIT_INDEX_FILE replaces the index in the git-dir just like it does in Git"
+        submodule.index_path(),
+        submodule.git_dir().join("index"),
+        "submodules use their own index"
     );
-
-    #[cfg(feature = "index")]
-    {
-        gix::index::File::from_state(gix::index::State::new(repo.object_hash()), index_file)
-            .write(Default::default())?;
-        assert!(
-            repo.index()?.entries().is_empty(),
-            "the override is read, not the index in the git-dir"
-        );
-    }
+    submodule.reload()?;
+    assert_eq!(
+        submodule.index_path(),
+        submodule.git_dir().join("index"),
+        "reloading preserves the submodule's own index"
+    );
     Ok(())
 }
 
@@ -564,103 +700,23 @@ fn git_index_file_relative_paths_use_the_cwd_when_opening() -> gix_testtools::Re
     let _env = gix_testtools::Env::new()
         .unset("GIT_DIR")
         .set("GIT_INDEX_FILE", "temporary-index");
+    std::fs::copy(repository.path().join(".git/index"), "temporary-index")?;
 
     let repo = discover_with_environment_overrides_isolated(repository.path())?;
 
     assert_eq!(
         repo.index_path(),
-        repo.current_dir().join("temporary-index"),
+        Path::new("temporary-index"),
         "relative paths start at the captured CWD, which is where Git invokes hooks"
+    );
+    assert!(
+        repo.index_path().is_file(),
+        "the repository retains its opening CWD, so the relative index path continues to identify the same file"
     );
     assert_ne!(
         repo.index_path(),
         repo.git_dir().join("temporary-index"),
-        "they are notably not relative to the git-dir"
-    );
-
-    #[cfg(feature = "index")]
-    {
-        gix::index::File::from_state(gix::index::State::new(repo.object_hash()), repo.index_path())
-            .write(Default::default())?;
-        assert!(
-            repo.index()?.entries().is_empty(),
-            "the relative path is resolved and read"
-        );
-    }
-    Ok(())
-}
-
-#[test]
-#[serial]
-#[cfg(feature = "index")]
-fn git_index_file_missing_yields_no_index() -> gix_testtools::Result {
-    let repository = gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?;
-    let index_file = repository.join(".git").join("missing");
-    let _env = gix_testtools::Env::new()
-        .unset("GIT_DIR")
-        .set("GIT_INDEX_FILE", index_file.to_string_lossy());
-
-    let repo = discover_with_environment_overrides_isolated(&repository)?;
-
-    assert!(
-        repo.git_dir().join("index").is_file(),
-        "the index in the git-dir exists and would be found without the override"
-    );
-    assert!(
-        repo.try_index()?.is_none(),
-        "a missing file reports no index instead of falling back to the git-dir"
-    );
-    assert!(
-        repo.index_or_empty()?.entries().is_empty(),
-        "and the usual empty-index semantics apply"
-    );
-    Ok(())
-}
-
-#[test]
-#[serial]
-fn git_index_file_empty_is_treated_as_unset() -> gix_testtools::Result {
-    let repository = gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?;
-    let _env = gix_testtools::Env::new().unset("GIT_DIR").set("GIT_INDEX_FILE", "");
-
-    let repo = discover_with_environment_overrides_isolated(&repository)?;
-
-    assert_eq!(
-        repo.index_path(),
-        repo.git_dir().join("index"),
-        "an empty value would otherwise resolve to the current directory itself"
-    );
-    Ok(())
-}
-
-#[test]
-#[serial]
-#[cfg(feature = "index")]
-fn git_index_file_receives_writes_while_the_git_dir_index_is_locked() -> gix_testtools::Result {
-    let repository = gix_testtools::scripted_fixture_writable("make_basic_repo.sh")?;
-    let index_file = repository.path().join(".git").join("temporary-index");
-    let _env = gix_testtools::Env::new()
-        .unset("GIT_DIR")
-        .set("GIT_INDEX_FILE", index_file.to_string_lossy());
-
-    let repo = discover_with_environment_overrides_isolated(repository.path())?;
-    let git_dir_index = repo.git_dir().join("index");
-    let git_dir_index_before = std::fs::read(&git_dir_index)?;
-
-    // `git commit <paths>` holds this lock for the duration of the commit, hooks included.
-    std::fs::write(repo.git_dir().join("index.lock"), [])?;
-
-    let mut index = (**repo.index_or_empty()?).clone();
-    index.write(Default::default())?;
-
-    assert!(
-        index_file.is_file(),
-        "the write lands on the override, so the lock in the git-dir isn't contended"
-    );
-    assert_eq!(
-        std::fs::read(&git_dir_index)?,
-        git_dir_index_before,
-        "and the index in the git-dir is left untouched"
+        "index file overrides notably are not relative to the git-dir"
     );
     Ok(())
 }

--- a/gix/tests/gix/repository/config/config_snapshot/mod.rs
+++ b/gix/tests/gix/repository/config/config_snapshot/mod.rs
@@ -235,18 +235,28 @@ fn apply_cli_overrides() -> crate::Result {
 
 #[test]
 fn reload_reloads_on_disk_changes() -> crate::Result {
-    use std::io::Write;
-
     let (mut repo, _tmp) = repo_rw("make_config_repo.sh")?;
     assert_eq!(repo.config_snapshot().integer("core.abbrev"), None);
+    let original_index = repo.index_path();
+    let changed_index = repo.git_dir().join("changed-index");
 
     let config_path = repo.git_dir().join("config");
-    let mut config = std::fs::OpenOptions::new().append(true).open(config_path)?;
-    writeln!(config, "\n[core]\n\tabbrev = 4")?;
+    let mut config = gix_config::File::from_path_no_includes(config_path.clone(), gix_config::Source::Local)?;
+    config.set_raw_value("core.abbrev", "4")?;
+    config.set_raw_value("gitoxide.core.indexFile", gix_path::into_bstr(&changed_index).as_ref())?;
+    std::fs::write(config_path, config.to_bstring())?;
 
     assert_eq!(repo.config_snapshot().integer("core.abbrev"), None);
+    assert_eq!(repo.index_path(), original_index, "repository locations remain cached");
+
     repo.reload()?;
+
     assert_eq!(repo.config_snapshot().integer("core.abbrev"), Some(4));
+    assert_eq!(
+        repo.index_path(),
+        changed_index,
+        "reload reapplies repository locations"
+    );
     Ok(())
 }
 

--- a/gix/tests/gix/repository/mod.rs
+++ b/gix/tests/gix/repository/mod.rs
@@ -145,9 +145,10 @@ mod dirwalk {
 #[test]
 fn size_in_memory() {
     let actual_size = std::mem::size_of::<Repository>();
+    // The selected index path adds one `PathBuf` to the repository.
     // Network-client features add protocol permission caching to `Repository::config`,
     // which grows the type by one more cached cell.
-    let limit = 1300;
+    let limit = 1324;
     assert!(
         actual_size <= limit,
         "size of Repository shouldn't change without us noticing, it's meant to be cloned: should have been below {limit:?}, was {actual_size}"

--- a/gix/tests/gix/repository/object.rs
+++ b/gix/tests/gix/repository/object.rs
@@ -31,7 +31,6 @@ mod object_database_impl {
     }
 }
 
-#[cfg(feature = "tree-editor")]
 mod edit_tree {
     use gix::bstr::{BStr, BString};
     use gix_object::tree::EntryKind;

--- a/gix/tests/gix/repository/open.rs
+++ b/gix/tests/gix/repository/open.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, error::Error};
 
 use gix::bstr::BString;
+use gix::config::tree::Key;
 
 use crate::util::named_subrepo_opts;
 
@@ -12,15 +13,17 @@ fn open_permissions_is_isolated() {
 
 #[test]
 #[serial_test::serial]
-fn discover_with_git_dir_environment_override_sets_trust() -> crate::Result {
-    let tmp = gix_testtools::tempfile::TempDir::new()?;
-    let initialized = gix::init(tmp.path())?;
+fn discover_with_git_dir_environment_override_uses_it_and_sets_trust() -> crate::Result {
+    let fallback = gix_testtools::tempfile::TempDir::new()?;
+    gix::init(fallback.path())?;
+    let overridden = gix_testtools::tempfile::TempDir::new()?;
+    let overridden = gix::init(overridden.path())?;
     let _env = gix_testtools::Env::new()
         .unset("GIT_WORK_TREE")
-        .set("GIT_DIR", initialized.git_dir().to_string_lossy().into_owned());
+        .set("GIT_DIR", overridden.git_dir().to_string_lossy().into_owned());
 
     let repo = gix::ThreadSafeRepository::discover_with_environment_overrides_opts(
-        tmp.path(),
+        fallback.path(),
         Default::default(),
         gix_sec::trust::Mapping {
             full: crate::restricted(),
@@ -30,8 +33,8 @@ fn discover_with_git_dir_environment_override_sets_trust() -> crate::Result {
 
     assert_eq!(
         repo.git_dir(),
-        initialized.git_dir(),
-        "the git-dir from the environment opens without panicking on missing trust"
+        overridden.git_dir(),
+        "the git-dir from the environment replaces the fallback and opens without panicking on missing trust"
     );
     Ok(())
 }
@@ -139,6 +142,127 @@ fn bare_repo_with_index() -> crate::Result {
     );
     assert_eq!(repo.kind(), gix::repository::Kind::Common);
     assert_eq!(repo.workdir(), None);
+    Ok(())
+}
+
+#[test]
+fn git_index_file_overrides_the_index_in_the_git_dir() -> crate::Result {
+    let repository = gix_testtools::scripted_fixture_writable("make_basic_repo.sh")?;
+    let index_file = repository.path().join(".git/temporary-index");
+    let repo = gix::open_opts(repository.path(), gix::open::Options::isolated())?;
+    assert_eq!(
+        repo.index_path(),
+        repo.git_dir().join("index"),
+        "this repo has no override"
+    );
+    #[cfg(feature = "index")]
+    assert_eq!(
+        repo.index()?.entries().len(),
+        1,
+        "the regular index is distinguishable from the override"
+    );
+
+    let mut repo = gix::open_opts(
+        repository.path(),
+        gix::open::Options::isolated().config_overrides([format!("gitoxide.core.indexFile={}", index_file.display())]),
+    )?;
+    assert_eq!(repo.index_path(), index_file, "the override was picked up");
+
+    let changed_index_file = repository.path().join(".git/changed-index");
+    {
+        let mut config = repo.config_snapshot_mut();
+        config.set_value(
+            &gix::config::tree::gitoxide::Core::INDEX_FILE,
+            changed_index_file.to_string_lossy(),
+        )?;
+    }
+    assert_eq!(
+        repo.index_path(),
+        index_file,
+        "the index location is repository state established during opening, like the git-dir and worktree"
+    );
+
+    #[cfg(feature = "index")]
+    {
+        gix::index::File::from_state(gix::index::State::new(repo.object_hash()), index_file)
+            .write(Default::default())?;
+        assert!(
+            repo.index()?.entries().is_empty(),
+            "the configured index is read, and it's initially empty"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "index")]
+fn git_index_file_missing_yields_no_index() -> crate::Result {
+    let repository = gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?;
+    let index_file = repository.join(".git/missing");
+    let repo = gix::open_opts(
+        &repository,
+        gix::open::Options::isolated().config_overrides([format!("gitoxide.core.indexFile={}", index_file.display())]),
+    )?;
+
+    assert!(
+        repo.git_dir().join("index").is_file(),
+        "the regular index would be found without the override"
+    );
+    assert!(repo.try_index()?.is_none(), "a missing override reports no index");
+    assert!(
+        repo.index_or_empty()?.entries().is_empty(),
+        "the usual empty-index semantics apply"
+    );
+    Ok(())
+}
+
+#[test]
+fn git_index_file_empty_is_invalid_even_with_lenient_config() -> crate::Result {
+    assert!(
+        gix::config::tree::gitoxide::Core::INDEX_FILE
+            .validated_assignment("".into())
+            .is_err(),
+        "the key itself rejects empty values"
+    );
+    let repository = gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?;
+    let err = gix::open_opts(
+        repository,
+        gix::open::Options::isolated().config_overrides(["gitoxide.core.indexFile="]),
+    )
+    .expect_err("an empty index path must be rejected");
+
+    assert_eq!(
+        err.source().expect("configuration error").to_string(),
+        "The key \"gitoxide.core.indexFile=\" (possibly from GIT_INDEX_FILE) was invalid",
+        "an empty index path is never ignored, even though configuration is lenient by default"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "index")]
+fn git_index_file_receives_writes_while_the_git_dir_index_is_locked() -> crate::Result {
+    let repository = gix_testtools::scripted_fixture_writable("make_basic_repo.sh")?;
+    let index_file = repository.path().join(".git/temporary-index");
+    let repo = gix::open_opts(
+        repository.path(),
+        gix::open::Options::isolated().config_overrides([format!("gitoxide.core.indexFile={}", index_file.display())]),
+    )?;
+    let git_dir_index = repo.git_dir().join("index");
+    let git_dir_index_before = std::fs::read(&git_dir_index)?;
+
+    // `git commit <paths>` holds this lock for the duration of the commit, hooks included.
+    assert!(!index_file.exists());
+    std::fs::write(repo.git_dir().join("index.lock"), [])?;
+    let mut index = (**repo.index_or_empty()?).clone();
+    index.write(Default::default())?;
+
+    assert!(index_file.is_file(), "the write lands on the configured index");
+    assert_eq!(
+        std::fs::read(&git_dir_index)?,
+        git_dir_index_before,
+        "the regular index is left untouched"
+    );
     Ok(())
 }
 

--- a/justfile
+++ b/justfile
@@ -149,8 +149,8 @@ check:
 
 # Run `cargo doc` on all crates
 doc $RUSTDOCFLAGS='-D warnings':
-    cargo doc --workspace --no-deps --features need-more-recent-msrv
-    cargo doc --features=max,lean,small --workspace --no-deps --features need-more-recent-msrv
+    cargo doc --workspace --no-deps
+    cargo doc --features=max,lean,small --workspace --no-deps
 
 # Run all unit tests
 unit-tests:
@@ -225,7 +225,7 @@ unit-tests:
     env GIX_TEST_FIXTURE_HASH=sha1 cargo nextest run -p gix-worktree-stream --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix-worktree-stream --features sha256 --no-fail-fast
     cargo nextest run -p gix --no-default-features --features basic,comfort,max-performance-safe --no-fail-fast
-    cargo nextest run -p gix --no-default-features --features basic,extras,comfort,need-more-recent-msrv --no-fail-fast
+    cargo nextest run -p gix --no-default-features --features basic,extras,comfort --no-fail-fast
     cargo nextest run -p gix --features async-network-client --no-fail-fast
     env GIX_TEST_FIXTURE_HASH=sha256 cargo nextest run -p gix --features async-network-client --no-fail-fast
     cargo nextest run -p gix --features blocking-network-client --no-fail-fast


### PR DESCRIPTION
Git tells its hooks which index to work on through `GIT_INDEX_FILE`, and for `git commit -a` and `git commit <paths>` that is a temporary index while the real one stays locked. A gix-based pre-commit hook therefore sees an empty staged set under `commit -a`, and cannot take the index lock under `commit <paths>`. This PR fixes that as discussed in #2890.

I used a config key, `gitoxide.core.indexFile`, rather than the `open::Options` field I originally suggested, to follow `gitoxide.core.shallowFile`. The tradeoff is that it cannot be scoped to a single repository, so submodules, linked worktrees and alternates opened in-process inherit it, as they do for `GIT_WORK_TREE` and `GIT_NAMESPACE`.

A split index moved out of the git directory will not find its `sharedindex.*`, since we look beside the index file and Git looks in `$GIT_DIR`. This change makes that reachable, though not through hooks, as Git keeps its temporary index in the git directory. Closing it means passing the git directory into `File::at()` (a breaking change), so it is out of scope here; happy to follow up if you want it.

I kept the tests next to the `git_worktree_*` ones, since anything setting `GIT_INDEX_FILE` in the main test binary bleeds into the tests running alongside it, and `#[serial]` doesn't help there. Happy to move them if that's not the right place. I also ran a gix hook under real Git: the index it sees matches `git ls-files -s` for `commit -a`, `commit <paths>` and a plain `commit`.
