### PR TITLE
change!: make checkout() optionally consider the previous index

### DIFF
--- a/gitoxide-core/src/index/checkout.rs
+++ b/gitoxide-core/src/index/checkout.rs
@@ -82,6 +82,7 @@ pub fn checkout_exclusive(
         errors,
         collisions,
         files_updated,
+        files_removed: _,
         bytes_written,
         delayed_paths_unknown,
         delayed_paths_unprocessed,
@@ -89,6 +90,7 @@ pub fn checkout_exclusive(
         Some(repo) => gix::worktree::state::checkout(
             &mut index,
             dest_directory,
+            None,
             EmptyOrDb {
                 empty_files,
                 db: repo.objects.into_arc()?,
@@ -101,6 +103,7 @@ pub fn checkout_exclusive(
         None => gix::worktree::state::checkout(
             &mut index,
             dest_directory,
+            None,
             Empty,
             &files,
             &bytes,

--- a/gix-worktree-state/src/checkout/function.rs
+++ b/gix-worktree-state/src/checkout/function.rs
@@ -7,6 +7,13 @@ use crate::checkout::chunk;
 
 /// Checkout the entire `index` into `dir`, and resolve objects found in index entries with `objects` to write their content to their
 /// respective path in `dir`.
+/// If `previous_index` is `Some`, remove files that are tracked in it but absent from `index` before writing anything,
+/// along with directories that become empty that way, similar to how `git checkout` removes files when switching revisions.
+/// Untracked files are never removed. Files that appear to have changed on disk since `previous_index` was written
+/// are not removed either, but instead cause a [`RemovalPrevented`](crate::checkout::Error::RemovalPrevented) error,
+/// unless [`overwrite_existing`](crate::checkout::Options::overwrite_existing) is set.
+/// Pass `None` to leave everything but the checked out files alone, which is all that's needed when
+/// checking out into an empty directory.
 /// Use `files` to count each fully checked out file, and count the amount written `bytes`. If `should_interrupt` is `true`, the
 /// operation will abort.
 /// `options` provide a lot of context on how to perform the operation.
@@ -15,9 +22,11 @@ use crate::checkout::chunk;
 ///
 /// Note that interruption still produce an `Ok(…)` value, so the caller should look at `should_interrupt` to communicate the outcome.
 ///
+#[expect(clippy::too_many_arguments)]
 pub fn checkout<Find>(
     index: &mut gix_index::State,
     dir: impl Into<std::path::PathBuf>,
+    previous_index: Option<&gix_index::State>,
     objects: Find,
     files: &dyn gix_features::progress::Count,
     bytes: &dyn gix_features::progress::Count,
@@ -28,7 +37,17 @@ where
     Find: gix_object::Find + Send + Clone,
 {
     let paths = index.take_path_backing();
-    let res = checkout_inner(index, &paths, dir, objects, files, bytes, should_interrupt, options);
+    let res = checkout_inner(
+        index,
+        &paths,
+        dir,
+        previous_index,
+        objects,
+        files,
+        bytes,
+        should_interrupt,
+        options,
+    );
     index.return_path_backing(paths);
     res
 }
@@ -38,6 +57,7 @@ fn checkout_inner<Find>(
     index: &mut gix_index::State,
     paths: &gix_index::PathStorage,
     dir: impl Into<std::path::PathBuf>,
+    previous_index: Option<&gix_index::State>,
     objects: Find,
     files: &dyn gix_features::progress::Count,
     bytes: &dyn gix_features::progress::Count,
@@ -50,6 +70,20 @@ where
     let num_files = files.counter();
     let num_bytes = bytes.counter();
     let dir = dir.into();
+
+    let mut removal_errors = Vec::new();
+    let files_removed = match previous_index {
+        Some(previous_index) => super::removal::remove_stale_entries(
+            &dir,
+            previous_index,
+            index,
+            paths,
+            &mut removal_errors,
+            should_interrupt,
+            &options,
+        )?,
+        None => 0,
+    };
     let (chunk_size, thread_limit, num_threads) = gix_features::parallel::optimize_chunk_size_and_thread_limit(
         100,
         index.entries().len().into(),
@@ -146,10 +180,12 @@ where
             as u64;
     }
 
+    removal_errors.extend(errors);
     Ok(crate::checkout::Outcome {
         files_updated,
+        files_removed,
         collisions,
-        errors,
+        errors: removal_errors,
         bytes_written,
         delayed_paths_unknown,
         delayed_paths_unprocessed,

--- a/gix-worktree-state/src/checkout/mod.rs
+++ b/gix-worktree-state/src/checkout/mod.rs
@@ -24,6 +24,8 @@ pub struct ErrorRecord {
 pub struct Outcome {
     /// The amount of files updated, or created.
     pub files_updated: usize,
+    /// The amount of files removed as they were tracked in the previous index, but not in the index that was checked out.
+    pub files_removed: usize,
     /// The amount of bytes written to disk,
     pub bytes_written: u64,
     /// The encountered collisions, which can happen on a case-insensitive filesystem.
@@ -54,6 +56,8 @@ pub struct Options {
     /// If true, default false, worktree entries on disk will be overwritten with content from the index
     /// even if they appear to be changed. When creating directories that clash with existing worktree entries,
     /// these will try to delete the existing entry.
+    /// Additionally, files that are tracked in the previous index but not in the index to be checked out will
+    /// be removed even if they appear to be changed.
     /// This is similar in behaviour as `git checkout --force`.
     ///
     /// Note that when `destination_is_initially_empty` is `false`, existing files may still have their
@@ -100,8 +104,11 @@ pub enum Error {
     FilterPathUnknown { rela_path: BString },
     #[error("The following paths were delayed and apparently forgotten to be processed by the filter driver: ")]
     FilterPathsUnprocessed { rela_paths: Vec<BString> },
+    #[error("Refusing to remove '{rela_path}' which changed on disk after it was checked out last")]
+    RemovalPrevented { rela_path: BString },
 }
 
 mod chunk;
 mod entry;
 pub(crate) mod function;
+mod removal;

--- a/gix-worktree-state/src/checkout/removal.rs
+++ b/gix-worktree-state/src/checkout/removal.rs
@@ -1,0 +1,215 @@
+use std::{
+    collections::BTreeSet,
+    path::Path,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use bstr::{BStr, BString, ByteSlice};
+use gix_index::entry::{Flags, Mode, Stat};
+
+use crate::checkout;
+
+/// Remove all files from `dir` that are tracked in `previous_index` but not in `index`, along with
+/// directories that become empty as a result, and return the amount of removed files.
+///
+/// Files that appear to have changed on disk since `previous_index` was written are not removed, but
+/// either abort the operation or are recorded in `errors`, depending on
+/// [`keep_going`](checkout::Options::keep_going). [`overwrite_existing`](checkout::Options::overwrite_existing)
+/// removes such files nonetheless. Untracked files are never touched, which also keeps
+/// the directories they reside in alive.
+pub fn remove_stale_entries(
+    dir: &Path,
+    previous_index: &gix_index::State,
+    index: &gix_index::State,
+    paths: &gix_index::PathStorageRef,
+    errors: &mut Vec<checkout::ErrorRecord>,
+    should_interrupt: &AtomicBool,
+    options: &checkout::Options,
+) -> Result<usize, checkout::Error> {
+    let mut files_removed = 0;
+    let mut new_paths = index.entries().iter().map(|e| e.path_in(paths)).peekable();
+    let mut leading = LeadingDirectories::default();
+    let mut dirs_to_prune = BTreeSet::<BString>::new();
+    let mut prev_rela_path = None;
+    for entry in previous_index.entries() {
+        if should_interrupt.load(Ordering::Relaxed) {
+            break;
+        }
+        if entry.flags.contains(Flags::SKIP_WORKTREE) || matches!(entry.mode, Mode::DIR | Mode::COMMIT) {
+            continue;
+        }
+        let rela_path = entry.path(previous_index);
+        if prev_rela_path == Some(rela_path) {
+            continue;
+        }
+        prev_rela_path = Some(rela_path);
+        while new_paths.peek().is_some_and(|new_path| *new_path < rela_path) {
+            new_paths.next();
+        }
+        if new_paths.peek() == Some(&rela_path) {
+            continue;
+        }
+        match remove_entry(dir, entry, rela_path, &mut leading, &mut dirs_to_prune, options) {
+            Ok(true) => files_removed += 1,
+            Ok(false) => {}
+            Err(err) => {
+                if options.keep_going {
+                    errors.push(checkout::ErrorRecord {
+                        path: rela_path.into(),
+                        error: Box::new(err),
+                    });
+                } else {
+                    return Err(err);
+                }
+            }
+        }
+    }
+    remove_empty_directories(dir, dirs_to_prune);
+    Ok(files_removed)
+}
+
+/// Remove the file previously checked out as `entry` at `rela_path` within `dir`, and return `true` if it was removed.
+fn remove_entry(
+    dir: &Path,
+    entry: &gix_index::Entry,
+    rela_path: &BStr,
+    leading: &mut LeadingDirectories,
+    dirs_to_prune: &mut BTreeSet<BString>,
+    options: &checkout::Options,
+) -> Result<bool, checkout::Error> {
+    for component in rela_path.split(|b| *b == b'/') {
+        gix_worktree::validate::path::component(component.as_bstr(), None, options.validate)
+            .map_err(std::io::Error::other)?;
+    }
+    let parent = rela_path.rfind_byte(b'/').map(|slash| rela_path[..slash].as_bstr());
+    if let Some(parent) = parent {
+        if !leading.is_intact(dir, parent)? {
+            return Ok(false);
+        }
+    }
+    let path = dir.join(
+        gix_path::try_from_bstr(rela_path).map_err(|_| checkout::Error::IllformedUtf8 {
+            path: rela_path.to_owned(),
+        })?,
+    );
+    let md = match gix_index::fs::Metadata::from_path_no_follow(&path) {
+        Ok(md) => md,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            if let Some(parent) = parent {
+                dirs_to_prune.insert(parent.to_owned());
+            }
+            return Ok(false);
+        }
+        Err(err) => return Err(err.into()),
+    };
+    if md.is_dir() {
+        if !options.overwrite_existing {
+            return Err(checkout::Error::RemovalPrevented {
+                rela_path: rela_path.to_owned(),
+            });
+        }
+        std::fs::remove_dir_all(&path)?;
+    } else {
+        if !options.overwrite_existing {
+            let kind_matches = md.is_symlink() == (entry.mode == Mode::SYMLINK);
+            let fs_stat = Stat::from_fs(&md)?;
+            if !kind_matches || !entry.stat.matches(&fs_stat, options.stat_options) {
+                return Err(checkout::Error::RemovalPrevented {
+                    rela_path: rela_path.to_owned(),
+                });
+            }
+        }
+        if md.is_symlink() {
+            gix_fs::symlink::remove(&path)?;
+        } else {
+            std::fs::remove_file(&path)?;
+        }
+    }
+    if let Some(parent) = parent {
+        dirs_to_prune.insert(parent.to_owned());
+    }
+    Ok(true)
+}
+
+/// A cache for information about the leading directories of previously deleted files, all relative to the
+/// worktree root. As entries are sorted by path, consecutive entries share most of their leading path.
+#[derive(Default)]
+struct LeadingDirectories {
+    /// A path whose components are all known to be directories on disk.
+    verified: BString,
+    /// A path whose last component is known to not be a directory, so nothing beneath it can be removed.
+    blocked: Option<BString>,
+}
+
+impl LeadingDirectories {
+    /// Return `true` if all components of `parent` below `base` are directories on disk, without ever
+    /// following symlinks, similar to how `git` verifies leading paths before unlinking an entry.
+    fn is_intact(&mut self, base: &Path, parent: &BStr) -> std::io::Result<bool> {
+        if let Some(blocked) = self.blocked.as_ref() {
+            if is_component_prefix(blocked.as_bstr(), parent) {
+                return Ok(false);
+            }
+        }
+        let common = component_prefix_len(self.verified.as_bstr(), parent);
+        let mut verified: BString = parent[..common].into();
+        for component in parent[common..].split(|b| *b == b'/').filter(|c| !c.is_empty()) {
+            if !verified.is_empty() {
+                verified.push(b'/');
+            }
+            verified.extend_from_slice(component);
+            let path = gix_path::try_from_bstr(verified.as_bstr())
+                .map_err(|_| std::io::Error::other("path component contained illformed UTF-8"))?;
+            match std::fs::symlink_metadata(base.join(path)) {
+                Ok(meta) if meta.is_dir() => {}
+                Ok(_) => {
+                    self.blocked = Some(verified);
+                    return Ok(false);
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    self.blocked = Some(verified);
+                    return Ok(false);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        self.verified = verified;
+        Ok(true)
+    }
+}
+
+/// Return `true` if `path` is equal to `prefix` or resides beneath it.
+fn is_component_prefix(prefix: &BStr, path: &BStr) -> bool {
+    path == prefix || (path.starts_with(prefix) && path.get(prefix.len()) == Some(&b'/'))
+}
+
+/// Return the length in bytes of the longest shared directory prefix of `lhs` and `rhs`.
+fn component_prefix_len(lhs: &BStr, rhs: &BStr) -> usize {
+    let mut len = 0;
+    let mut lhs = lhs.split(|b| *b == b'/');
+    let mut rhs = rhs.split(|b| *b == b'/');
+    loop {
+        let (Some(a), Some(b)) = (lhs.next(), rhs.next()) else {
+            return len;
+        };
+        if a != b || a.is_empty() {
+            return len;
+        }
+        len = if len == 0 { a.len() } else { len + 1 + a.len() };
+    }
+}
+
+/// Remove all directories in `dirs` that are empty, along with their parents that become empty in turn,
+/// while leaving directories that still contain untracked files untouched.
+fn remove_empty_directories(base: &Path, mut dirs: BTreeSet<BString>) {
+    while let Some(dir) = dirs.pop_last() {
+        let Ok(path) = gix_path::try_from_bstr(dir.as_bstr()) else {
+            continue;
+        };
+        if std::fs::remove_dir(base.join(path)).is_err() {
+            continue;
+        }
+        if let Some(slash) = dir.rfind_byte(b'/') {
+            dirs.insert(dir[..slash].into());
+        }
+    }
+}

--- a/gix-worktree-state/tests/worktree-state/checkout.rs
+++ b/gix-worktree-state/tests/worktree-state/checkout.rs
@@ -814,6 +814,7 @@ fn checkout_index_in_tmp_dir_opts(
     let outcome = gix_worktree_state::checkout(
         &mut index,
         destination.path(),
+        None,
         db,
         &progress::Discard,
         &progress::Discard,
@@ -860,6 +861,130 @@ fn setup_filter_pipeline(opts: &mut gix_filter::pipeline::Options) {
         process: Some((driver_exe() + " process").into()),
         required: true,
     }];
+}
+
+#[test]
+fn stale_files_are_removed_when_previous_index_is_provided() -> crate::Result {
+    let mut opts = opts_from_probe();
+    let (source_tree, destination, index, _outcome) =
+        checkout_index_in_tmp_dir(opts.clone(), "make_mixed_without_submodules_and_symlinks", None)?;
+
+    let mut new_index = (*index).clone();
+    new_index.remove_entries(|_, path, _| path == "executable" || path.starts_with_str("dir/"));
+
+    std::fs::write(destination.path().join("untracked"), b"untracked")?;
+    std::fs::write(destination.path().join("dir").join("untracked"), b"untracked in dir")?;
+
+    opts.destination_is_initially_empty = false;
+    let odb = odb_at(source_tree.join(".git").join("objects"))?
+        .into_inner()
+        .into_arc()?;
+    let outcome = gix_worktree_state::checkout(
+        &mut new_index,
+        destination.path(),
+        Some(&index),
+        odb,
+        &progress::Discard,
+        &progress::Discard,
+        &AtomicBool::default(),
+        opts,
+    )?;
+
+    assert_eq!(
+        outcome.files_removed, 3,
+        "'executable', 'dir/content' and 'dir/sub-dir/file' are stale"
+    );
+    assert!(outcome.errors.is_empty());
+    assert!(outcome.collisions.is_empty());
+    let dest = destination.path();
+    assert!(!dest.join("executable").exists());
+    assert!(!dest.join("dir").join("content").exists());
+    assert!(
+        !dest.join("dir").join("sub-dir").exists(),
+        "directories that become empty are removed as well"
+    );
+    assert!(
+        dest.join("dir").join("untracked").is_file(),
+        "untracked files are kept, along with the directories that contain them"
+    );
+    assert!(dest.join("untracked").is_file());
+    assert!(dest.join("empty").is_file());
+    assert!(dest.join(".gitattributes").is_file());
+    Ok(())
+}
+
+#[test]
+fn stale_files_with_local_changes_are_not_removed() -> crate::Result {
+    let mut opts = opts_from_probe();
+    let (source_tree, destination, index, _outcome) =
+        checkout_index_in_tmp_dir(opts.clone(), "make_mixed_without_submodules_and_symlinks", None)?;
+    let objects_dir = source_tree.join(".git").join("objects");
+
+    let mut new_index = (*index).clone();
+    new_index.remove_entries(|_, path, _| path == "executable");
+    std::fs::write(
+        destination.path().join("executable"),
+        b"modified content that is longer than before",
+    )?;
+
+    opts.destination_is_initially_empty = false;
+    let err = gix_worktree_state::checkout(
+        &mut new_index,
+        destination.path(),
+        Some(&index),
+        odb_at(objects_dir.clone())?.into_inner().into_arc()?,
+        &progress::Discard,
+        &progress::Discard,
+        &AtomicBool::default(),
+        opts.clone(),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            gix_worktree_state::checkout::Error::RemovalPrevented { ref rela_path } if rela_path == "executable"
+        ),
+        "without keep-going, a locally modified stale file aborts the checkout: {err}"
+    );
+    assert!(
+        destination.path().join("executable").is_file(),
+        "the modified file is kept"
+    );
+
+    opts.keep_going = true;
+    let outcome = gix_worktree_state::checkout(
+        &mut new_index,
+        destination.path(),
+        Some(&index),
+        odb_at(objects_dir.clone())?.into_inner().into_arc()?,
+        &progress::Discard,
+        &progress::Discard,
+        &AtomicBool::default(),
+        opts.clone(),
+    )?;
+    assert_eq!(outcome.files_removed, 0);
+    assert_eq!(outcome.errors.len(), 1);
+    assert_eq!(outcome.errors[0].path, "executable");
+    assert!(destination.path().join("executable").is_file());
+
+    opts.keep_going = false;
+    opts.overwrite_existing = true;
+    let outcome = gix_worktree_state::checkout(
+        &mut new_index,
+        destination.path(),
+        Some(&index),
+        odb_at(objects_dir)?.into_inner().into_arc()?,
+        &progress::Discard,
+        &progress::Discard,
+        &AtomicBool::default(),
+        opts,
+    )?;
+    assert_eq!(
+        outcome.files_removed, 1,
+        "overwrite-existing removes even modified files, like checkout --force"
+    );
+    assert!(!destination.path().join("executable").exists());
+    Ok(())
 }
 
 #[test]

--- a/gix/src/clone/checkout.rs
+++ b/gix/src/clone/checkout.rs
@@ -131,6 +131,7 @@ pub mod main_worktree {
             let outcome = gix_worktree_state::checkout(
                 &mut index,
                 workdir,
+                None,
                 repo.objects.clone().into_arc()?,
                 &files,
                 &bytes,


### PR DESCRIPTION
We've noticed some issues with how `checkout()` works differently from `git checkout` in gitoxide, since it does not remove files that become untracked when checking out into an existing working dir:

- https://github.com/rustsec/advisory-db/issues/3131

This PR adds a `previous_index: Option<&gix_index::State>` argument to make it more obvious that this is a thing that people need to think about, and makes it easier to get CLI-like behavior.

(With help from Claude.)