### PR TITLE
Switch to `at_opts` from `at` in `gix-odb` tests

### DIFF
--- a/gix-archive/tests/archive.rs
+++ b/gix-archive/tests/archive.rs
@@ -341,14 +341,7 @@ mod from_tree {
             let hex = std::fs::read(dir.join("head.hex"))?;
             gix_hash::ObjectId::from_hex(hex.trim())?
         };
-        let odb = gix_odb::at_opts(
-            dir.join(".git").join("objects"),
-            Vec::new(),
-            gix_odb::store::init::Options {
-                object_hash: gix_testtools::object_hash(),
-                ..Default::default()
-            },
-        )?;
+        let odb = gix_odb::at(dir.join(".git").join("objects"), gix_testtools::object_hash())?;
 
         let mut collection = Default::default();
         let mut buf = Default::default();

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -168,14 +168,7 @@ impl Fixture {
                 ..Default::default()
             },
         );
-        let odb = gix_odb::at_opts(
-            worktree_path.join(".git/objects"),
-            Vec::new(),
-            gix_odb::store::init::Options {
-                object_hash,
-                ..Default::default()
-            },
-        )?;
+        let odb = gix_odb::at(worktree_path.join(".git/objects"), object_hash)?;
 
         let mut reference = gix_ref::file::Store::find(&store, "HEAD")?;
 

--- a/gix-diff/tests/diff/main.rs
+++ b/gix-diff/tests/diff/main.rs
@@ -15,14 +15,7 @@ fn fixture_hash_kind() -> gix_hash::Kind {
 }
 
 fn open_odb(objects_dir: impl Into<std::path::PathBuf>) -> std::io::Result<gix_odb::Handle> {
-    gix_odb::at_opts(
-        objects_dir,
-        Vec::new(),
-        gix_odb::store::init::Options {
-            object_hash: fixture_hash_kind(),
-            ..Default::default()
-        },
-    )
+    gix_odb::at(objects_dir, fixture_hash_kind())
 }
 
 fn normalize_patch_snapshot(input: &str) -> String {

--- a/gix-diff/tests/diff/tree_with_rewrites.rs
+++ b/gix-diff/tests/diff/tree_with_rewrites.rs
@@ -1909,14 +1909,7 @@ mod util {
         rhs: impl Into<Option<&'static str>>,
     ) -> gix_testtools::Result<(Vec<u8>, Vec<u8>, gix_diff::blob::Platform, gix_odb::Handle)> {
         let root = repo_workdir()?;
-        let odb = gix_odb::at_opts(
-            root.join(".git/objects"),
-            Vec::new(),
-            gix_odb::store::init::Options {
-                object_hash: fixture_hash_kind(),
-                ..Default::default()
-            },
-        )?;
+        let odb = gix_odb::at(root.join(".git/objects"), fixture_hash_kind())?;
         let lhs = read_tree(&odb, &root, lhs.into())?;
         let rhs = read_tree(&odb, &root, rhs.into())?;
 

--- a/gix-fsck/tests/connectivity/mod.rs
+++ b/gix-fsck/tests/connectivity/mod.rs
@@ -13,15 +13,7 @@ fn check_missing<'a>(repo_name: &str, commits: impl IntoIterator<Item = &'a Obje
             .join(repo_name)
             .join(".git")
             .join("objects");
-        let mut db = gix_odb::at_opts(
-            fixture_path,
-            Vec::new(),
-            gix_odb::store::init::Options {
-                object_hash: gix_testtools::object_hash(),
-                ..Default::default()
-            },
-        )
-        .expect("valid odb");
+        let mut db = gix_odb::at(fixture_path, gix_testtools::object_hash()).expect("valid odb");
         db.refresh_never();
         db
     };

--- a/gix-index/tests/index/main.rs
+++ b/gix-index/tests/index/main.rs
@@ -52,14 +52,7 @@ pub fn hex_to_id(hex: &str) -> ObjectId {
 
 /// Get an object database handle for `objects_dir`, respecting the hash kind configured for tests.
 pub fn odb_at(objects_dir: impl Into<PathBuf>) -> Result<gix_odb::Handle> {
-    Ok(gix_odb::at_opts(
-        objects_dir,
-        Vec::new(),
-        gix_odb::store::init::Options {
-            object_hash: gix_testtools::object_hash(),
-            ..Default::default()
-        },
-    )?)
+    Ok(gix_odb::at(objects_dir, gix_testtools::object_hash())?)
 }
 
 pub fn fixture_index_path(name: &str) -> PathBuf {

--- a/gix-merge/tests/merge/tree/baseline.rs
+++ b/gix-merge/tests/merge/tree/baseline.rs
@@ -169,15 +169,7 @@ impl Iterator for Expectations<'_> {
             unknown => unreachable!("Unknown conflict style: '{unknown}'"),
         };
         let object_hash = gix_testtools::object_hash();
-        let odb = gix_odb::at_opts(
-            subdir_path.join(".git/objects"),
-            Vec::new(),
-            gix_odb::store::init::Options {
-                object_hash,
-                ..Default::default()
-            },
-        )
-        .expect("object dir exists");
+        let odb = gix_odb::at(subdir_path.join(".git/objects"), object_hash).expect("object dir exists");
         let objects = gix_odb::memory::Proxy::new(odb, object_hash);
         let our_commit_id = gix_hash::ObjectId::from_hex(our_commit_id.as_bytes()).unwrap();
         let their_commit_id = gix_hash::ObjectId::from_hex(their_commit_id.as_bytes()).unwrap();

--- a/gix-merge/tests/merge/tree/cartesian.rs
+++ b/gix-merge/tests/merge/tree/cartesian.rs
@@ -61,14 +61,7 @@ fn records_status_quo_sha1() -> crate::Result {
         "the fixture must contain the unordered Cartesian product; each case is merged both ways"
     );
 
-    let odb = gix_odb::at_opts(
-        repo.join(".git/objects"),
-        Vec::new(),
-        gix_odb::store::init::Options {
-            object_hash: gix_hash::Kind::Sha1,
-            ..Default::default()
-        },
-    )?;
+    let odb = gix_odb::at(repo.join(".git/objects"), gix_hash::Kind::Sha1)?;
     let objects = gix_odb::memory::Proxy::new(odb, gix_hash::Kind::Sha1);
     let base_tree_id =
         gix_hash::ObjectId::from_hex(std::fs::read_to_string(repo.join(".git/base.tree"))?.trim().as_bytes())?;
@@ -890,14 +883,7 @@ fn records_submodule_status_quo_sha1() -> crate::Result {
         "the submodule fixture must contain the full unordered Cartesian product"
     );
 
-    let odb = gix_odb::at_opts(
-        repo.join(".git/objects"),
-        Vec::new(),
-        gix_odb::store::init::Options {
-            object_hash: gix_hash::Kind::Sha1,
-            ..Default::default()
-        },
-    )?;
+    let odb = gix_odb::at(repo.join(".git/objects"), gix_hash::Kind::Sha1)?;
     let objects = gix_odb::memory::Proxy::new(odb, gix_hash::Kind::Sha1);
     let mut graph = gix_revwalk::Graph::new(&objects, None);
     let mut diff_resource_cache = new_diff_resource_cache(&repo);

--- a/gix-negotiate/tests/baseline/mod.rs
+++ b/gix-negotiate/tests/baseline/mod.rs
@@ -24,14 +24,7 @@ fn run() -> crate::Result {
             let obj_buf = RefCell::new(Vec::new());
             let buf = std::fs::read(base.join(format!("baseline.{algo_name}")))?;
             let object_hash = gix_testtools::object_hash();
-            let store = gix_odb::at_opts(
-                base.join("client").join(".git/objects"),
-                Vec::new(),
-                gix_odb::store::init::Options {
-                    object_hash,
-                    ..Default::default()
-                },
-            )?;
+            let store = gix_odb::at(base.join("client").join(".git/objects"), object_hash)?;
             let refs = gix_ref::file::Store::at(
                 base.join("client").join(".git"),
                 gix_ref::store::init::Options {

--- a/gix-object/tests/object/tree/editor.rs
+++ b/gix-object/tests/object/tree/editor.rs
@@ -877,14 +877,7 @@ mod utils {
 
     pub(super) fn tree_odb() -> gix_testtools::Result<gix_odb::Handle> {
         let root = gix_testtools::scripted_fixture_read_only("make_trees.sh")?;
-        Ok(gix_odb::at_opts(
-            root.join(".git/objects"),
-            Vec::new(),
-            gix_odb::store::init::Options {
-                object_hash: crate::fixture_hash_kind(),
-                ..Default::default()
-            },
-        )?)
+        Ok(gix_odb::at(root.join(".git/objects"), crate::fixture_hash_kind())?)
     }
 
     pub(super) fn find_tree(odb: &impl gix_object::FindExt, id: ObjectId) -> gix_testtools::Result<Tree> {

--- a/gix-object/tests/object/tree/iter.rs
+++ b/gix-object/tests/object/tree/iter.rs
@@ -147,14 +147,7 @@ mod lookup_entry {
 
         pub(super) fn tree_odb() -> gix_testtools::Result<gix_odb::Handle> {
             let root = gix_testtools::scripted_fixture_read_only("make_trees.sh")?;
-            Ok(gix_odb::at_opts(
-                root.join(".git/objects"),
-                Vec::new(),
-                gix_odb::store::init::Options {
-                    object_hash: crate::fixture_hash_kind(),
-                    ..Default::default()
-                },
-            )?)
+            Ok(gix_odb::at(root.join(".git/objects"), crate::fixture_hash_kind())?)
         }
 
         pub(super) fn lookup_entry_by_path(path: &str) -> gix_testtools::Result<Option<gix_object::tree::Entry>> {

--- a/gix-odb/src/lib.rs
+++ b/gix-odb/src/lib.rs
@@ -192,3 +192,16 @@ pub fn at_opts(
     .to_handle();
     Ok(Cache::from(handle))
 }
+
+/// Create a new cached handle to the object store with `.git/objects` provided in `objects_dir`,
+/// with `object_hash` as the hash of contained objects to write.
+pub fn at(objects_dir: impl Into<PathBuf>, object_hash: gix_hash::Kind) -> std::io::Result<Handle> {
+    at_opts(
+        objects_dir,
+        None,
+        store::init::Options {
+            object_hash,
+            ..Default::default()
+        },
+    )
+}

--- a/gix-odb/src/lib.rs
+++ b/gix-odb/src/lib.rs
@@ -192,8 +192,3 @@ pub fn at_opts(
     .to_handle();
     Ok(Cache::from(handle))
 }
-
-/// Create a new cached handle to the object store.
-pub fn at(objects_dir: impl Into<PathBuf>) -> std::io::Result<Handle> {
-    at_opts(objects_dir, Vec::new(), Default::default())
-}

--- a/gix-odb/tests/doctest.rs
+++ b/gix-odb/tests/doctest.rs
@@ -4,13 +4,6 @@
 /// Return an empty object database that lives as long as its temporary directory.
 pub fn empty_store() -> Result<(tempfile::TempDir, gix_odb::Handle), std::io::Error> {
     let dir = tempfile::tempdir()?;
-    let store = gix_odb::at_opts(
-        dir.path(),
-        None,
-        gix_odb::store::init::Options {
-            object_hash: gix_testtools::object_hash(),
-            ..Default::default()
-        },
-    )?;
+    let store = gix_odb::at(dir.path(), gix_testtools::object_hash())?;
     Ok((dir, store))
 }

--- a/gix-odb/tests/doctest.rs
+++ b/gix-odb/tests/doctest.rs
@@ -4,6 +4,13 @@
 /// Return an empty object database that lives as long as its temporary directory.
 pub fn empty_store() -> Result<(tempfile::TempDir, gix_odb::Handle), std::io::Error> {
     let dir = tempfile::tempdir()?;
-    let store = gix_odb::at(dir.path())?;
+    let store = gix_odb::at_opts(
+        dir.path(),
+        None,
+        gix_odb::store::init::Options {
+            object_hash: gix_testtools::object_hash(),
+            ..Default::default()
+        },
+    )?;
     Ok((dir, store))
 }

--- a/gix-odb/tests/odb/find.rs
+++ b/gix-odb/tests/odb/find.rs
@@ -1,15 +1,7 @@
 use gix_testtools::fixture_path;
 
 fn db() -> gix_odb::Handle {
-    gix_odb::at_opts(
-        fixture_path("objects"),
-        None,
-        gix_odb::store::init::Options {
-            object_hash: gix_hash::Kind::Sha1,
-            ..Default::default()
-        },
-    )
-    .expect("valid object path")
+    gix_odb::at(fixture_path("objects"), gix_hash::Kind::Sha1).expect("valid object path")
 }
 
 use crate::hex_to_id;

--- a/gix-odb/tests/odb/find.rs
+++ b/gix-odb/tests/odb/find.rs
@@ -1,7 +1,15 @@
 use gix_testtools::fixture_path;
 
 fn db() -> gix_odb::Handle {
-    gix_odb::at(fixture_path("objects")).expect("valid object path")
+    gix_odb::at_opts(
+        fixture_path("objects"),
+        None,
+        gix_odb::store::init::Options {
+            object_hash: gix_hash::Kind::Sha1,
+            ..Default::default()
+        },
+    )
+    .expect("valid object path")
 }
 
 use crate::hex_to_id;

--- a/gix-odb/tests/odb/main.rs
+++ b/gix-odb/tests/odb/main.rs
@@ -28,31 +28,15 @@ pub fn fixture_options() -> gix_odb::store::init::Options {
 /// Open an object store at `objects_dir`.
 /// The static SHA-1 fixtures keep using [`db()`]/[`db_small_packs()`] instead.
 pub fn odb_at(objects_dir: impl Into<std::path::PathBuf>) -> std::io::Result<gix_odb::Handle> {
-    gix_odb::at_opts(objects_dir, Vec::new(), fixture_options())
+    gix_odb::at(objects_dir, gix_testtools::object_hash())
 }
 
 fn db() -> gix_odb::Handle {
-    gix_odb::at_opts(
-        fixture_path("objects"),
-        None,
-        gix_odb::store::init::Options {
-            object_hash: gix_hash::Kind::Sha1,
-            ..Default::default()
-        },
-    )
-    .expect("valid object path")
+    gix_odb::at(fixture_path("objects"), gix_hash::Kind::Sha1).expect("valid object path")
 }
 
 fn db_small_packs() -> gix_odb::Handle {
-    gix_odb::at_opts(
-        fixture_path("repos/small-packs.git/objects"),
-        None,
-        gix_odb::store::init::Options {
-            object_hash: gix_hash::Kind::Sha1,
-            ..Default::default()
-        },
-    )
-    .unwrap()
+    gix_odb::at(fixture_path("repos/small-packs.git/objects"), gix_hash::Kind::Sha1).unwrap()
 }
 
 pub mod alternate;

--- a/gix-odb/tests/odb/main.rs
+++ b/gix-odb/tests/odb/main.rs
@@ -32,11 +32,27 @@ pub fn odb_at(objects_dir: impl Into<std::path::PathBuf>) -> std::io::Result<gix
 }
 
 fn db() -> gix_odb::Handle {
-    gix_odb::at(fixture_path("objects")).expect("valid object path")
+    gix_odb::at_opts(
+        fixture_path("objects"),
+        None,
+        gix_odb::store::init::Options {
+            object_hash: gix_hash::Kind::Sha1,
+            ..Default::default()
+        },
+    )
+    .expect("valid object path")
 }
 
 fn db_small_packs() -> gix_odb::Handle {
-    gix_odb::at(fixture_path("repos/small-packs.git/objects")).unwrap()
+    gix_odb::at_opts(
+        fixture_path("repos/small-packs.git/objects"),
+        None,
+        gix_odb::store::init::Options {
+            object_hash: gix_hash::Kind::Sha1,
+            ..Default::default()
+        },
+    )
+    .unwrap()
 }
 
 pub mod alternate;

--- a/gix-odb/tests/odb/store/dynamic.rs
+++ b/gix-odb/tests/odb/store/dynamic.rs
@@ -5,7 +5,7 @@ use gix_object::{Exists, FindExt, Write};
 use gix_odb::{Header, store, store::iter::Ordering};
 use gix_testtools::fixture_path;
 
-use crate::{db, hex_to_id, hex_to_id_for_hash};
+use crate::{db, hex_to_id, hex_to_id_for_hash, odb_at};
 
 /// A syntactically valid object id matching the handle's own hash length, all bytes `0xaa`.
 fn missing_id(handle: &gix_odb::Handle) -> ObjectId {
@@ -69,7 +69,17 @@ fn db_with_all_object_sources() -> crate::Result<(gix_odb::Handle, gix_testtools
             object_hash: gix_hash::Kind::Sha1,
         },
     )?;
-    Ok((gix_odb::at(objects_dir.path())?, objects_dir))
+    Ok((
+        gix_odb::at_opts(
+            objects_dir.path(),
+            None,
+            gix_odb::store::init::Options {
+                object_hash: gix_hash::Kind::Sha1,
+                ..Default::default()
+            },
+        )?,
+        objects_dir,
+    ))
 }
 
 #[test]
@@ -301,7 +311,14 @@ fn an_object_in_a_pack_moved_by_an_external_process_can_be_found_from_a_stale_ha
         )?;
     }
 
-    let stale_handle = gix_odb::at(tmp.path().join("objects"))?;
+    let stale_handle = gix_odb::at_opts(
+        tmp.path().join("objects"),
+        None,
+        gix_odb::store::init::Options {
+            object_hash: gix_hash::Kind::Sha1,
+            ..Default::default()
+        },
+    )?;
     let id = hex_to_id("dd25c539efbb0ab018caa4cda2d133285634e9b5");
     assert!(
         stale_handle.exists(&id),
@@ -335,12 +352,18 @@ fn an_object_in_a_pack_moved_by_an_external_process_can_be_found_from_a_stale_ha
 #[test]
 fn write() -> crate::Result {
     let dir = gix_testtools::tempfile::tempdir()?;
-    let mut handle = gix_odb::at(dir.path())?;
+    let mut handle = odb_at(dir.path())?;
     // It should refresh once even if the refresh mode is never, just to initialize the index
     handle.refresh_never();
 
     let written_id = handle.write_buf(gix_object::Kind::Blob, b"hello world")?;
-    assert_eq!(written_id, hex_to_id("95d09f2b10159347eece71399a7e2e907ea3df4f"));
+    assert_eq!(
+        written_id,
+        hex_to_id_for_hash(
+            "95d09f2b10159347eece71399a7e2e907ea3df4f",
+            "fee53a18d32820613c0527aa79be5cb30173c823a9b448fa4817767cc84c6f03"
+        )
+    );
     Ok(())
 }
 
@@ -957,7 +980,14 @@ fn auto_refresh_with_and_without_id_stability() -> crate::Result {
     hide_pack("pack-11fdfa9e156ab73caae3b6da867192221f2089c2");
     hide_pack("pack-a2bf8e71d8c18879e499335762dd95119d93d9f1");
 
-    let handle = gix_odb::at(tmp.path().join("objects"))?;
+    let handle = gix_odb::at_opts(
+        tmp.path().join("objects"),
+        None,
+        gix_odb::store::init::Options {
+            object_hash: gix_hash::Kind::Sha1,
+            ..Default::default()
+        },
+    )?;
     let mut buf = Vec::new();
     assert!(
         handle

--- a/gix-odb/tests/odb/store/dynamic.rs
+++ b/gix-odb/tests/odb/store/dynamic.rs
@@ -69,17 +69,7 @@ fn db_with_all_object_sources() -> crate::Result<(gix_odb::Handle, gix_testtools
             object_hash: gix_hash::Kind::Sha1,
         },
     )?;
-    Ok((
-        gix_odb::at_opts(
-            objects_dir.path(),
-            None,
-            gix_odb::store::init::Options {
-                object_hash: gix_hash::Kind::Sha1,
-                ..Default::default()
-            },
-        )?,
-        objects_dir,
-    ))
+    Ok((gix_odb::at(objects_dir.path(), gix_hash::Kind::Sha1)?, objects_dir))
 }
 
 #[test]
@@ -311,14 +301,7 @@ fn an_object_in_a_pack_moved_by_an_external_process_can_be_found_from_a_stale_ha
         )?;
     }
 
-    let stale_handle = gix_odb::at_opts(
-        tmp.path().join("objects"),
-        None,
-        gix_odb::store::init::Options {
-            object_hash: gix_hash::Kind::Sha1,
-            ..Default::default()
-        },
-    )?;
+    let stale_handle = gix_odb::at(tmp.path().join("objects"), gix_hash::Kind::Sha1)?;
     let id = hex_to_id("dd25c539efbb0ab018caa4cda2d133285634e9b5");
     assert!(
         stale_handle.exists(&id),
@@ -980,14 +963,7 @@ fn auto_refresh_with_and_without_id_stability() -> crate::Result {
     hide_pack("pack-11fdfa9e156ab73caae3b6da867192221f2089c2");
     hide_pack("pack-a2bf8e71d8c18879e499335762dd95119d93d9f1");
 
-    let handle = gix_odb::at_opts(
-        tmp.path().join("objects"),
-        None,
-        gix_odb::store::init::Options {
-            object_hash: gix_hash::Kind::Sha1,
-            ..Default::default()
-        },
-    )?;
+    let handle = gix_odb::at(tmp.path().join("objects"), gix_hash::Kind::Sha1)?;
     let mut buf = Vec::new();
     assert!(
         handle

--- a/gix-odb/tests/odb/store/linked.rs
+++ b/gix-odb/tests/odb/store/linked.rs
@@ -58,14 +58,14 @@ mod init {
     use gix_hash::ObjectId;
     use gix_object::Exists;
 
-    use crate::{alternate::alternate, db};
+    use crate::{alternate::alternate, db, odb_at};
 
     #[test]
     fn multiple_linked_repositories_via_alternates() -> crate::Result {
         let tmp = gix_testtools::tempfile::TempDir::new()?;
         let (object_path, _linked_object_path) = alternate(tmp.path().join("a"), tmp.path().join("b"))?;
-        let db = gix_odb::at(object_path.clone())?;
-        db.exists(&ObjectId::null(gix_hash::Kind::Sha1)); // trigger load
+        let db = odb_at(object_path.clone())?;
+        db.exists(&ObjectId::null(gix_testtools::object_hash())); // trigger load
 
         assert_eq!(db.store_ref().metrics().loose_dbs, 2);
         assert_eq!(db.iter()?.count(), 0, "the test locations are actually empty");
@@ -76,8 +76,8 @@ mod init {
     #[test]
     fn a_db_without_alternates() -> crate::Result {
         let tmp = gix_testtools::tempfile::TempDir::new()?;
-        let db = gix_odb::at(tmp.path())?;
-        db.exists(&ObjectId::null(gix_hash::Kind::Sha1)); // trigger load
+        let db = odb_at(tmp.path())?;
+        db.exists(&ObjectId::null(gix_testtools::object_hash())); // trigger load
         assert_eq!(db.store_ref().metrics().loose_dbs, 1);
         assert_eq!(db.store_ref().path(), tmp.path());
         Ok(())

--- a/gix-ref/tests/refs/file/mod.rs
+++ b/gix-ref/tests/refs/file/mod.rs
@@ -41,14 +41,7 @@ pub fn store_options() -> gix_ref::store::init::Options {
 }
 
 pub fn odb_at(objects_dir: impl Into<std::path::PathBuf>) -> std::io::Result<gix_odb::Handle> {
-    gix_odb::at_opts(
-        objects_dir,
-        Vec::new(),
-        gix_odb::store::init::Options {
-            object_hash: crate::fixture_hash_kind(),
-            ..Default::default()
-        },
-    )
+    gix_odb::at(objects_dir, crate::fixture_hash_kind())
 }
 
 struct EmptyCommit;

--- a/gix-revision/tests/revision/main.rs
+++ b/gix-revision/tests/revision/main.rs
@@ -90,12 +90,5 @@ fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
 }
 
 fn odb_at(objects_dir: impl Into<std::path::PathBuf>) -> Result<gix_odb::Handle> {
-    Ok(gix_odb::at_opts(
-        objects_dir,
-        Vec::new(),
-        gix_odb::store::init::Options {
-            object_hash: gix_testtools::object_hash(),
-            ..Default::default()
-        },
-    )?)
+    Ok(gix_odb::at(objects_dir, gix_testtools::object_hash())?)
 }

--- a/gix-status/tests/status/main.rs
+++ b/gix-status/tests/status/main.rs
@@ -26,17 +26,10 @@ pub fn fixture_path_rw_slow(name: &str) -> gix_testtools::tempfile::TempDir {
 }
 
 fn odb_at(git_dir: &std::path::Path, object_hash: gix_hash::Kind) -> gix_odb::HandleArc {
-    gix_odb::at_opts(
-        git_dir.join("objects"),
-        Vec::new(),
-        gix_odb::store::init::Options {
-            object_hash,
-            ..Default::default()
-        },
-    )
-    .unwrap()
-    .into_arc()
-    .unwrap()
+    gix_odb::at(git_dir.join("objects"), object_hash)
+        .unwrap()
+        .into_arc()
+        .unwrap()
 }
 
 static SHA1_TO_SHA256_HASHES: std::sync::LazyLock<HashMap<&str, &str>> = std::sync::LazyLock::new(|| {

--- a/gix-traverse/tests/traverse/util.rs
+++ b/gix-traverse/tests/traverse/util.rs
@@ -247,14 +247,7 @@ pub fn fixture(script_name: &str) -> Result<PathBuf> {
 
 /// Get an object database handle for `objects_dir`, respecting the hash kind configured for tests.
 pub fn odb_at(objects_dir: impl Into<PathBuf>) -> Result<gix_odb::Handle> {
-    Ok(gix_odb::at_opts(
-        objects_dir,
-        Vec::new(),
-        gix_odb::store::init::Options {
-            object_hash: gix_testtools::object_hash(),
-            ..Default::default()
-        },
-    )?)
+    Ok(gix_odb::at(objects_dir, gix_testtools::object_hash())?)
 }
 
 /// Get an object database handle from a fixture script that creates a single repository.

--- a/gix-worktree-state/tests/worktree-state/main.rs
+++ b/gix-worktree-state/tests/worktree-state/main.rs
@@ -11,12 +11,5 @@ pub fn fixture_path(name: &str) -> PathBuf {
 }
 
 fn odb_at(objects_dir: impl Into<std::path::PathBuf>) -> Result<gix_odb::Handle> {
-    Ok(gix_odb::at_opts(
-        objects_dir,
-        Vec::new(),
-        gix_odb::store::init::Options {
-            object_hash: gix_testtools::object_hash(),
-            ..Default::default()
-        },
-    )?)
+    Ok(gix_odb::at(objects_dir, gix_testtools::object_hash())?)
 }

--- a/gix-worktree-stream/tests/stream.rs
+++ b/gix-worktree-stream/tests/stream.rs
@@ -259,14 +259,7 @@ mod from_tree {
             let hex = std::fs::read(dir.join("head.hex"))?;
             gix_hash::ObjectId::from_hex(hex.trim())?
         };
-        let odb = gix_odb::at_opts(
-            dir.join(".git").join("objects"),
-            Vec::new(),
-            gix_odb::store::init::Options {
-                object_hash: gix_testtools::object_hash(),
-                ..Default::default()
-            },
-        )?;
+        let odb = gix_odb::at(dir.join(".git").join("objects"), gix_testtools::object_hash())?;
 
         let mut collection = Default::default();
         let mut buf = Default::default();

--- a/gix-worktree/tests/worktree/stack/ignore.rs
+++ b/gix-worktree/tests/worktree/stack/ignore.rs
@@ -118,14 +118,7 @@ fn check_against_baseline() -> crate::Result {
         false,
         Default::default(),
     )?;
-    let odb = gix_odb::at_opts(
-        git_dir.join("objects"),
-        Vec::new(),
-        gix_odb::store::init::Options {
-            object_hash: gix_testtools::object_hash(),
-            ..Default::default()
-        },
-    )?;
+    let odb = gix_odb::at(git_dir.join("objects"), gix_testtools::object_hash())?;
     let parse_ignore = gix_ignore::search::Ignore::default();
     let state = gix_worktree::stack::State::for_add(
         Default::default(),


### PR DESCRIPTION
`gix_odb::at_opts()` forces callers to select a hash while `gix_odb::at()` defaults to SHA-1 in SHA-1/SHA-256 builds, making most tests that use `at` fail under `GIX_TEXT_FIXTURE_HASH=sha256`. This has been a common theme in making tests SHA-256-ready: switching from `at` to `at_opts`, so that `object_hash` can be explicitly passed. If my LSP is correct, this PR switches the last remaining uses of `at` to `at_opts`.

`gix_odb::at()` implicitly selects SHA-1 as the default hash in SHA-1/SHA-256 builds which can be unexpected, cannot be overwritten and is a potential source of bugs. `gix_odb::at_opts()`, on the other hand, forces callers to explicitly provide `Options` which contain `object_hash`.

If I’m not missing anything, `at` does not have any callers anymore, now that the remaining ones are switched to `at_opts`. Which makes me wonder: can we remove `at` altogether? This PR is an attempt at answering that question.

Update after CI was green: it appears we could remove `gix_odb::at` if we wanted to. Other options include deprecating it or adding a warning to its docs that clearly state the potential for bugs in SHA-1/SHA-256 builds. @Byron What do you think?