### PR TITLE
feat: add `State::tree_mut()`

### DIFF
--- a/gix-index/src/access/mod.rs
+++ b/gix-index/src/access/mod.rs
@@ -630,6 +630,10 @@ impl State {
     pub fn tree(&self) -> Option<&extension::Tree> {
         self.tree.as_ref()
     }
+    /// Mutably access the `tree` extension.
+    pub fn tree_mut(&mut self) -> Option<&mut extension::Tree> {
+        self.tree.as_mut()
+    }
     /// Remove the `tree` extension.
     pub fn remove_tree(&mut self) -> Option<extension::Tree> {
         self.tree.take()


### PR DESCRIPTION
Adds `State::tree_mut()`, mirroring `entries_mut()` beside `entries()`.

`tree()` reads the extension and `remove_tree()` takes it, and every field of `extension::Tree` is public, so callers can already build an invalidated tree. They cannot write one back, since `State.tree` is private.

Without it, invalidating the sub-trees affected by an entry change means discarding the whole extension, so the next tree-write traverses every path instead of only the changed ones. Git invalidates only the nodes covering the changed paths.

`write()` documents that the tree extension is serialized as-is and `**not** recomputed or invalidated to match the entries`, and prescribes `remove_tree()` as the interim workaround for #2421. This PR does not change that: it lets a caller invalidate precisely instead of discarding, which is the same workaround at lower cost.

