### PR TITLE
test: add tests for symlinks in `gix-blame`

### DIFF
--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -799,6 +799,11 @@ mod symlinks {
     fn file_becomes_symlink() -> gix_testtools::Result {
         run_test("file-then-symlink", "file-becomes-symlink.baseline")
     }
+
+    #[test]
+    fn symlink_becomes_file() -> gix_testtools::Result {
+        run_test("symlink-then-file", "symlink-becomes-file.baseline")
+    }
 }
 
 fn fixture_path() -> gix_testtools::Result<PathBuf> {

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -748,6 +748,59 @@ mod untracked_changes {
     }
 }
 
+mod symlinks {
+    use gix_blame::BlameRanges;
+
+    use crate::{Baseline, Fixture};
+
+    fn run_test(source_file_name: &str, baseline_name: &str) -> gix_testtools::Result {
+        let worktree_path = gix_testtools::scripted_fixture_read_only("make_blame_symlinks_repo.sh")?;
+        let mut fixture = Fixture::for_worktree_path(worktree_path.to_path_buf())?;
+
+        let lines_blamed = fixture
+            .blame_file(
+                source_file_name.into(),
+                gix_blame::Options {
+                    diff_algorithm: gix_diff::blob::Algorithm::Histogram,
+                    ranges: BlameRanges::default(),
+                    since: None,
+                    rewrites: Some(gix_diff::Rewrites::default()),
+                    debug_track_path: false,
+                },
+            )?
+            .entries;
+
+        assert_eq!(lines_blamed.len(), 1);
+
+        let git_dir = worktree_path.join(".git");
+        let baseline = Baseline::collect(git_dir.join(baseline_name), source_file_name.into())?;
+
+        pretty_assertions::assert_eq!(lines_blamed, baseline);
+
+        Ok(())
+    }
+
+    #[test]
+    fn lines_added_to_file_targeted_by_symlink() -> gix_testtools::Result {
+        run_test("symlink", "symlink.baseline")
+    }
+
+    #[test]
+    fn symlink_changing_target() -> gix_testtools::Result {
+        run_test("symlink-changing-target", "symlink-changing-target.baseline")
+    }
+
+    #[test]
+    fn symlink_renamed() -> gix_testtools::Result {
+        run_test("symlink-after-rename", "symlink-renamed.baseline")
+    }
+
+    #[test]
+    fn file_becomes_symlink() -> gix_testtools::Result {
+        run_test("file-then-symlink", "file-becomes-symlink.baseline")
+    }
+}
+
 fn fixture_path() -> gix_testtools::Result<PathBuf> {
     gix_testtools::scripted_fixture_read_only("make_blame_repo.sh")
 }

--- a/gix-blame/tests/fixtures/generated-archives/.gitignore
+++ b/gix-blame/tests/fixtures/generated-archives/.gitignore
@@ -5,3 +5,7 @@
 # variants share this constraint.
 make_blame_repo.tar
 make_blame_repo_sha256.tar
+
+# Uses `ln -s`.
+make_blame_symlinks_repo.tar
+make_blame_symlinks_repo_sha256.tar

--- a/gix-blame/tests/fixtures/generated-archives/.gitignore
+++ b/gix-blame/tests/fixtures/generated-archives/.gitignore
@@ -6,6 +6,7 @@
 make_blame_repo.tar
 make_blame_repo_sha256.tar
 
-# Uses `ln -s`.
+# Uses `ln -s`, including breakout symlinks (`../..`) that cannot be safely
+# extracted on Windows.
 make_blame_symlinks_repo.tar
 make_blame_symlinks_repo_sha256.tar

--- a/gix-blame/tests/fixtures/make_blame_symlinks_repo.sh
+++ b/gix-blame/tests/fixtures/make_blame_symlinks_repo.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+git init -q
+git config --local diff.algorithm histogram
+
+git checkout -q -b main
+
+seq 1 4 > target.txt
+git add target.txt
+git commit -q -m c1-create-target
+
+ln -s target.txt symlink
+git add symlink
+git commit -q -m c2-create-symlink
+
+seq 1 6 > target.txt
+git add target.txt
+git commit -q -m c3-change-target
+
+seq 2 5 > second-target.txt
+ln -s second-target.txt symlink-changing-target
+git add second-target.txt symlink-changing-target
+git commit -q -m c4-create-second-target
+
+rm symlink-changing-target
+ln -s target.txt symlink-changing-target
+git add symlink-changing-target
+git commit -q -m c5-change-symlink-target
+
+ln -s target.txt symlink-before-rename
+git add symlink-before-rename
+git commit -q -m c6-create-symlink-before-rename
+
+rm symlink-before-rename
+ln -s target.txt symlink-after-rename
+git add symlink-after-rename symlink-before-rename
+git commit -q -m c7-rename-symlink
+
+seq 1 3 > file-then-symlink
+git add file-then-symlink
+git commit -q -m c8-create-file
+
+rm file-then-symlink
+ln -s target.txt file-then-symlink
+git add file-then-symlink
+git commit -q -m c9-change-file-to-symlink
+
+git blame --porcelain symlink > .git/symlink.baseline
+git blame --porcelain symlink-changing-target > .git/symlink-changing-target.baseline
+git blame --porcelain symlink-after-rename > .git/symlink-renamed.baseline
+git blame --porcelain file-then-symlink > .git/file-becomes-symlink.baseline

--- a/gix-blame/tests/fixtures/make_blame_symlinks_repo.sh
+++ b/gix-blame/tests/fixtures/make_blame_symlinks_repo.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
+# Exercise blame for five distinct symlink histories:
+# - the target file's contents change after the symlink is created, while the
+#   symlink itself remains unchanged;
+# - the symlink's stored target changes from one path to another;
+# - the symlink is renamed without changing its target, exercising rename tracking;
+# - a regular file is replaced by a symlink at the same path, changing its mode;
+# - a symlink is replaced by a regular file, changing the mode in reverse.
 git init -q
 git config --local diff.algorithm histogram
 
@@ -46,7 +53,17 @@ ln -s target.txt file-then-symlink
 git add file-then-symlink
 git commit -q -m c9-change-file-to-symlink
 
+ln -s target.txt symlink-then-file
+git add symlink-then-file
+git commit -q -m c10-create-symlink
+
+rm symlink-then-file
+echo regular-file > symlink-then-file
+git add symlink-then-file
+git commit -q -m c11-change-symlink-to-file
+
 git blame --porcelain symlink > .git/symlink.baseline
 git blame --porcelain symlink-changing-target > .git/symlink-changing-target.baseline
 git blame --porcelain symlink-after-rename > .git/symlink-renamed.baseline
 git blame --porcelain file-then-symlink > .git/file-becomes-symlink.baseline
+git blame --porcelain symlink-then-file > .git/symlink-becomes-file.baseline


### PR DESCRIPTION
This PR adds dedicated tests for symlinks in `gix-blame`. None of the tests required any code changes to make them pass. This is based on a [TODO][todo] mentioned in [this comment][comment].

I think the `TODO` comment can potentially be removed. We might also want to change it to highlight the fact that we force `set_resource` to treat symlinks as blobs by unconditionally passing `EntryKind::Blob`. As far as I can tell at least, `set_resource` does not check on its own whether an object is a symlink, but trusts its caller.

[todo]: https://github.com/GitoxideLabs/gitoxide/blob/dc370d9cacb4b06a132d2ffaaf224cc770173742/gix-blame/src/file/function.rs#L767
[comment]: https://github.com/GitoxideLabs/gitoxide/pull/2719#pullrequestreview-4872028758.