### PR TITLE
Pass object hash explicitly in a few tests

### DIFF
--- a/gix-odb/tests/odb/store/loose.rs
+++ b/gix-odb/tests/odb/store/loose.rs
@@ -8,7 +8,13 @@ use pretty_assertions::assert_eq;
 use crate::hex_to_id;
 
 fn ldb() -> Store {
-    Store::at(fixture_path("objects"), Options::default())
+    Store::at(
+        fixture_path("objects"),
+        Options {
+            object_hash: gix_hash::Kind::Sha1,
+            ..Options::default()
+        },
+    )
 }
 
 fn limited_ldb(limit: usize) -> Store {
@@ -16,6 +22,7 @@ fn limited_ldb(limit: usize) -> Store {
         fixture_path("objects"),
         Options {
             alloc_limit_bytes: Some(limit),
+            object_hash: gix_hash::Kind::Sha1,
             ..Default::default()
         },
     )
@@ -92,7 +99,13 @@ mod write {
     #[test]
     fn read_and_write() -> crate::Result {
         let dir = gix_testtools::tempfile::tempdir()?;
-        let db = loose::Store::at(dir.path(), loose::Options::default());
+        let db = loose::Store::at(
+            dir.path(),
+            loose::Options {
+                object_hash: gix_hash::Kind::Sha1,
+                ..Default::default()
+            },
+        );
         let mut buf = Vec::new();
         let mut buf2 = Vec::new();
 
@@ -239,7 +252,13 @@ mod lookup_prefix {
             b"fake",
         )
         .unwrap();
-        let store = gix_odb::loose::Store::at(objects_dir.path(), gix_odb::loose::Options::default());
+        let store = gix_odb::loose::Store::at(
+            objects_dir.path(),
+            gix_odb::loose::Options {
+                object_hash: gix_hash::Kind::Sha1,
+                ..Default::default()
+            },
+        );
         let input_id = hex_to_id("37d4e6c5c48ba0d245164c4e10d5f41140cab980");
         let prefix = gix_hash::Prefix::new(&input_id, 4).unwrap();
         assert_eq!(

--- a/gix-odb/tests/odb/store/loose.rs
+++ b/gix-odb/tests/odb/store/loose.rs
@@ -76,6 +76,7 @@ mod write {
                 dir.path(),
                 loose::Options {
                     compression: level,
+                    object_hash: gix_testtools::object_hash(),
                     ..Default::default()
                 },
             );
@@ -181,7 +182,13 @@ mod write {
         let dir = gix_testtools::tempfile::tempdir()?;
 
         fn write_empty_trees(dir: &std::path::Path) {
-            let db = loose::Store::at(dir, loose::Options::default());
+            let db = loose::Store::at(
+                dir,
+                loose::Options {
+                    object_hash: gix_testtools::object_hash(),
+                    ..Default::default()
+                },
+            );
             let empty_tree = gix_object::Tree::empty();
             for _ in 0..2 {
                 let id = db.write(&empty_tree).expect("works");
@@ -309,7 +316,7 @@ mod find {
     use gix_odb::loose;
 
     use crate::{
-        hex_to_id,
+        hex_to_id, hex_to_id_for_hash,
         store::loose::{ldb, limited_ldb, locate_oid},
     };
 
@@ -322,11 +329,27 @@ mod find {
         let tmp = gix_testtools::tempfile::tempdir()?;
         let base = tmp.path().join("aa");
         std::fs::create_dir(&base)?;
-        std::fs::write(base.join("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), [])?;
-        let db = loose::Store::at(tmp.path(), loose::Options::default());
+        std::fs::write(
+            base.join(match gix_testtools::object_hash() {
+                gix_hash::Kind::Sha1 => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                gix_hash::Kind::Sha256 => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                _ => unimplemented!(),
+            }),
+            [],
+        )?;
+        let db = loose::Store::at(
+            tmp.path(),
+            loose::Options {
+                object_hash: gix_testtools::object_hash(),
+                ..Default::default()
+            },
+        );
 
         let mut buf = Vec::new();
-        let id = hex_to_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let id = hex_to_id_for_hash(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        );
         assert!(db.try_find(&id, &mut buf).is_err(), "it must not panic");
         assert!(db.try_header(&id).is_err(), "it must not panic");
 

--- a/gix-odb/tests/odb/store/loose.rs
+++ b/gix-odb/tests/odb/store/loose.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::AtomicBool;
+use std::{path::PathBuf, sync::atomic::AtomicBool};
 
 use gix_features::progress;
 use gix_odb::loose::{Options, Store};
@@ -8,10 +8,18 @@ use pretty_assertions::assert_eq;
 use crate::hex_to_id;
 
 fn ldb() -> Store {
+    ldb_at(fixture_path("objects"))
+}
+
+fn ldb_at(path: impl Into<PathBuf>) -> Store {
+    ldb_at_opts(path, gix_hash::Kind::Sha1)
+}
+
+fn ldb_at_opts(path: impl Into<PathBuf>, object_hash: gix_hash::Kind) -> Store {
     Store::at(
-        fixture_path("objects"),
+        path,
         Options {
-            object_hash: gix_hash::Kind::Sha1,
+            object_hash,
             ..Options::default()
         },
     )
@@ -63,7 +71,7 @@ mod write {
     use gix_object::Write;
     use gix_odb::loose;
 
-    use crate::store::loose::{locate_oid, object_ids};
+    use crate::store::loose::{ldb_at, ldb_at_opts, locate_oid, object_ids};
 
     #[test]
     fn compression_level_is_respected() -> crate::Result {
@@ -100,13 +108,7 @@ mod write {
     #[test]
     fn read_and_write() -> crate::Result {
         let dir = gix_testtools::tempfile::tempdir()?;
-        let db = loose::Store::at(
-            dir.path(),
-            loose::Options {
-                object_hash: gix_hash::Kind::Sha1,
-                ..Default::default()
-            },
-        );
+        let db = ldb_at(dir.path());
         let mut buf = Vec::new();
         let mut buf2 = Vec::new();
 
@@ -182,13 +184,7 @@ mod write {
         let dir = gix_testtools::tempfile::tempdir()?;
 
         fn write_empty_trees(dir: &std::path::Path) {
-            let db = loose::Store::at(
-                dir,
-                loose::Options {
-                    object_hash: gix_testtools::object_hash(),
-                    ..Default::default()
-                },
-            );
+            let db = ldb_at_opts(dir, gix_testtools::object_hash());
             let empty_tree = gix_object::Tree::empty();
             for _ in 0..2 {
                 let id = db.write(&empty_tree).expect("works");
@@ -231,7 +227,10 @@ mod lookup_prefix {
     use gix_testtools::fixture_path;
     use maplit::hashset;
 
-    use crate::{hex_to_id, store::loose::ldb};
+    use crate::{
+        hex_to_id,
+        store::loose::{ldb, ldb_at},
+    };
 
     #[test]
     fn returns_none_for_prefixes_without_any_match() {
@@ -259,13 +258,7 @@ mod lookup_prefix {
             b"fake",
         )
         .unwrap();
-        let store = gix_odb::loose::Store::at(
-            objects_dir.path(),
-            gix_odb::loose::Options {
-                object_hash: gix_hash::Kind::Sha1,
-                ..Default::default()
-            },
-        );
+        let store = ldb_at(objects_dir.path());
         let input_id = hex_to_id("37d4e6c5c48ba0d245164c4e10d5f41140cab980");
         let prefix = gix_hash::Prefix::new(&input_id, 4).unwrap();
         assert_eq!(
@@ -317,7 +310,7 @@ mod find {
 
     use crate::{
         hex_to_id, hex_to_id_for_hash,
-        store::loose::{ldb, limited_ldb, locate_oid},
+        store::loose::{ldb, ldb_at_opts, limited_ldb, locate_oid},
     };
 
     fn find<'a>(hex: &str, buf: &'a mut Vec<u8>) -> gix_object::Data<'a> {
@@ -337,13 +330,7 @@ mod find {
             }),
             [],
         )?;
-        let db = loose::Store::at(
-            tmp.path(),
-            loose::Options {
-                object_hash: gix_testtools::object_hash(),
-                ..Default::default()
-            },
-        );
+        let db = ldb_at_opts(tmp.path(), gix_testtools::object_hash());
 
         let mut buf = Vec::new();
         let id = hex_to_id_for_hash(

--- a/gix-ref/src/store/file/loose/reflog/create_or_update/tests.rs
+++ b/gix-ref/src/store/file/loose/reflog/create_or_update/tests.rs
@@ -7,9 +7,35 @@ use super::*;
 
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-/// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
+static SHA1_TO_SHA256_HASHES: std::sync::LazyLock<std::collections::HashMap<&str, &str>> =
+    std::sync::LazyLock::new(|| {
+        [
+            (
+                "28ce6a8b26aa170e1de65536fe8abe1832bd3242",
+                "28ce6a8b26aa170e1de65536fe8abe1832bd3242000000000000000000000000",
+            ),
+            (
+                "0000000000000000000000111111111111111111",
+                "0000000000000000000000111111111111111111000000000000000000000000",
+            ),
+        ]
+        .into()
+    });
+
+/// Convert a hexadecimal SHA-1 hash or the corresponding SHA-256 hash into an `ObjectId` or
+/// _panic_.
 fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
-    gix_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
+    match gix_testtools::object_hash() {
+        gix_hash::Kind::Sha1 => gix_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex"),
+        gix_hash::Kind::Sha256 => gix_hash::ObjectId::from_hex(
+            SHA1_TO_SHA256_HASHES
+                .get(hex)
+                .unwrap_or_else(|| panic!("SHA-1 {hex} wasn't mapped to SHA-256 yet"))
+                .as_bytes(),
+        )
+        .expect("64 bytes hex"),
+        _ => unimplemented!(),
+    }
 }
 
 fn empty_store(writemode: WriteReflog) -> Result<(TempDir, file::Store)> {
@@ -18,6 +44,7 @@ fn empty_store(writemode: WriteReflog) -> Result<(TempDir, file::Store)> {
         dir.path().into(),
         crate::store::init::Options {
             write_reflog: writemode,
+            object_hash: gix_testtools::object_hash(),
             ..Default::default()
         },
     );
@@ -74,7 +101,7 @@ fn missing_reflog_creates_it_even_if_similarly_named_empty_dir_exists_and_append
                 assert_eq!(
                     reflog_lines(&store, full_name_str, &mut buf)?,
                     vec![crate::log::Line {
-                        previous_oid: gix_hash::Kind::Sha1.null(),
+                        previous_oid: gix_testtools::object_hash().null(),
                         new_oid: new,
                         signature: committer.clone(),
                         message: "the message".into()
@@ -181,7 +208,7 @@ fn reflog_write_normalizes_committer_name_and_email_like_git() -> Result {
     assert_eq!(
         reflog_lines(&store, full_name_str, &mut buf)?,
         vec![crate::log::Line {
-            previous_oid: gix_hash::Kind::Sha1.null(),
+            previous_oid: gix_testtools::object_hash().null(),
             new_oid: new,
             signature: Signature {
                 name: "committer".into(),

--- a/gix-ref/tests/transaction_fd_limit.rs
+++ b/gix-ref/tests/transaction_fd_limit.rs
@@ -18,7 +18,14 @@ fn large_transactions_hold_a_constant_number_of_file_descriptors() -> gix_testto
     }
 
     let dir = gix_testtools::tempfile::TempDir::new()?;
-    let store = file::Store::at(dir.path().into(), Default::default());
+    let object_hash = gix_testtools::object_hash();
+    let store = file::Store::at(
+        dir.path().into(),
+        gix_ref::store::init::Options {
+            object_hash,
+            ..Default::default()
+        },
+    );
     let edits = (0..20).map(|i| RefEdit {
         change: Change::Update {
             log: LogChange {
@@ -27,7 +34,7 @@ fn large_transactions_hold_a_constant_number_of_file_descriptors() -> gix_testto
                 message: "log peeled".into(),
             },
             expected: PreviousValue::MustNotExist,
-            new: Target::Object(gix_hash::Kind::Sha1.empty_blob()),
+            new: Target::Object(object_hash.empty_blob()),
         },
         name: format!("refs/heads/fd-{i:02}").try_into().expect("valid ref name"),
         deref: false,


### PR DESCRIPTION
This is a small PR that makes a few tests in `gix-odb` and `gix-ref` use `gix_testtools::object_hash()` instead of picking SHA-1 through `Default::default()` or by hard-coding `Sha1`.

While doing that, I also changed some tests in `gix-odb` to hard-code `Sha1` instead of implicitly picking it through, e. g., `Options::default()`. That was mostly to help remind future me that these locations are, in fact, SHA-1-only as they exercise SHA-1-only fixtures. Feel free to ignore this change if you think it’s too pedantic, though. 😉