### PR TITLE
feat!: require `object_hash` in `Store::at`

### DIFF
--- a/gitoxide-core/src/pack/explode.rs
+++ b/gitoxide-core/src/pack/explode.rs
@@ -149,13 +149,7 @@ impl gix::objs::Write for OutputWriter {
 impl OutputWriter {
     fn new(path: Option<impl AsRef<Path>>, compress: bool, object_hash: gix::hash::Kind) -> Self {
         match path {
-            Some(path) => OutputWriter::Loose(loose::Store::at(
-                path.as_ref(),
-                loose::Options {
-                    object_hash,
-                    ..Default::default()
-                },
-            )),
+            Some(path) => OutputWriter::Loose(loose::Store::at(path.as_ref(), object_hash)),
             None => OutputWriter::Sink(
                 odb::sink(object_hash).compress(compress.then_some(gix::zlib::Compression::BEST_SPEED)),
             ),
@@ -229,15 +223,7 @@ pub fn pack_or_pack_index(
                 let out = OutputWriter::new(object_path.clone(), sink_compress, object_hash);
                 let loose_odb = verify
                     .then(|| {
-                        object_path.as_ref().map(|path| {
-                            loose::Store::at(
-                                path,
-                                loose::Options {
-                                    object_hash,
-                                    ..Default::default()
-                                },
-                            )
-                        })
+                        object_path.as_ref().map(|path| loose::Store::at(path, object_hash))
                     })
                     .flatten();
                 let mut read_buf = Vec::new();

--- a/gix-odb/src/lib.rs
+++ b/gix-odb/src/lib.rs
@@ -177,15 +177,18 @@ pub struct Store {
 
 /// Create a new cached handle to the object store with support for additional options.
 ///
+/// `object_hash` is the hash of contained objects and the hash used when writing objects.
 /// `replacements` is an iterator over pairs of old and new object ids for replacement support.
 /// This means that when asking for object `X`, one will receive object `X-replaced` given an iterator like `Some((X, X-replaced))`.
 pub fn at_opts(
     objects_dir: impl Into<PathBuf>,
+    object_hash: gix_hash::Kind,
     replacements: impl IntoIterator<Item = (gix_hash::ObjectId, gix_hash::ObjectId)>,
     options: store::init::Options,
 ) -> std::io::Result<Handle> {
     let handle = OwnShared::new(Store::at_opts(
         objects_dir.into(),
+        object_hash,
         &mut replacements.into_iter(),
         options,
     )?)
@@ -196,12 +199,5 @@ pub fn at_opts(
 /// Create a new cached handle to the object store with `.git/objects` provided in `objects_dir`,
 /// with `object_hash` as the hash of contained objects to write.
 pub fn at(objects_dir: impl Into<PathBuf>, object_hash: gix_hash::Kind) -> std::io::Result<Handle> {
-    at_opts(
-        objects_dir,
-        None,
-        store::init::Options {
-            object_hash,
-            ..Default::default()
-        },
-    )
+    at_opts(objects_dir, object_hash, None, store::init::Options::default())
 }

--- a/gix-odb/src/store_impls/dynamic/handle.rs
+++ b/gix-odb/src/store_impls/dynamic/handle.rs
@@ -356,10 +356,10 @@ impl TryFrom<&super::Store> for super::Store {
     fn try_from(s: &super::Store) -> Result<Self, Self::Error> {
         super::Store::at_opts(
             s.path().into(),
+            s.object_hash,
             &mut s.replacements(),
             crate::store::init::Options {
                 slots: crate::store::init::Slots::Given(s.files.len().try_into().expect("BUG: too many slots")),
-                object_hash: s.object_hash,
                 use_multi_pack_index: false,
                 alloc_limit_bytes: s.alloc_limit_bytes,
                 current_dir: s.current_dir.clone().into(),

--- a/gix-odb/src/store_impls/dynamic/init.rs
+++ b/gix-odb/src/store_impls/dynamic/init.rs
@@ -12,8 +12,6 @@ use crate::{
 pub struct Options {
     /// How to obtain a size for the slot map.
     pub slots: Slots,
-    /// The kind of hash we expect in our packs and would use for loose object iteration and object writing.
-    pub object_hash: gix_hash::Kind,
     /// If false, no multi-pack indices will be used. If true, they will be used if their hash matches `object_hash`.
     pub use_multi_pack_index: bool,
     /// The maximum size of a single allocation caused by user-controlled on-disk pack data.
@@ -34,7 +32,6 @@ impl Default for Options {
     fn default() -> Self {
         Options {
             slots: Default::default(),
-            object_hash: Default::default(),
             use_multi_pack_index: true,
             alloc_limit_bytes: None,
             current_dir: None,
@@ -78,14 +75,15 @@ impl Store {
     /// Note that the `slots` isn't used for packs, these are included with their multi-index or index respectively.
     /// For example, In a repository with 250m objects and geometric packing one would expect 27 index/pack pairs,
     /// or a single multi-pack index.
+    /// `object_hash` is the hash expected in packs and used for loose object iteration and object writing.
     /// `replacements` is an iterator over pairs of old and new object ids for replacement support.
     /// This means that when asking for object `X`, one will receive object `X-replaced` given an iterator like `Some((X, X-replaced))`.
     pub fn at_opts(
         objects_dir: PathBuf,
+        object_hash: gix_hash::Kind,
         replacements: &mut dyn Iterator<Item = (gix_hash::ObjectId, gix_hash::ObjectId)>,
         Options {
             slots,
-            object_hash,
             use_multi_pack_index,
             alloc_limit_bytes,
             current_dir,

--- a/gix-odb/src/store_impls/dynamic/load_index.rs
+++ b/gix-odb/src/store_impls/dynamic/load_index.rs
@@ -246,10 +246,10 @@ impl super::Store {
                 db_paths
                     .iter()
                     .map(|path| {
-                        crate::loose::Store::at(
+                        crate::loose::Store::at_opts(
                             path,
+                            self.object_hash,
                             crate::loose::Options {
-                                object_hash: self.object_hash,
                                 alloc_limit_bytes: self.alloc_limit_bytes,
                                 compression: loose_compression,
                             },

--- a/gix-odb/src/store_impls/loose/mod.rs
+++ b/gix-odb/src/store_impls/loose/mod.rs
@@ -5,11 +5,9 @@ use std::path::{Path, PathBuf};
 
 use gix_features::fs;
 
-/// Options for use in [`Store::at()`].
+/// Options for use in [`Store::at_opts()`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Options {
-    /// The kind of hash to use when writing, finding, or iterating objects.
-    pub object_hash: gix_hash::Kind,
     /// The maximum size of a single allocation caused by user-controlled loose object data.
     ///
     /// If `None`, no additional limit is enforced.
@@ -24,7 +22,6 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Options {
-            object_hash: Default::default(),
             alloc_limit_bytes: None,
             compression: gix_zlib::Compression::BEST_SPEED,
         }
@@ -46,14 +43,25 @@ pub struct Store {
 
 /// Initialization
 impl Store {
-    /// Initialize the Db with the `objects_directory` containing the hexadecimal first byte subdirectories, which in turn
-    /// contain all loose objects.
+    /// Initialize the object database with the `objects_directory` containing the hexadecimal
+    /// first byte subdirectories, which in turn contain all loose objects.
     ///
     /// In a git repository, this would be `.git/objects`.
     ///
-    pub fn at(objects_directory: impl Into<PathBuf>, options: Options) -> Store {
+    /// Use `object_hash` to specify the db’s hash.
+    pub fn at(objects_directory: impl Into<PathBuf>, object_hash: gix_hash::Kind) -> Store {
+        Self::at_opts(objects_directory, object_hash, Default::default())
+    }
+
+    /// Initialize the object database with the `objects_directory` containing the hexadecimal
+    /// first byte subdirectories, which in turn contain all loose objects.
+    ///
+    /// In a git repository, this would be `.git/objects`.
+    ///
+    /// Use `object_hash` to specify the db’s hash and `options` to configure allocation limits and
+    /// compression level.
+    pub fn at_opts(objects_directory: impl Into<PathBuf>, object_hash: gix_hash::Kind, options: Options) -> Store {
         let Options {
-            object_hash,
             alloc_limit_bytes,
             compression,
         } = options;

--- a/gix-odb/tests/odb/main.rs
+++ b/gix-odb/tests/odb/main.rs
@@ -16,15 +16,6 @@ pub fn hex_to_id_for_hash(sha1: &str, sha256: &str) -> ObjectId {
 
 pub type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
-/// [`init::Options`](gix_odb::store::init::Options) respecting [`gix_testtools::object_hash()`]
-/// that regenerate under `GIX_TEST_FIXTURE_HASH` are opened with a matching object hash.
-pub fn fixture_options() -> gix_odb::store::init::Options {
-    gix_odb::store::init::Options {
-        object_hash: gix_testtools::object_hash(),
-        ..Default::default()
-    }
-}
-
 /// Open an object store at `objects_dir`.
 /// The static SHA-1 fixtures keep using [`db()`]/[`db_small_packs()`] instead.
 pub fn odb_at(objects_dir: impl Into<std::path::PathBuf>) -> std::io::Result<gix_odb::Handle> {

--- a/gix-odb/tests/odb/store/dynamic.rs
+++ b/gix-odb/tests/odb/store/dynamic.rs
@@ -185,10 +185,11 @@ fn multi_index_alloc_limit_bytes_falls_back_to_plain_indices() -> crate::Result 
     let expected = expected_pack_metrics(dir.path())?;
     let handle = gix_odb::at_opts(
         dir.path().join(".git/objects"),
+        gix_testtools::object_hash(),
         Vec::new(),
         gix_odb::store::init::Options {
             alloc_limit_bytes: Some(1),
-            ..crate::fixture_options()
+            ..Default::default()
         },
     )?;
 
@@ -414,8 +415,9 @@ fn object_replacement() -> crate::Result {
 
     let mut handle = gix_odb::at_opts(
         dir.join(".git/objects"),
+        gix_testtools::object_hash(),
         vec![(short_history_link, long_history_tip), unrelated_mapping],
-        crate::fixture_options(),
+        Default::default(),
     )?;
     drop(orphan);
 

--- a/gix-odb/tests/odb/store/loose.rs
+++ b/gix-odb/tests/odb/store/loose.rs
@@ -16,21 +16,15 @@ fn ldb_at(path: impl Into<PathBuf>) -> Store {
 }
 
 fn ldb_at_opts(path: impl Into<PathBuf>, object_hash: gix_hash::Kind) -> Store {
-    Store::at(
-        path,
-        Options {
-            object_hash,
-            ..Options::default()
-        },
-    )
+    Store::at(path, object_hash)
 }
 
 fn limited_ldb(limit: usize) -> Store {
-    Store::at(
+    Store::at_opts(
         fixture_path("objects"),
+        gix_hash::Kind::Sha1,
         Options {
             alloc_limit_bytes: Some(limit),
-            object_hash: gix_hash::Kind::Sha1,
             ..Default::default()
         },
     )
@@ -80,11 +74,11 @@ mod write {
         let mut sizes = Vec::new();
         for level in [Compression::NONE, Compression::BEST] {
             let dir = gix_testtools::tempfile::tempdir()?;
-            let db = loose::Store::at(
+            let db = loose::Store::at_opts(
                 dir.path(),
+                gix_testtools::object_hash(),
                 loose::Options {
                     compression: level,
-                    object_hash: gix_testtools::object_hash(),
                     ..Default::default()
                 },
             );
@@ -146,32 +140,20 @@ mod write {
     #[test]
     #[cfg(unix)]
     fn it_writes_objects_with_similar_permissions() -> crate::Result {
-        let hk = gix_testtools::object_hash();
+        let object_hash = gix_testtools::object_hash();
         let git_store = loose::Store::at(
             crate::scripted_fixture_read_only("repo_with_loose_objects.sh")?.join(".git/objects"),
-            loose::Options {
-                object_hash: hk,
-                ..Default::default()
-            },
+            object_hash,
         );
         let expected_perm = git_store
-            .object_path(&gix_hash::ObjectId::empty_blob(hk))
+            .object_path(&object_hash.empty_blob())
             .metadata()?
             .permissions();
 
         let tmp = gix_testtools::tempfile::TempDir::new()?;
-        let store = loose::Store::at(
-            tmp.path(),
-            loose::Options {
-                object_hash: hk,
-                ..Default::default()
-            },
-        );
+        let store = loose::Store::at(tmp.path(), object_hash);
         store.write_buf(gix_object::Kind::Blob, &[])?;
-        let actual_perm = store
-            .object_path(&gix_hash::ObjectId::empty_blob(hk))
-            .metadata()?
-            .permissions();
+        let actual_perm = store.object_path(&object_hash.empty_blob()).metadata()?.permissions();
         assert_eq!(
             actual_perm, expected_perm,
             "we explicitly equalize permissions to be similar to what `git` would do"

--- a/gix-pack/tests/pack/data/output/mod.rs
+++ b/gix-pack/tests/pack/data/output/mod.rs
@@ -41,11 +41,9 @@ fn db(kind: DbKind, object_hash: gix_hash::Kind) -> crate::Result<gix_odb::Handl
     let path: PathBuf = crate::scripted_fixture_read_only(name)?.join(".git").join("objects");
     gix_odb::Store::at_opts(
         path,
+        object_hash,
         &mut None.into_iter(),
-        gix_odb::store::init::Options {
-            object_hash,
-            ..Default::default()
-        },
+        gix_odb::store::init::Options::default(),
     )
     .map_err(Into::into)
     .map(|store| {

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -481,10 +481,10 @@ impl ThreadSafeRepository {
         Ok(ThreadSafeRepository {
             objects: OwnShared::new(gix_odb::Store::at_opts(
                 common_dir_ref.join("objects"),
+                config.object_hash,
                 &mut replacements.into_iter(),
                 gix_odb::store::init::Options {
                     slots: object_store_slots,
-                    object_hash: config.object_hash,
                     use_multi_pack_index: config.use_multi_pack_index,
                     alloc_limit_bytes: config.alloc_limit_bytes,
                     loose_compression: config.loose_compression,

--- a/gix/tests/gix/repository/object.rs
+++ b/gix/tests/gix/repository/object.rs
@@ -399,13 +399,7 @@ mod write_blob {
 #[test]
 fn writes_avoid_io_using_duplicate_check() -> crate::Result {
     let mut repo = crate::named_repo("make_packed_and_loose.sh")?;
-    let store = gix::odb::loose::Store::at(
-        repo.git_dir().join("objects"),
-        gix::odb::loose::Options {
-            object_hash: repo.object_hash(),
-            ..Default::default()
-        },
-    );
+    let store = gix::odb::loose::Store::at(repo.git_dir().join("objects"), repo.object_hash());
     let loose_count = store.iter().count();
     assert_eq!(loose_count, 3, "there are some loose objects");
     assert_eq!(


### PR DESCRIPTION
This PR is a small follow-up to #2901 which split `gix_odb::at(objects_dir: impl Into<PathBuf>)` into `gix_odb::at(objects_dir: impl Into<PathBuf>, object_hash: gix_hash::Kind)` and `gix_odb::at_opts(objects_dir: impl Into<PathBuf>, replacements: impl IntoIterator<Item = (gix_hash::ObjectId, gix_hash::ObjectId)>, options: store::init::Options)`. By always requiring callers to explicitly pass the object hash we eliminate the risk posed by `Default::default()` implicitly choosing `Sha1` in SHA-1/SHA-256 builds. This comes at the cost of callers having to explicitly pass a hash even in single-hash builds, but I would argue that it is trivial for callers to write their own wrapper if they want.

This PR goes even further than #2901 because it removes `object_hash` from `Options`, making hash selection explicit even in the `at_opts` case. I think this is cleaner, but, obviously, feel free to modify and adapt!