### PR TITLE
refactor!: remove `object_hash` from `gix_ref::store::init::Options`

### DIFF
--- a/gitoxide-core/src/remote.rs
+++ b/gitoxide-core/src/remote.rs
@@ -112,15 +112,15 @@ fn write_refs(
 
     let start = Instant::now();
     let precompose_unicode = gix::fs::Capabilities::probe(&directory).precompose_unicode;
-    let store = gix::RefStore::at(
+    let store = gix::RefStore::at_opts(
         directory,
+        object_hash,
         gix::refs::store::init::Options {
             write_reflog: if write_reflog {
                 gix::refs::store::WriteReflog::Always
             } else {
                 gix::refs::store::WriteReflog::Disable
             },
-            object_hash,
             precompose_unicode,
             prohibit_windows_device_names: cfg!(windows),
         },

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -160,11 +160,11 @@ impl Fixture {
         use gix_ref::store::WriteReflog;
 
         let object_hash = fixture_hash_kind();
-        let store = gix_ref::file::Store::at(
+        let store = gix_ref::file::Store::at_opts(
             worktree_path.join(".git"),
+            object_hash,
             gix_ref::store::init::Options {
                 write_reflog: WriteReflog::Disable,
-                object_hash,
                 ..Default::default()
             },
         );

--- a/gix-negotiate/tests/baseline/mod.rs
+++ b/gix-negotiate/tests/baseline/mod.rs
@@ -25,11 +25,11 @@ fn run() -> crate::Result {
             let buf = std::fs::read(base.join(format!("baseline.{algo_name}")))?;
             let object_hash = gix_testtools::object_hash();
             let store = gix_odb::at(base.join("client").join(".git/objects"), object_hash)?;
-            let refs = gix_ref::file::Store::at(
+            let refs = gix_ref::file::Store::at_opts(
                 base.join("client").join(".git"),
+                object_hash,
                 gix_ref::store::init::Options {
                     write_reflog: WriteReflog::Disable,
-                    object_hash,
                     ..Default::default()
                 },
             );

--- a/gix-ref/src/lib.rs
+++ b/gix-ref/src/lib.rs
@@ -62,8 +62,6 @@ pub mod store {
         pub struct Options {
             /// How to write the ref-log.
             pub write_reflog: super::WriteReflog,
-            /// The kind of hash to expect in
-            pub object_hash: gix_hash::Kind,
             /// The equivalent of `core.precomposeUnicode`.
             pub precompose_unicode: bool,
             /// If `true`, we will avoid reading from or writing to references that contains Windows device names

--- a/gix-ref/src/store/file/loose/mod.rs
+++ b/gix-ref/src/store/file/loose/mod.rs
@@ -32,7 +32,7 @@ mod init {
     impl file::Store {
         /// Create a new instance at the given `git_dir`, which commonly is a standard git repository with a
         /// `refs/` subdirectory.
-        /// Use [`at_opts()`](Self::at_opts) to adjust settings.
+        /// Use [`at_opts()`](Self::at_opts) to adjust options.
         ///
         /// Note that if [`precompose_unicode`](crate::store::init::Options::precompose_unicode) is set in the options,
         /// the `git_dir` is also expected to use precomposed unicode, or else some operations that strip prefixes will fail.
@@ -70,7 +70,7 @@ mod init {
 
         /// Like [`at()`][file::Store::at()], but for _linked_ work-trees which use `git_dir` as private ref store and `common_dir` for
         /// shared references.
-        /// Use [`for_linked_worktree_opts()`](Self::for_linked_worktree_opts) to adjust settings.
+        /// Use [`for_linked_worktree_opts()`](Self::for_linked_worktree_opts) to adjust options.
         ///
         /// Note that if [`precompose_unicode`](crate::store::init::Options::precompose_unicode) is set, the `git_dir` and
         /// `common_dir` are also expected to use precomposed unicode, or else some operations that strip prefixes will fail.

--- a/gix-ref/src/store/file/loose/mod.rs
+++ b/gix-ref/src/store/file/loose/mod.rs
@@ -32,15 +32,25 @@ mod init {
     impl file::Store {
         /// Create a new instance at the given `git_dir`, which commonly is a standard git repository with a
         /// `refs/` subdirectory.
+        /// Use [`at_opts()`](Self::at_opts) to adjust settings.
+        ///
+        /// Note that if [`precompose_unicode`](crate::store::init::Options::precompose_unicode) is set in the options,
+        /// the `git_dir` is also expected to use precomposed unicode, or else some operations that strip prefixes will fail.
+        pub fn at(git_dir: PathBuf, object_hash: gix_hash::Kind) -> Self {
+            Self::at_opts(git_dir, object_hash, Default::default())
+        }
+
+        /// Create a new instance at the given `git_dir`, which commonly is a standard git repository with a
+        /// `refs/` subdirectory.
         /// Use [`Options`](crate::store::init::Options) to adjust settings.
         ///
         /// Note that if [`precompose_unicode`](crate::store::init::Options::precompose_unicode) is set in the options,
         /// the `git_dir` is also expected to use precomposed unicode, or else some operations that strip prefixes will fail.
-        pub fn at(
+        pub fn at_opts(
             git_dir: PathBuf,
+            object_hash: gix_hash::Kind,
             crate::store::init::Options {
                 write_reflog,
-                object_hash,
                 precompose_unicode,
                 prohibit_windows_device_names,
             }: crate::store::init::Options,
@@ -60,15 +70,25 @@ mod init {
 
         /// Like [`at()`][file::Store::at()], but for _linked_ work-trees which use `git_dir` as private ref store and `common_dir` for
         /// shared references.
+        /// Use [`for_linked_worktree_opts()`](Self::for_linked_worktree_opts) to adjust settings.
         ///
         /// Note that if [`precompose_unicode`](crate::store::init::Options::precompose_unicode) is set, the `git_dir` and
         /// `common_dir` are also expected to use precomposed unicode, or else some operations that strip prefixes will fail.
-        pub fn for_linked_worktree(
+        pub fn for_linked_worktree(git_dir: PathBuf, common_dir: PathBuf, object_hash: gix_hash::Kind) -> Self {
+            Self::for_linked_worktree_opts(git_dir, common_dir, object_hash, Default::default())
+        }
+
+        /// Like [`at_opts()`][Self::at_opts()], but for _linked_ work-trees which use `git_dir` as private ref store and `common_dir` for
+        /// shared references.
+        ///
+        /// Note that if [`precompose_unicode`](crate::store::init::Options::precompose_unicode) is set, the `git_dir` and
+        /// `common_dir` are also expected to use precomposed unicode, or else some operations that strip prefixes will fail.
+        pub fn for_linked_worktree_opts(
             git_dir: PathBuf,
             common_dir: PathBuf,
+            object_hash: gix_hash::Kind,
             crate::store::init::Options {
                 write_reflog,
-                object_hash,
                 precompose_unicode,
                 prohibit_windows_device_names,
             }: crate::store::init::Options,

--- a/gix-ref/src/store/file/loose/reflog/create_or_update/tests.rs
+++ b/gix-ref/src/store/file/loose/reflog/create_or_update/tests.rs
@@ -40,11 +40,11 @@ fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
 
 fn empty_store(writemode: WriteReflog) -> Result<(TempDir, file::Store)> {
     let dir = TempDir::new()?;
-    let store = file::Store::at(
+    let store = file::Store::at_opts(
         dir.path().into(),
+        gix_testtools::object_hash(),
         crate::store::init::Options {
             write_reflog: writemode,
-            object_hash: gix_testtools::object_hash(),
             ..Default::default()
         },
     );

--- a/gix-ref/src/store/general/init.rs
+++ b/gix-ref/src/store/general/init.rs
@@ -19,7 +19,7 @@ use crate::file;
 )]
 impl crate::Store {
     /// Create a new store at the given location, typically the `.git/` directory.
-    /// Use [`at_opts()`](Self::at_opts) to adjust settings.
+    /// Use [`at_opts()`](Self::at_opts) to adjust options.
     ///
     /// Note that if [`precompose_unicode`](crate::store::init::Options::precompose_unicode) is set in the options,
     /// the `git_dir` is also expected to use precomposed unicode, or else some operations that strip prefixes will fail.

--- a/gix-ref/src/store/general/init.rs
+++ b/gix-ref/src/store/general/init.rs
@@ -19,16 +19,29 @@ use crate::file;
 )]
 impl crate::Store {
     /// Create a new store at the given location, typically the `.git/` directory.
+    /// Use [`at_opts()`](Self::at_opts) to adjust settings.
+    ///
+    /// Note that if [`precompose_unicode`](crate::store::init::Options::precompose_unicode) is set in the options,
+    /// the `git_dir` is also expected to use precomposed unicode, or else some operations that strip prefixes will fail.
+    pub fn at(git_dir: PathBuf, object_hash: gix_hash::Kind) -> Result<Self, Error> {
+        Self::at_opts(git_dir, object_hash, Default::default())
+    }
+
+    /// Create a new store at the given location, typically the `.git/` directory.
     /// Use [`opts`](crate::store::init::Options) to adjust settings.
     ///
     /// Note that if [`precompose_unicode`](crate::store::init::Options::precompose_unicode) is set in the options,
     /// the `git_dir` is also expected to use precomposed unicode, or else some operations that strip prefixes will fail.
-    pub fn at(git_dir: PathBuf, opts: crate::store::init::Options) -> Result<Self, Error> {
+    pub fn at_opts(
+        git_dir: PathBuf,
+        object_hash: gix_hash::Kind,
+        opts: crate::store::init::Options,
+    ) -> Result<Self, Error> {
         // for now, just try to read the directory - later we will do that naturally as we have to figure out if it's a ref-table or not.
         std::fs::read_dir(&git_dir)?;
         Ok(crate::Store {
             inner: crate::store::State::Loose {
-                store: file::Store::at(git_dir, opts),
+                store: file::Store::at_opts(git_dir, object_hash, opts),
             },
         })
     }

--- a/gix-ref/tests/refs/file/mod.rs
+++ b/gix-ref/tests/refs/file/mod.rs
@@ -19,25 +19,18 @@ pub fn store_at(name: &str) -> crate::Result<Store> {
 
 pub fn named_store_at(script_name: &str, name: &str) -> crate::Result<Store> {
     let path = crate::scripted_fixture_read_only(script_name)?;
-    Ok(Store::at(path.join(name).join(".git"), store_options()))
+    Ok(Store::at(path.join(name).join(".git"), crate::fixture_hash_kind()))
 }
 
 pub fn store_at_with_args(name: &str, args: impl IntoIterator<Item = impl Into<String>>) -> crate::Result<Store> {
     let path = crate::scripted_fixture_read_only_with_args(name, args)?;
-    Ok(Store::at(path.join(".git"), store_options()))
+    Ok(Store::at(path.join(".git"), crate::fixture_hash_kind()))
 }
 
 fn store_writable(name: &str) -> crate::Result<(gix_testtools::tempfile::TempDir, Store)> {
     let dir = crate::scripted_fixture_writable(name)?;
     let git_dir = dir.path().join(".git");
-    Ok((dir, Store::at(git_dir, store_options())))
-}
-
-pub fn store_options() -> gix_ref::store::init::Options {
-    gix_ref::store::init::Options {
-        object_hash: crate::fixture_hash_kind(),
-        ..Default::default()
-    }
+    Ok((dir, Store::at(git_dir, crate::fixture_hash_kind())))
 }
 
 pub fn odb_at(objects_dir: impl Into<std::path::PathBuf>) -> std::io::Result<gix_odb::Handle> {

--- a/gix-ref/tests/refs/file/store/mod.rs
+++ b/gix-ref/tests/refs/file/store/mod.rs
@@ -25,11 +25,11 @@ fn precompose_unicode_journey() -> crate::Result {
     let root = tmp.path().join(decomposed_a);
     std::fs::create_dir(&root)?;
 
-    let store_decomposed = gix_ref::file::Store::at(
+    let store_decomposed = gix_ref::file::Store::at_opts(
         root,
+        crate::fixture_hash_kind(),
         gix_ref::store::init::Options {
             write_reflog: WriteReflog::Always,
-            object_hash: crate::fixture_hash_kind(),
             precompose_unicode: false,
             ..Default::default()
         },
@@ -54,11 +54,11 @@ fn precompose_unicode_journey() -> crate::Result {
         return Ok(());
     }
 
-    let store_precomposed = gix_ref::file::Store::at(
+    let store_precomposed = gix_ref::file::Store::at_opts(
         tmp.path().join(precomposed_a), // it's important that root paths are also precomposed then.
+        crate::fixture_hash_kind(),
         gix_ref::store::init::Options {
             write_reflog: WriteReflog::Always,
-            object_hash: crate::fixture_hash_kind(),
             precompose_unicode: true,
             ..Default::default()
         },

--- a/gix-ref/tests/refs/file/store/reflog.rs
+++ b/gix-ref/tests/refs/file/store/reflog.rs
@@ -1,9 +1,9 @@
 fn store() -> crate::Result<crate::file::Store> {
-    Ok(crate::file::Store::at(
+    Ok(crate::file::Store::at_opts(
         crate::scripted_fixture_read_only("make_repo_for_reflog.sh")?.join(".git"),
+        crate::fixture_hash_kind(),
         gix_ref::store::init::Options {
             write_reflog: gix_ref::store::WriteReflog::Disable,
-            object_hash: crate::fixture_hash_kind(),
             ..Default::default()
         },
     ))

--- a/gix-ref/tests/refs/file/transaction/mod.rs
+++ b/gix-ref/tests/refs/file/transaction/mod.rs
@@ -20,7 +20,7 @@ pub(crate) mod prepare_and_commit {
 
     pub(crate) fn empty_store() -> crate::Result<(gix_testtools::tempfile::TempDir, file::Store)> {
         let dir = gix_testtools::tempfile::TempDir::new().unwrap();
-        let store = file::Store::at(dir.path().into(), crate::file::store_options());
+        let store = file::Store::at(dir.path().into(), crate::fixture_hash_kind());
         Ok((dir, store))
     }
 

--- a/gix-ref/tests/refs/file/worktree.rs
+++ b/gix-ref/tests/refs/file/worktree.rs
@@ -29,7 +29,7 @@ fn main_store(
     let (dir, tmp) = dir(packed, writable)?;
     let git_dir = dir.join("repo").join(".git");
     Ok((
-        gix_ref::file::Store::at(git_dir.clone(), crate::file::store_options()),
+        gix_ref::file::Store::at(git_dir.clone(), crate::fixture_hash_kind()),
         crate::file::odb_at(git_dir.join("objects"))?,
         tmp,
     ))
@@ -50,7 +50,7 @@ fn worktree_store(
         .into_repository_and_work_tree_directories();
     let common_dir = git_dir.join("../..");
     Ok((
-        gix_ref::file::Store::for_linked_worktree(git_dir, common_dir.clone(), crate::file::store_options()),
+        gix_ref::file::Store::for_linked_worktree(git_dir, common_dir.clone(), crate::fixture_hash_kind()),
         crate::file::odb_at(common_dir.join("objects"))?,
         tmp,
     ))

--- a/gix-ref/tests/refs/store.rs
+++ b/gix-ref/tests/refs/store.rs
@@ -3,11 +3,11 @@
 fn is_send_and_sync() {
     pub fn store_at(name: &str) -> crate::Result<gix_ref::file::Store> {
         let path = crate::scripted_fixture_read_only(name)?;
-        Ok(gix_ref::file::Store::at(
+        Ok(gix_ref::file::Store::at_opts(
             path.join(".git"),
+            crate::fixture_hash_kind(),
             gix_ref::store::init::Options {
                 write_reflog: gix_ref::store::WriteReflog::Normal,
-                object_hash: crate::fixture_hash_kind(),
                 ..Default::default()
             },
         ))

--- a/gix-ref/tests/transaction_fd_limit.rs
+++ b/gix-ref/tests/transaction_fd_limit.rs
@@ -19,13 +19,7 @@ fn large_transactions_hold_a_constant_number_of_file_descriptors() -> gix_testto
 
     let dir = gix_testtools::tempfile::TempDir::new()?;
     let object_hash = gix_testtools::object_hash();
-    let store = file::Store::at(
-        dir.path().into(),
-        gix_ref::store::init::Options {
-            object_hash,
-            ..Default::default()
-        },
-    );
+    let store = file::Store::at(dir.path().into(), object_hash);
     let edits = (0..20).map(|i| RefEdit {
         change: Change::Update {
             log: LogChange {

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -226,15 +226,17 @@ impl ThreadSafeRepository {
             let object_hash = repo_config.object_hash;
             let ref_store_init_opts = gix_ref::store::init::Options {
                 write_reflog: reflog,
-                object_hash,
                 precompose_unicode: repo_config.precompose_unicode,
                 prohibit_windows_device_names: repo_config.protect_windows,
             };
             match &common_dir {
-                Some(common_dir) => {
-                    crate::RefStore::for_linked_worktree(git_dir.to_owned(), common_dir.into(), ref_store_init_opts)
-                }
-                None => crate::RefStore::at(git_dir.to_owned(), ref_store_init_opts),
+                Some(common_dir) => crate::RefStore::for_linked_worktree_opts(
+                    git_dir.to_owned(),
+                    common_dir.into(),
+                    object_hash,
+                    ref_store_init_opts,
+                ),
+                None => crate::RefStore::at_opts(git_dir.to_owned(), object_hash, ref_store_init_opts),
             }
         };
         let head = refs.find("HEAD").ok();


### PR DESCRIPTION
- Split `gix_ref::file::Store::at` into `at` and `at_opts`.
- Split `gix_ref::file::Store::for_linked_worktree` as well.
- Split `gix_ref::Store::at` as well.

This PR continues work done in #2901 for `gix-odb` where `gix_odb::at` was split into `gix_odb::at` and `gix_odb::at_opts` while `object_hash` was removed from `gix_odb::store::init::Options` and #2916 where the same change was done for `gix_ref::file::Store::at`.

This forces callers to explicitly choose a hash, eliminating the risk that `Sha1` is implicitly chosen for them in SHA-1/SHA-256 builds through `Default::default()` without them being aware of it or noticing. This comes at the cost of callers having to always pass the hash, but that seems like a reasonable trade-off.