### PR TITLE
fix: terminate lock error parent traversal

### DIFF
--- a/gix-ref/src/store/file/transaction/prepare.rs
+++ b/gix-ref/src/store/file/transaction/prepare.rs
@@ -400,11 +400,8 @@ impl Transaction<'_, '_> {
                             let mut ref_name = change.name();
                             while let Some(parent_idx) = cursor {
                                 let parent = &updates[parent_idx];
-                                if parent.parent_index.is_none() {
-                                    ref_name = parent.name();
-                                } else {
-                                    cursor = parent.parent_index;
-                                }
+                                ref_name = parent.name();
+                                cursor = parent.parent_index;
                             }
                             ref_name
                         },

--- a/gix-ref/tests/refs/file/transaction/prepare_and_commit/create_or_update/mod.rs
+++ b/gix-ref/tests/refs/file/transaction/prepare_and_commit/create_or_update/mod.rs
@@ -544,6 +544,37 @@ fn windows_device_name_check_runs_before_lock_acquisition() -> crate::Result {
 }
 
 #[test]
+fn lock_failure_on_symbolic_referent_is_reported_for_the_symbolic_ref() -> crate::Result {
+    let (keep, store) = empty_store()?;
+    std::fs::write(keep.path().join("HEAD"), b"ref: refs/heads/main\n")?;
+    std::fs::create_dir_all(keep.path().join("refs/heads"))?;
+    std::fs::write(keep.path().join("refs/heads/main.lock"), b"")?;
+
+    let err = store
+        .transaction()
+        .prepare(
+            Some(RefEdit {
+                change: Change::Update {
+                    log: LogChange::default(),
+                    new: Target::Object(hex_to_id("28ce6a8b26aa170e1de65536fe8abe1832bd3242")),
+                    expected: PreviousValue::Any,
+                },
+                name: "HEAD".try_into()?,
+                deref: true,
+            }),
+            Fail::Immediately,
+            Fail::Immediately,
+        )
+        .unwrap_err();
+
+    assert!(
+        matches!(err, transaction::prepare::Error::LockAcquire { full_name, .. } if full_name == "HEAD"),
+        "the lock error should name the symbolic ref that initiated the dereferenced update"
+    );
+    Ok(())
+}
+
+#[test]
 fn symbolic_head_missing_referent_then_update_referent() -> crate::Result {
     for reflog_writemode in &[WriteReflog::Normal, WriteReflog::Disable, WriteReflog::Always] {
         let (_keep, mut store) = empty_store()?;


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #2920

## Summary

- terminate parent traversal when relabeling a dereferenced ref's lock acquisition error
- preserve the initiating symbolic ref name in the returned error
- cover a locked `refs/heads/main` reached through symbolic `HEAD`

## Git baseline

Git 2.55.0.dirty's files backend returns lock acquisition errors for symbolic references instead of spinning. Related behavior is covered in `t/t0600-reffiles-backend.sh`.

## Validation

- `cargo test -p gix-ref`
- `cargo clippy -p gix-ref --tests -- -D warnings`
- `git diff --check`
- `codex review --commit d918e67bb1` (no findings)

## Commit

- `d918e67bb1 fix: terminate lock error parent traversal (#2920)`
