### PR TITLE
gix config refresh and writing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,6 +2557,7 @@ dependencies = [
  "signal-hook 0.4.4",
  "signal-hook-registry",
  "tempfile",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/gix-fs/src/lib.rs
+++ b/gix-fs/src/lib.rs
@@ -116,6 +116,49 @@ pub fn current_dir(precompose_unicode: bool) -> std::io::Result<PathBuf> {
     })
 }
 
+/// Adjust `permissions` according to Git's shared-repository permission policy.
+///
+/// `permissions` should normally be the permissions of a newly created file, read back after the operating system has
+/// applied the process umask. Apply this function before the file is made visible at its final path. Existing permission
+/// bits not governed by the policy are preserved.
+///
+/// `shared_repository_permissions` uses Git's compact signed encoding and usually comes from parsing the effective
+/// `core.sharedRepository` configuration value:
+///
+/// - `0` leaves the permissions produced by the umask unchanged. An absent key, `umask`, boolean `false`, and legacy
+///   value `0` produce this.
+/// - A positive mode is ORed into the post-umask mode. A bare key, `group`, boolean `true`, and legacy value `1` usually
+///   produce `0o660`; `all`, `world`, `everybody`, and legacy value `2` usually produce `0o664`.
+/// - A negative mode replaces the low nine Unix permission bits with its absolute value. Git-compatible parsers use this
+///   for explicit octal configuration such as `0640`, represented here as `-0o640`, so it can remove bits allowed by the
+///   umask instead of merely adding bits.
+///
+/// Callers must pass the parsed encoding, not an explicit octal configuration value directly. On non-Unix platforms the
+/// shared-repository mode has no portable representation in [`std::fs::Permissions`], so this function returns
+/// `permissions` unchanged.
+pub fn adjust_shared_repository_permissions(
+    permissions: std::fs::Permissions,
+    shared_repository_permissions: i32,
+) -> std::fs::Permissions {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = permissions;
+        let mode = permissions.mode();
+        permissions.set_mode(if shared_repository_permissions < 0 {
+            (mode & !0o777) | (-shared_repository_permissions) as u32
+        } else {
+            mode | shared_repository_permissions as u32
+        });
+        permissions
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = shared_repository_permissions;
+        permissions
+    }
+}
+
 /// A stack of path components with the delegation of side-effects as the currently set path changes, component by component.
 #[derive(Clone)]
 pub struct Stack {

--- a/gix-fs/tests/fs/main.rs
+++ b/gix-fs/tests/fs/main.rs
@@ -5,3 +5,24 @@ mod dir;
 mod read_dir;
 mod snapshot;
 mod stack;
+
+#[test]
+#[cfg(unix)]
+fn shared_repository_permissions_are_applied_after_the_umask() {
+    use std::os::unix::fs::PermissionsExt;
+    let adjust = |mode, shared_repository_permissions| {
+        gix_fs::adjust_shared_repository_permissions(
+            std::fs::Permissions::from_mode(mode),
+            shared_repository_permissions,
+        )
+        .mode()
+    };
+
+    assert_eq!(adjust(0o640, 0), 0o640, "zero retains the post-umask mode");
+    assert_eq!(adjust(0o600, 0o660), 0o660, "a positive mode adds permissions");
+    assert_eq!(
+        adjust(0o1755, -0o640),
+        0o1640,
+        "a negative mode replaces permission bits but retains unrelated mode bits"
+    );
+}

--- a/gix-lock/src/acquire.rs
+++ b/gix-lock/src/acquire.rs
@@ -75,17 +75,7 @@ impl File {
         mode: Fail,
         boundary_directory: Option<PathBuf>,
     ) -> Result<File, Error> {
-        let (lock_path, handle) = lock_with_mode(at_path.as_ref(), mode, boundary_directory, &|p, d, c| {
-            if let Some(permissions) = default_permissions() {
-                gix_tempfile::writable_at_with_permissions(p, d, c, permissions)
-            } else {
-                gix_tempfile::writable_at(p, d, c)
-            }
-        })?;
-        Ok(File {
-            inner: handle,
-            lock_path,
-        })
+        Self::acquire_to_update_resource_inner(at_path.as_ref(), mode, boundary_directory, &keep_resource)
     }
 
     /// Like [`acquire_to_update_resource()`](File::acquire_to_update_resource), but allows to set filesystem permissions using `make_permissions`.
@@ -95,12 +85,64 @@ impl File {
         boundary_directory: Option<PathBuf>,
         make_permissions: impl Fn() -> std::fs::Permissions,
     ) -> Result<File, Error> {
-        let (lock_path, handle) = lock_with_mode(at_path.as_ref(), mode, boundary_directory, &|p, d, c| {
-            gix_tempfile::writable_at_with_permissions(p, d, c, make_permissions())
-        })?;
+        let (resource_path, lock_path, handle) = lock_with_mode(
+            at_path.as_ref(),
+            mode,
+            boundary_directory,
+            &keep_resource,
+            &|p, d, c| gix_tempfile::writable_at_with_permissions(p, d, c, make_permissions()),
+        )?;
         Ok(File {
             inner: handle,
             lock_path,
+            resource_path,
+        })
+    }
+
+    /// Like [`acquire_to_update_resource()`](File::acquire_to_update_resource), but follows symlinks at `at_path`
+    /// before creating the lock file, matching Git's default lock-file behavior.
+    pub fn acquire_to_update_resource_following_symlinks(
+        at_path: impl AsRef<Path>,
+        mode: Fail,
+        boundary_directory: Option<PathBuf>,
+    ) -> Result<File, Error> {
+        Self::acquire_to_update_resource_inner(at_path.as_ref(), mode, boundary_directory, &resolve_symlink)
+    }
+
+    /// Like [`acquire_to_update_resource_following_symlinks()`](File::acquire_to_update_resource_following_symlinks),
+    /// but adjusts the permissions that remain after applying the process umask.
+    pub fn acquire_to_update_resource_following_symlinks_with_permissions(
+        at_path: impl AsRef<Path>,
+        mode: Fail,
+        boundary_directory: Option<PathBuf>,
+        adjust_permissions: impl Fn(std::fs::Permissions) -> std::fs::Permissions,
+    ) -> Result<File, Error> {
+        let mut lock = Self::acquire_to_update_resource_following_symlinks(at_path, mode, boundary_directory)?;
+        lock.with_mut(|file| {
+            let permissions = adjust_permissions(file.metadata()?.permissions());
+            file.set_permissions(permissions)
+        })?;
+        Ok(lock)
+    }
+
+    fn acquire_to_update_resource_inner(
+        at_path: &Path,
+        mode: Fail,
+        boundary_directory: Option<PathBuf>,
+        resolve_resource: &dyn Fn(&Path) -> PathBuf,
+    ) -> Result<File, Error> {
+        let (resource_path, lock_path, handle) =
+            lock_with_mode(at_path, mode, boundary_directory, resolve_resource, &|p, d, c| {
+                if let Some(permissions) = default_permissions() {
+                    gix_tempfile::writable_at_with_permissions(p, d, c, permissions)
+                } else {
+                    gix_tempfile::writable_at(p, d, c)
+                }
+            })?;
+        Ok(File {
+            inner: handle,
+            lock_path,
+            resource_path,
         })
     }
 }
@@ -124,17 +166,24 @@ impl Marker {
         mode: Fail,
         boundary_directory: Option<PathBuf>,
     ) -> Result<Marker, Error> {
-        let (lock_path, handle) = lock_with_mode(at_path.as_ref(), mode, boundary_directory, &|p, d, c| {
-            if let Some(permissions) = default_permissions() {
-                gix_tempfile::mark_at_with_permissions(p, d, c, permissions)
-            } else {
-                gix_tempfile::mark_at(p, d, c)
-            }
-        })?;
+        let (resource_path, lock_path, handle) = lock_with_mode(
+            at_path.as_ref(),
+            mode,
+            boundary_directory,
+            &keep_resource,
+            &|p, d, c| {
+                if let Some(permissions) = default_permissions() {
+                    gix_tempfile::mark_at_with_permissions(p, d, c, permissions)
+                } else {
+                    gix_tempfile::mark_at(p, d, c)
+                }
+            },
+        )?;
         Ok(Marker {
             created_from_file: false,
             inner: handle,
             lock_path,
+            resource_path,
         })
     }
 
@@ -145,13 +194,18 @@ impl Marker {
         boundary_directory: Option<PathBuf>,
         make_permissions: impl Fn() -> std::fs::Permissions,
     ) -> Result<Marker, Error> {
-        let (lock_path, handle) = lock_with_mode(at_path.as_ref(), mode, boundary_directory, &|p, d, c| {
-            gix_tempfile::mark_at_with_permissions(p, d, c, make_permissions())
-        })?;
+        let (resource_path, lock_path, handle) = lock_with_mode(
+            at_path.as_ref(),
+            mode,
+            boundary_directory,
+            &keep_resource,
+            &|p, d, c| gix_tempfile::mark_at_with_permissions(p, d, c, make_permissions()),
+        )?;
         Ok(Marker {
             created_from_file: false,
             inner: handle,
             lock_path,
+            resource_path,
         })
     }
 }
@@ -166,43 +220,69 @@ fn dir_cleanup(boundary: Option<PathBuf>) -> (ContainingDirectory, AutoRemove) {
     }
 }
 
+fn resolve_symlink(path: &Path) -> PathBuf {
+    let mut path = path.to_owned();
+    for _ in 0..5 {
+        let Ok(destination) = std::fs::read_link(&path) else {
+            break;
+        };
+        path = if destination.is_absolute() {
+            destination
+        } else {
+            path.parent().unwrap_or_else(|| Path::new("")).join(destination)
+        };
+    }
+    path
+}
+
+fn keep_resource(path: &Path) -> PathBuf {
+    path.to_owned()
+}
+
 fn lock_with_mode<T>(
     resource: &Path,
     mode: Fail,
     boundary_directory: Option<PathBuf>,
+    resolve_resource: &dyn Fn(&Path) -> PathBuf,
     try_lock: &dyn Fn(&Path, ContainingDirectory, AutoRemove) -> std::io::Result<T>,
-) -> Result<(PathBuf, T), Error> {
+) -> Result<(PathBuf, PathBuf, T), Error> {
     use std::io::ErrorKind::*;
     let (directory, cleanup) = dir_cleanup(boundary_directory);
-    let lock_path = add_lock_suffix(resource);
+    let try_once = |cleanup| {
+        let resource_path = resolve_resource(resource);
+        let lock_path = add_lock_suffix(&resource_path);
+        match try_lock(&lock_path, directory, cleanup) {
+            Ok(value) => Ok((resource_path, lock_path, value)),
+            Err(err) => Err((err, resource_path)),
+        }
+    };
     let mut attempts = 1;
     match mode {
-        Fail::Immediately => try_lock(&lock_path, directory, cleanup),
+        Fail::Immediately => try_once(cleanup),
         Fail::AfterDurationWithBackoff(time) => {
             for wait in backoff::Quadratic::default_with_random().until_no_remaining(time) {
                 attempts += 1;
-                match try_lock(&lock_path, directory, cleanup.clone()) {
-                    Ok(v) => return Ok((lock_path, v)),
+                match try_once(cleanup.clone()) {
+                    Ok(value) => return Ok(value),
                     #[cfg(windows)]
-                    Err(err) if err.kind() == AlreadyExists || err.kind() == PermissionDenied => {
+                    Err((err, _)) if err.kind() == AlreadyExists || err.kind() == PermissionDenied => {
                         std::thread::sleep(wait);
                         continue;
                     }
                     #[cfg(not(windows))]
-                    Err(err) if err.kind() == AlreadyExists => {
+                    Err((err, _)) if err.kind() == AlreadyExists => {
                         std::thread::sleep(wait);
                         continue;
                     }
-                    Err(err) => return Err(Error::from(err)),
+                    Err((err, _)) => return Err(Error::from(err)),
                 }
             }
-            try_lock(&lock_path, directory, cleanup)
+            try_once(cleanup)
         }
     }
-    .map(|v| (lock_path, v))
-    .map_err(|err| match err.kind() {
+    .map_err(|(err, resource_path)| match err.kind() {
         AlreadyExists => Error::PermanentlyLocked {
-            resource_path: resource.into(),
+            resource_path,
             mode,
             attempts,
         },
@@ -211,10 +291,9 @@ fn lock_with_mode<T>(
 }
 
 fn add_lock_suffix(resource_path: &Path) -> PathBuf {
-    resource_path.with_extension(resource_path.extension().map_or_else(
-        || DOT_LOCK_SUFFIX.chars().skip(1).collect(),
-        |ext| format!("{}{}", ext.to_string_lossy(), DOT_LOCK_SUFFIX),
-    ))
+    let mut lock_path = resource_path.as_os_str().to_owned();
+    lock_path.push(DOT_LOCK_SUFFIX);
+    lock_path.into()
 }
 
 fn default_permissions() -> Option<std::fs::Permissions> {
@@ -241,5 +320,42 @@ mod tests {
     #[test]
     fn add_lock_suffix_to_file_without_extension() {
         assert_eq!(add_lock_suffix(Path::new("hello")), Path::new("hello.lock"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn add_lock_suffix_preserves_non_utf8_bytes() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let path = Path::new(std::ffi::OsStr::from_bytes(b"hello.\xff"));
+        assert_eq!(add_lock_suffix(path).as_os_str().as_bytes(), b"hello.\xff.lock");
+    }
+
+    #[test]
+    fn resource_is_resolved_on_each_lock_attempt() {
+        let resolutions = std::cell::Cell::new(0);
+        let resolve = |_: &Path| {
+            let current = resolutions.get();
+            resolutions.set(current + 1);
+            PathBuf::from(if current == 0 { "first" } else { "second" })
+        };
+        let (resource_path, lock_path, ()) = lock_with_mode(
+            Path::new("link"),
+            Fail::AfterDurationWithBackoff(Duration::ZERO),
+            None,
+            &resolve,
+            &|path, _, _| {
+                if path == Path::new("first.lock") {
+                    Err(std::io::ErrorKind::AlreadyExists.into())
+                } else {
+                    Ok(())
+                }
+            },
+        )
+        .expect("the second target can be locked");
+
+        assert_eq!(resolutions.get(), 2, "the resource is resolved before every attempt");
+        assert_eq!(resource_path, Path::new("second"), "the locked target is retained");
+        assert_eq!(lock_path, Path::new("second.lock"), "the lock follows that target");
     }
 }

--- a/gix-lock/src/acquire.rs
+++ b/gix-lock/src/acquire.rs
@@ -63,6 +63,14 @@ impl File {
     /// If `boundary_directory` is given, non-existing directories will be created automatically and removed in the case of
     /// a rollback. Otherwise the containing directory is expected to exist, even though the resource doesn't have to.
     ///
+    /// If `resolve_resource` is set, it is called before each lock attempt and its returned path becomes both the lock
+    /// target and the eventual commit target. With `None`, `at_path` is used unchanged. [`resolve_symlink()`] provides the
+    /// resolver used by Git-style callers that must update a symlink's target instead of replacing the link itself.
+    ///
+    /// If `adjust_permissions` is set, it receives the newly created lock file's permissions after the process umask was
+    /// applied. The returned permissions are set on the lock file and ultimately reach the committed resource. With
+    /// `None`, no permission metadata is read or rewritten.
+    ///
     /// Note that permissions will be set to `0o666`, which usually results in `0o644` after passing a default umask, on Unix systems.
     ///
     /// ### Warning of potential resource leak
@@ -70,12 +78,48 @@ impl File {
     /// Please note that the underlying file will remain if destructors don't run, as is the case when interrupting the application.
     /// This results in the resource being locked permanently unless the lock file is removed by other means.
     /// See [the crate documentation](crate) for more information.
+    pub fn acquire(
+        at_path: impl AsRef<Path>,
+        mode: Fail,
+        boundary_directory: Option<PathBuf>,
+        resolve_resource: Option<&dyn Fn(&Path) -> PathBuf>,
+        adjust_permissions: Option<&dyn Fn(std::fs::Permissions) -> std::fs::Permissions>,
+    ) -> Result<File, Error> {
+        let resolve_resource = resolve_resource.unwrap_or(&keep_resource);
+        let (resource_path, lock_path, handle) = lock_with_mode(
+            at_path.as_ref(),
+            mode,
+            boundary_directory,
+            resolve_resource,
+            &|p, d, c| {
+                if let Some(permissions) = default_permissions() {
+                    gix_tempfile::writable_at_with_permissions(p, d, c, permissions)
+                } else {
+                    gix_tempfile::writable_at(p, d, c)
+                }
+            },
+        )?;
+        let mut lock = File {
+            inner: handle,
+            lock_path,
+            resource_path,
+        };
+        if let Some(adjust_permissions) = adjust_permissions {
+            lock.with_mut(|file| {
+                let permissions = adjust_permissions(file.metadata()?.permissions());
+                file.set_permissions(permissions)
+            })?;
+        }
+        Ok(lock)
+    }
+
+    /// Like [`acquire()`](Self::acquire) without resolving the resource or adjusting the post-umask permissions.
     pub fn acquire_to_update_resource(
         at_path: impl AsRef<Path>,
         mode: Fail,
         boundary_directory: Option<PathBuf>,
     ) -> Result<File, Error> {
-        Self::acquire_to_update_resource_inner(at_path.as_ref(), mode, boundary_directory, &keep_resource)
+        Self::acquire(at_path, mode, boundary_directory, None, None)
     }
 
     /// Like [`acquire_to_update_resource()`](File::acquire_to_update_resource), but allows to set filesystem permissions using `make_permissions`.
@@ -106,7 +150,7 @@ impl File {
         mode: Fail,
         boundary_directory: Option<PathBuf>,
     ) -> Result<File, Error> {
-        Self::acquire_to_update_resource_inner(at_path.as_ref(), mode, boundary_directory, &resolve_symlink)
+        Self::acquire(at_path, mode, boundary_directory, Some(&resolve_symlink), None)
     }
 
     /// Like [`acquire_to_update_resource_following_symlinks()`](File::acquire_to_update_resource_following_symlinks),
@@ -117,33 +161,13 @@ impl File {
         boundary_directory: Option<PathBuf>,
         adjust_permissions: impl Fn(std::fs::Permissions) -> std::fs::Permissions,
     ) -> Result<File, Error> {
-        let mut lock = Self::acquire_to_update_resource_following_symlinks(at_path, mode, boundary_directory)?;
-        lock.with_mut(|file| {
-            let permissions = adjust_permissions(file.metadata()?.permissions());
-            file.set_permissions(permissions)
-        })?;
-        Ok(lock)
-    }
-
-    fn acquire_to_update_resource_inner(
-        at_path: &Path,
-        mode: Fail,
-        boundary_directory: Option<PathBuf>,
-        resolve_resource: &dyn Fn(&Path) -> PathBuf,
-    ) -> Result<File, Error> {
-        let (resource_path, lock_path, handle) =
-            lock_with_mode(at_path, mode, boundary_directory, resolve_resource, &|p, d, c| {
-                if let Some(permissions) = default_permissions() {
-                    gix_tempfile::writable_at_with_permissions(p, d, c, permissions)
-                } else {
-                    gix_tempfile::writable_at(p, d, c)
-                }
-            })?;
-        Ok(File {
-            inner: handle,
-            lock_path,
-            resource_path,
-        })
+        Self::acquire(
+            at_path,
+            mode,
+            boundary_directory,
+            Some(&resolve_symlink),
+            Some(&adjust_permissions),
+        )
     }
 }
 
@@ -220,7 +244,11 @@ fn dir_cleanup(boundary: Option<PathBuf>) -> (ContainingDirectory, AutoRemove) {
     }
 }
 
-fn resolve_symlink(path: &Path) -> PathBuf {
+/// Resolve up to five consecutive symbolic links at `path`, returning the last target reached.
+///
+/// Relative link targets are resolved against the directory containing their link. If `path` isn't a symbolic link, or
+/// if a link can't be read, the current path is returned unchanged.
+pub fn resolve_symlink(path: &Path) -> PathBuf {
     let mut path = path.to_owned();
     for _ in 0..5 {
         let Ok(destination) = std::fs::read_link(&path) else {

--- a/gix-lock/src/file.rs
+++ b/gix-lock/src/file.rs
@@ -1,15 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::{DOT_LOCK_SUFFIX, File, Marker};
-
-fn strip_lock_suffix(lock_path: &Path) -> PathBuf {
-    let ext = lock_path
-        .extension()
-        .expect("at least our own extension")
-        .to_str()
-        .expect("no illegal UTF8 in extension");
-    lock_path.with_extension(ext.split_at(ext.len().saturating_sub(DOT_LOCK_SUFFIX.len())).0)
-}
+use crate::{File, Marker};
 
 impl File {
     /// Obtain a mutable reference to the write handle and call `f(out)` with it.
@@ -23,6 +14,7 @@ impl File {
             inner: self.inner.close()?,
             created_from_file: true,
             lock_path: self.lock_path,
+            resource_path: self.resource_path,
         })
     }
 
@@ -33,7 +25,7 @@ impl File {
 
     /// Return the path at which the locked resource resides
     pub fn resource_path(&self) -> PathBuf {
-        strip_lock_suffix(&self.lock_path)
+        self.resource_path.clone()
     }
 }
 
@@ -73,6 +65,6 @@ impl Marker {
 
     /// Return the path at which the locked resource resides
     pub fn resource_path(&self) -> PathBuf {
-        strip_lock_suffix(&self.lock_path)
+        self.resource_path.clone()
     }
 }

--- a/gix-lock/src/lib.rs
+++ b/gix-lock/src/lib.rs
@@ -60,6 +60,7 @@ pub mod commit;
 pub struct File {
     inner: gix_tempfile::Handle<Writable>,
     lock_path: PathBuf,
+    resource_path: PathBuf,
 }
 
 /// Locks a resource to allow related resources to be updated using [files][File].
@@ -72,6 +73,7 @@ pub struct Marker {
     inner: gix_tempfile::Handle<Closed>,
     created_from_file: bool,
     lock_path: PathBuf,
+    resource_path: PathBuf,
 }
 
 ///

--- a/gix-lock/tests/lock/file.rs
+++ b/gix-lock/tests/lock/file.rs
@@ -139,6 +139,79 @@ mod acquire {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn lock_following_symlinks_writes_their_target() -> crate::Result {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir()?;
+        let target = dir.path().join("target");
+        let intermediate = dir.path().join("intermediate");
+        let resource = dir.path().join("resource");
+        symlink("target", &intermediate)?;
+        symlink("intermediate", &resource)?;
+
+        let mut file =
+            gix_lock::File::acquire_to_update_resource_following_symlinks(&resource, fail_immediately(), None)?;
+        assert_eq!(file.resource_path(), target);
+        file.write_all(b"new state")?;
+        file.commit()?;
+
+        assert!(resource.symlink_metadata()?.file_type().is_symlink());
+        assert!(intermediate.symlink_metadata()?.file_type().is_symlink());
+        assert_eq!(std::fs::read(target)?, b"new state");
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn lock_permissions_can_be_adjusted_after_applying_the_umask() -> crate::Result {
+        use std::{cell::Cell, os::unix::fs::PermissionsExt};
+
+        let dir = tempfile::tempdir()?;
+        let resource = dir.path().join("resource");
+        let mode_before_adjustment = Cell::new(0);
+        let file = gix_lock::File::acquire_to_update_resource_following_symlinks_with_permissions(
+            &resource,
+            fail_immediately(),
+            None,
+            |mut permissions| {
+                let mode = permissions.mode();
+                mode_before_adjustment.set(mode);
+                permissions.set_mode(mode | 0o660);
+                permissions
+            },
+        )?;
+        assert_eq!(
+            file.lock_path().metadata()?.permissions().mode(),
+            mode_before_adjustment.get() | 0o660,
+            "the adjustment sees and changes the mode left by the umask"
+        );
+        file.commit()?;
+        assert_eq!(
+            resource.metadata()?.permissions().mode(),
+            mode_before_adjustment.get() | 0o660,
+            "the adjusted mode reaches the resource"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resource_path_does_not_parse_the_lock_file_name() -> crate::Result {
+        let dir = tempfile::tempdir()?;
+        let resource_dir = dir.path().join("resource");
+        std::fs::create_dir(&resource_dir)?;
+        let mut resource = resource_dir.into_os_string();
+        resource.push(std::path::MAIN_SEPARATOR.to_string());
+        let resource = std::path::PathBuf::from(resource);
+
+        let file = gix_lock::File::acquire_to_update_resource(&resource, fail_immediately(), None)?;
+        assert_eq!(file.resource_path(), resource);
+        let err = file.commit().expect_err("a file cannot replace a directory");
+        assert_eq!(err.instance.resource_path(), resource);
+        Ok(())
+    }
+
+    #[test]
     fn lock_non_existing_dir_fails() -> crate::Result {
         let dir = tempfile::tempdir()?;
         let resource = dir.path().join("a").join("resource.ext");

--- a/gix-lock/tests/lock/file.rs
+++ b/gix-lock/tests/lock/file.rs
@@ -170,17 +170,13 @@ mod acquire {
         let dir = tempfile::tempdir()?;
         let resource = dir.path().join("resource");
         let mode_before_adjustment = Cell::new(0);
-        let file = gix_lock::File::acquire_to_update_resource_following_symlinks_with_permissions(
-            &resource,
-            fail_immediately(),
-            None,
-            |mut permissions| {
-                let mode = permissions.mode();
-                mode_before_adjustment.set(mode);
-                permissions.set_mode(mode | 0o660);
-                permissions
-            },
-        )?;
+        let adjust_permissions = |mut permissions: std::fs::Permissions| {
+            let mode = permissions.mode();
+            mode_before_adjustment.set(mode);
+            permissions.set_mode(mode | 0o660);
+            permissions
+        };
+        let file = gix_lock::File::acquire(&resource, fail_immediately(), None, None, Some(&adjust_permissions))?;
         assert_eq!(
             file.lock_path().metadata()?.permissions().mode(),
             mode_before_adjustment.get() | 0o660,

--- a/gix-tempfile/Cargo.toml
+++ b/gix-tempfile/Cargo.toml
@@ -52,6 +52,9 @@ hp-hashmap = ["dep:dashmap"]
 [target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2.186", default-features = false }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.1", features = ["Win32_Storage_FileSystem"] }
+
 [package.metadata.docs.rs]
 all-features = true
 features = ["document-features"]

--- a/gix-tempfile/src/forksafe.rs
+++ b/gix-tempfile/src/forksafe.rs
@@ -4,6 +4,109 @@ use tempfile::{NamedTempFile, TempPath};
 
 use crate::{AutoRemove, handle};
 
+/// Move `source` over `destination` while preserving its persistent Windows file attributes.
+///
+/// `tempfile` creates named temporary files with `FILE_ATTRIBUTE_TEMPORARY`. Its Windows persistence
+/// implementation changes all attributes to `FILE_ATTRIBUTE_NORMAL` before moving the file, which also discards
+/// attributes deliberately applied after creation, notably `FILE_ATTRIBUTE_READONLY`. `MoveFileExW()` additionally
+/// refuses to replace a read-only destination. This function handles both constraints while keeping `source`
+/// recoverable for a retry when the move fails.
+///
+/// # I/O per attempt
+///
+/// The ordinary successful path makes four Win32 filesystem calls:
+///
+/// 1. Read and remember all attributes of `source`.
+/// 2. Remove only `FILE_ATTRIBUTE_TEMPORARY` from `source`; if that was its sole attribute, use
+///    `FILE_ATTRIBUTE_NORMAL` because Windows doesn't accept an empty attribute set.
+/// 3. Read `destination`'s attributes. `INVALID_FILE_ATTRIBUTES` is allowed here because a missing destination is a
+///    valid target; `MoveFileExW()` will report other lookup failures authoritatively.
+/// 4. Move `source` over `destination` with `MOVEFILE_REPLACE_EXISTING`. The moved file retains every original source
+///    attribute except `FILE_ATTRIBUTE_TEMPORARY`.
+///
+/// A read-only destination adds one attribute write before the move to clear `FILE_ATTRIBUTE_READONLY`. On failure,
+/// attribute writes restore the exact source attributes and, if changed, the exact destination attributes. Restoration
+/// is best-effort so its errors don't hide the operation that failed; the original error is returned. Each outer retry
+/// repeats this sequence.
+///
+/// These are metadata and namespace operations: file contents aren't read or copied, and cross-volume moves fail because
+/// `MOVEFILE_COPY_ALLOWED` isn't requested. This function doesn't flush contents or retry transient errors; its caller
+/// owns those responsibilities. Once the move succeeds, it disables `tempfile`'s cleanup before returning so dropping
+/// the wrapper can't act on the stale source path.
+#[cfg(windows)]
+fn persist_windows(source: &mut TempfileOrTemppath, destination: &Path) -> std::io::Result<()> {
+    use std::{iter, os::windows::ffi::OsStrExt};
+
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_READONLY, FILE_ATTRIBUTE_TEMPORARY, GetFileAttributesW,
+        INVALID_FILE_ATTRIBUTES, MOVEFILE_REPLACE_EXISTING, MoveFileExW, SetFileAttributesW,
+    };
+
+    fn wide(path: &Path) -> Vec<u16> {
+        path.as_os_str().encode_wide().chain(iter::once(0)).collect()
+    }
+
+    fn usable_attributes(attributes: u32) -> u32 {
+        if attributes == 0 {
+            FILE_ATTRIBUTE_NORMAL
+        } else {
+            attributes
+        }
+    }
+
+    let source_path = wide(match &*source {
+        TempfileOrTemppath::Tempfile(file) => file.path(),
+        TempfileOrTemppath::Temppath(path) => path,
+    });
+    let destination_path = wide(destination);
+    // SAFETY: Both paths are encoded as NUL-terminated UTF-16 strings and remain alive for all calls.
+    #[expect(unsafe_code)]
+    unsafe {
+        let source_attributes = GetFileAttributesW(source_path.as_ptr());
+        if source_attributes == INVALID_FILE_ATTRIBUTES {
+            return Err(std::io::Error::last_os_error());
+        }
+        let persisted_attributes = usable_attributes(source_attributes & !FILE_ATTRIBUTE_TEMPORARY);
+        if SetFileAttributesW(source_path.as_ptr(), persisted_attributes) == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let destination_attributes = GetFileAttributesW(destination_path.as_ptr());
+        let destination_was_readonly =
+            destination_attributes != INVALID_FILE_ATTRIBUTES && destination_attributes & FILE_ATTRIBUTE_READONLY != 0;
+        if destination_was_readonly
+            && SetFileAttributesW(
+                destination_path.as_ptr(),
+                usable_attributes(destination_attributes & !FILE_ATTRIBUTE_READONLY),
+            ) == 0
+        {
+            let err = std::io::Error::last_os_error();
+            let _ = SetFileAttributesW(source_path.as_ptr(), source_attributes);
+            return Err(err);
+        }
+
+        if MoveFileExW(
+            source_path.as_ptr(),
+            destination_path.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING,
+        ) != 0
+        {
+            match source {
+                TempfileOrTemppath::Tempfile(file) => file.disable_cleanup(true),
+                TempfileOrTemppath::Temppath(path) => path.disable_cleanup(true),
+            }
+            return Ok(());
+        }
+
+        let err = std::io::Error::last_os_error();
+        let _ = SetFileAttributesW(source_path.as_ptr(), source_attributes);
+        if destination_was_readonly {
+            let _ = SetFileAttributesW(destination_path.as_ptr(), destination_attributes);
+        }
+        Err(err)
+    }
+}
+
 enum TempfileOrTemppath {
     Tempfile(NamedTempFile),
     Temppath(TempPath),
@@ -68,46 +171,21 @@ impl ForksafeTempfile {
             // ERROR_SHARING_VIOLATION
         }
 
-        match self.inner {
-            TempfileOrTemppath::Tempfile(file) => {
-                let mut current_file = file;
-                for attempt in 0..MAX_ATTEMPTS {
-                    match current_file.persist(path) {
-                        Ok(file) => return Ok(Some(file)),
-                        Err(err) if attempt + 1 < MAX_ATTEMPTS && should_retry(&err.error) => {
-                            std::thread::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS));
-                            current_file = err.file;
-                        }
-                        Err(err) => {
-                            return Err((err.error, {
-                                self.inner = TempfileOrTemppath::Tempfile(err.file);
-                                self
-                            }));
-                        }
-                    }
+        for attempt in 0..MAX_ATTEMPTS {
+            match persist_windows(&mut self.inner, path) {
+                Ok(()) => {
+                    return Ok(match self.inner {
+                        TempfileOrTemppath::Tempfile(file) => Some(file.into_file()),
+                        TempfileOrTemppath::Temppath(_) => None,
+                    });
                 }
-                unreachable!("loop always returns")
-            }
-            TempfileOrTemppath::Temppath(temppath) => {
-                let mut current_path = temppath;
-                for attempt in 0..MAX_ATTEMPTS {
-                    match current_path.persist(path) {
-                        Ok(_) => return Ok(None),
-                        Err(err) if attempt + 1 < MAX_ATTEMPTS && should_retry(&err.error) => {
-                            std::thread::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS));
-                            current_path = err.path;
-                        }
-                        Err(err) => {
-                            return Err((err.error, {
-                                self.inner = TempfileOrTemppath::Temppath(err.path);
-                                self
-                            }));
-                        }
-                    }
+                Err(err) if attempt + 1 < MAX_ATTEMPTS && should_retry(&err) => {
+                    std::thread::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS));
                 }
-                unreachable!("loop always returns")
+                Err(err) => return Err((err, self)),
             }
         }
+        unreachable!("loop always returns")
     }
 
     #[cfg(not(windows))]

--- a/gix-tempfile/tests/tempfile/handle.rs
+++ b/gix-tempfile/tests/tempfile/handle.rs
@@ -127,6 +127,36 @@ mod at_path {
     }
 
     #[test]
+    #[cfg(windows)]
+    fn persistence_replaces_readonly_files_and_retains_the_tempfiles_permissions() -> crate::Result {
+        let dir = tempfile::tempdir()?;
+        let tempfile_path = dir.path().join("file.lock");
+        let destination = dir.path().join("file");
+        std::fs::write(&destination, b"old")?;
+        let mut destination_permissions = std::fs::metadata(&destination)?.permissions();
+        destination_permissions.set_readonly(true);
+        std::fs::set_permissions(&destination, destination_permissions)?;
+
+        let mut handle = gix_tempfile::writable_at(&tempfile_path, ContainingDirectory::Exists, AutoRemove::Tempfile)?;
+        handle.with_mut(|file| {
+            file.write_all(b"new")?;
+            let mut permissions = file.as_file().metadata()?.permissions();
+            permissions.set_readonly(true);
+            file.as_file().set_permissions(permissions)
+        })??;
+
+        drop(handle.persist(&destination)?);
+        assert_eq!(std::fs::read(&destination)?, b"new", "the destination was replaced");
+        let mut permissions = std::fs::metadata(&destination)?.permissions();
+        let is_readonly = permissions.readonly();
+        #[expect(clippy::permissions_set_readonly_false, reason = "this test only runs on Windows")]
+        permissions.set_readonly(false);
+        std::fs::set_permissions(&destination, permissions)?;
+        assert!(is_readonly, "the persisted tempfile retained its read-only permission");
+        Ok(())
+    }
+
+    #[test]
     fn it_can_create_the_containing_directory_and_remove_it_on_drop() -> crate::Result {
         let dir = tempfile::tempdir()?;
         let first_dir = "dir";

--- a/gix/src/config/cache/access.rs
+++ b/gix/src/config/cache/access.rs
@@ -252,6 +252,16 @@ impl Cache {
         Ok((out[0], out[1]))
     }
 
+    pub(crate) fn config_lock_timeout(&self) -> Result<gix_lock::acquire::Fail, config::lock_timeout::Error> {
+        Core::CONFIG_LOCK_TIMEOUT
+            .try_into_lock_timeout(
+                self.resolved
+                    .integer_filter(Core::CONFIG_LOCK_TIMEOUT, &mut self.filter_config_section.clone()),
+            )
+            .with_leniency(self.lenient_config)
+            .map(|value| value.unwrap_or_else(|| Fail::from(Duration::from_millis(1000))))
+    }
+
     /// The path to the user-level excludes file to ignore certain files in the worktree.
     #[cfg(feature = "excludes")]
     pub(crate) fn excludes_file(&self) -> Result<Option<PathBuf>, gix_config::path::interpolate::Error> {

--- a/gix/src/config/file_mut.rs
+++ b/gix/src/config/file_mut.rs
@@ -1,0 +1,160 @@
+//! A transaction for editing one physical configuration file.
+
+use std::{
+    io::Read,
+    ops::{Deref, DerefMut},
+};
+
+use super::FileTransaction;
+
+/// The error produced when opening or committing a [`FileTransaction`].
+#[derive(Debug, thiserror::Error)]
+#[expect(missing_docs)]
+pub enum Error {
+    #[error(transparent)]
+    LockTimeout(#[from] super::lock_timeout::Error),
+    #[error(transparent)]
+    InvalidSharedRepository(#[from] crate::config::key::GenericErrorWithValue),
+    #[error("Could not acquire the lock for the configuration file")]
+    AcquireLock(#[from] gix_lock::acquire::Error),
+    #[error("Could not read metadata of the configuration file at {path:?}")]
+    Metadata {
+        source: std::io::Error,
+        path: std::path::PathBuf,
+    },
+    #[error("Could not read the configuration file at {path:?}")]
+    Read {
+        source: std::io::Error,
+        path: std::path::PathBuf,
+    },
+    #[error("Could not parse the configuration file at {path:?}")]
+    Parse {
+        source: gix_config::file::init::Error,
+        path: std::path::PathBuf,
+    },
+    #[error("Could not write the configuration file at {path:?}")]
+    Write {
+        source: std::io::Error,
+        path: std::path::PathBuf,
+    },
+    #[error("Could not commit the configuration file lock")]
+    CommitLock(#[from] gix_lock::commit::Error<gix_lock::File>),
+}
+
+impl FileTransaction {
+    pub(crate) fn open(
+        path: std::path::PathBuf,
+        trust: gix_sec::Trust,
+        lock_mode: gix_lock::acquire::Fail,
+        shared_repository_permissions: i32,
+    ) -> Result<Self, Error> {
+        let adjust_permissions =
+            |permissions| gix_fs::adjust_shared_repository_permissions(permissions, shared_repository_permissions);
+        let adjust_permissions: Option<&dyn Fn(std::fs::Permissions) -> std::fs::Permissions> =
+            (shared_repository_permissions != 0).then_some(&adjust_permissions);
+        let mut lock = gix_lock::File::acquire(
+            &path,
+            lock_mode,
+            None,
+            Some(&gix_lock::acquire::resolve_symlink),
+            adjust_permissions,
+        )?;
+        let source = gix_config::Source::Local;
+        let path = lock.resource_path();
+        let config = match std::fs::File::open(&path) {
+            Ok(mut file) => {
+                let permissions = file
+                    .metadata()
+                    .map_err(|source| Error::Metadata {
+                        source,
+                        path: path.clone(),
+                    })?
+                    .permissions();
+                lock.with_mut(|file| file.set_permissions(permissions))
+                    .map_err(|source| Error::Write {
+                        source,
+                        path: path.clone(),
+                    })?;
+                let mut bytes = Vec::new();
+                file.read_to_end(&mut bytes).map_err(|source| Error::Read {
+                    source,
+                    path: path.clone(),
+                })?;
+                gix_config::File::from_bytes_no_includes(
+                    &bytes,
+                    gix_config::file::Metadata::from(source).at(path.clone()).with(trust),
+                    Default::default(),
+                )
+                .map_err(|source| Error::Parse {
+                    source,
+                    path: path.clone(),
+                })?
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                gix_config::File::new(gix_config::file::Metadata::from(source).at(path).with(trust))
+            }
+            Err(source) => return Err(Error::Read { source, path }),
+        };
+        Ok(FileTransaction { lock, config })
+    }
+
+    /// Write this physical file atomically without changing any repository instance.
+    pub fn commit(mut self) -> Result<(), Error> {
+        let path = self.lock.resource_path();
+        self.config
+            .write_to(&mut self.lock)
+            .map_err(|source| Error::Write { source, path })?;
+        self.lock.commit()?;
+        Ok(())
+    }
+}
+
+/// Resolve Git's effective `core.sharedRepository` permission policy.
+///
+/// # Lookup peculiarities
+///
+/// The normal caller passes the repository's already-resolved configuration snapshot, not the physical file that
+/// [`FileTransaction`] is about to edit. The snapshot contains expanded includes and configuration scopes in precedence
+/// order. Consequently, changing `core.sharedRepository` through that transaction doesn't affect the permissions of the same
+/// transaction; the repository must be reloaded before a later transaction observes the new value.
+///
+/// Section and key matching is ASCII-case-insensitive. Sections are visited in merged load order, but only when `filter`
+/// accepts their metadata and the header is exactly `[core]`, without a subsection. Within each eligible section,
+/// [`gix_config::file::SectionRef::value_implicit()`] selects the last `sharedRepository` entry. Sections without such an
+/// entry are skipped, and the last value remaining across all eligible sections wins, matching Git's single-value config
+/// lookup. Thus a later rejected section, `[core "subsection"]`, or `[core]` section without this key doesn't mask an
+/// earlier accepted value.
+///
+/// An absent key means the default `umask` policy. A bare `sharedRepository` entry is different: it is an implicit boolean
+/// `true`, equivalent to `group`.
+///
+/// Values are parsed by [`crate::config::tree::core::SharedRepository::try_into_shared_repository()`].
+pub(crate) fn shared_repository_permissions(
+    config: &gix_config::File,
+    filter: fn(&gix_config::file::Metadata) -> bool,
+) -> Result<i32, Error> {
+    let value = config.sections_by_name_and_filter("core", filter).and_then(|sections| {
+        sections
+            .filter(|section| section.header().subsection_name().is_none())
+            .filter_map(|section| section.value_implicit("sharedRepository"))
+            .last()
+    });
+    let Some(value) = value else { return Ok(0) };
+    crate::config::tree::Core::SHARED_REPOSITORY
+        .try_into_shared_repository(value)
+        .map_err(Into::into)
+}
+
+impl Deref for FileTransaction {
+    type Target = gix_config::File;
+
+    fn deref(&self) -> &Self::Target {
+        &self.config
+    }
+}
+
+impl DerefMut for FileTransaction {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.config
+    }
+}

--- a/gix/src/config/mod.rs
+++ b/gix/src/config/mod.rs
@@ -4,6 +4,8 @@ use gix_features::threading::OnceCell;
 use crate::{Repository, bstr::BString, repository::identity};
 
 pub(crate) mod cache;
+pub mod file_mut;
+
 mod snapshot;
 #[cfg(feature = "credentials")]
 pub use snapshot::credential_helpers;
@@ -13,6 +15,15 @@ pub mod overrides;
 
 pub mod tree;
 pub use tree::root::Tree;
+
+/// A locked, mutable physical configuration file.
+///
+/// Includes are not expanded. Dropping this value releases the lock and discards all changes;
+/// [`commit()`](Self::commit()) writes them atomically. The owning repository is not updated.
+pub struct FileTransaction {
+    pub(crate) lock: gix_lock::File,
+    pub(crate) config: gix_config::File,
+}
 
 /// A platform to access configuration values as read from disk.
 ///
@@ -29,8 +40,6 @@ pub struct Snapshot<'repo> {
 /// Note that these values won't update even if the underlying file(s) change.
 ///
 /// Use [`forget()`][Self::forget()] to not apply any of the changes.
-// TODO: make it possible to load snapshots with reloading via .config() and write mutated snapshots back to disk which should be the way
-//       to affect all instances of a repo, probably via `config_mut()` and `config_mut_at()`.
 pub struct SnapshotMut<'repo> {
     /// The owning repository.
     pub repo: Option<&'repo mut Repository>,

--- a/gix/src/config/tree/sections/core.rs
+++ b/gix/src/config/tree/sections/core.rs
@@ -36,6 +36,9 @@ impl Core {
     pub const FS_CACHE: keys::Boolean = keys::Boolean::new_boolean("fsCache", &config::Tree::CORE);
     /// The `core.ignoreCase` key.
     pub const IGNORE_CASE: keys::Boolean = keys::Boolean::new_boolean("ignoreCase", &config::Tree::CORE);
+    /// The `core.configLockTimeout` key.
+    pub const CONFIG_LOCK_TIMEOUT: keys::LockTimeout =
+        keys::LockTimeout::new_lock_timeout("configLockTimeout", &config::Tree::CORE);
     /// The `core.filesRefLockTimeout` key.
     pub const FILES_REF_LOCK_TIMEOUT: keys::LockTimeout =
         keys::LockTimeout::new_lock_timeout("filesRefLockTimeout", &config::Tree::CORE);
@@ -64,6 +67,9 @@ impl Core {
     /// The `core.repositoryFormatVersion` key.
     pub const REPOSITORY_FORMAT_VERSION: keys::UnsignedInteger =
         keys::UnsignedInteger::new_unsigned_integer("repositoryFormatVersion", &config::Tree::CORE);
+    /// The `core.sharedRepository` key.
+    pub const SHARED_REPOSITORY: SharedRepository =
+        SharedRepository::new_with_validate("sharedRepository", &config::Tree::CORE, validate::SharedRepository);
     /// The `core.symlinks` key.
     pub const SYMLINKS: keys::Boolean = keys::Boolean::new_boolean("symlinks", &config::Tree::CORE);
     /// The `core.trustCTime` key.
@@ -127,6 +133,7 @@ impl Section for Core {
             &Self::FILE_MODE,
             &Self::FS_CACHE,
             &Self::IGNORE_CASE,
+            &Self::CONFIG_LOCK_TIMEOUT,
             &Self::FILES_REF_LOCK_TIMEOUT,
             &Self::PACKED_REFS_TIMEOUT,
             &Self::MULTIPACK_INDEX,
@@ -134,6 +141,7 @@ impl Section for Core {
             &Self::LOG_ALL_REF_UPDATES,
             &Self::PRECOMPOSE_UNICODE,
             &Self::REPOSITORY_FORMAT_VERSION,
+            &Self::SHARED_REPOSITORY,
             &Self::SYMLINKS,
             &Self::TRUST_C_TIME,
             &Self::WORKTREE,
@@ -171,6 +179,9 @@ pub type LogAllRefUpdates = keys::Any<validate::LogAllRefUpdates>;
 
 /// The `core.disambiguate` key.
 pub type Disambiguate = keys::Any<validate::Disambiguate>;
+
+/// The `core.sharedRepository` key.
+pub type SharedRepository = keys::Any<validate::SharedRepository>;
 
 #[cfg(feature = "attributes")]
 mod filter {
@@ -310,6 +321,45 @@ mod filter {
 }
 #[cfg(feature = "attributes")]
 pub use filter::*;
+
+mod shared_repository {
+    use crate::{bstr::ByteSlice, config, config::tree::core::SharedRepository};
+
+    impl SharedRepository {
+        /// Parse `value` as Git's `core.sharedRepository` permission policy.
+        ///
+        /// `None` represents a bare key (without value) and is treated as boolean `true`, equivalent to `group`. The result uses Git's
+        /// compact encoding: `0` leaves permissions to the process umask, a positive mode ORs in permission bits after the
+        /// umask, and a negative mode replaces the permission bits.
+        pub fn try_into_shared_repository(
+            &'static self,
+            value: Option<impl gix_utils::AsBStr>,
+        ) -> Result<i32, config::key::GenericErrorWithValue> {
+            let Some(value) = value else { return Ok(0o660) };
+            let value = value.as_bstr();
+            match value.as_bytes() {
+                b"umask" => return Ok(0),
+                b"group" => return Ok(0o660),
+                b"all" | b"world" | b"everybody" => return Ok(0o664),
+                _ => {}
+            }
+
+            if let Some(mode) = value.to_str().ok().and_then(|value| u32::from_str_radix(value, 8).ok()) {
+                return match mode {
+                    0 => Ok(0),
+                    1 => Ok(0o660),
+                    2 => Ok(0o664),
+                    mode if mode & 0o600 == 0o600 => Ok(-((mode & 0o666) as i32)),
+                    _ => Err(config::key::GenericErrorWithValue::from_value(self, value.into())),
+                };
+            }
+
+            gix_config::Boolean::try_from(value)
+                .map(|value| if value.0 { 0o660 } else { 0 })
+                .map_err(|err| config::key::GenericErrorWithValue::from_value(self, value.into()).with_source(err))
+        }
+    }
+}
 
 #[cfg(feature = "revision")]
 mod disambiguate {
@@ -477,6 +527,15 @@ mod validate {
             // config::cache::util::parse_core_abbrev, so here we just use Kind::longest()
             // to allow the most permissive upper bound.
             super::Core::ABBREV.try_into_abbreviation(value, gix_hash::Kind::longest())?;
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct SharedRepository;
+    impl keys::Validate for SharedRepository {
+        fn validate(&self, value: &BStr) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+            super::Core::SHARED_REPOSITORY.try_into_shared_repository(Some(value))?;
             Ok(())
         }
     }

--- a/gix/src/config/tree/sections/gitoxide.rs
+++ b/gix/src/config/tree/sections/gitoxide.rs
@@ -168,6 +168,16 @@ mod subsections {
                 .with_environment_override("GIX_EXTERNAL_COMMAND_STDERR");
 
         /// The `gitoxide.core.refsNamespace` key.
+        ///
+        /// It selects the reference namespace used when opening or reloading a repository. Namespaces let multiple
+        /// logical repositories share the same object database without exposing or overwriting each other's branches
+        /// and tags. For example, in namespace `foo`, the logical reference `refs/heads/main` is read from and written
+        /// to `refs/namespaces/foo/refs/heads/main`, with the namespace hidden from returned reference names.
+        ///
+        /// Only reference access is scoped; the object database, configuration, and worktree remain shared. If unset,
+        /// references are accessed without a namespace. When repository-local environment variables are permitted,
+        /// `GIT_NAMESPACE` overrides this key and accepts the same syntax. Slash-separated values form nested
+        /// namespaces, so `foo/bar` expands to `refs/namespaces/foo/refs/namespaces/bar/`.
         pub const REFS_NAMESPACE: RefsNamespace =
             keys::Any::new_with_validate("refsNamespace", &Gitoxide::CORE, super::validate::RefsNamespace)
                 .with_environment_override("GIT_NAMESPACE");

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -609,10 +609,12 @@ fn check_safe_directories(
     safe_dirs: &[BString],
 ) -> Result<(), Error> {
     let mut is_safe = false;
-    let path_to_test = match gix_path::realpath_opts(path_to_test, current_dir, gix_path::realpath::MAX_SYMLINKS) {
-        Ok(p) => p,
-        Err(_) => path_to_test.to_owned(),
+    let realpath_or_original = |path: &std::path::Path| {
+        std::fs::canonicalize(path)
+            .or_else(|_| gix_path::realpath_opts(path, current_dir, gix_path::realpath::MAX_SYMLINKS))
+            .unwrap_or_else(|_| path.to_owned())
     };
+    let path_to_test = realpath_or_original(path_to_test);
     for safe_dir in safe_dirs {
         let safe_dir = safe_dir.as_bstr();
         if safe_dir == "*" {
@@ -638,10 +640,10 @@ fn check_safe_directories(
             }
             if safe_dir.ends_with("*") {
                 let safe_dir = safe_dir.parent().expect("* is last component");
-                if path_to_test.strip_prefix(safe_dir).is_ok() {
+                if path_to_test.strip_prefix(realpath_or_original(safe_dir)).is_ok() {
                     is_safe = true;
                 }
-            } else if safe_dir == path_to_test {
+            } else if realpath_or_original(&safe_dir) == path_to_test {
                 is_safe = true;
             }
         }

--- a/gix/src/repository/config/mod.rs
+++ b/gix/src/repository/config/mod.rs
@@ -24,7 +24,28 @@ impl crate::Repository {
         config::Snapshot { repo: self }
     }
 
-    /// Return the editor selected by Git's precedence rules.
+    /// Lock and open `path` as one physical configuration file without expanding its includes.
+    ///
+    /// Relative paths are resolved against the current directory captured when this repository was opened. Dropping the
+    /// returned transaction releases the lock and discards its changes. Committing it only updates the file; call
+    /// [`reload()`](Self::reload()) explicitly to rebuild this repository from the changed configuration.
+    pub fn config_file_mut(
+        &self,
+        path: impl Into<std::path::PathBuf>,
+    ) -> Result<config::FileTransaction, config::file_mut::Error> {
+        let path = path.into();
+        let path = if path.is_absolute() {
+            path
+        } else {
+            self.current_dir().join(path)
+        };
+        let lock_mode = self.config.config_lock_timeout()?;
+        let shared_repository_permissions =
+            config::file_mut::shared_repository_permissions(&self.config.resolved, self.filter_config_section())?;
+        config::FileTransaction::open(path, self.git_dir_trust(), lock_mode, shared_repository_permissions)
+    }
+
+    /// Return the editor program selected by Git's precedence rules.
     ///
     /// `GIT_EDITOR` takes precedence over `core.editor`. If the terminal isn't dumb, `VISUAL` is considered next,
     /// followed by `EDITOR`. If none are set, a bundled `vi` (or its `vim` implementation) is returned when available

--- a/gix/tests/gix/config/file_mut.rs
+++ b/gix/tests/gix/config/file_mut.rs
@@ -1,0 +1,353 @@
+use crate::repository::config::config_snapshot::options_with_includes;
+use crate::{named_repo, repo_rw_opts};
+use std::io::Write;
+
+#[test]
+fn locks_and_edits_one_physical_file_until_explicit_reload() -> crate::Result {
+    let (mut repo, _tmp) = repo_rw_opts("make_config_repo.sh", options_with_includes())?;
+    let git_config_path = repo.git_dir().join("config");
+    let target_path = repo.workdir().expect("worktree repository").join("a.config");
+    std::fs::write(
+        &target_path,
+        br#"# leading comment
+leading = value
+[a]
+  local-override = included
+
+[committer]
+  name = committer
+  email = committer@email
+# trailing comment
+"#,
+    )?;
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&git_config_path)?
+        .write_all(
+            br#"
+[include]
+  path = ../a.config
+"#,
+        )?;
+    repo.reload()?;
+    let git_config_before = std::fs::read(&git_config_path)?;
+
+    repo.config_snapshot_mut().set_raw_value("memory.value", "transient")?;
+    let mut file = repo.config_file_mut(&target_path)?;
+    match repo.config_file_mut(&target_path) {
+        Err(gix::config::file_mut::Error::AcquireLock(_)) => {}
+        Err(err) => panic!("lock contention must be reported precisely: {err:?}"),
+        Ok(_) => panic!("a second transaction must not acquire the same lock"),
+    }
+    file.set_raw_value("a.local-override", "written")?;
+    file.commit()?;
+
+    assert_eq!(
+        std::fs::read(&git_config_path)?,
+        git_config_before,
+        "the root file is untouched"
+    );
+    let written = std::fs::read_to_string(&target_path)?;
+    insta::assert_snapshot!(written, "frontmatter + postmatter are preserved, it doesn't create new sections", @"
+    # leading comment
+    leading = value
+    [a]
+      local-override = written
+
+    [committer]
+      name = committer
+      email = committer@email
+    # trailing comment
+    ");
+    assert_eq!(
+        repo.config_snapshot()
+            .string("a.local-override")
+            .expect("cached include value"),
+        "included",
+        "committing a file doesn't refresh the repository"
+    );
+    assert_eq!(
+        repo.config_snapshot().string("memory.value").expect("in-memory value"),
+        "transient",
+        "the in-memory value is preserved as well, the repo doesn't change after all"
+    );
+
+    repo.reload()?;
+    assert_eq!(
+        repo.config_snapshot()
+            .string("a.local-override")
+            .expect("reloaded include value"),
+        "written",
+        "after a reload, the written value is observed"
+    );
+    assert!(
+        repo.config_snapshot().string("memory.value").is_none(),
+        "reload discards in-memory configuration"
+    );
+    Ok(())
+}
+
+#[test]
+fn honors_core_config_lock_timeout() -> crate::Result {
+    let (mut repo, _tmp) = repo_rw_opts("make_config_repo.sh", gix::open::Options::isolated())?;
+    let config_path = repo.git_dir().join("config");
+    let mut lock_path = config_path.as_os_str().to_owned();
+    lock_path.push(".lock");
+    let lock_path = std::path::PathBuf::from(lock_path);
+    std::fs::write(&lock_path, b"held")?;
+    let release_path = lock_path.clone();
+    let release = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        std::fs::remove_file(release_path)
+    });
+
+    let file = repo.config_file_mut(&config_path);
+    release.join().expect("lock-release thread does not panic")?;
+    drop(file?);
+
+    repo.config_snapshot_mut()
+        .set_raw_value(gix::config::tree::Core::CONFIG_LOCK_TIMEOUT, "0")?;
+    std::fs::write(&lock_path, b"held")?;
+    let err = match repo.config_file_mut(config_path) {
+        Ok(_) => panic!("a zero timeout must not wait for the lock"),
+        Err(err) => err,
+    };
+    std::fs::remove_file(lock_path)?;
+    assert!(matches!(
+        err,
+        gix::config::file_mut::Error::AcquireLock(gix::lock::acquire::Error::PermanentlyLocked {
+            mode: gix::lock::acquire::Fail::Immediately,
+            ..
+        })
+    ));
+    Ok(())
+}
+
+#[test]
+fn preserves_permissions() -> crate::Result {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (repo, _tmp) = repo_rw_opts("make_config_repo.sh", options_with_includes())?;
+        let target_path = repo.workdir().expect("worktree repository").join("a.config");
+        std::fs::set_permissions(&target_path, std::fs::Permissions::from_mode(0o600))?;
+        let mut file = repo.config_file_mut(&target_path)?;
+        file.set_raw_value("a.local-override", "written")?;
+        file.commit()?;
+        assert_eq!(
+            std::fs::metadata(target_path)?.permissions().mode() & 0o777,
+            0o600,
+            "writing preserves file permissions"
+        );
+    }
+    #[cfg(windows)]
+    {
+        let (repo, _tmp) = repo_rw_opts("make_config_repo.sh", options_with_includes())?;
+        let target_path = repo.workdir().expect("worktree repository").join("a.config");
+        let mut permissions = std::fs::metadata(&target_path)?.permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&target_path, permissions)?;
+
+        let mut file = repo.config_file_mut(&target_path)?;
+        file.set_raw_value("a.local-override", "written")?;
+        file.commit()?;
+
+        let mut permissions = std::fs::metadata(&target_path)?.permissions();
+        let is_readonly = permissions.readonly();
+        #[expect(clippy::permissions_set_readonly_false, reason = "this test only runs on Windows")]
+        permissions.set_readonly(false);
+        std::fs::set_permissions(&target_path, permissions)?;
+        assert!(is_readonly, "writing preserves read-only file permissions");
+    }
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn follows_symlinked_configuration_files() -> crate::Result {
+    use std::os::unix::fs::symlink;
+
+    let repo = named_repo("make_basic_repo.sh")?;
+    let dir = gix_testtools::tempfile::tempdir()?;
+    let target = dir.path().join("target.config");
+    let link = dir.path().join("link.config");
+    std::fs::write(
+        &target,
+        br#"[core]
+  abbrev = 7
+"#,
+    )?;
+    symlink("target.config", &link)?;
+
+    let mut file = repo.config_file_mut(&link)?;
+    match repo.config_file_mut(&target) {
+        Err(gix::config::file_mut::Error::AcquireLock(_)) => {}
+        Err(err) => panic!("the target must report lock contention: {err:?}"),
+        Ok(_) => panic!("the symlink and its target must use the same lock"),
+    }
+    file.set_raw_value("core.abbrev", "8")?;
+    file.commit()?;
+
+    assert!(
+        link.symlink_metadata()?.file_type().is_symlink(),
+        "the symlink isn't altered"
+    );
+    let config = gix_config::File::from_path_no_includes(target, gix_config::Source::Local)?;
+    assert_eq!(
+        config.string("core.abbrev").expect("updated value"),
+        "8",
+        "the write goes to the symlink target"
+    );
+    Ok(())
+}
+
+#[test]
+fn supports_empty_and_missing_files() -> crate::Result {
+    let repo = named_repo("make_basic_repo.sh")?;
+    let dir = gix_testtools::tempfile::tempdir()?;
+    let empty = dir.path().join("empty.config");
+    std::fs::write(&empty, b"# retained\n")?;
+
+    let mut file = repo.config_file_mut(&empty)?;
+    file.set_raw_value("fresh.value", "first")?;
+    file.commit()?;
+    insta::assert_snapshot!(std::fs::read_to_string(&empty)?, "comment-only frontmatter is retained", @"
+    # retained
+    [fresh]
+    	value = first
+    ");
+
+    let missing = dir.path().join("missing.config");
+    let mut file = repo.config_file_mut(&missing)?;
+    file.set_raw_value("fresh.value", "created")?;
+    file.commit()?;
+    let config = gix_config::File::from_path_no_includes(missing, gix_config::Source::Local)?;
+    assert_eq!(config.string("fresh.value").expect("created value"), "created");
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn applies_shared_repository_permissions_to_new_files() -> crate::Result {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut repo = named_repo("make_basic_repo.sh")?;
+    repo.config_snapshot_mut()
+        .set_raw_value(gix::config::tree::Core::SHARED_REPOSITORY, "group")?;
+    let dir = gix_testtools::tempfile::tempdir()?;
+    let path = dir.path().join("missing.config");
+    let mut file = repo.config_file_mut(&path)?;
+    file.set_raw_value("fresh.value", "created")?;
+    file.commit()?;
+
+    assert_eq!(
+        path.metadata()?.permissions().mode() & 0o777,
+        (0o666 & !gix_testtools::umask()) | 0o660,
+        "new configuration files honor core.sharedRepository after applying the umask"
+    );
+    Ok(())
+}
+
+#[test]
+fn semantic_validation_happens_on_reload() -> crate::Result {
+    let (mut repo, _tmp) = repo_rw_opts("make_config_repo.sh", options_with_includes().strict_config(true))?;
+    let original_format_version = repo.config_snapshot().integer("core.repositoryFormatVersion");
+    let config_path = repo.git_dir().join("config");
+    let mut file = repo.config_file_mut(&config_path)?;
+    file.set_raw_value("core.repositoryFormatVersion", "2")?;
+    file.commit()?;
+
+    let disk = gix_config::File::from_path_no_includes(config_path, gix_config::Source::Local)?;
+    assert_eq!(disk.integer("core.repositoryFormatVersion")?, Some(2));
+    let err = match repo.reload() {
+        Ok(_) => panic!("the persisted repository format must be rejected while reopening"),
+        Err(err) => err,
+    };
+    assert!(
+        matches!(
+            err,
+            gix::open::Error::Config(gix::config::Error::UnsupportedRepositoryFormatVersion { version: 2 })
+        ),
+        "reload reports the semantic error: {err:?}"
+    );
+    assert_eq!(
+        repo.config_snapshot().integer("core.repositoryFormatVersion"),
+        original_format_version,
+        "a failed reload leaves the live repository unchanged"
+    );
+    Ok(())
+}
+
+#[test]
+fn include_changes_take_effect_only_after_reload() -> crate::Result {
+    let (mut repo, _tmp) = repo_rw_opts("make_config_repo.sh", options_with_includes())?;
+    let replacement_path = repo.workdir().expect("worktree repository").join("replacement.config");
+    std::fs::write(
+        &replacement_path,
+        br#"[replacement]
+value = visible
+"#,
+    )?;
+
+    let mut file = repo.config_file_mut(repo.git_dir().join("config"))?;
+    file.set_raw_value("include.path", "../replacement.config")?;
+    file.commit()?;
+    assert!(
+        repo.config_snapshot().string("replacement.value").is_none(),
+        "commit leaves the cached include graph untouched"
+    );
+
+    repo.reload()?;
+    assert_eq!(
+        repo.config_snapshot()
+            .string("replacement.value")
+            .expect("replacement include"),
+        "visible"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn paths_with_parent_components_retain_symlink_semantics() -> crate::Result {
+    use std::os::unix::fs::symlink;
+
+    let repo = named_repo("make_basic_repo.sh")?;
+    let dir = gix_testtools::tempfile::tempdir()?;
+    let logical = dir.path().join("logical");
+    let physical = dir.path().join("physical");
+    std::fs::create_dir(&logical)?;
+    std::fs::create_dir_all(physical.join("child"))?;
+    symlink(physical.join("child"), logical.join("link"))?;
+    std::fs::write(
+        logical.join("config"),
+        br#"[target]
+value = lexical
+"#,
+    )?;
+    std::fs::write(
+        physical.join("config"),
+        br#"[target]
+value = physical
+"#,
+    )?;
+
+    let mut file = repo.config_file_mut(logical.join("link/../config"))?;
+    file.set_raw_value("target.value", "written")?;
+    file.commit()?;
+
+    let lexical = gix_config::File::from_path_no_includes(logical.join("config"), gix_config::Source::Local)?;
+    let physical = gix_config::File::from_path_no_includes(physical.join("config"), gix_config::Source::Local)?;
+    assert_eq!(
+        lexical.string("target.value").expect("lexical value"),
+        "lexical",
+        "`link/..` must not collapse to `logical`, leaving `logical/config` untouched"
+    );
+    assert_eq!(
+        physical.string("target.value").expect("physical value"),
+        "written",
+        "following `link` before `..` resolves the write to `physical/config`"
+    );
+    Ok(())
+}

--- a/gix/tests/gix/config/mod.rs
+++ b/gix/tests/gix/config/mod.rs
@@ -1,1 +1,2 @@
+mod file_mut;
 mod tree;

--- a/gix/tests/gix/config/tree.rs
+++ b/gix/tests/gix/config/tree.rs
@@ -487,6 +487,45 @@ mod core {
     }
 
     #[test]
+    fn shared_repository() -> crate::Result {
+        for (value, expected) in [
+            (None, 0o660),
+            (Some("umask"), 0),
+            (Some("false"), 0),
+            (Some("0"), 0),
+            (Some("group"), 0o660),
+            (Some("true"), 0o660),
+            (Some("1"), 0o660),
+            (Some("all"), 0o664),
+            (Some("world"), 0o664),
+            (Some("everybody"), 0o664),
+            (Some("2"), 0o664),
+            (Some("0640"), -0o640),
+        ] {
+            assert_eq!(
+                Core::SHARED_REPOSITORY.try_into_shared_repository(value)?,
+                expected,
+                "value {value:?}"
+            );
+            if let Some(value) = value {
+                assert!(Core::SHARED_REPOSITORY.validate(value.into()).is_ok());
+            }
+        }
+
+        for value in ["0400", "invalid"] {
+            assert_eq!(
+                Core::SHARED_REPOSITORY
+                    .try_into_shared_repository(Some(value))
+                    .unwrap_err()
+                    .to_string(),
+                format!("The key \"core.sharedRepository={value}\" was invalid")
+            );
+            assert!(Core::SHARED_REPOSITORY.validate(value.into()).is_err());
+        }
+        Ok(())
+    }
+
+    #[test]
     fn timeouts() -> crate::Result {
         assert_eq!(
             Core::FILES_REF_LOCK_TIMEOUT.try_into_lock_timeout(Ok(Some(0)))?,

--- a/gix/tests/gix/repository/config/config_snapshot/mod.rs
+++ b/gix/tests/gix/repository/config/config_snapshot/mod.rs
@@ -1,6 +1,6 @@
 use gix::config::tree::{Branch, Core, Key, Pack, gitoxide};
 
-use crate::{named_repo, repo_rw};
+use crate::{named_repo, repo_rw, repo_rw_opts};
 
 #[cfg(feature = "credentials")]
 mod credential_helpers;
@@ -270,4 +270,189 @@ fn reload_discards_in_memory_only_changes() -> crate::Result {
     repo.reload()?;
     assert_eq!(repo.config_snapshot().integer("core.abbrev"), None);
     Ok(())
+}
+
+#[test]
+fn reload_rebuilds_includes_even_when_the_file_was_empty_or_missing() -> crate::Result {
+    let (mut repo, _tmp) = repo_rw_opts("make_config_repo.sh", options_with_includes())?;
+    let included_path = repo.workdir().expect("worktree repository").join("a.config");
+
+    std::fs::write(&included_path, b"# no sections yet\n")?;
+    repo.reload()?;
+    assert_eq!(
+        repo.config_snapshot()
+            .string("a.local-override")
+            .expect("root value remains"),
+        "base"
+    );
+
+    std::fs::write(&included_path, b"[fresh]\nvalue = populated\n")?;
+    repo.reload()?;
+    assert_eq!(
+        repo.config_snapshot().string("fresh.value").expect("new include value"),
+        "populated"
+    );
+
+    std::fs::remove_file(&included_path)?;
+    repo.reload()?;
+    assert!(
+        repo.config_snapshot().string("fresh.value").is_none(),
+        "a missing include contributes no values"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "index")]
+fn reload_preserves_the_reduced_trust_allocation_limit() -> crate::Result {
+    let fixture = gix_testtools::scripted_fixture_writable("make_config_repo.sh")?;
+    let mut repo = gix::open_opts(
+        fixture.path(),
+        crate::util::restricted()
+            .with(gix_sec::Trust::Reduced)
+            .config_overrides(["gitoxide.objects.allocLimitIfReducedTrust=1"]),
+    )?;
+    assert!(repo.open_index().is_err(), "the opening fallback limits allocations");
+
+    repo.reload()?;
+    assert!(
+        repo.open_index().is_err(),
+        "reopening reapplies the reduced-trust allocation limit"
+    );
+    Ok(())
+}
+
+#[test]
+#[serial_test::serial]
+fn reload_reapplies_per_file_safe_directory_trust() -> crate::Result {
+    let fixture = gix_testtools::scripted_fixture_writable("make_config_repo.sh")?;
+    let included_path = fixture.path().join("a.config");
+    let mut included = gix_config::File::from_path_no_includes(included_path.clone(), gix_config::Source::Local)?;
+    included.set_raw_value(Core::SSH_COMMAND, "trusted-ssh")?;
+    std::fs::write(&included_path, included.to_bstring())?;
+
+    let global_path = fixture.path().join("global.config");
+    let mut global = gix_config::File::new(gix_config::file::Metadata::from(gix_config::Source::User));
+    global.set_raw_value(
+        "safe.directory",
+        gix_path::into_bstr(&std::fs::canonicalize(&included_path)?).as_ref(),
+    )?;
+    std::fs::write(&global_path, global.to_bstring())?;
+    let _env = gix_testtools::Env::new().set("GIT_CONFIG_GLOBAL", global_path.display().to_string());
+    let mut permissions = gix::open::Permissions::isolated();
+    permissions.config.user = true;
+    permissions.config.includes = true;
+    permissions.env.git_prefix = gix_sec::Permission::Allow;
+    let mut repo = gix::open_opts(
+        fixture.path(),
+        gix::open::Options::isolated()
+            .permissions(permissions)
+            .with(gix_sec::Trust::Reduced),
+    )?;
+    assert_eq!(
+        repo.config_snapshot().trusted_program(Core::SSH_COMMAND),
+        Some("trusted-ssh".into())
+    );
+
+    repo.reload()?;
+    assert_eq!(
+        repo.config_snapshot().trusted_program(Core::SSH_COMMAND),
+        Some("trusted-ssh".into()),
+        "reopening repeats per-file trust promotion"
+    );
+    Ok(())
+}
+
+#[test]
+fn reload_resolves_onbranch_includes_from_unnamespaced_head() -> crate::Result {
+    use std::io::Write;
+
+    let (mut repo, _tmp) = repo_rw_opts("make_config_repo.sh", options_with_includes())?;
+    let current_branch = repo
+        .head_name()?
+        .expect("the fixture has a symbolic HEAD")
+        .shorten()
+        .to_string();
+    let config_path = repo.git_dir().join("config");
+    let worktree = repo.workdir().expect("worktree repository");
+    std::fs::write(worktree.join("current-branch.config"), b"[refresh]\nbranch = current\n")?;
+    std::fs::write(worktree.join("other-branch.config"), b"[refresh]\nbranch = other\n")?;
+
+    let mut disk = gix_config::File::from_path_no_includes(config_path.clone(), gix_config::Source::Local)?;
+    disk.set_raw_value("gitoxide.core.refsNamespace", "config-refresh")?;
+    std::fs::write(&config_path, disk.to_bstring())?;
+    std::fs::OpenOptions::new().append(true).open(&config_path)?.write_all(
+        format!(
+            "\n[includeIf \"onbranch:{current_branch}\"]\n  path = ../current-branch.config\n\
+             [includeIf \"onbranch:config-refresh-other\"]\n  path = ../other-branch.config\n"
+        )
+        .as_bytes(),
+    )?;
+    repo.reload()?;
+    assert!(repo.namespace().is_some(), "the reopened repository uses a namespace");
+    assert_eq!(
+        repo.config_snapshot()
+            .string("refresh.branch")
+            .expect("current include"),
+        "current"
+    );
+
+    std::fs::write(repo.git_dir().join("HEAD"), b"ref: refs/heads/config-refresh-other\n")?;
+    repo.reload()?;
+    assert_eq!(
+        repo.config_snapshot().string("refresh.branch").expect("new include"),
+        "other",
+        "HEAD conditions are resolved without the configured reference namespace"
+    );
+    Ok(())
+}
+
+#[test]
+#[cfg(all(feature = "sha1", feature = "sha256"))]
+fn reload_rebuilds_object_stores_for_a_new_object_format() -> crate::Result {
+    let (mut repo, _tmp) = repo_rw("make_config_repo.sh")?;
+    let new_object_hash = match repo.object_hash() {
+        gix::hash::Kind::Sha1 => gix::hash::Kind::Sha256,
+        gix::hash::Kind::Sha256 => gix::hash::Kind::Sha1,
+        _ => unreachable!("this test only enables SHA-1 and SHA-256"),
+    };
+    let config_path = repo.git_dir().join("config");
+    let mut disk = gix_config::File::from_path_no_includes(config_path.clone(), gix_config::Source::Local)?;
+    disk.set_raw_value("core.repositoryFormatVersion", "1")?;
+    disk.set_raw_value("extensions.objectFormat", new_object_hash.to_string())?;
+    std::fs::write(config_path, disk.to_bstring())?;
+
+    repo.reload()?;
+    assert_eq!(repo.object_hash(), new_object_hash);
+    assert_eq!(repo.write_blob(b"new object format")?.kind(), new_object_hash);
+    Ok(())
+}
+
+#[test]
+fn reload_keeps_opening_overrides_and_discards_runtime_edits() -> crate::Result {
+    let options = options_with_includes().config_overrides(["refresh.open=from-options"]);
+    let (mut repo, _tmp) = repo_rw_opts("make_config_repo.sh", options)?;
+    repo.config_snapshot_mut()
+        .append_config(["refresh.runtime=from-api"], gix_config::Source::Api)?;
+    assert_eq!(
+        repo.config_snapshot().string("refresh.runtime").expect("runtime value"),
+        "from-api"
+    );
+
+    repo.reload()?;
+    assert_eq!(
+        repo.config_snapshot().string("refresh.open").expect("opening override"),
+        "from-options"
+    );
+    assert!(
+        repo.config_snapshot().string("refresh.runtime").is_none(),
+        "reload discards transient API sections"
+    );
+    Ok(())
+}
+
+pub(crate) fn options_with_includes() -> gix::open::Options {
+    let mut permissions = gix::open::Permissions::isolated();
+    permissions.config.includes = true;
+    gix::open::Options::isolated().permissions(permissions)
 }

--- a/gix/tests/gix/repository/config/mod.rs
+++ b/gix/tests/gix/repository/config/mod.rs
@@ -1,4 +1,4 @@
-mod config_snapshot;
+pub(crate) mod config_snapshot;
 #[cfg(feature = "command")]
 mod editor;
 mod identity;

--- a/gix/tests/gix/repository/mod.rs
+++ b/gix/tests/gix/repository/mod.rs
@@ -7,7 +7,7 @@ fn blob_id(repo: &Repository, data: &[u8]) -> gix_hash::ObjectId {
 #[cfg(feature = "blame")]
 mod blame;
 mod branch;
-mod config;
+pub(crate) mod config;
 #[cfg(feature = "excludes")]
 mod excludes;
 #[cfg(feature = "attributes")]

--- a/gix/tests/repository.rs
+++ b/gix/tests/repository.rs
@@ -3,6 +3,67 @@ use serial_test::serial;
 
 #[test]
 #[serial]
+fn config_file_paths_use_the_cwd_captured_while_opening() -> gix_testtools::Result {
+    let fixture = gix_testtools::scripted_fixture_writable("make_config_repo.sh")?;
+    let elsewhere = gix_testtools::tempfile::tempdir()?;
+    let _cwd = gix_testtools::set_current_dir(fixture.path())?;
+    let mut repo = gix::open_opts(".", gix::open::Options::isolated())?;
+    std::env::set_current_dir(elsewhere.path())?;
+
+    let mut file = repo.config_file_mut(".git/config")?;
+    file.set_raw_value("physical.after-cwd-change", "written")?;
+    file.commit()?;
+    assert!(
+        !elsewhere.path().join(".git/config").exists(),
+        "the process's new working directory is not used"
+    );
+    repo.reload()?;
+    assert_eq!(
+        repo.config_snapshot()
+            .string("physical.after-cwd-change")
+            .expect("reloaded value"),
+        "written"
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[cfg(target_os = "macos")]
+fn config_file_paths_follow_a_precomposed_opening_cwd() -> gix_testtools::Result {
+    let tmp = gix_testtools::tempfile::tempdir()?;
+    let decomposed = tmp.path().join("a\u{308}");
+    std::fs::create_dir(&decomposed)?;
+    let repo = gix::init(&decomposed)?;
+    let config_path = repo.git_dir().join("config");
+    let mut disk = gix_config::File::from_path_no_includes(config_path.clone(), gix_config::Source::Local)?;
+    disk.set_raw_value("core.precomposeUnicode", "true")?;
+    std::fs::write(&config_path, disk.to_bstring())?;
+    drop(repo);
+
+    let _cwd = gix_testtools::set_current_dir(&decomposed)?;
+    let original_cwd = std::env::current_dir()?;
+    let repo = gix::open_opts(".", gix::open::Options::isolated())?;
+    assert_ne!(
+        repo.current_dir(),
+        original_cwd,
+        "core.precomposeUnicode must normalize the captured CWD before it becomes the base for relative config paths"
+    );
+    let mut file = repo.config_file_mut(".git/config")?;
+    file.set_raw_value("physical.precomposed", "written")?;
+    file.commit()?;
+
+    let disk = gix_config::File::from_path_no_includes(config_path.clone(), gix_config::Source::Local)?;
+    assert_eq!(
+        disk.string("physical.precomposed").expect("written value"),
+        "written",
+        "the relative .git/config path must still reach the initialized repository after precomposing its stored CWD"
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
 fn relative_paths_use_the_cwd_captured_when_opening() -> gix_testtools::Result {
     let root = gix::path::realpath(gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?)?;
     let nested = root.join("some/very");


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- add `Repository::config()` and `config_mut()` accessors that refresh changed configuration files while leaving snapshot-only access free of freshness I/O
- preserve runtime API sections across reloads without duplicating `open::Options::config_overrides()`
- add `SnapshotMut::commit_to_file()` to atomically write one exact file designation with lock-first mtime validation, permission preservation, and deleted-file recreation
- reject stale files, forged designations, override-only sources, and invalid snapshots before changing disk or in-memory state

## Commits

- `4c759f742e` — refresh repository configuration on access, including the platform-specific size guard
- `9bacd89ae1` — write mutable configuration snapshots to disk

## Git baseline

Git's `config.c` clears and reloads repository configuration with includes, and its file mutation path locks `<path>.lock`, preserves the file mode, then commits by atomic rename. This change adapts those behaviors to long-lived `gix::Repository` snapshots and adds the requested mtime stale-write guard.

## Validation

- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix --test gix repository::config::config_snapshot`
- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix --test gix repository::config::config_snapshot::commit_to_file`
- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix --test gix repository::size_in_memory -- --exact`
- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix --test gix --features async-network-client repository::size_in_memory -- --exact`
- `cargo clippy -p gix --all-targets -- -D warnings`
- `cargo deny --workspace --all-features check bans licenses sources`
- `env GIX_TEST_IGNORE_ARCHIVES=1 just ci-test`
- GitHub CI before the Tix-only history cleanup: all 32 checks passed; the resulting tree is unchanged

The required one-time `codex review --commit` invocation was attempted for each original pre-squash commit, but the review service rejected all four because the account usage limit was exhausted. Independent agent audits were completed for both feature commits and the Windows CI fix.

## Reported issue

### Original report

~~~text
While gix::Repository::index() checks if the index file has to be reloaded, the git configuration has no such mechanism. `config_snapshot_mut()` is intentionally a snapshot, and refreshing it is currently impossible.
It would be a start if there was a `config()` or `config_mut()` that returns a snapshot (just like the current accessors), but after checking that none of the included configuration files changed. This information is readily present in section metadata. If any of these files changed according to the modification date, then reload the configuration just like it happens when opening (or reloading) so side-effects are handled.
Make sure that open::Options::config_overrides() aren't duplicated, and that API-only sections aren't lost either.
~~~

### Write-back follow-up

~~~text
In a separate commit, let's also add a way to write back changes to any file, based on the in-memory file. This will never write API or env overrides, but writes back any section that matches the desigation metadata. This entails a way to select which single file to write probably by passing section metadata identifying the file, to obtaina lock, and to write changes back to the file if it's not stale based on the mtime should should have. A deleted file is not considered stale.
If the file to write changed after the snapshot was obtained, fail. In that case, the user has to retry with a refreshed file.
~~~

### Clarification

~~~text
>  - Capture original file designations and mtime baselines when creating the mutable snapshot.

No, this information is part of what `repo.cache` holds, and the `config_snapshot_mut()` call for instance won't do additional IO. This is only done by `config()` and `config_mut()` respectively.


> - Resolve symlinks, acquire the target’s gix_lock::File, then compare mtimes while holding the lock.

Don't do that, only the local configuration files are (likely) writable and support locks there, and system wide ones probably aren't. But yeah, hold the lock before comparing the mtime of the file to write.
~~~
