### PR TITLE
feat: compare fundamental types with textual representations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,6 +1985,7 @@ dependencies = [
 name = "gix-hash"
 version = "0.26.1"
 dependencies = [
+ "bstr",
  "document-features",
  "faster-hex",
  "gix-features",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "bstr",
  "document-features",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.64.0"
+version = "0.64.1"
 dependencies = [
  "bstr",
  "criterion",
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.74.0"
+version = "0.74.1"
 dependencies = [
  "bstr",
  "clru",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "async-std",
  "bisync",
@@ -2368,7 +2368,7 @@ version = "0.0.0"
 
 [[package]]
 name = "gix-ref"
-version = "0.67.0"
+version = "0.67.1"
 dependencies = [
  "document-features",
  "gix-actor",

--- a/etc/scripts/cargo-check-all.sh
+++ b/etc/scripts/cargo-check-all.sh
@@ -31,6 +31,7 @@ cargo check -p gitoxide-core --features gix/sha1,async-client
 cargo check -p gix-pack --no-default-features --features sha1
 cargo check -p gix-pack --no-default-features --features sha1,generate
 cargo check -p gix-pack --no-default-features --features sha1,streaming-input
+cargo check -p gix-hash --no-default-features --features sha1,bstr
 cargo check -p gix-hash --all-features
 cargo check -p gix-object --all-features
 cargo check -p gix-attributes --features serde

--- a/gitoxide-core/Cargo.toml
+++ b/gitoxide-core/Cargo.toml
@@ -50,12 +50,12 @@ serde = ["gix/serde", "dep:serde_json", "dep:serde", "bytesize/serde"]
 [dependencies]
 # deselect everything else (like "performance") as this should be controllable by the parent application.
 gix = { version = "^0.87.0", path = "../gix", default-features = false, features = ["merge", "blob-diff", "blame", "revision", "mailmap", "excludes", "attributes", "worktree-mutation", "credentials", "interrupt", "status", "dirwalk", "command"] }
-gix-pack-for-configuration-only = { package = "gix-pack", version = "^0.74.0", path = "../gix-pack", default-features = false, features = ["pack-cache-lru-dynamic", "pack-cache-lru-static", "generate", "streaming-input"] }
+gix-pack-for-configuration-only = { package = "gix-pack", version = "^0.74.1", path = "../gix-pack", default-features = false, features = ["pack-cache-lru-dynamic", "pack-cache-lru-static", "generate", "streaming-input"] }
 gix-transport-configuration-only = { package = "gix-transport", version = "^0.59.0", path = "../gix-transport", default-features = false }
 gix-archive-for-configuration-only = { package = "gix-archive", version = "^0.36.0", path = "../gix-archive", optional = true, features = ["tar", "tar_gz"] }
 gix-status = { version = "^0.34.0", path = "../gix-status" }
 gix-fsck = { version = "^0.25.0", path = "../gix-fsck" }
-gix-error-for-configuration-only = { package = "gix-error", version = "^0.3.0", path = "../gix-error", features = ["anyhow"] }
+gix-error-for-configuration-only = { package = "gix-error", version = "^0.3.1", path = "../gix-error", features = ["anyhow"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 anyhow = "1.0.102"
 thiserror = "2.0.18"

--- a/gix-archive/Cargo.toml
+++ b/gix-archive/Cargo.toml
@@ -32,14 +32,14 @@ zip = ["dep:rawzip", "dep:flate2"]
 
 [dependencies]
 gix-worktree-stream = { version = "^0.36.0", path = "../gix-worktree-stream" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 gix-path = { version = "^0.12.5", path = "../gix-path", optional = true }
 gix-date = { version = "^0.16.0", path = "../gix-date" }
 
 flate2 = { version = "1.1.9", optional = true, default-features = false, features = ["zlib-rs"] }
 rawzip = { version = "0.4.3", optional = true }
 
-gix-error = { version = "^0.3.0", path = "../gix-error" }
+gix-error = { version = "^0.3.1", path = "../gix-error" }
 bstr = { version = "1.12.0", default-features = false }
 
 tar = { version = "0.4.46", optional = true }

--- a/gix-blame/Cargo.toml
+++ b/gix-blame/Cargo.toml
@@ -18,14 +18,14 @@ sha1 = ["gix-hash/sha1"]
 sha256 = ["gix-hash/sha256"]
 
 [dependencies]
-gix-error = { version = "^0.3.0", path = "../gix-error" }
+gix-error = { version = "^0.3.1", path = "../gix-error" }
 gix-commitgraph = { version = "^0.39.0", path = "../gix-commitgraph" }
 gix-revwalk = { version = "^0.35.0", path = "../gix-revwalk" }
 gix-trace = { version = "^0.1.21", path = "../gix-trace" }
 gix-date = { version = "^0.16.0", path = "../gix-date" }
 gix-diff = { version = "^0.67.0", path = "../gix-diff", default-features = false, features = ["blob"] }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
 gix-worktree = { version = "^0.56.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }
 gix-traverse = { version = "^0.61.0", path = "../gix-traverse" }
 

--- a/gix-dir/Cargo.toml
+++ b/gix-dir/Cargo.toml
@@ -29,7 +29,7 @@ gix-fs = { version = "^0.22.1", path = "../gix-fs" }
 gix-path = { version = "^0.12.5", path = "../gix-path" }
 gix-pathspec = { version = "^0.20.0", path = "../gix-pathspec" }
 gix-worktree = { version = "^0.56.0", path = "../gix-worktree", default-features = false }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 gix-ignore = { version = "^0.22.1", path = "../gix-ignore" }
 gix-utils = { version = "^0.3.6", path = "../gix-utils", features = ["bstr"] }
 

--- a/gix-error/Cargo.toml
+++ b/gix-error/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-error"
-version = "0.3.0"
+version = "0.3.1"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project to provide common errors and error-handling utilities"

--- a/gix-error/src/exn/ext.rs
+++ b/gix-error/src/exn/ext.rs
@@ -179,6 +179,57 @@ where
     }
 }
 
+/// Extension methods for results containing an already boxed error.
+///
+/// This complements [`ResultExt`], whose blanket implementation cannot accept boxed trait objects.
+///
+/// Without it, a boxed error has to be converted explicitly:
+///
+/// ```
+/// use std::error::Error;
+/// use gix_error::{ResultExt, message};
+///
+/// type BoxedError = Box<dyn Error + Send + Sync + 'static>;
+///
+/// fn before(result: Result<(), BoxedError>) -> Result<(), gix_error::Exn<gix_error::Message>> {
+///     result
+///         .map_err(gix_error::Error::from_boxed)
+///         .or_raise(|| message("operation failed"))
+/// }
+/// ```
+///
+/// With `BoxedResultExt`, the boxed error can be turned into erased `Exn` directly.
+///
+/// ```
+/// use std::error::Error;
+/// use gix_error::{BoxedResultExt, ResultExt, message};
+///
+/// type BoxedError = Box<dyn Error + Send + Sync + 'static>;
+///
+/// fn after(result: Result<(), BoxedError>) -> Result<(), gix_error::Exn<gix_error::Message>> {
+///     result.or_erased().or_raise(|| message("operation failed"))
+/// }
+/// ```
+pub trait BoxedResultExt {
+    /// The `Ok` type.
+    type Success;
+
+    /// Type-erase the boxed error inside the [`Result`].
+    fn or_erased(self) -> Result<Self::Success, Exn>;
+}
+
+impl<T> BoxedResultExt for Result<T, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    type Success = T;
+
+    #[track_caller]
+    fn or_erased(self) -> Result<Self::Success, Exn> {
+        match self {
+            Ok(v) => Ok(v),
+            Err(e) => Err(Exn::new(crate::Untyped::from_boxed(e))),
+        }
+    }
+}
+
 impl<T, E> ResultExt for Result<T, Exn<E>>
 where
     E: std::error::Error + Send + Sync + 'static,

--- a/gix-error/src/exn/ext.rs
+++ b/gix-error/src/exn/ext.rs
@@ -182,34 +182,6 @@ where
 /// Extension methods for results containing an already boxed error.
 ///
 /// This complements [`ResultExt`], whose blanket implementation cannot accept boxed trait objects.
-///
-/// Without it, a boxed error has to be converted explicitly:
-///
-/// ```
-/// use std::error::Error;
-/// use gix_error::{ResultExt, message};
-///
-/// type BoxedError = Box<dyn Error + Send + Sync + 'static>;
-///
-/// fn before(result: Result<(), BoxedError>) -> Result<(), gix_error::Exn<gix_error::Message>> {
-///     result
-///         .map_err(gix_error::Error::from_boxed)
-///         .or_raise(|| message("operation failed"))
-/// }
-/// ```
-///
-/// With `BoxedResultExt`, the boxed error can be turned into erased `Exn` directly.
-///
-/// ```
-/// use std::error::Error;
-/// use gix_error::{BoxedResultExt, ResultExt, message};
-///
-/// type BoxedError = Box<dyn Error + Send + Sync + 'static>;
-///
-/// fn after(result: Result<(), BoxedError>) -> Result<(), gix_error::Exn<gix_error::Message>> {
-///     result.or_erased().or_raise(|| message("operation failed"))
-/// }
-/// ```
 pub trait BoxedResultExt {
     /// The `Ok` type.
     type Success;

--- a/gix-error/src/exn/mod.rs
+++ b/gix-error/src/exn/mod.rs
@@ -17,7 +17,7 @@
 #![deny(missing_docs)]
 
 mod ext;
-pub use ext::{ErrorExt, OptionExt, ResultExt};
+pub use ext::{BoxedResultExt, ErrorExt, OptionExt, ResultExt};
 
 mod impls;
 #[cfg(any(feature = "tree-error", not(feature = "auto-chain-error")))]

--- a/gix-error/src/lib.rs
+++ b/gix-error/src/lib.rs
@@ -314,7 +314,7 @@
 mod exn;
 
 pub use bstr;
-pub use exn::{ErrorExt, Exn, Frame, OptionExt, ResultExt, Something, Untyped};
+pub use exn::{BoxedResultExt, ErrorExt, Exn, Frame, OptionExt, ResultExt, Something, Untyped};
 
 /// An error type that wraps an inner type-erased boxed `std::error::Error` or an `Exn` frame.
 ///

--- a/gix-fsck/Cargo.toml
+++ b/gix-fsck/Cargo.toml
@@ -21,9 +21,9 @@ sha1 = ["gix-hash/sha1"]
 sha256 = ["gix-hash/sha256"]
 
 [dependencies]
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
 gix-hashtable = { version = "^0.16.0", path = "../gix-hashtable" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 
 [dev-dependencies]
 gix-odb = { path = "../gix-odb", features = ["sha1", "sha256"] }

--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-hash"
-version = "0.26.1"
+version = "0.26.2"
 description = "Borrowed and owned git hash digests used to identify git objects"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 repository = "https://github.com/GitoxideLabs/gitoxide"

--- a/gix-hash/Cargo.toml
+++ b/gix-hash/Cargo.toml
@@ -23,10 +23,13 @@ sha1 = ["dep:sha1-checked"]
 sha256 = ["dep:sha2"]
 ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
 serde = ["dep:serde", "faster-hex/serde"]
+## Enable comparisons between [`ObjectId`](https://docs.rs/gix-hash/latest/gix_hash/enum.ObjectId.html) and `bstr` types.
+bstr = ["dep:bstr"]
 
 [dependencies]
 gix-features = { version = "^0.49.1", path = "../gix-features", features = ["progress"] }
 
+bstr = { version = "1.12.0", optional = true, default-features = false, features = ["alloc"] }
 thiserror = "2.0.18"
 faster-hex = { version = "0.10.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
@@ -36,7 +39,7 @@ sha2 = { version = "0.11.0", optional = true, default-features = false }
 document-features = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
-gix-hash = { path = ".", features = ["sha1", "sha256"] }
+gix-hash = { path = ".", features = ["sha1", "sha256", "bstr"] }
 gix-testtools = { path = "../tests/tools", default-features = false }
 
 [package.metadata.docs.rs]

--- a/gix-hash/src/change_id.rs
+++ b/gix-hash/src/change_id.rs
@@ -87,11 +87,28 @@ impl std::fmt::Display for ChangeId {
     }
 }
 
+impl ChangeId {
+    fn eq_str(&self, other: &str) -> bool {
+        self.to_reverse_hex().eq_str(other)
+    }
+}
+
+impl_partial_eq_str!(ChangeId);
+
 impl ReverseHexDisplay<'_> {
     pub(crate) fn new(inner: &oid, hex_len: usize) -> ReverseHexDisplay<'_> {
         ReverseHexDisplay { inner, hex_len }
     }
+
+    fn eq_str(&self, other: &str) -> bool {
+        let mut buf = Kind::hex_buf();
+        let reverse_hex = encode_reverse_hex(self.inner, &mut buf);
+        reverse_hex[..self.hex_len.min(reverse_hex.len())] == *other
+    }
 }
+
+// Keep this directional as truncated displays aren't uniquely identified by their text.
+impl_partial_eq_str_one_way!(ReverseHexDisplay<'_>);
 
 impl std::fmt::Display for ReverseHexDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/gix-hash/src/lib.rs
+++ b/gix-hash/src/lib.rs
@@ -31,6 +31,52 @@
 #[cfg(all(not(feature = "sha1"), not(feature = "sha256")))]
 compile_error!("Please set either the `sha1` or the `sha256` feature flag");
 
+macro_rules! impl_partial_eq_str_one_way {
+    ($type:ty) => {
+        impl PartialEq<str> for $type {
+            fn eq(&self, other: &str) -> bool {
+                self.eq_str(other)
+            }
+        }
+
+        impl PartialEq<&str> for $type {
+            fn eq(&self, other: &&str) -> bool {
+                self.eq_str(other)
+            }
+        }
+
+        impl PartialEq<String> for $type {
+            fn eq(&self, other: &String) -> bool {
+                self.eq_str(other)
+            }
+        }
+    };
+}
+
+macro_rules! impl_partial_eq_str {
+    ($type:ty) => {
+        impl_partial_eq_str_one_way!($type);
+
+        impl PartialEq<$type> for str {
+            fn eq(&self, other: &$type) -> bool {
+                other.eq_str(self)
+            }
+        }
+
+        impl PartialEq<$type> for &str {
+            fn eq(&self, other: &$type) -> bool {
+                other.eq_str(self)
+            }
+        }
+
+        impl PartialEq<$type> for String {
+            fn eq(&self, other: &$type) -> bool {
+                other.eq_str(self)
+            }
+        }
+    };
+}
+
 #[path = "oid.rs"]
 mod borrowed;
 pub use borrowed::{Error, oid};

--- a/gix-hash/src/object_id.rs
+++ b/gix-hash/src/object_id.rs
@@ -4,6 +4,9 @@ use std::{
     ops::Deref,
 };
 
+#[cfg(feature = "bstr")]
+use bstr::{BStr, BString, ByteSlice};
+
 use crate::{Kind, borrowed::oid};
 
 #[cfg(feature = "sha1")]
@@ -340,6 +343,62 @@ impl Borrow<oid> for ObjectId {
 impl std::fmt::Display for ObjectId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_hex())
+    }
+}
+
+impl ObjectId {
+    fn eq_str(&self, other: &str) -> bool {
+        self.as_ref().eq_str(other)
+    }
+
+    #[cfg(feature = "bstr")]
+    fn eq_bstr(&self, other: &BStr) -> bool {
+        let mut hex = Kind::hex_buf();
+        self.as_ref().hex_to_buf(&mut hex).as_bytes() == other.as_bytes()
+    }
+}
+
+impl_partial_eq_str!(ObjectId);
+
+#[cfg(feature = "bstr")]
+impl PartialEq<BStr> for ObjectId {
+    fn eq(&self, other: &BStr) -> bool {
+        self.eq_bstr(other)
+    }
+}
+
+#[cfg(feature = "bstr")]
+impl PartialEq<&BStr> for ObjectId {
+    fn eq(&self, other: &&BStr) -> bool {
+        self.eq_bstr(other)
+    }
+}
+
+#[cfg(feature = "bstr")]
+impl PartialEq<BString> for ObjectId {
+    fn eq(&self, other: &BString) -> bool {
+        self.eq_bstr(other.as_bstr())
+    }
+}
+
+#[cfg(feature = "bstr")]
+impl PartialEq<ObjectId> for BStr {
+    fn eq(&self, other: &ObjectId) -> bool {
+        other.eq_bstr(self)
+    }
+}
+
+#[cfg(feature = "bstr")]
+impl PartialEq<ObjectId> for &BStr {
+    fn eq(&self, other: &ObjectId) -> bool {
+        other.eq_bstr(self)
+    }
+}
+
+#[cfg(feature = "bstr")]
+impl PartialEq<ObjectId> for BString {
+    fn eq(&self, other: &ObjectId) -> bool {
+        other.eq_bstr(self.as_bstr())
     }
 }
 

--- a/gix-hash/src/oid.rs
+++ b/gix-hash/src/oid.rs
@@ -55,6 +55,17 @@ impl std::fmt::Display for HexDisplay<'_> {
     }
 }
 
+impl HexDisplay<'_> {
+    pub(crate) fn eq_str(&self, other: &str) -> bool {
+        let mut hex = Kind::hex_buf();
+        let hex = self.inner.hex_to_buf(hex.as_mut());
+        hex[..self.hex_len.min(hex.len())] == *other
+    }
+}
+
+// Keep this directional as truncated displays aren't uniquely identified by their text.
+impl_partial_eq_str_one_way!(HexDisplay<'_>);
+
 impl std::fmt::Debug for oid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -197,6 +208,10 @@ impl oid {
         out.write_all(&hex[..hex_len])
     }
 
+    pub(crate) fn eq_str(&self, other: &str) -> bool {
+        self.to_hex().eq_str(other)
+    }
+
     /// Returns `true` if this hash consists of all null bytes.
     #[inline]
     #[doc(alias = "is_zero", alias = "git2")]
@@ -330,6 +345,20 @@ impl PartialEq<ObjectId> for &oid {
         *self == other.as_ref()
     }
 }
+
+impl PartialEq<String> for &oid {
+    fn eq(&self, other: &String) -> bool {
+        self.eq_str(other)
+    }
+}
+
+impl PartialEq<&oid> for String {
+    fn eq(&self, other: &&oid) -> bool {
+        other.eq_str(self)
+    }
+}
+
+impl_partial_eq_str!(oid);
 
 /// Manually created from a version that uses a slice, and we forcefully try to convert it into a borrowed array of the desired size
 /// Could be improved by fitting this into serde.

--- a/gix-hash/src/prefix.rs
+++ b/gix-hash/src/prefix.rs
@@ -207,6 +207,15 @@ impl std::fmt::Display for Prefix {
     }
 }
 
+impl Prefix {
+    fn eq_str(&self, other: &str) -> bool {
+        self.bytes.to_hex_with_len(self.hex_len).eq_str(other)
+    }
+}
+
+// Keep this directional as the hash kind and unused suffix aren't uniquely identified by the displayed prefix.
+impl_partial_eq_str_one_way!(Prefix);
+
 impl From<ObjectId> for Prefix {
     fn from(oid: ObjectId) -> Self {
         Prefix {

--- a/gix-hash/tests/hash/comparisons.rs
+++ b/gix-hash/tests/hash/comparisons.rs
@@ -1,0 +1,153 @@
+#[cfg(feature = "bstr")]
+use bstr::{BString, ByteSlice};
+use gix_hash::{ChangeId, Prefix};
+
+use crate::hex_to_id;
+
+macro_rules! assert_text_eq {
+    ($value:expr, $text:expr) => {{
+        let value = $value;
+        let text = $text;
+        let owned = text.to_owned();
+        assert!(value == text, "the value compares with a string literal");
+        assert!(text == value, "string-literal comparison is symmetric");
+        assert!(&value == text, "a borrowed value compares with str");
+        assert!(text == &value, "str comparison with a borrowed value is symmetric");
+        assert!(value == owned, "the value compares with String");
+        assert!(owned == value, "String comparison is symmetric");
+    }};
+}
+
+macro_rules! assert_text_ne {
+    ($value:expr, $text:expr) => {{
+        let value = $value;
+        let text = $text;
+        assert!(value != text, "different text does not compare equal");
+        assert!(text != value, "inequality is symmetric");
+    }};
+}
+
+macro_rules! assert_text_eq_one_way {
+    ($value:expr, $text:expr) => {{
+        let value = $value;
+        let text = $text;
+        let owned = text.to_owned();
+        assert!(value == text, "the value compares with a string literal");
+        assert!(&value == text, "a borrowed value compares with str");
+        assert!(value == owned, "the value compares with String");
+    }};
+}
+
+macro_rules! assert_text_ne_one_way {
+    ($value:expr, $text:expr) => {{
+        let value = $value;
+        let text = $text;
+        assert!(value != text, "different text does not match the value");
+    }};
+}
+
+fn compare_all(object_hex: &str, reverse_hex: &str) {
+    let id = hex_to_id(object_hex);
+    let object_hex_upper = object_hex.to_ascii_uppercase();
+    assert_text_eq!(id, object_hex);
+    assert_text_ne!(id, object_hex_upper.as_str());
+    assert_text_ne!(id, &object_hex[..object_hex.len() - 1]);
+    let invalid_object_hex = format!("g{}", &object_hex[1..]);
+    assert_text_ne!(id, invalid_object_hex.as_str());
+    #[cfg(feature = "bstr")]
+    {
+        let borrowed = object_hex.as_bytes().as_bstr();
+        let owned = BString::from(object_hex);
+        assert!(id == borrowed, "ObjectId compares with BStr");
+        assert!(borrowed == id, "BStr comparison with ObjectId is symmetric");
+        assert!(id == owned, "ObjectId compares with BString");
+        assert!(owned == id, "BString comparison with ObjectId is symmetric");
+        assert!(
+            id != object_hex_upper.as_bytes().as_bstr(),
+            "ObjectId only matches canonical lowercase BStr text"
+        );
+        assert!(
+            object_hex_upper.as_bytes().as_bstr() != id,
+            "non-canonical BStr comparison is symmetric"
+        );
+        assert!(
+            id != invalid_object_hex.as_bytes().as_bstr(),
+            "ObjectId rejects invalid hex in BStr"
+        );
+        assert!(
+            invalid_object_hex.as_bytes().as_bstr() != id,
+            "invalid BStr comparison is symmetric"
+        );
+        assert!(
+            id != b"\xff".as_bstr(),
+            "ObjectId does not match non-UTF-8 BStr content"
+        );
+        assert!(b"\xff".as_bstr() != id, "non-UTF-8 BStr comparison is symmetric");
+    }
+
+    let borrowed = id.as_ref();
+    assert!(borrowed == object_hex, "oid compares with str");
+    assert!(object_hex == borrowed, "str comparison with oid is symmetric");
+    assert!(
+        borrowed != object_hex_upper,
+        "oid only matches canonical lowercase text"
+    );
+    assert!(object_hex_upper != borrowed, "non-canonical comparison is symmetric");
+    assert!(
+        borrowed != &object_hex[..object_hex.len() - 1],
+        "oid requires the exact length"
+    );
+    assert!(borrowed != invalid_object_hex.as_str(), "oid rejects invalid hex");
+
+    let change_id = ChangeId::from(id);
+    let reverse_hex_upper = reverse_hex.to_ascii_uppercase();
+    assert_text_eq!(change_id, reverse_hex);
+    assert_text_ne!(change_id, reverse_hex_upper.as_str());
+    assert_text_ne!(change_id, &reverse_hex[..reverse_hex.len() - 1]);
+    let invalid_reverse_hex = format!("j{}", &reverse_hex[1..]);
+    assert_text_ne!(change_id, invalid_reverse_hex.as_str());
+
+    let prefix_len = 17;
+    let prefix = Prefix::new(&id, prefix_len).expect("the requested prefix length is valid");
+    let object_prefix = &object_hex[..prefix_len];
+    let object_prefix_upper = object_prefix.to_ascii_uppercase();
+    assert_text_eq_one_way!(prefix, object_prefix);
+    assert_text_ne_one_way!(prefix, object_prefix_upper.as_str());
+    assert_text_ne_one_way!(prefix, &object_hex[..prefix_len + 1]);
+    assert_text_ne_one_way!(prefix, "abcdefg");
+
+    assert_text_eq_one_way!(id.to_hex_with_len(prefix_len), object_prefix);
+    assert_text_ne_one_way!(id.to_hex_with_len(prefix_len), object_prefix_upper.as_str());
+    assert_text_ne_one_way!(id.to_hex_with_len(prefix_len), &object_hex[..prefix_len + 1]);
+    assert_text_ne_one_way!(id.to_hex_with_len(prefix_len), "abcdefg");
+
+    let reverse_prefix = &reverse_hex[..prefix_len];
+    let reverse_prefix_upper = reverse_prefix.to_ascii_uppercase();
+    assert_text_eq_one_way!(change_id.to_reverse_hex_with_len(prefix_len), reverse_prefix);
+    assert_text_ne_one_way!(
+        change_id.to_reverse_hex_with_len(prefix_len),
+        reverse_prefix_upper.as_str()
+    );
+    assert_text_ne_one_way!(
+        change_id.to_reverse_hex_with_len(prefix_len),
+        &reverse_hex[..prefix_len + 1]
+    );
+    assert_text_ne_one_way!(change_id.to_reverse_hex_with_len(prefix_len), "abcdefg");
+}
+
+#[test]
+fn compares_sha1_with_text() {
+    compare_all(
+        "0123456789abcdef0123456789abcdef01234567",
+        "zyxwvutsrqponmlkzyxwvutsrqponmlkzyxwvuts",
+    );
+}
+
+#[test]
+#[cfg(feature = "sha256")]
+fn compares_sha256_with_text() {
+    compare_all(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "zyxwvutsrqponmlkzyxwvutsrqponmlkzyxwvutsrqponmlkzyxwvutsrqponmlk",
+    );
+}

--- a/gix-hash/tests/hash/main.rs
+++ b/gix-hash/tests/hash/main.rs
@@ -1,6 +1,7 @@
 use gix_hash::ObjectId;
 
 mod change_id;
+mod comparisons;
 mod hasher;
 mod kind;
 mod object_id;

--- a/gix-mailmap/Cargo.toml
+++ b/gix-mailmap/Cargo.toml
@@ -22,7 +22,7 @@ serde = ["dep:serde", "bstr/serde", "gix-actor/serde"]
 gix-actor = { version = "^0.42.0", path = "../gix-actor" }
 gix-date = { version = "^0.16.0", path = "../gix-date" }
 bstr = { version = "1.12.0", default-features = false, features = ["std", "unicode"] }
-gix-error = { version = "^0.3.0", path = "../gix-error" }
+gix-error = { version = "^0.3.1", path = "../gix-error" }
 serde = { version = "1.0.114", optional = true, default-features = false, features = ["derive"] }
 
 document-features = { version = "0.2.0", optional = true }

--- a/gix-merge/Cargo.toml
+++ b/gix-merge/Cargo.toml
@@ -28,8 +28,8 @@ sha256 = ["gix-hash/sha256"]
 serde = ["dep:serde", "gix-hash/serde", "gix-object/serde"]
 
 [dependencies]
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 gix-filter = { version = "^0.34.0", path = "../gix-filter" }
 gix-worktree = { version = "^0.56.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }
 gix-command = { version = "^0.10.0", path = "../gix-command" }

--- a/gix-merge/tests/merge/blob/platform.rs
+++ b/gix-merge/tests/merge/blob/platform.rs
@@ -221,7 +221,7 @@ theirs
                 })
                 .unwrap()
                 .unwrap(),
-            hex_to_id("424860eef4edb9f5a2dacbbd6dc8c2d2e7645035"),
+            "424860eef4edb9f5a2dacbbd6dc8c2d2e7645035",
             "there is no need to write a buffer here, it just returns one of our inputs"
         );
 

--- a/gix-negotiate/Cargo.toml
+++ b/gix-negotiate/Cargo.toml
@@ -22,8 +22,8 @@ sha1 = ["gix-hash/sha1"]
 sha256 = ["gix-hash/sha256"]
 
 [dependencies]
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 gix-date = { version = "^0.16.0", path = "../gix-date" }
 gix-commitgraph = { version = "^0.39.0", path = "../gix-commitgraph" }
 gix-revwalk = { version = "^0.35.0", path = "../gix-revwalk" }

--- a/gix-note/Cargo.toml
+++ b/gix-note/Cargo.toml
@@ -24,10 +24,10 @@ sha1 = ["gix-hash/sha1", "gix-object/sha1", "gix-hashtable/sha1" ]
 sha256 = ["gix-hash/sha256", "gix-object/sha256",  "gix-hashtable/sha256" ]
 
 [dependencies]
-gix-error = { version = "^0.3.0", path = "../gix-error" }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
+gix-error = { version = "^0.3.1", path = "../gix-error" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
 gix-hashtable = { version = "^0.16.0", path = "../gix-hashtable" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 
 [dev-dependencies]
 gix-note = { path = ".", features = ["sha1", "sha256"] }

--- a/gix-object/CHANGELOG.md
+++ b/gix-object/CHANGELOG.md
@@ -5,7 +5,136 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.64.1 (2026-08-23)
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 2 commits contributed to the release.
+ - 1 day passed between releases.
+ - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Use fundamental-type comparisons throughout tests ([`47536a5`](https://github.com/GitoxideLabs/gitoxide/commit/47536a5c2b22da3a9f4892c8af5e460c2d5bda0a))
+    - Merge pull request #2933 from GitoxideLabs/report-august ([`b8914ff`](https://github.com/GitoxideLabs/gitoxide/commit/b8914ffda5bc8f6ea851aaf1f720140acfe96dbb))
+</details>
+
+## 0.64.0 (2026-08-22)
+
+### New Features
+
+ - <csr-id-ca7563e17a53344ae07f3cfc1742023fb72fdd7d/> add explicit commit signing to gix-object
+   <!-- agent -->
+   Add plumbing for signing commits through external OpenPGP, X.509, and SSH
+   programs under the shared signature feature. Accept fully resolved signer
+   options so callers control the program, key, environment, and arguments
+   without introducing repository configuration into the object crate.
+   
+   Replace an existing signature using the hash-appropriate commit header,
+   normalize signer output, and report process and malformed-output failures
+   with context. Cover every supported format, SHA-256 headers, replacement,
+   literal SSH keys, and verify generated signatures through the sibling
+   plumbing verifier as well as the external reference programs.
+ - <csr-id-5b90699525c939ccab570f884e4dd567a7161d16/> add commit signature verification to gix-object via `commit::SignedData::verify()`
+   <!-- agent -->
+   Add feature-gated plumbing for verifying OpenPGP, X.509, and SSH commit
+   signatures with fully resolved programs, arguments, environments, trust
+   thresholds, and SSH policy inputs. Keep repository configuration out of
+   the object crate while exposing Git-compatible status, identity, key, and
+   fingerprint results.
+   
+   Stream signed commit data directly to OpenPGP and SSH verifiers without
+   reconstructing it. Use a temporary payload only where gpgsm requires a
+   file, and cover Git status parsing plus unsupported and mismatched formats.
+ - <csr-id-a30f44225ce0190e4a537bfe61127a0cd9f2763b/> recognize SHA-256 commit signature headers
+   <!-- agent -->
+   Teach commit parsing and signature extraction about the gpgsig-sha256
+   header used by Git when signing SHA-256 commits. Treat it like gpgsig
+   when locating the embedded signature while preserving the actual header
+   name when reconstructing the signed payload.
+   
+   Cover both full commit parsing and token iteration so callers observe
+   the signature consistently through either API.
+ - <csr-id-c6cf668e9c25f8a73cbb0318a5dd56fa5952f825/> add `tree::name_order()` for git-style tree-entry comparison
+ - <csr-id-e5370e63b8fcadef7e1e1e2cb28f781999444c70/> support Assisted-by commit trailers, count them as attributions.
+   <!-- agent -->
+   
+   Expose Assisted-by predicates and iterators alongside Co-authored-by, and
+   include agent assistance in the general attribution stream without treating
+   assistants as authors.
+ - <csr-id-f2e90e985650cc6148c2fcb0453acac3aae1889d/> expose commit message blocks via `Commit::body()::message_blocks()`
+   This allows parsing messages that have been concatenated, and each message
+   has its own trailers.
+
+### New Features (BREAKING)
+
+ - <csr-id-26d231b4bc6f32a53b62e9d115445092cd90a1d2/> support signing and verifying annotated tags
+   Breaking as it renames `Tag::pgp_signature` to `signature`.
+   
+   <!-- agent -->
+   Extend `gix-object` signature support from commits to annotated tags.
+   
+   **Signature infrastructure**
+   
+   - Move object-independent signing and verification machinery into the shared
+     `gix_object::signature` module.
+   - Keep signature discovery available without the `signature` feature.
+   - Continue using the existing signing and verification options and
+     shared verification outcome for all object types.
+   
+   **Annotated tags**
+   
+   - Add `Tag::sign()` and `TagRef::sign()`.
+   - Add signature accessors that report both the armor and detected format.
+   - Add raw extraction of a tag signature and its exact signed bytes.
+   - Recognize OpenPGP signature/message, X.509, and SSH armor markers.
+   - Match Git by selecting the last recognized marker at a line boundary.
+   - Support native SHA-1 and SHA-256 tags without compatibility headers or
+     multiple signatures.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 16 commits contributed to the release over the course of 30 calendar days.
+ - 30 days passed between releases.
+ - 7 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Update manifests prior to release ([`ebe9095`](https://github.com/GitoxideLabs/gitoxide/commit/ebe9095f2888d3c12447ea5eed9d0afdb0fd5aeb))
+    - Merge pull request #2930 from GitoxideLabs/gix-notes ([`7424676`](https://github.com/GitoxideLabs/gitoxide/commit/7424676f86cd3f5a67c53f8db6baf0803e937d4a))
+    - Improve `Tree::bisect_entry()` to be more succinct ([`579544e`](https://github.com/GitoxideLabs/gitoxide/commit/579544e14e0dde22733c58624c7454c50aa1df75))
+    - Merge pull request #2905 from GitoxideLabs/various-improvements ([`f3bbfad`](https://github.com/GitoxideLabs/gitoxide/commit/f3bbfadd4b4f1d72c85c62eb3d7ae337c922f945))
+    - Support signing and verifying annotated tags ([`26d231b`](https://github.com/GitoxideLabs/gitoxide/commit/26d231b4bc6f32a53b62e9d115445092cd90a1d2))
+    - Add explicit commit signing to gix-object ([`ca7563e`](https://github.com/GitoxideLabs/gitoxide/commit/ca7563e17a53344ae07f3cfc1742023fb72fdd7d))
+    - Add commit signature verification to gix-object via `commit::SignedData::verify()` ([`5b90699`](https://github.com/GitoxideLabs/gitoxide/commit/5b90699525c939ccab570f884e4dd567a7161d16))
+    - Recognize SHA-256 commit signature headers ([`a30f442`](https://github.com/GitoxideLabs/gitoxide/commit/a30f44225ce0190e4a537bfe61127a0cd9f2763b))
+    - Adapt to changes in `gix-testtools` ([`0cbe539`](https://github.com/GitoxideLabs/gitoxide/commit/0cbe53971687fb3b1959925aa9d8dc89deb5b474))
+    - Add `tree::name_order()` for git-style tree-entry comparison ([`c6cf668`](https://github.com/GitoxideLabs/gitoxide/commit/c6cf668e9c25f8a73cbb0318a5dd56fa5952f825))
+    - Merge pull request #2901 from cruessler/switch-to-gix-odb-at-opts ([`2a4d996`](https://github.com/GitoxideLabs/gitoxide/commit/2a4d996ca53bd38a5e9889da0b180580315d905f))
+    - Introduce `Store::at()` where possible ([`17fea2a`](https://github.com/GitoxideLabs/gitoxide/commit/17fea2ab8a1c23f2e8bc50b78b90feb1e361f66a))
+    - Merge pull request #2834 from GitoxideLabs/tix-improvements ([`2fadbc7`](https://github.com/GitoxideLabs/gitoxide/commit/2fadbc79986d84520ffb7f4ef85dabd0a7469d16))
+    - Support Assisted-by commit trailers, count them as attributions. ([`e5370e6`](https://github.com/GitoxideLabs/gitoxide/commit/e5370e63b8fcadef7e1e1e2cb28f781999444c70))
+    - Expose commit message blocks via `Commit::body()::message_blocks()` ([`f2e90e9`](https://github.com/GitoxideLabs/gitoxide/commit/f2e90e985650cc6148c2fcb0453acac3aae1889d))
+    - Merge pull request #2812 from GitoxideLabs/report-july ([`ae8845a`](https://github.com/GitoxideLabs/gitoxide/commit/ae8845a47c4c87e0996a119822106cf09036340b))
+</details>
+
+## 0.63.0 (2026-07-23)
 
 ### New Features
 
@@ -17,7 +146,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 10 commits contributed to the release.
+ - 12 commits contributed to the release.
  - 31 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -35,6 +164,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-actor v0.41.2, gix-features v0.49.0, gix-hash v0.26.0, gix-hashtable v0.16.0, gix-object v0.63.0, gix-glob v0.27.0, gix-attributes v0.34.0, gix-packetline v0.22.0, gix-filter v0.33.0, gix-fs v0.22.0, gix-chunk v0.7.3, gix-commitgraph v0.38.0, gix-revwalk v0.34.0, gix-traverse v0.60.0, gix-worktree-stream v0.35.0, gix-archive v0.35.0, gix-bitmap v0.3.3, gix-tempfile v24.0.0, gix-lock v24.0.0, gix-index v0.54.0, gix-pathspec v0.19.0, gix-ignore v0.22.0, gix-worktree v0.55.0, gix-imara-diff v0.2.4, gix-diff v0.66.0, gix-blame v0.16.0, gix-ref v0.66.0, gix-config v0.59.0, gix-discover v0.54.0, gix-dir v0.28.0, gix-mailmap v0.33.2, gix-revision v0.48.0, gix-merge v0.19.0, gix-negotiate v0.34.0, gix-zlib v0.1.0, gix-pack v0.73.0, gix-odb v0.83.0, gix-refspec v0.44.0, gix-shallow v0.13.0, gix-transport v0.58.0, gix-protocol v0.64.0, gix-status v0.33.0, gix-submodule v0.33.0, gix-worktree-state v0.33.0, gix v0.86.0, gix-fsck v0.24.0, gitoxide-core v0.60.0, gix-tix v0.1.0, gitoxide v0.56.0, safety bump 40 crates ([`842bc44`](https://github.com/GitoxideLabs/gitoxide/commit/842bc447e3aeacf5d9d36f7f8a01068eda4b7999))
+    - Update changelogs prior to release ([`cb6ec7d`](https://github.com/GitoxideLabs/gitoxide/commit/cb6ec7dce283943d811b1600b577f586d7a13e1f))
     - Release gix-trace v0.1.21, gix-validate v0.11.3, gix-path v0.12.3, gix-utils v0.3.5, gix-config-value v0.19.0, gix-prompt v0.16.0, gix-sec v0.14.2, gix-url v0.37.0, gix-credentials v0.39.0, safety bump 18 crates ([`f0ec710`](https://github.com/GitoxideLabs/gitoxide/commit/f0ec71076aa1cef3181b77946ee556a89c651b8e))
     - Merge pull request #2722 from GitoxideLabs/reasons ([`c16b5a1`](https://github.com/GitoxideLabs/gitoxide/commit/c16b5a1892704b7c72a253bdd74a6848dd61032a))
     - Replace lint allowances with expectations ([`43ff87a`](https://github.com/GitoxideLabs/gitoxide/commit/43ff87a73897b70313e3a58e7de82231be5b59ad))

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -68,13 +68,14 @@ document-features = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 gix-object = { path = ".", features = ["signature", "sha1", "sha256"] }
-criterion = "0.8.2"
-pretty_assertions = "1.0.0"
-insta = "1.46.3"
+gix-hash = { path = "../gix-hash", features = ["bstr"] }
 gix-testtools = { path = "../tests/tools", default-features = false }
 gix-odb = { path = "../gix-odb" }
 gix-path = { path = "../gix-path" }
 termtree = "1.0.0"
+criterion = "0.8.2"
+pretty_assertions = "1.0.0"
+insta = "1.46.3"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gix-object/Cargo.toml
+++ b/gix-object/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-object"
-version = "0.64.0"
+version = "0.64.1"
 description = "Immutable and mutable git objects with decoding and encoding support"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 repository = "https://github.com/GitoxideLabs/gitoxide"
@@ -44,7 +44,7 @@ serde = [
 gix-features = { version = "^0.49.1", path = "../gix-features", features = [
     "progress",
 ] }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
 gix-hashtable = { version = "^0.16.0", path = "../gix-hashtable" }
 gix-validate = { version = "^0.11.4", path = "../gix-validate" }
 gix-actor = { version = "^0.42.0", path = "../gix-actor" }

--- a/gix-object/tests/object/commit/from_bytes.rs
+++ b/gix-object/tests/object/commit/from_bytes.rs
@@ -6,7 +6,7 @@ use smallvec::SmallVec;
 
 use crate::{
     commit::{LONG_MESSAGE, MERGE_TAG, SIGNATURE},
-    fixture_name, fixture_oid, hex_to_id, linus_signature,
+    fixture_name, fixture_oid, linus_signature,
 };
 
 #[test]
@@ -104,7 +104,7 @@ committer Name <name@example.com> 1312735823 +0518
 message";
     let commit = CommitRef::from_bytes(input, gix_hash::Kind::Sha1)?;
     assert_eq!(commit.tree, b"7989DFB2EC2F41914611A22FB30BBC2B3849DF9A".as_bstr());
-    assert_eq!(commit.tree(), hex_to_id("7989dfb2ec2f41914611a22fb30bbc2b3849df9a"));
+    assert_eq!(commit.tree(), "7989dfb2ec2f41914611a22fb30bbc2b3849df9a");
     Ok(())
 }
 

--- a/gix-object/tests/object/commit/iter.rs
+++ b/gix-object/tests/object/commit/iter.rs
@@ -120,7 +120,7 @@ fn signed_singleline() -> crate::Result {
         CommitRefIter::from_bytes(&fixture_name("commit", "signed-singleline.txt"), gix_hash::Kind::Sha1)
             .parent_ids()
             .collect::<Vec<_>>(),
-        vec![hex_to_id("09d8d3a12e161a7f6afb522dbe8900a9c09bce06")]
+        vec!["09d8d3a12e161a7f6afb522dbe8900a9c09bce06"]
     );
     Ok(())
 }
@@ -166,8 +166,8 @@ fn mergetag() -> crate::Result {
     assert_eq!(
         iter.parent_ids().collect::<Vec<_>>(),
         vec![
-            hex_to_id("44ebe016df3aad96e3be8f95ec52397728dd7701"),
-            hex_to_id("8d485da0ddee79d0e6713405694253d401e41b93")
+            "44ebe016df3aad96e3be8f95ec52397728dd7701",
+            "8d485da0ddee79d0e6713405694253d401e41b93"
         ]
     );
     assert_eq!(iter.message().ok(), Some(LONG_MESSAGE.into()));

--- a/gix-object/tests/object/commit/mod.rs
+++ b/gix-object/tests/object/commit/mod.rs
@@ -156,13 +156,13 @@ mod method {
     use gix_object::CommitRef;
     use pretty_assertions::assert_eq;
 
-    use crate::{fixture_name, hex_to_id, signature};
+    use crate::{fixture_name, signature};
 
     #[test]
     fn tree() -> crate::Result {
         let fixture = fixture_name("commit", "unsigned.txt");
         let commit = CommitRef::from_bytes(&fixture, gix_hash::Kind::Sha1)?;
-        assert_eq!(commit.tree(), hex_to_id("1b2dfb4ac5e42080b682fc676e9738c94ce6d54d"));
+        assert_eq!(commit.tree(), "1b2dfb4ac5e42080b682fc676e9738c94ce6d54d");
         assert_eq!(commit.tree, "1b2dfb4ac5e42080b682fc676e9738c94ce6d54d");
         Ok(())
     }

--- a/gix-object/tests/object/tag/mod.rs
+++ b/gix-object/tests/object/tag/mod.rs
@@ -1,4 +1,4 @@
-use crate::{hex_to_id, signature};
+use crate::signature;
 use gix_object::{Kind, TagRef, TagRefIter, bstr::ByteSlice};
 
 use crate::fixture_name;
@@ -189,7 +189,7 @@ sha256-tag-signature
 fn target() -> crate::Result {
     let fixture = fixture_name("tag", "signed.txt");
     let tag_ref = TagRef::from_bytes(&fixture, gix_hash::Kind::Sha1)?;
-    assert_eq!(tag_ref.target(), hex_to_id("ffa700b4aca13b80cb6b98a078e7c96804f8e0ec"));
+    assert_eq!(tag_ref.target(), "ffa700b4aca13b80cb6b98a078e7c96804f8e0ec");
     assert_eq!(tag_ref.target, "ffa700b4aca13b80cb6b98a078e7c96804f8e0ec".as_bytes());
 
     let gix_object::Tag {
@@ -200,7 +200,7 @@ fn target() -> crate::Result {
         message,
         signature,
     } = tag_ref.into_owned()?;
-    assert_eq!(target.to_string(), tag_ref.target);
+    assert_eq!(target, tag_ref.target);
     assert_eq!(target_kind, tag_ref.target_kind);
     assert_eq!(name, tag_ref.name);
     let expected_tagger = tag_ref.tagger()?.map(Into::into);
@@ -362,10 +362,7 @@ tag uppercase-target
 message";
     let tag = TagRef::from_bytes(input, gix_hash::Kind::Sha1)?;
     assert_eq!(tag.target, b"FFA700B4ACA13B80CB6B98A078E7C96804F8E0EC".as_bstr());
-    assert_eq!(
-        tag.target(),
-        crate::hex_to_id("ffa700b4aca13b80cb6b98a078e7c96804f8e0ec")
-    );
+    assert_eq!(tag.target(), "ffa700b4aca13b80cb6b98a078e7c96804f8e0ec");
     Ok(())
 }
 

--- a/gix-pack/CHANGELOG.md
+++ b/gix-pack/CHANGELOG.md
@@ -5,7 +5,243 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.74.1 (2026-08-23)
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 2 commits contributed to the release.
+ - 1 day passed between releases.
+ - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Use fundamental-type comparisons throughout tests ([`47536a5`](https://github.com/GitoxideLabs/gitoxide/commit/47536a5c2b22da3a9f4892c8af5e460c2d5bda0a))
+    - Merge pull request #2933 from GitoxideLabs/report-august ([`b8914ff`](https://github.com/GitoxideLabs/gitoxide/commit/b8914ffda5bc8f6ea851aaf1f720140acfe96dbb))
+</details>
+
+## 0.74.0 (2026-08-22)
+
+### New Features
+
+ - <csr-id-40a4ca7d1802361850a6a4a6aef91c8c2c5d730f/> expose index-less parallel pack traversal (cache Tree, Context, Options)
+   Re-export `cache::delta::{Tree, traverse::{Context, Options}}` at `cache` so
+   external callers can build a delta `Tree` directly from a pack header scan and
+   resolve all of its objects in parallel via `Tree::traverse` -- without a
+   pre-built `.idx`. This is the index-less companion to the already-public,
+   idx-verified `index::File::traverse_with_index`.
+   
+   Minimal surface by design: the `delta` module stays `pub(crate)`, so only the
+   three already-documented items a caller names become public -- `pub mod delta`
+   would instead expose the module's internal error types and constructors and fail
+   `#![deny(missing_docs)]`. `Tree::from_offsets_in_pack` (already public) builds the
+   tree straight from the pack; `with_capacity`/`add_root`/`add_child` remain for
+   callers who assemble it by ascending pack offset themselves.
+   
+   Additive and non-breaking; `cargo doc` is clean under `-D warnings`, and a
+   doc-test anchors the index-less path (`Tree::from_offsets_in_pack`). Shape
+   approved in #2922.
+
+### Bug Fixes
+
+ - <csr-id-916f5d8c32deb0a03bb6a01c8d8e9c4b6c69d186/> validate delta base sizes during entry decoding
+   <!-- agent -->
+   Reject delta instruction streams whose declared base size differs from the
+   resolved base object. The regression demonstrates that a REF_DELTA could
+   previously reconstruct successfully despite lying about its base size.
+   
+   Git reference: patch_delta() compares the decoded source size with src_size
+   before applying instructions, observed at cf5497b14c5a.
+ - <csr-id-d7bbb8e053c3ce9c24fe0a4bf1aaaca7b7a58270/> resolve delta trees lazily in a lock-free pool
+   <!-- agent -->
+   --- Summary of findings
+   
+   The lazy, stealable resolver fixes the pathological phpstan pack without
+   regressing the Linux best case. At 16 threads, phpstan falls from the
+   98.38-second baseline resolver time to 22.70 seconds, while the Linux
+   best-case resolver improves slightly from 11.81 to 11.33 seconds. Charged
+   peak memory on phpstan falls from 13.14 GB to 2.16 GB, and the Linux best
+   case falls from 1.96 GB to 1.76 GB.
+   
+   Across the measured packs, gix resolver speedup at 16 threads ranges from
+   10.80x to 12.48x over its new serial path. On phpstan, gix is 1.07x faster
+   than Git at one thread and 2.31x faster at 16 threads. On the identical
+   10.9M-object Linux payload, gix's SHA-256 resolver is 2.72x to 2.99x faster
+   than its SHA-1 resolver, confirming that the slow SHA-1 implementation
+   dominates much of the remaining absolute cost.
+   
+   The Git SHA-256 comparison was initially unfair: the local Git build used
+   the portable SHA256_BLK backend while RustCrypto selected ARMv8 SHA-2
+   instructions. Rebuilding Git with OpenSSL reduced its eight-thread wall
+   time from 144.15 to 40.45 seconds and user CPU time from 471.94 to
+   99.81 seconds. All final Git SHA-256 comparisons use that faster backend.
+   
+   --- Pathological phpstan pack
+   
+   The pack contains 100.7k objects but expands to 174.6 GB because one root
+   ends in a deep, expensive delta tree. The previous resolver takes
+   98.53 seconds wall clock and has a 13.14 GB peak memory footprint.
+   
+   The new resolver takes 283.41, 71.94, 36.42, and 22.83 seconds wall clock
+   at 1, 4, 8, and 16 threads. Its resolver speedups are 3.94x, 7.81x, and
+   12.48x relative to one thread, remaining nearly linear through eight
+   threads. Peak memory footprint is 0.68, 0.75, 1.17, and 2.16 GB
+   respectively. Thus the fastest run is 4.31x faster than the old wall time
+   while using 84% less charged peak memory.
+   
+   Git was measured at 1, 2, 4, 8, and 16 threads while keeping its aggregate
+   delta-base cache allowance at least as large as the default eight-thread
+   allowance of 8 times 96 MiB. Git takes 304.51, 168.06, 98.80, 65.41, and
+   52.79 seconds, for 5.77x one-to-sixteen-thread scaling. At equal thread
+   counts, gix is 1.07x, 1.37x, 1.80x, and 2.31x faster at 1, 4, 8, and
+   16 threads.
+   
+   At the nearest wall-time operating points, gix at four threads takes
+   71.94 seconds with a 0.75 GB peak footprint, while Git at eight threads
+   takes 65.41 seconds with a 1.90 GB peak footprint. gix therefore uses
+   61% less charged working memory near Git-matching throughput.
+   
+   --- Linux best-case pack
+   
+   The 7.6M-object fixture expands to 95.6 GB and guards the already-friendly
+   case. The old implementation takes 13.68 seconds wall clock and
+   11.81 seconds in the resolver. The new implementation takes 137.48,
+   36.75, 19.81, and 13.16 seconds wall clock at 1, 4, 8, and 16 threads;
+   resolver scaling reaches 11.97x at 16 threads.
+   
+   The 16-thread result is slightly faster than the old implementation, with
+   11.33 seconds in the resolver, and lowers peak footprint from 1.96 to
+   1.76 GB. Peak footprint remains effectively constant from one through
+   16 threads. Git takes 156.65, 60.48, 45.48, and 42.97 seconds at the same
+   thread counts, so gix's advantage grows from 1.14x to 3.27x.
+   
+   --- SHA-1 and SHA-256 sibling packs
+   
+   The sibling packs contain 10.9M objects, expand to 146.7 GB, and preserve
+   the same compressed payload and delta topology. This isolates hashing from
+   work distribution.
+   
+   For SHA-1, gix takes 212.57, 56.58, 30.60, and 20.74 seconds wall clock at
+   1, 4, 8, and 16 threads. Resolver scaling reaches 11.36x at 16 threads.
+   The default eight-thread Git run takes 125.11 seconds, while gix takes
+   30.60 seconds at eight threads and 20.74 seconds at 16.
+   
+   For SHA-256, gix takes 72.47, 21.83, 12.58, and 8.67 seconds wall clock.
+   Resolver scaling reaches 10.80x at 16 threads. Against OpenSSL-backed Git,
+   gix is 1.21x, 2.02x, 3.22x, and 5.61x faster at equal thread counts.
+   Git improves from 87.85 seconds at one thread to 40.45 seconds at eight,
+   then regresses to 48.68 seconds at 16 with 204.81 seconds of system CPU.
+   
+   --- Hasher and scheduler interpretation
+   
+   On identical pack data, gix SHA-256 resolver time is 70.31 seconds at one
+   thread versus 210.35 seconds for SHA-1, and 6.51 seconds at 16 threads
+   versus 18.51 seconds for SHA-1. SHA-256 is therefore 2.99x faster
+   serially and 2.84x faster at 16 threads, with a 2.72x to 2.99x advantage
+   throughout the measured range.
+   
+   The similar 10.80x to 12.48x gix scaling across pathological, best-case,
+   SHA-1, and SHA-256 packs argues against lock contention being the main
+   high-thread limitation. The remaining flattening is consistent with
+   finite parallel work, scheduling overhead, memory bandwidth, and hashing
+   cost.
+   
+   --- Memory interpretation
+   
+   The resolver no longer materializes the unresolved internal-node frontier.
+   It resolves a child only when a worker starts it, shares immutable bases
+   between sibling tasks, and recycles the final base reference. A linear
+   chain therefore needs roughly two object buffers per active worker instead
+   of retaining every intermediate base.
+   
+   macOS max RSS includes clean file-backed pages. gix maps the pack, so its
+   reported RSS can include most of a multi-gigabyte pack even when those
+   pages are reclaimable; Git reads through bounded pread buffers. Peak memory
+   footprint better represents charged working memory here. On phpstan, gix
+   max RSS grows from 7.20 to 8.90 GB across 1 to 16 threads, but charged
+   footprint grows from only 0.68 to 2.16 GB. On the Linux best case,
+   footprint stays at 1.76 GB across the same range.
+   
+   --- Implementation
+   
+   Use lock-free local deques and a shared root injector so idle workers can
+   steal branches from the last expensive root without every worker hoarding
+   roots. Enable this resolver through the gix parallel feature.
+   
+   Regression tests prove that internal siblings are not all materialized
+   before descent and that two workers can concurrently resolve children from
+   one remaining root. The scheduler follows the proven Git index-pack
+   principles of bounded live delta bases and keeping independent delta work
+   available, informed by builtin/index-pack.c at cf5497b14c.
+ - <csr-id-64b9efefb9a538a0c40f3413d6c758a17bbc2daf/> resolve in-pack ref deltas while indexing
+   Valid packs may encode a base inside the same pack with REF_DELTA and may
+   place the delta before that base. The streaming lookup previously treated an
+   object-database miss as fatal, while index construction rejected every remaining
+   ref delta.
+   
+   Keep lookup misses in the stream and park ref-delta children by base object ID
+   until traversal resolves the matching object. This preserves external thin-pack
+   injection and reuses the existing delta tree for forward and chained references.
+   
+   Git reference: a23bace963d508bd96983cc637131392d3face18, builtin/index-pack.c and t/t5300-pack-object.sh.
+
+### Refactor (BREAKING)
+
+ - <csr-id-c055803f6412e15ed9470b6427508fd89f235212/> remove `object_hash` from `Options`
+   This forces callers to explicitly choose a hash, eliminating the risk
+   that `Sha1` is implicitly chosen for them in SHA-1/SHA-256 builds
+   through `Default::default()` without them being aware of it or noticing.
+   This comes at the cost of callers having to always pass the hash, but
+   that seems like a reasonable trade-off.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 19 commits contributed to the release over the course of 30 calendar days.
+ - 30 days passed between releases.
+ - 5 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 3 unique issues were worked on: [#1025](https://github.com/GitoxideLabs/gitoxide/issues/1025), [#2424](https://github.com/GitoxideLabs/gitoxide/issues/2424), [#2868](https://github.com/GitoxideLabs/gitoxide/issues/2868)
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **[#1025](https://github.com/GitoxideLabs/gitoxide/issues/1025)**
+    - Resolve in-pack ref deltas while indexing ([`64b9efe`](https://github.com/GitoxideLabs/gitoxide/commit/64b9efefb9a538a0c40f3413d6c758a17bbc2daf))
+ * **[#2424](https://github.com/GitoxideLabs/gitoxide/issues/2424)**
+    - Resolve delta trees lazily in a lock-free pool ([`d7bbb8e`](https://github.com/GitoxideLabs/gitoxide/commit/d7bbb8e053c3ce9c24fe0a4bf1aaaca7b7a58270))
+ * **[#2868](https://github.com/GitoxideLabs/gitoxide/issues/2868)**
+    - Validate delta base sizes during entry decoding ([`916f5d8`](https://github.com/GitoxideLabs/gitoxide/commit/916f5d8c32deb0a03bb6a01c8d8e9c4b6c69d186))
+ * **Uncategorized**
+    - Update manifests prior to release ([`ebe9095`](https://github.com/GitoxideLabs/gitoxide/commit/ebe9095f2888d3c12447ea5eed9d0afdb0fd5aeb))
+    - Merge pull request #2926 from cruessler/remove-object-hash-from-options ([`b2d919a`](https://github.com/GitoxideLabs/gitoxide/commit/b2d919a11655fdab5c47001ec1b21d7bbebe24c0))
+    - Remove `object_hash` from `Options` ([`c055803`](https://github.com/GitoxideLabs/gitoxide/commit/c055803f6412e15ed9470b6427508fd89f235212))
+    - Merge pull request #2905 from GitoxideLabs/various-improvements ([`f3bbfad`](https://github.com/GitoxideLabs/gitoxide/commit/f3bbfadd4b4f1d72c85c62eb3d7ae337c922f945))
+    - Adapt to changes in `gix-testtools` ([`0cbe539`](https://github.com/GitoxideLabs/gitoxide/commit/0cbe53971687fb3b1959925aa9d8dc89deb5b474))
+    - Merge pull request #2923 from rdicosmo/swh-expose-delta-tree-main ([`c4426f0`](https://github.com/GitoxideLabs/gitoxide/commit/c4426f034d5423c66cc5c15725587d9688deada3))
+    - Review ([`dcb8ccd`](https://github.com/GitoxideLabs/gitoxide/commit/dcb8ccd96dad396042c9db217085fdf15293a19f))
+    - Expose index-less parallel pack traversal (cache Tree, Context, Options) ([`40a4ca7`](https://github.com/GitoxideLabs/gitoxide/commit/40a4ca7d1802361850a6a4a6aef91c8c2c5d730f))
+    - Merge pull request #2916 from cruessler/require-object-hash-in-store-at ([`dd8c759`](https://github.com/GitoxideLabs/gitoxide/commit/dd8c759e0343c2b5c9776c948d109e9d1ea5943b))
+    - Adapt to changes in `gix-odb` ([`1dc741f`](https://github.com/GitoxideLabs/gitoxide/commit/1dc741fedb08f167e652c31bfa6c4016d3b0a192))
+    - Merge pull request #2869 from GitoxideLabs/validate-delta-base-size ([`9c12c2d`](https://github.com/GitoxideLabs/gitoxide/commit/9c12c2d45cbfdaee65bdbb26df2d41063d3b39f1))
+    - Merge pull request #2867 from GitoxideLabs/fix-url-authority-parsing ([`cc3ee80`](https://github.com/GitoxideLabs/gitoxide/commit/cc3ee8060ad7a32ee8d2eb9139854be7f7561b70))
+    - Release gix-path v0.12.4, gix-command v0.9.2, gix-config-value v0.19.1, gix-url v0.37.1, gix-credentials v0.39.1, gix-transport v0.58.1 ([`ab4fcb0`](https://github.com/GitoxideLabs/gitoxide/commit/ab4fcb0364ec4d01115595198f383b1ad9c29808))
+    - Merge pull request #2852 from GitoxideLabs/delta-tree-parallelism ([`4a6cf9d`](https://github.com/GitoxideLabs/gitoxide/commit/4a6cf9d53da4490590d7a92f03775246fa905cb9))
+    - Merge pull request #2825 from GitoxideLabs/azure-compatibility ([`9b787f6`](https://github.com/GitoxideLabs/gitoxide/commit/9b787f68dfdb2855c1570e4abe9387d9247a7051))
+    - Merge pull request #2812 from GitoxideLabs/report-july ([`ae8845a`](https://github.com/GitoxideLabs/gitoxide/commit/ae8845a47c4c87e0996a119822106cf09036340b))
+</details>
+
+## 0.73.0 (2026-07-23)
 
 ### Bug Fixes
 
@@ -33,7 +269,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 25 commits contributed to the release.
+ - 27 commits contributed to the release.
  - 31 days passed between releases.
  - 4 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 3 unique issues were worked on: [#2611](https://github.com/GitoxideLabs/gitoxide/issues/2611), [#2676](https://github.com/GitoxideLabs/gitoxide/issues/2676), [#2690](https://github.com/GitoxideLabs/gitoxide/issues/2690)
@@ -51,6 +287,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * **[#2690](https://github.com/GitoxideLabs/gitoxide/issues/2690)**
     - Cap remaining gix-pack allocations ([`ace687c`](https://github.com/GitoxideLabs/gitoxide/commit/ace687ce6803fc761a75344d0aa7dea64c54f2cb))
  * **Uncategorized**
+    - Release gix-actor v0.41.2, gix-features v0.49.0, gix-hash v0.26.0, gix-hashtable v0.16.0, gix-object v0.63.0, gix-glob v0.27.0, gix-attributes v0.34.0, gix-packetline v0.22.0, gix-filter v0.33.0, gix-fs v0.22.0, gix-chunk v0.7.3, gix-commitgraph v0.38.0, gix-revwalk v0.34.0, gix-traverse v0.60.0, gix-worktree-stream v0.35.0, gix-archive v0.35.0, gix-bitmap v0.3.3, gix-tempfile v24.0.0, gix-lock v24.0.0, gix-index v0.54.0, gix-pathspec v0.19.0, gix-ignore v0.22.0, gix-worktree v0.55.0, gix-imara-diff v0.2.4, gix-diff v0.66.0, gix-blame v0.16.0, gix-ref v0.66.0, gix-config v0.59.0, gix-discover v0.54.0, gix-dir v0.28.0, gix-mailmap v0.33.2, gix-revision v0.48.0, gix-merge v0.19.0, gix-negotiate v0.34.0, gix-zlib v0.1.0, gix-pack v0.73.0, gix-odb v0.83.0, gix-refspec v0.44.0, gix-shallow v0.13.0, gix-transport v0.58.0, gix-protocol v0.64.0, gix-status v0.33.0, gix-submodule v0.33.0, gix-worktree-state v0.33.0, gix v0.86.0, gix-fsck v0.24.0, gitoxide-core v0.60.0, gix-tix v0.1.0, gitoxide v0.56.0, safety bump 40 crates ([`842bc44`](https://github.com/GitoxideLabs/gitoxide/commit/842bc447e3aeacf5d9d36f7f8a01068eda4b7999))
+    - Update changelogs prior to release ([`cb6ec7d`](https://github.com/GitoxideLabs/gitoxide/commit/cb6ec7dce283943d811b1600b577f586d7a13e1f))
     - Release gix-trace v0.1.21, gix-validate v0.11.3, gix-path v0.12.3, gix-utils v0.3.5, gix-config-value v0.19.0, gix-prompt v0.16.0, gix-sec v0.14.2, gix-url v0.37.0, gix-credentials v0.39.0, safety bump 18 crates ([`f0ec710`](https://github.com/GitoxideLabs/gitoxide/commit/f0ec71076aa1cef3181b77946ee556a89c651b8e))
     - Merge pull request #2722 from GitoxideLabs/reasons ([`c16b5a1`](https://github.com/GitoxideLabs/gitoxide/commit/c16b5a1892704b7c72a253bdd74a6848dd61032a))
     - Replace lint allowances with expectations ([`43ff87a`](https://github.com/GitoxideLabs/gitoxide/commit/43ff87a73897b70313e3a58e7de82231be5b59ad))

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-pack"
-version = "0.74.0"
+version = "0.74.1"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 authors = ["Sebastian Thiel <sebastian.thiel@icloud.com>"]
 license = "MIT OR Apache-2.0"
@@ -46,10 +46,10 @@ wasm = ["gix-diff?/wasm"]
 gix-features = { version = "^0.49.1", path = "../gix-features", features = ["crc32", "progress"] }
 gix-zlib = { version = "^0.1.0", path = "../gix-zlib" }
 gix-path = { version = "^0.12.5", path = "../gix-path" }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
 gix-chunk = { version = "^0.8.0", path = "../gix-chunk" }
-gix-error = { version = "^0.3.0", path = "../gix-error" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-error = { version = "^0.3.1", path = "../gix-error" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 gix-hashtable = { version = "^0.16.0", path = "../gix-hashtable", optional = true }
 
 # for streaming of packs (input, output)

--- a/gix-pack/tests/pack/data/file.rs
+++ b/gix-pack/tests/pack/data/file.rs
@@ -11,12 +11,12 @@ mod method {
 
     use gix_features::progress;
 
-    use crate::{SMALL_PACK, data::file::pack_at, hex_to_id, pack_from_memory_at};
+    use crate::{SMALL_PACK, data::file::pack_at, pack_from_memory_at};
 
     #[test]
     fn checksum() {
         let p = pack_at(SMALL_PACK);
-        assert_eq!(p.checksum(), hex_to_id("0f3ea84cd1bba10c2a03d736a460635082833e59"));
+        assert_eq!(p.checksum(), "0f3ea84cd1bba10c2a03d736a460635082833e59");
     }
 
     #[test]

--- a/gix-pack/tests/pack/index.rs
+++ b/gix-pack/tests/pack/index.rs
@@ -6,8 +6,7 @@ use gix_object::{self as object};
 use gix_odb::pack;
 
 use crate::{
-    INDEX_V1, PACK_FOR_INDEX_V1, SMALL_PACK, SMALL_PACK_INDEX, fixture_path, hex_to_id, leaked_fixture_bytes,
-    pack_from_memory_at,
+    INDEX_V1, PACK_FOR_INDEX_V1, SMALL_PACK, SMALL_PACK_INDEX, fixture_path, leaked_fixture_bytes, pack_from_memory_at,
 };
 
 fn memory_backed_index(at: &str) -> gix_pack::index::File<&'static [u8]> {
@@ -589,7 +588,7 @@ fn verify_integrity_respects_pack_alloc_limit_bytes() -> Result<(), Box<dyn std:
 
 #[test]
 fn iter() -> Result<(), Box<dyn std::error::Error>> {
-    for (path, kind, num_objects, index_checksum, pack_checksum) in &[
+    for (path, kind, num_objects, index_checksum, pack_checksum) in [
         (
             INDEX_V1,
             index::Version::V1,
@@ -613,8 +612,8 @@ fn iter() -> Result<(), Box<dyn std::error::Error>> {
         ),
     ] {
         let idx = index::File::at(fixture_path(path), gix_hash::Kind::Sha1)?;
-        assert_eq!(idx.version(), *kind);
-        assert_eq!(idx.num_objects(), *num_objects);
+        assert_eq!(idx.version(), kind);
+        assert_eq!(idx.num_objects(), num_objects);
         assert_eq!(
             idx.verify_integrity(
                 None::<gix_pack::index::verify::PackContext<'_, fn() -> cache::Never>>,
@@ -624,9 +623,9 @@ fn iter() -> Result<(), Box<dyn std::error::Error>> {
             .map(|o| (o.actual_index_checksum, o.pack_traverse_statistics))?,
             (idx.index_checksum(), None)
         );
-        assert_eq!(idx.index_checksum(), hex_to_id(index_checksum));
-        assert_eq!(idx.pack_checksum(), hex_to_id(pack_checksum));
-        assert_eq!(idx.iter().count(), *num_objects as usize);
+        assert_eq!(idx.index_checksum(), index_checksum);
+        assert_eq!(idx.pack_checksum(), pack_checksum);
+        assert_eq!(idx.iter().count(), num_objects as usize);
     }
     Ok(())
 }

--- a/gix-pack/tests/pack/multi_index/write.rs
+++ b/gix-pack/tests/pack/multi_index/write.rs
@@ -6,8 +6,6 @@ use std::{
 use gix_features::progress;
 use gix_testtools::fixture_path;
 
-use crate::hex_to_id;
-
 /// Writes a multi-index from the static SHA-1 pack indices, with pinned SHA-1 expectations.
 /// The SHA-256 counterpart lives in [`from_a_hash_parameterized_pack`] below.
 #[test]
@@ -18,7 +16,7 @@ fn from_paths() -> crate::Result {
 
     assert_eq!(
         written.outcome.multi_index_checksum,
-        hex_to_id("d34d327039a3554f8a644b29e07b903fa71ef269")
+        "d34d327039a3554f8a644b29e07b903fa71ef269"
     );
 
     assert_eq!(written.file.num_indices(), 3);

--- a/gix-packetline/CHANGELOG.md
+++ b/gix-packetline/CHANGELOG.md
@@ -5,7 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.22.1 (2026-08-23)
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 2 commits contributed to the release over the course of 30 calendar days.
+ - 31 days passed between releases.
+ - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Use fundamental-type comparisons throughout tests ([`47536a5`](https://github.com/GitoxideLabs/gitoxide/commit/47536a5c2b22da3a9f4892c8af5e460c2d5bda0a))
+    - Merge pull request #2812 from GitoxideLabs/report-july ([`ae8845a`](https://github.com/GitoxideLabs/gitoxide/commit/ae8845a47c4c87e0996a119822106cf09036340b))
+</details>
+
+## 0.22.0 (2026-07-23)
 
 ### Changed (BREAKING)
 
@@ -19,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <csr-read-only-do-not-edit/>
 
- - 6 commits contributed to the release.
+ - 8 commits contributed to the release.
  - 37 days passed between releases.
  - 1 commit was understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
@@ -31,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Release gix-actor v0.41.2, gix-features v0.49.0, gix-hash v0.26.0, gix-hashtable v0.16.0, gix-object v0.63.0, gix-glob v0.27.0, gix-attributes v0.34.0, gix-packetline v0.22.0, gix-filter v0.33.0, gix-fs v0.22.0, gix-chunk v0.7.3, gix-commitgraph v0.38.0, gix-revwalk v0.34.0, gix-traverse v0.60.0, gix-worktree-stream v0.35.0, gix-archive v0.35.0, gix-bitmap v0.3.3, gix-tempfile v24.0.0, gix-lock v24.0.0, gix-index v0.54.0, gix-pathspec v0.19.0, gix-ignore v0.22.0, gix-worktree v0.55.0, gix-imara-diff v0.2.4, gix-diff v0.66.0, gix-blame v0.16.0, gix-ref v0.66.0, gix-config v0.59.0, gix-discover v0.54.0, gix-dir v0.28.0, gix-mailmap v0.33.2, gix-revision v0.48.0, gix-merge v0.19.0, gix-negotiate v0.34.0, gix-zlib v0.1.0, gix-pack v0.73.0, gix-odb v0.83.0, gix-refspec v0.44.0, gix-shallow v0.13.0, gix-transport v0.58.0, gix-protocol v0.64.0, gix-status v0.33.0, gix-submodule v0.33.0, gix-worktree-state v0.33.0, gix v0.86.0, gix-fsck v0.24.0, gitoxide-core v0.60.0, gix-tix v0.1.0, gitoxide v0.56.0, safety bump 40 crates ([`842bc44`](https://github.com/GitoxideLabs/gitoxide/commit/842bc447e3aeacf5d9d36f7f8a01068eda4b7999))
+    - Update changelogs prior to release ([`cb6ec7d`](https://github.com/GitoxideLabs/gitoxide/commit/cb6ec7dce283943d811b1600b577f586d7a13e1f))
     - Release gix-trace v0.1.21, gix-validate v0.11.3, gix-path v0.12.3, gix-utils v0.3.5, gix-config-value v0.19.0, gix-prompt v0.16.0, gix-sec v0.14.2, gix-url v0.37.0, gix-credentials v0.39.0, safety bump 18 crates ([`f0ec710`](https://github.com/GitoxideLabs/gitoxide/commit/f0ec71076aa1cef3181b77946ee556a89c651b8e))
     - Merge pull request #2728 from GitoxideLabs/try-bisync ([`adf4b7a`](https://github.com/GitoxideLabs/gitoxide/commit/adf4b7af7eed083c871a6572cb41316dcf6e568e))
     - Replace `maybe-async` with `bisync`. ([`c3f2244`](https://github.com/GitoxideLabs/gitoxide/commit/c3f2244541f0b6419d30782fbae825d33bd5fe16))

--- a/gix-packetline/Cargo.toml
+++ b/gix-packetline/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-packetline"
-version = "0.22.0"
+version = "0.22.1"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate of the gitoxide project implementing the pkt-line serialization format"

--- a/gix-packetline/tests/packetline/read/sideband.rs
+++ b/gix-packetline/tests/packetline/read/sideband.rs
@@ -82,10 +82,7 @@ async fn read_pack_with_progress_extraction() -> crate::Result {
     drop(pack_entries);
 
     assert_eq!(
-        last.trailer
-            .expect("trailer to exist on last entry")
-            .to_hex()
-            .to_string(),
+        last.trailer.expect("trailer to exist on last entry"),
         "150a1045f04dc0fc2dbf72313699fda696bf4126"
     );
     assert_eq!(

--- a/gix-protocol/Cargo.toml
+++ b/gix-protocol/Cargo.toml
@@ -76,15 +76,15 @@ gix-features = { version = "^0.49.1", path = "../gix-features", features = [
     "progress",
 ] }
 gix-transport = { version = "^0.59.0", path = "../gix-transport" }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
 gix-shallow = { version = "^0.13.0", path = "../gix-shallow" }
 gix-date = { version = "^0.16.0", path = "../gix-date" }
 gix-utils = { version = "^0.3.6", path = "../gix-utils" }
-gix-ref = { version = "^0.67.0", path = "../gix-ref" }
+gix-ref = { version = "^0.67.1", path = "../gix-ref" }
 
 gix-trace = { version = "^0.1.21", path = "../gix-trace", optional = true }
 gix-negotiate = { version = "^0.35.0", path = "../gix-negotiate", optional = true }
-gix-object = { version = "^0.64.0", path = "../gix-object", optional = true }
+gix-object = { version = "^0.64.1", path = "../gix-object", optional = true }
 gix-revwalk = { version = "^0.35.0", path = "../gix-revwalk", optional = true }
 gix-credentials = { version = "^0.40.0", path = "../gix-credentials", optional = true }
 gix-refspec = { version = "^0.45.0", path = "../gix-refspec", optional = true }
@@ -110,7 +110,7 @@ document-features = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }
-gix-packetline = { path = "../gix-packetline", version = "^0.22.0" }
+gix-packetline = { path = "../gix-packetline", version = "^0.22.1" }
 gix-protocol = { path = "../gix-protocol", features = ["sha1"] }
 
 [package.metadata.docs.rs]

--- a/gix-protocol/tests/protocol/fetch/response.rs
+++ b/gix-protocol/tests/protocol/fetch/response.rs
@@ -353,8 +353,7 @@ mod v2 {
             assert_eq!(bytes_read, 1643, "should be able to read the whole pack");
             assert_eq!(&buf[..4], b"PACK");
             assert_eq!(
-                gix_hash::ObjectId::from_bytes_or_panic(&buf[buf.len() - gix_hash::Kind::Sha1.len_in_bytes()..])
-                    .to_string(),
+                gix_hash::ObjectId::from_bytes_or_panic(&buf[buf.len() - gix_hash::Kind::Sha1.len_in_bytes()..]),
                 "f34c9be7e0c3ef2c3ed7c62cc7791dbf6dc5ec9a"
             );
             Ok(())

--- a/gix-ref/Cargo.toml
+++ b/gix-ref/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "gix-ref"
-version = "0.67.0"
+version = "0.67.1"
 repository = "https://github.com/GitoxideLabs/gitoxide"
 license = "MIT OR Apache-2.0"
 description = "A crate to handle git references"
@@ -29,8 +29,8 @@ parallel = ["gix-features/parallel"]
 gix-features = { version = "^0.49.1", path = "../gix-features", features = ["walkdir"] }
 gix-fs = { version = "^0.22.1", path = "../gix-fs" }
 gix-path = { version = "^0.12.5", path = "../gix-path" }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 gix-utils = { version = "^0.3.6", path = "../gix-utils" }
 gix-validate = { version = "^0.11.4", path = "../gix-validate" }
 gix-actor = { version = "^0.42.0", path = "../gix-actor" }

--- a/gix-ref/src/compare.rs
+++ b/gix-ref/src/compare.rs
@@ -1,0 +1,126 @@
+use crate::{
+    FullName, FullNameRef, Namespace, PartialName, PartialNameRef, Reference,
+    bstr::{BStr, BString, ByteSlice},
+    file, packed,
+};
+
+macro_rules! impl_partial_eq {
+    ($left_type:ty, $right_type:ty, $left:ident => $left_bytes:expr, $right:ident => $right_bytes:expr) => {
+        impl PartialEq<$right_type> for $left_type {
+            fn eq(&self, other: &$right_type) -> bool {
+                let $left = self;
+                let $right = other;
+                $left_bytes == $right_bytes
+            }
+        }
+    };
+}
+
+macro_rules! impl_partial_eq_pair {
+    ($left_type:ty, $right_type:ty, $left:ident => $left_bytes:expr, $right:ident => $right_bytes:expr) => {
+        impl_partial_eq!($left_type, $right_type, $left => $left_bytes, $right => $right_bytes);
+        impl_partial_eq!($right_type, $left_type, $right => $right_bytes, $left => $left_bytes);
+    };
+}
+
+macro_rules! impl_partial_eq_bytes {
+    ($type:ty, $value:ident => $bytes:expr) => {
+        impl_partial_eq_pair!($type, str, $value => $bytes.as_bytes(), other => other.as_bytes());
+        impl_partial_eq_pair!($type, &str, $value => $bytes.as_bytes(), other => other.as_bytes());
+        impl_partial_eq_pair!($type, String, $value => $bytes.as_bytes(), other => other.as_bytes());
+        impl_partial_eq_pair!($type, BStr, $value => $bytes.as_bytes(), other => other.as_bytes());
+        impl_partial_eq_pair!($type, &BStr, $value => $bytes.as_bytes(), other => other.as_bytes());
+        impl_partial_eq_pair!($type, BString, $value => $bytes.as_bytes(), other => other.as_bytes());
+    };
+}
+
+macro_rules! impl_partial_eq_reference {
+    ($type:ty, $value:ident => $name:expr) => {
+        impl_partial_eq!($type, str, $value => $name.as_bytes(), other => other.as_bytes());
+        impl_partial_eq!($type, &str, $value => $name.as_bytes(), other => other.as_bytes());
+        impl_partial_eq!($type, String, $value => $name.as_bytes(), other => other.as_bytes());
+        impl_partial_eq!($type, BStr, $value => $name.as_bytes(), other => other.as_bytes());
+        impl_partial_eq!($type, &BStr, $value => $name.as_bytes(), other => other.as_bytes());
+        impl_partial_eq!($type, BString, $value => $name.as_bytes(), other => other.as_bytes());
+        impl_partial_eq!(
+            $type,
+            FullName,
+            $value => $name.as_bytes(),
+            other => other.as_bstr().as_bytes()
+        );
+        impl_partial_eq!(
+            $type,
+            FullNameRef,
+            $value => $name.as_bytes(),
+            other => other.as_bstr().as_bytes()
+        );
+        impl_partial_eq!(
+            $type,
+            &FullNameRef,
+            $value => $name.as_bytes(),
+            other => other.as_bstr().as_bytes()
+        );
+    };
+}
+
+impl_partial_eq_bytes!(FullName, value => value.as_bstr());
+impl_partial_eq_bytes!(FullNameRef, value => value.as_bstr());
+impl_partial_eq_bytes!(PartialName, value => value.as_ref().as_bstr());
+impl_partial_eq_bytes!(PartialNameRef, value => value.as_bstr());
+impl_partial_eq_bytes!(Namespace, value => value.as_bstr());
+
+impl_partial_eq_pair!(
+    &FullNameRef,
+    String,
+    name => name.as_bstr().as_bytes(),
+    text => text.as_bytes()
+);
+impl_partial_eq_pair!(
+    &FullNameRef,
+    BString,
+    name => name.as_bstr().as_bytes(),
+    text => text.as_bytes()
+);
+impl_partial_eq_pair!(
+    &PartialNameRef,
+    String,
+    name => name.as_bstr().as_bytes(),
+    text => text.as_bytes()
+);
+impl_partial_eq_pair!(
+    &PartialNameRef,
+    BString,
+    name => name.as_bstr().as_bytes(),
+    text => text.as_bytes()
+);
+
+impl_partial_eq_pair!(
+    FullName,
+    FullNameRef,
+    owned => owned.as_bstr().as_bytes(),
+    borrowed => borrowed.as_bstr().as_bytes()
+);
+impl_partial_eq_pair!(
+    FullName,
+    &FullNameRef,
+    owned => owned.as_bstr().as_bytes(),
+    borrowed => borrowed.as_bstr().as_bytes()
+);
+impl_partial_eq_pair!(
+    PartialName,
+    PartialNameRef,
+    owned => owned.as_ref().as_bstr().as_bytes(),
+    borrowed => borrowed.as_bstr().as_bytes()
+);
+impl_partial_eq_pair!(
+    PartialName,
+    &PartialNameRef,
+    owned => owned.as_ref().as_bstr().as_bytes(),
+    borrowed => borrowed.as_bstr().as_bytes()
+);
+
+// Keep these comparisons one-way: same-type reference equality is structural, so reverse
+// implementations would let references with different targets form a non-transitive chain through their name.
+impl_partial_eq_reference!(Reference, value => value.name.as_bstr());
+impl_partial_eq_reference!(file::loose::Reference, value => value.name.as_bstr());
+impl_partial_eq_reference!(packed::Reference<'_>, value => value.name.as_bstr());

--- a/gix-ref/src/lib.rs
+++ b/gix-ref/src/lib.rs
@@ -31,6 +31,7 @@ use gix_object::bstr::{BStr, BString};
 mod store_impl;
 pub use store_impl::{file, packed};
 
+mod compare;
 mod fullname;
 ///
 pub mod name;

--- a/gix-ref/src/store/file/log/line.rs
+++ b/gix-ref/src/store/file/log/line.rs
@@ -162,11 +162,6 @@ pub mod decode {
     mod test_decode {
         use super::*;
 
-        /// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
-        fn hex_to_oid(hex: &str) -> gix_hash::ObjectId {
-            gix_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
-        }
-
         fn with_newline(mut v: Vec<u8>) -> Vec<u8> {
             v.push(b'\n');
             v
@@ -229,11 +224,8 @@ pub mod decode {
                     message: b"pull --ff-only: Fast-forward".as_bstr(),
                 };
                 assert_eq!(res, actual);
-                assert_eq!(
-                    actual.previous_oid(),
-                    hex_to_oid("a5828ae6b52137b913b978e16cd2334482eb4c1f")
-                );
-                assert_eq!(actual.new_oid(), hex_to_oid("89b43f80a514aee58b662ad606e6352e03eaeee4"));
+                assert_eq!(actual.previous_oid(), "a5828ae6b52137b913b978e16cd2334482eb4c1f");
+                assert_eq!(actual.new_oid(), "89b43f80a514aee58b662ad606e6352e03eaeee4");
             }
         }
 

--- a/gix-ref/src/store/packed/decode/tests.rs
+++ b/gix-ref/src/store/packed/decode/tests.rs
@@ -9,11 +9,6 @@ mod reference {
 
     const HASH_KIND: gix_hash::Kind = gix_hash::Kind::Sha1;
 
-    /// Convert a hexadecimal hash into its corresponding `ObjectId` or _panic_.
-    fn hex_to_id(hex: &str) -> gix_hash::ObjectId {
-        gix_hash::ObjectId::from_hex(hex.as_bytes()).expect("40 bytes hex")
-    }
-
     #[test]
     fn invalid() {
         let mut input = b"# what looks like a comment".as_slice();
@@ -41,8 +36,8 @@ mod reference {
 
         assert!(input.is_empty(), "exhausted");
         assert_eq!(parsed.name, FullNameRef::new_unchecked("refs/heads/uppercase".into()));
-        assert_eq!(parsed.target(), hex_to_id("d53c4b0f91f1b29769c9430f2d1c0bcab1170c75"));
-        assert_eq!(parsed.object(), hex_to_id("e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37"));
+        assert_eq!(parsed.target(), "d53c4b0f91f1b29769c9430f2d1c0bcab1170c75");
+        assert_eq!(parsed.object(), "e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37");
         Ok(())
     }
 
@@ -71,8 +66,8 @@ mod reference {
                 object: Some("e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37".into())
             }
         );
-        assert_eq!(parsed.target(), hex_to_id("d53c4b0f91f1b29769c9430f2d1c0bcab1170c75"));
-        assert_eq!(parsed.object(), hex_to_id("e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37"));
+        assert_eq!(parsed.target(), "d53c4b0f91f1b29769c9430f2d1c0bcab1170c75");
+        assert_eq!(parsed.object(), "e9cdc958e7ce2290e2d7958cdb5aa9323ef35d37");
 
         let parsed = decode::reference(&mut input, HASH_KIND).unwrap();
         assert!(input.is_empty(), "exhausted");

--- a/gix-ref/tests/refs/equality.rs
+++ b/gix-ref/tests/refs/equality.rs
@@ -1,0 +1,193 @@
+use gix_ref::{
+    FullName, FullNameRef, PartialName, Target,
+    bstr::{BStr, BString, ByteSlice},
+};
+
+macro_rules! assert_natural_equality {
+    ($value:ident, $matching:literal, $different:literal) => {{
+        let matching = $matching;
+        let matching_string = matching.to_owned();
+        let matching_bstr = matching.as_bytes().as_bstr();
+        let matching_bstring: BString = matching.as_bytes().into();
+
+        assert_eq!($value, matching, "the value matches str");
+        assert_eq!(matching, $value, "str comparison is symmetric");
+        assert_eq!($value, matching_string, "the value matches String");
+        assert_eq!(matching_string, $value, "String comparison is symmetric");
+        assert_eq!($value, matching_bstr, "the value matches BStr");
+        assert_eq!(matching_bstr, $value, "BStr comparison is symmetric");
+        assert_eq!($value, matching_bstring, "the value matches BString");
+        assert_eq!(matching_bstring, $value, "BString comparison is symmetric");
+
+        let different = $different;
+        let different_string = different.to_owned();
+        let different_bstr = different.as_bytes().as_bstr();
+        let different_bstring: BString = different.as_bytes().into();
+
+        assert_ne!($value, different, "the value differs from str");
+        assert_ne!(different, $value, "str inequality is symmetric");
+        assert_ne!($value, different_string, "the value differs from String");
+        assert_ne!(different_string, $value, "String inequality is symmetric");
+        assert_ne!($value, different_bstr, "the value differs from BStr");
+        assert_ne!(different_bstr, $value, "BStr inequality is symmetric");
+        assert_ne!($value, different_bstring, "the value differs from BString");
+        assert_ne!(different_bstring, $value, "BString inequality is symmetric");
+    }};
+}
+
+macro_rules! assert_binary_equality {
+    ($value:ident, $matching:expr, $different:expr) => {{
+        let matching: &BStr = $matching;
+        let matching_owned = matching.to_owned();
+        assert_eq!($value, matching, "the value matches non-UTF-8 BStr");
+        assert_eq!(matching, $value, "non-UTF-8 BStr comparison is symmetric");
+        assert_eq!($value, matching_owned, "the value matches non-UTF-8 BString");
+        assert_eq!(matching_owned, $value, "non-UTF-8 BString comparison is symmetric");
+
+        let different: &BStr = $different;
+        let different_owned = different.to_owned();
+        assert_ne!($value, different, "the value differs from BStr");
+        assert_ne!(different, $value, "BStr inequality is symmetric");
+        assert_ne!($value, different_owned, "the value differs from BString");
+        assert_ne!(different_owned, $value, "BString inequality is symmetric");
+    }};
+}
+
+macro_rules! assert_reference_name_equality {
+    ($reference:ident, $name:ident) => {{
+        let name_ref: &FullNameRef = $name.as_ref();
+        assert_eq!($reference, $name, "the reference matches its owned name");
+        assert_eq!($reference, name_ref, "the reference matches its borrowed name");
+
+        let matching = "refs/heads/main";
+        assert_eq!($reference, matching, "the reference matches str");
+        assert_eq!($reference, matching.to_owned(), "the reference matches String");
+        assert_eq!($reference, matching.as_bytes().as_bstr(), "the reference matches BStr");
+        assert_eq!($reference, BString::from(matching), "the reference matches BString");
+
+        let different = "refs/heads/other";
+        assert_ne!($reference, different, "the reference differs from str");
+        assert_ne!($reference, different.to_owned(), "the reference differs from String");
+        assert_ne!(
+            $reference,
+            different.as_bytes().as_bstr(),
+            "the reference differs from BStr"
+        );
+        assert_ne!(
+            $reference,
+            BString::from(different),
+            "the reference differs from BString"
+        );
+    }};
+}
+
+#[test]
+fn name_types_compare_with_text_and_byte_strings() -> gix_testtools::Result {
+    let full = FullName::try_from("refs/heads/main")?;
+    let full_ref: &FullNameRef = full.as_ref();
+    assert_eq!(full, full_ref, "owned and borrowed full names match");
+    assert_eq!(full_ref, full, "full-name comparison is symmetric");
+    assert_natural_equality!(full, "refs/heads/main", "refs/heads/other");
+    assert_natural_equality!(full_ref, "refs/heads/main", "refs/heads/other");
+
+    let partial = PartialName::try_from("heads/main")?;
+    let partial_ref = partial.as_ref();
+    assert_eq!(partial, partial_ref, "owned and borrowed partial names match");
+    assert_eq!(partial_ref, partial, "partial-name comparison is symmetric");
+    assert_natural_equality!(partial, "heads/main", "heads/other");
+    assert_natural_equality!(partial_ref, "heads/main", "heads/other");
+
+    let namespace = gix_ref::namespace::expand("foo")?;
+    assert_natural_equality!(namespace, "refs/namespaces/foo/", "refs/namespaces/bar/");
+    Ok(())
+}
+
+#[test]
+fn names_compare_as_exact_bytes() -> gix_testtools::Result {
+    let full_bytes = b"refs/heads/\xff".as_bstr();
+    let full = FullName::try_from(full_bytes)?;
+    let full_ref: &FullNameRef = full.as_ref();
+    assert_binary_equality!(full, full_bytes, b"refs/heads/other".as_bstr());
+    assert_binary_equality!(full_ref, full_bytes, b"refs/heads/other".as_bstr());
+
+    let partial_bytes = b"heads/\xff".as_bstr();
+    let partial = PartialName::try_from(partial_bytes.to_owned())?;
+    let partial_ref = partial.as_ref();
+    assert_binary_equality!(partial, partial_bytes, b"heads/other".as_bstr());
+    assert_binary_equality!(partial_ref, partial_bytes, b"heads/other".as_bstr());
+
+    let namespace = gix_ref::namespace::expand(b"\xff".as_bstr())?;
+    assert_binary_equality!(
+        namespace,
+        b"refs/namespaces/\xff/".as_bstr(),
+        b"refs/namespaces/other/".as_bstr()
+    );
+    Ok(())
+}
+
+#[test]
+fn references_compare_by_name_without_changing_structural_equality() -> gix_testtools::Result {
+    let name = FullName::try_from("refs/heads/main")?;
+    let raw = gix_ref::Reference {
+        name: name.clone(),
+        target: Target::Symbolic(FullName::try_from("refs/heads/target-a")?),
+        peeled: None,
+    };
+    let raw_with_other_target = gix_ref::Reference {
+        name: name.clone(),
+        target: Target::Symbolic(FullName::try_from("refs/heads/target-b")?),
+        peeled: None,
+    };
+    assert_ne!(raw, raw_with_other_target, "structural equality still includes targets");
+    let raw_with_peeled = gix_ref::Reference {
+        peeled: Some(gix_hash::ObjectId::from_hex(
+            b"0000000000000000000000000000000000000000",
+        )?),
+        ..raw.clone()
+    };
+    assert_ne!(
+        raw, raw_with_peeled,
+        "structural equality still includes peeled objects"
+    );
+    assert_reference_name_equality!(raw, name);
+
+    let loose = gix_ref::file::loose::Reference {
+        name: name.clone(),
+        target: Target::Symbolic(FullName::try_from("refs/heads/target-a")?),
+    };
+    let loose_with_other_target = gix_ref::file::loose::Reference {
+        name: name.clone(),
+        target: Target::Symbolic(FullName::try_from("refs/heads/target-b")?),
+    };
+    assert_ne!(
+        loose, loose_with_other_target,
+        "loose-reference structural equality still includes targets"
+    );
+    assert_reference_name_equality!(loose, name);
+
+    let packed = gix_ref::packed::Reference {
+        name: name.as_ref(),
+        target: b"0000000000000000000000000000000000000000".as_bstr(),
+        object: None,
+    };
+    let packed_with_other_target = gix_ref::packed::Reference {
+        name: name.as_ref(),
+        target: b"1111111111111111111111111111111111111111".as_bstr(),
+        object: None,
+    };
+    assert_ne!(
+        packed, packed_with_other_target,
+        "packed-reference structural equality still includes targets"
+    );
+    let packed_with_peeled = gix_ref::packed::Reference {
+        name: name.as_ref(),
+        target: packed.target,
+        object: Some(b"1111111111111111111111111111111111111111".as_bstr()),
+    };
+    assert_ne!(
+        packed, packed_with_peeled,
+        "packed-reference structural equality still includes peeled objects"
+    );
+    assert_reference_name_equality!(packed, name);
+    Ok(())
+}

--- a/gix-ref/tests/refs/file/log.rs
+++ b/gix-ref/tests/refs/file/log.rs
@@ -109,7 +109,7 @@ mod iter {
         mod with_buffer_big_enough_for_largest_line {
             use gix_ref::log::Line;
 
-            use crate::{file::log::iter::reflog, sha1_hex_to_id};
+            use crate::file::log::iter::reflog;
 
             #[test]
             fn single_line() -> crate::Result {
@@ -129,8 +129,8 @@ mod iter {
                         signature: _,
                         message,
                     } = iter.next().expect("a single line")?;
-                    assert_eq!(previous_oid, sha1_hex_to_id("0000000000000000000000000000000000000000"));
-                    assert_eq!(new_oid, sha1_hex_to_id("134385f6d781b7e97062102c6a483440bfda2a03"));
+                    assert_eq!(previous_oid, "0000000000000000000000000000000000000000");
+                    assert_eq!(new_oid, "134385f6d781b7e97062102c6a483440bfda2a03");
                     assert_eq!(message, "commit (initial): c1");
                     assert!(iter.next().is_none(), "iterator depleted");
                 }
@@ -157,8 +157,8 @@ mod iter {
                             signature: _,
                             message,
                         } = iter.next().expect("a single line")?;
-                        assert_eq!(previous_oid, sha1_hex_to_id("0000000000000000000000000000000000000000"));
-                        assert_eq!(new_oid, sha1_hex_to_id("134385f6d781b7e97062102c6a483440bfda2a03"));
+                        assert_eq!(previous_oid, "0000000000000000000000000000000000000000");
+                        assert_eq!(new_oid, "134385f6d781b7e97062102c6a483440bfda2a03");
                         assert_eq!(message, "commit (initial): c1");
                         let Line {
                             previous_oid,
@@ -167,8 +167,8 @@ mod iter {
                             message,
                         } = iter.next().expect("a single line")?;
                         assert_eq!(message, "commit (initial): c2");
-                        assert_eq!(previous_oid, sha1_hex_to_id("1000000000000000000000000000000000000000"));
-                        assert_eq!(new_oid, sha1_hex_to_id("234385f6d781b7e97062102c6a483440bfda2a03"));
+                        assert_eq!(previous_oid, "1000000000000000000000000000000000000000");
+                        assert_eq!(new_oid, "234385f6d781b7e97062102c6a483440bfda2a03");
                         assert!(iter.next().is_none(), "iterator depleted");
                     }
                 }

--- a/gix-ref/tests/refs/file/reference.rs
+++ b/gix-ref/tests/refs/file/reference.rs
@@ -136,7 +136,7 @@ mod peel {
 
         let commit = hex_to_id("134385f6d781b7e97062102c6a483440bfda2a03");
         assert_eq!(r.peel_to_id(&store, &EmptyCommit)?, commit);
-        assert_eq!(r.name.as_bstr(), "refs/remotes/origin/multi-link-target3");
+        assert_eq!(r, "refs/remotes/origin/multi-link-target3");
 
         let mut r: Reference = store.find_loose("dt1")?.into();
         assert_eq!(
@@ -189,13 +189,13 @@ mod peel {
         let store = file::store()?;
         let mut r: Reference = store.find_loose("loop-a")?.into();
         assert_eq!(r.kind(), gix_ref::Kind::Symbolic, "there is something to peel");
-        assert_eq!(r.name.as_bstr(), "refs/loop-a");
+        assert_eq!(r, "refs/loop-a");
 
         assert!(matches!(
             r.peel_to_id(&store, &gix_object::find::Never).unwrap_err(),
             gix_ref::peel::to_id::Error::FollowToObject(gix_ref::peel::to_object::Error::Cycle { .. })
         ));
-        assert_eq!(r.name.as_bstr(), "refs/loop-a", "the ref is not changed on error");
+        assert_eq!(r, "refs/loop-a", "the ref is not changed on error");
 
         let mut r: Reference = store.find_loose("loop-a")?.into();
         let err = r
@@ -324,17 +324,17 @@ mod parse {
         fn peeled_sha256() {
             use std::convert::TryInto;
 
-            let input = &b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"[..];
+            let input = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
             let reference = Reference::try_from_path(
                 "HEAD".try_into().expect("valid static name"),
-                input,
+                input.as_bytes(),
                 gix_hash::Kind::Sha256,
             )
             .unwrap();
             assert_eq!(reference.kind(), gix_ref::Kind::Object);
             let target_id = reference.target.to_ref().try_id().expect("non-symbolic").to_owned();
             assert_eq!(target_id.kind(), gix_hash::Kind::Sha256);
-            assert_eq!(target_id, gix_hash::ObjectId::from_hex(input).unwrap());
+            assert_eq!(target_id, input);
         }
     }
 }

--- a/gix-ref/tests/refs/file/store/find.rs
+++ b/gix-ref/tests/refs/file/store/find.rs
@@ -13,7 +13,7 @@ mod existing {
             let c1 = hex_to_id("134385f6d781b7e97062102c6a483440bfda2a03");
             let r = store.find("main")?;
             assert_eq!(r.target.into_id(), c1);
-            assert_eq!(r.name.as_bstr(), "refs/heads/main");
+            assert_eq!(r.name, "refs/heads/main");
             let r = store
                 .find("A")
                 .unwrap_or_else(|_| panic!("{fixture}: should find capitalized refs"));
@@ -113,7 +113,7 @@ mod loose {
         fn capitalized_branch() -> crate::Result {
             let store = store()?;
             assert_eq!(
-                store.find("A")?.name.as_bstr(),
+                store.find("A")?,
                 "refs/heads/A",
                 "capitalized loose refs can be found fine"
             );
@@ -123,14 +123,14 @@ mod loose {
         #[test]
         fn success_and_failure() -> crate::Result {
             let store = store()?;
-            for (partial_name, expected_path) in &[("main", Some("refs/heads/main")), ("does-not-exist", None)] {
-                let reference = store.find_loose(*partial_name);
+            for (partial_name, expected_path) in [("main", Some("refs/heads/main")), ("does-not-exist", None)] {
+                let reference = store.find_loose(partial_name);
                 match expected_path {
-                    Some(expected_path) => assert_eq!(reference?.name.as_bstr(), expected_path),
+                    Some(expected_path) => assert_eq!(reference?, expected_path),
                     None => match reference {
                         Ok(_) => panic!("Expected error"),
                         Err(gix_ref::file::find::existing::Error::NotFound { name }) => {
-                            assert_eq!(name, Path::new(*partial_name));
+                            assert_eq!(name, Path::new(partial_name));
                         }
                         Err(err) => panic!("Unexpected err: {err:?}"),
                     },
@@ -170,7 +170,7 @@ mod loose {
             ("refs/heads/main", "refs/heads/main", gix_ref::Kind::Object),
         ] {
             let reference = store.try_find_loose(*partial_name)?.expect("exists");
-            assert_eq!(reference.name.as_bstr(), expected_path);
+            assert_eq!(reference, *expected_path);
             assert_eq!(reference.target.to_ref().kind(), *expected_ref_kind);
         }
         Ok(())

--- a/gix-ref/tests/refs/file/store/iter.rs
+++ b/gix-ref/tests/refs/file/store/iter.rs
@@ -35,18 +35,11 @@ mod with_namespace {
             "refs/namespaces/bar/refs/remotes/origin/multi-link-target3",
             "refs/namespaces/bar/refs/tags/multi-link-target2",
         ];
-        assert_eq!(
-            namespaced_refs
-                .iter()
-                .map(gix_ref::FullName::as_bstr)
-                .collect::<Vec<_>>(),
-            expected_namespaced_refs
-        );
+        assert_eq!(namespaced_refs, expected_namespaced_refs);
         assert_eq!(
             store
                 .loose_iter_prefixed(ns_two.as_bstr().try_into().unwrap())?
                 .map(Result::unwrap)
-                .map(|r| r.name.into_inner())
                 .collect::<Vec<_>>(),
             [
                 "refs/namespaces/bar/refs/heads/multi-link-target1",
@@ -60,7 +53,6 @@ mod with_namespace {
                 .expect("present")
                 .iter_prefixed(ns_two.as_bstr().to_owned())?
                 .map(Result::unwrap)
-                .map(|r| r.name.to_owned().into_inner())
                 .collect::<Vec<_>>(),
             ["refs/namespaces/bar/refs/remotes/origin/multi-link-target3"]
         );
@@ -71,9 +63,7 @@ mod with_namespace {
                 "it finds namespaced items by fully qualified name"
             );
             assert_eq!(
-                store
-                    .find(fullname.as_bstr().splitn_str(2, b"/").nth(1).expect("name").as_bstr())?
-                    .name,
+                store.find(fullname.as_bstr().splitn_str(2, b"/").nth(1).expect("name").as_bstr())?,
                 fullname,
                 "it will find namespaced items just by their shortened (but not shortest) name"
             );
@@ -121,7 +111,7 @@ mod with_namespace {
                     |r: gix_ref::Reference| if r.name.as_bstr().starts_with_str("refs/namespaces") {
                         None
                     } else {
-                        Some(r.name.as_bstr().to_owned())
+                        Some(r)
                     }
                 )
                 .collect::<Vec<_>>(),
@@ -159,14 +149,11 @@ mod with_namespace {
             .map(Result::unwrap)
             .map(|r: gix_ref::Reference| r.name)
             .collect::<Vec<_>>();
-        assert_eq!(
-            ref_names.iter().map(gix_ref::FullName::as_bstr).collect::<Vec<_>>(),
-            expected_refs
-        );
+        assert_eq!(ref_names, expected_refs);
 
         for fullname in ref_names {
             assert_eq!(
-                ns_store.find(fullname.as_bstr())?.name,
+                ns_store.find(fullname.as_bstr())?,
                 fullname,
                 "it finds namespaced items by fully qualified name, excluding namespace"
             );
@@ -177,9 +164,7 @@ mod with_namespace {
                 "it won't find namespaced items by their store-relative name with namespace"
             );
             assert_eq!(
-                ns_store
-                    .find(fullname.as_bstr().splitn_str(2, b"/").nth(1).expect("name").as_bstr())?
-                    .name,
+                ns_store.find(fullname.as_bstr().splitn_str(2, b"/").nth(1).expect("name").as_bstr())?,
                 fullname,
                 "it finds partial names within the namespace"
             );
@@ -191,11 +176,7 @@ mod with_namespace {
             "packed refs have no namespace support at all"
         );
         assert_eq!(
-            ns_store
-                .loose_iter()?
-                .map(Result::unwrap)
-                .map(|r| r.name.into_inner())
-                .collect::<Vec<_>>(),
+            ns_store.loose_iter()?.map(Result::unwrap).collect::<Vec<_>>(),
             [
                 "refs/heads/multi-link-target1",
                 "refs/multi-link",
@@ -207,11 +188,7 @@ mod with_namespace {
         {
             let prev = ns_store.namespace.take();
             assert_eq!(
-                ns_store
-                    .loose_iter()?
-                    .map(Result::unwrap)
-                    .map(|r| r.name.into_inner())
-                    .collect::<Vec<_>>(),
+                ns_store.loose_iter()?.map(Result::unwrap).collect::<Vec<_>>(),
                 [
                     "refs/namespaces/bar/refs/heads/multi-link-target1",
                     "refs/namespaces/bar/refs/multi-link",
@@ -227,12 +204,7 @@ mod with_namespace {
         ns_store.namespace = ns_one.into();
 
         assert_eq!(
-            ns_store
-                .iter()?
-                .all()?
-                .map(Result::unwrap)
-                .map(|r: gix_ref::Reference| r.name.into_inner())
-                .collect::<Vec<_>>(),
+            ns_store.iter()?.all()?.map(Result::unwrap).collect::<Vec<_>>(),
             vec!["refs/d1", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"],
         );
         Ok(())
@@ -260,11 +232,7 @@ fn packed_file_iter() -> crate::Result {
 fn pseudo_refs_iter() -> crate::Result {
     let store = store_at("make_pseudo_ref_repository.sh")?;
 
-    let actual = store
-        .iter_pseudo()?
-        .map(Result::unwrap)
-        .map(|r: gix_ref::Reference| r.name.as_bstr().to_string())
-        .collect::<Vec<_>>();
+    let actual = store.iter_pseudo()?.map(Result::unwrap).collect::<Vec<_>>();
 
     assert_eq!(actual, ["FETCH_HEAD", "HEAD", "JIRI_HEAD"]);
     Ok(())
@@ -295,10 +263,7 @@ fn loose_iter_with_broken_refs() -> crate::Result {
         actual[first_error].as_ref().expect_err("unparsable ref").to_string(),
         msg
     );
-    let ref_paths: Vec<_> = actual
-        .drain(..first_error)
-        .filter_map(|e| e.ok().map(|e| e.name.into_inner()))
-        .collect();
+    let ref_paths: Vec<_> = actual.drain(..first_error).filter_map(Result::ok).collect();
 
     assert_eq!(
         ref_paths,
@@ -335,23 +300,17 @@ fn loose_iter_with_prefix() -> crate::Result {
     let actual = store()?
         .loose_iter_prefixed(prefix_with_slash.try_into().unwrap())?
         .collect::<Result<Vec<_>, _>>()
-        .expect("no broken ref in this subset")
-        .into_iter()
-        .map(|e| e.name.into_inner())
-        .collect::<Vec<_>>();
+        .expect("no broken ref in this subset");
 
     assert_eq!(
         actual,
-        vec![
+        [
             "refs/heads/A",
             "refs/heads/d1",
             "refs/heads/dt1",
             "refs/heads/main",
             "refs/heads/multi-link-target1",
-        ]
-        .into_iter()
-        .map(String::from)
-        .collect::<Vec<_>>(),
+        ],
         "all paths are as expected"
     );
     Ok(())
@@ -363,23 +322,17 @@ fn loose_iter_with_partial_prefix_dir() -> crate::Result {
     let actual = store()?
         .loose_iter_prefixed(prefix_without_slash.try_into().unwrap())?
         .collect::<Result<Vec<_>, _>>()
-        .expect("no broken ref in this subset")
-        .into_iter()
-        .map(|e| e.name.into_inner())
-        .collect::<Vec<_>>();
+        .expect("no broken ref in this subset");
 
     assert_eq!(
         actual,
-        vec![
+        [
             "refs/heads/A",
             "refs/heads/d1",
             "refs/heads/dt1",
             "refs/heads/main",
             "refs/heads/multi-link-target1",
-        ]
-        .into_iter()
-        .map(String::from)
-        .collect::<Vec<_>>(),
+        ],
         "all paths are as expected"
     );
     Ok(())
@@ -390,19 +343,9 @@ fn loose_iter_with_partial_prefix() -> crate::Result {
     let actual = store()?
         .loose_iter_prefixed(b"refs/heads/d".as_bstr().try_into().unwrap())?
         .collect::<Result<Vec<_>, _>>()
-        .expect("no broken ref in this subset")
-        .into_iter()
-        .map(|e| e.name.into_inner())
-        .collect::<Vec<_>>();
+        .expect("no broken ref in this subset");
 
-    assert_eq!(
-        actual,
-        vec!["refs/heads/d1", "refs/heads/dt1"]
-            .into_iter()
-            .map(String::from)
-            .collect::<Vec<_>>(),
-        "all paths are as expected"
-    );
+    assert_eq!(actual, ["refs/heads/d1", "refs/heads/dt1"], "all paths are as expected");
     Ok(())
 }
 

--- a/gix-ref/tests/refs/file/store/mod.rs
+++ b/gix-ref/tests/refs/file/store/mod.rs
@@ -44,7 +44,7 @@ fn precompose_unicode_journey() -> crate::Result {
         .commit(committer().to_ref(&mut buf))?;
 
     let r = store_decomposed.iter()?.all()?.next().expect("created one ref")?;
-    assert_eq!(r.name.as_bstr(), decomposed_ref, "no transformation happens by default");
+    assert_eq!(r.name, decomposed_ref, "no transformation happens by default");
 
     // For some reason, `tmpfs` can qualify as decomposing, but it then doesn't really work the same as expected here
     // to the point where the precomposed iteration can't find a single reference.
@@ -67,18 +67,17 @@ fn precompose_unicode_journey() -> crate::Result {
     let precomposed_ref = format!("refs/heads/{precomposed_a}");
     let r = store_precomposed.iter()?.all()?.next().expect("created one ref")?;
     assert_eq!(
-        r.name.as_bstr(),
-        precomposed_ref,
+        r.name, precomposed_ref,
         "it transforms all refs it sees to precomposed format, in order to unify it with what we store in packed-refs (precomposed)"
     );
 
     assert_eq!(
-        store_precomposed.find(precomposed_a)?.name.as_bstr(),
+        store_precomposed.find(precomposed_a)?,
         precomposed_ref,
         "can find as precomposed, even though on disk is decomposed it is decomposed"
     );
     assert_eq!(
-        store_precomposed.find(decomposed_a)?.name.as_bstr(),
+        store_precomposed.find(decomposed_a)?,
         decomposed_ref,
         "can find as decomposed, and it keeps it as is to not violate expectations of the returned name being equal to the input (when comparing as bytes)"
     );
@@ -90,8 +89,7 @@ fn precompose_unicode_journey() -> crate::Result {
         .prepare(Some(create_at(&decomposed_ref)), Fail::Immediately, Fail::Immediately)?
         .commit(committer().to_ref(&mut buf))?;
     assert_eq!(
-        edits[0].name.as_bstr(),
-        decomposed_ref,
+        edits[0].name, decomposed_ref,
         "it doesn't alter the composition style to allow input and output to remain unchanged"
     );
 
@@ -196,7 +194,7 @@ fn precompose_unicode_journey() -> crate::Result {
         )?
         .commit(committer().to_ref(&mut buf))?;
     assert_eq!(
-        edits[0].change.new_value().unwrap().try_name().unwrap().as_bstr(),
+        edits[0].change.new_value().unwrap().try_name().unwrap(),
         decomposed_ref,
         "the composition doesn't change, it matches the original edit"
     );
@@ -206,8 +204,7 @@ fn precompose_unicode_journey() -> crate::Result {
             .expect("exists")
             .target
             .try_name()
-            .unwrap()
-            .as_bstr(),
+            .unwrap(),
         decomposed_ref,
         "on disk it's stored in the original format as well"
     );

--- a/gix-ref/tests/refs/file/transaction/prepare_and_commit/create_or_update/mod.rs
+++ b/gix-ref/tests/refs/file/transaction/prepare_and_commit/create_or_update/mod.rs
@@ -421,7 +421,7 @@ fn symbolic_reference_writes_reflog_if_previous_value_is_set() -> crate::Result 
         .commit(committer().to_ref(&mut TimeBuf::default()))?;
     assert_eq!(edits.len(), 1, "no split was performed");
     let head = store.find_loose(&edits[0].name)?;
-    assert_eq!(head.name.as_bstr(), "refs/heads/symbolic");
+    assert_eq!(head, "refs/heads/symbolic");
     assert_eq!(head.kind(), gix_ref::Kind::Symbolic);
     assert_eq!(
         head.target.to_ref().try_name().map(gix_ref::FullNameRef::as_bstr),
@@ -622,7 +622,7 @@ fn symbolic_head_missing_referent_then_update_referent() -> crate::Result {
         );
 
         let head = store.find_loose(&edits[0].name)?;
-        assert_eq!(head.name.as_bstr(), "HEAD");
+        assert_eq!(head, "HEAD");
         assert_eq!(head.kind(), gix_ref::Kind::Symbolic);
         assert_eq!(
             std::fs::read_to_string(store.git_dir().join("HEAD"))?,

--- a/gix-ref/tests/refs/fullname.rs
+++ b/gix-ref/tests/refs/fullname.rs
@@ -119,8 +119,7 @@ fn shorten_and_category() {
                 let (cat, short_name) = cat_and_short_name.expect("we know it's set");
                 let actual = cat.to_full_name(short_name).expect("valid input = valid output");
                 assert_eq!(
-                    actual.as_ref().as_bstr(),
-                    input,
+                    actual, input,
                     "{input}: {cat:?}:{short_name}: categories and short-names can round-trip"
                 );
             }
@@ -147,15 +146,13 @@ fn shorten_and_category() {
 #[test]
 fn to_full_name() -> gix_testtools::Result {
     assert_eq!(
-        Category::LocalBranch.to_full_name("refs/heads/full")?.as_bstr(),
+        Category::LocalBranch.to_full_name("refs/heads/full")?,
         "refs/heads/full",
         "prefixes aren't duplicated"
     );
 
     assert_eq!(
-        Category::LocalBranch
-            .to_full_name("refs/remotes/origin/other")?
-            .as_bstr(),
+        Category::LocalBranch.to_full_name("refs/remotes/origin/other")?,
         "refs/heads/refs/remotes/origin/other",
         "full names with a different category will be prefixed, to support 'main-worktree' special cases"
     );
@@ -166,12 +163,12 @@ fn to_full_name() -> gix_testtools::Result {
 #[test]
 fn local_branch_head_is_representable_as_full_ref_name() -> gix_testtools::Result {
     assert_eq!(
-        Category::LocalBranch.to_full_name("HEAD")?.as_bstr(),
+        Category::LocalBranch.to_full_name("HEAD")?,
         "refs/heads/HEAD",
         "generic full-name construction accepts names that are invalid only in branch-specific contexts"
     );
     assert_eq!(
-        Category::LocalBranch.to_full_name("refs/heads/HEAD")?.as_bstr(),
+        Category::LocalBranch.to_full_name("refs/heads/HEAD")?,
         "refs/heads/HEAD",
         "fully qualified names keep their category prefix de-duplicated"
     );
@@ -182,21 +179,14 @@ fn local_branch_head_is_representable_as_full_ref_name() -> gix_testtools::Resul
 fn prefix_with_namespace_and_stripping() {
     let ns = gix_ref::namespace::expand("foo").unwrap();
     let mut name: gix_ref::FullName = "refs/heads/main".try_into().unwrap();
+    assert_eq!(name.prefix_namespace(&ns), "refs/namespaces/foo/refs/heads/main");
     assert_eq!(
-        name.prefix_namespace(&ns).as_bstr(),
-        "refs/namespaces/foo/refs/heads/main"
-    );
-    assert_eq!(
-        name.prefix_namespace(&ns).as_bstr(),
+        name.prefix_namespace(&ns),
         "refs/namespaces/foo/refs/heads/main",
         "idempotent prefixing"
     );
-    assert_eq!(name.strip_namespace(&ns).as_bstr(), "refs/heads/main");
-    assert_eq!(
-        name.strip_namespace(&ns).as_bstr(),
-        "refs/heads/main",
-        "idempotent stripping"
-    );
+    assert_eq!(name.strip_namespace(&ns), "refs/heads/main");
+    assert_eq!(name.strip_namespace(&ns), "refs/heads/main", "idempotent stripping");
 }
 
 #[test]

--- a/gix-ref/tests/refs/main.rs
+++ b/gix-ref/tests/refs/main.rs
@@ -63,6 +63,7 @@ fn translate_sha1_to_fixture_sha256(hex: &str) -> String {
 
 pub use gix_testtools::Result;
 
+mod equality;
 mod file;
 mod fullname;
 mod partialname {

--- a/gix-ref/tests/refs/main.rs
+++ b/gix-ref/tests/refs/main.rs
@@ -72,7 +72,7 @@ mod partialname {
     #[test]
     fn join() -> crate::Result {
         let pn = PartialName::try_from("no-trailing-slash")?;
-        assert_eq!(pn.join("name".into())?.as_ref().as_bstr(), "no-trailing-slash/name");
+        assert_eq!(pn.join("name".into())?, "no-trailing-slash/name");
 
         let err = PartialName::try_from("trailing-slash/").unwrap_err();
         assert!(

--- a/gix-ref/tests/refs/namespace.rs
+++ b/gix-ref/tests/refs/namespace.rs
@@ -17,16 +17,13 @@ fn into_namespaced_prefix() {
 mod expand {
     #[test]
     fn components_end_with_trailing_slash_to_help_with_prefix_stripping() {
-        assert_eq!(
-            gix_ref::namespace::expand("foo").unwrap().as_bstr(),
-            "refs/namespaces/foo/"
-        );
+        assert_eq!(gix_ref::namespace::expand("foo").unwrap(), "refs/namespaces/foo/");
     }
 
     #[test]
     fn each_component_expands_to_the_namespace_prefix_individually() {
         assert_eq!(
-            gix_ref::namespace::expand("foo/bar").unwrap().as_bstr(),
+            gix_ref::namespace::expand("foo/bar").unwrap(),
             "refs/namespaces/foo/refs/namespaces/bar/"
         );
     }

--- a/gix-ref/tests/refs/packed/find.rs
+++ b/gix-ref/tests/refs/packed/find.rs
@@ -23,7 +23,7 @@ fn capitalized_branch() -> crate::Result {
     let packed_refs = store.open_packed_buffer()?.expect("packed-refs exist");
 
     assert_eq!(
-        packed_refs.find("A")?.name.as_bstr(),
+        packed_refs.find("A")?,
         "refs/heads/A",
         "fully capitalized refs aren't just considered pseudorefs"
     );
@@ -102,7 +102,7 @@ fn partial_name_to_full_name_conversion_rules_are_applied() -> crate::Result {
     let packed = store.open_packed_buffer()?.expect("packed-refs exists");
 
     assert_eq!(
-        store.find_loose("origin")?.name.as_bstr(),
+        store.find_loose("origin")?,
         "refs/remotes/origin/HEAD",
         "a special that only applies to loose refs"
     );
@@ -110,37 +110,33 @@ fn partial_name_to_full_name_conversion_rules_are_applied() -> crate::Result {
         packed.try_find("origin")?.is_none(),
         "packed refs don't have this special case as they don't store HEADs or symrefs"
     );
-    assert_eq!(
-        store.find_loose("HEAD")?.name.as_bstr(),
-        "HEAD",
-        "HEAD can be found in loose stores"
-    );
+    assert_eq!(store.find_loose("HEAD")?, "HEAD", "HEAD can be found in loose stores");
     assert!(
         packed.try_find("HEAD")?.is_none(),
         "packed refs definitely don't contain HEAD"
     );
     assert_eq!(
-        packed.try_find("head-or-tag")?.expect("present").name.as_bstr(),
+        packed.try_find("head-or-tag")?.expect("present"),
         "refs/tags/head-or-tag",
         "it finds tags first"
     );
     assert_eq!(
-        packed.try_find("heads/head-or-tag")?.expect("present").name.as_bstr(),
+        packed.try_find("heads/head-or-tag")?.expect("present"),
         "refs/heads/head-or-tag",
         "it finds heads when disambiguated"
     );
     assert_eq!(
-        packed.try_find("main")?.expect("present").name.as_bstr(),
+        packed.try_find("main")?.expect("present"),
         "refs/heads/main",
         "it finds local heads before remote ones"
     );
     assert_eq!(
-        packed.try_find("origin/main")?.expect("present").name.as_bstr(),
+        packed.try_find("origin/main")?.expect("present"),
         "refs/remotes/origin/main",
         "it finds remote heads when disambiguated"
     );
     assert_eq!(
-        packed.try_find("remotes/origin/main")?.expect("present").name.as_bstr(),
+        packed.try_find("remotes/origin/main")?.expect("present"),
         "refs/remotes/origin/main",
         "more specification is possible, too"
     );

--- a/gix-ref/tests/refs/packed/iter.rs
+++ b/gix-ref/tests/refs/packed/iter.rs
@@ -1,4 +1,3 @@
-use gix_object::bstr::ByteSlice;
 use gix_ref::packed;
 
 use crate::file::{store_at, store_with_packed_refs};
@@ -30,52 +29,39 @@ fn iter_prefix() -> crate::Result {
     assert_eq!(
         packed
             .iter_prefixed("refs/heads/".into())?
-            .map(|r| r.map(|r| r.name.as_bstr()))
             .collect::<Result<Vec<_>, _>>()?,
-        vec![
-            "refs/heads/A".as_bytes().as_bstr(),
-            "refs/heads/d1".into(),
-            "refs/heads/dt1".into(),
-            "refs/heads/main".into()
-        ]
+        vec!["refs/heads/A", "refs/heads/d1", "refs/heads/dt1", "refs/heads/main"]
     );
 
     assert_eq!(
         packed
             .iter_prefixed("refs/heads/d".into())?
-            .map(|r| r.map(|r| r.name.as_bstr()))
             .collect::<Result<Vec<_>, _>>()?,
-        vec!["refs/heads/d1".as_bytes().as_bstr(), "refs/heads/dt1".into(),],
+        vec!["refs/heads/d1", "refs/heads/dt1"],
         "partial prefixes are fine, they don't have to resemble or be a directory"
     );
 
     assert_eq!(
         packed
             .iter_prefixed("refs/remotes/".into())?
-            .map(|r| r.map(|r| r.name.as_bstr()))
             .collect::<Result<Vec<_>, _>>()?,
-        vec![
-            "refs/remotes/origin/main".as_bytes().as_bstr(),
-            "refs/remotes/origin/multi-link-target3".into(),
-        ]
+        vec!["refs/remotes/origin/main", "refs/remotes/origin/multi-link-target3",]
     );
 
     let last_ref_in_file = "refs/tags/t1";
     assert_eq!(
         packed
             .iter_prefixed(last_ref_in_file.into())?
-            .map(|r| r.map(|r| r.name.as_bstr()))
             .collect::<Result<Vec<_>, _>>()?,
-        vec![last_ref_in_file.as_bytes().as_bstr()],
+        vec![last_ref_in_file],
         "prefixes which are a ref also work, this one is the last of the file"
     );
     let first_ref_in_file = "refs/d1";
     assert_eq!(
         packed
             .iter_prefixed(first_ref_in_file.into())?
-            .map(|r| r.map(|r| r.name.as_bstr()))
             .collect::<Result<Vec<_>, _>>()?,
-        vec![first_ref_in_file.as_bytes().as_bstr()],
+        vec![first_ref_in_file],
         "prefixes which are a ref also work, and this one at the beginning of the file"
     );
     Ok(())

--- a/gix-ref/tests/refs/reference.rs
+++ b/gix-ref/tests/refs/reference.rs
@@ -17,9 +17,9 @@ fn strip_namespace() {
         peeled: None,
     };
     r.strip_namespace(&ns);
-    assert_eq!(r.name.as_bstr(), "refs/heads/main", "name is stripped");
+    assert_eq!(r.name, "refs/heads/main", "name is stripped");
     assert!(
-        matches!(r.target, Target::Symbolic(n) if n.as_bstr() == "refs/tags/foo"),
+        matches!(r.target, Target::Symbolic(n) if n == "refs/tags/foo"),
         "and the symbolic target as well"
     );
 }

--- a/gix-ref/tests/refs/transaction.rs
+++ b/gix-ref/tests/refs/transaction.rs
@@ -99,18 +99,14 @@ mod refedit_ext {
         use std::cell::Cell;
 
         use gix_ref::{
-            FullNameRef, PartialNameRef, Target,
+            PartialNameRef, Target,
             transaction::{Change, LogChange, PreviousValue, RefEdit, RefEditsExt, RefLog},
         };
 
         use crate::{hex_to_id, transaction::refedit_ext::MockStore};
 
         fn find<'a>(edits: &'a [RefEdit], name: &str) -> &'a RefEdit {
-            let name: &FullNameRef = name.try_into().unwrap();
-            edits
-                .iter()
-                .find(|e| e.name.as_bstr() == name.as_bstr())
-                .expect("always available")
+            edits.iter().find(|e| e.name == name).expect("always available")
         }
 
         #[test]

--- a/gix-refspec/Cargo.toml
+++ b/gix-refspec/Cargo.toml
@@ -22,7 +22,7 @@ sha256 = ["gix-hash/sha256"]
 
 [dependencies]
 gix-validate = { version = "^0.11.4", path = "../gix-validate" }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
 
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 thiserror = "2.0.18"

--- a/gix-revision/Cargo.toml
+++ b/gix-revision/Cargo.toml
@@ -31,9 +31,9 @@ merge_base = ["dep:gix-trace", "dep:bitflags"]
 serde = ["dep:serde", "gix-hash/serde", "gix-object/serde"]
 
 [dependencies]
-gix-error = { version = "^0.3.0", path = "../gix-error" }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-error = { version = "^0.3.1", path = "../gix-error" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 gix-date = { version = "^0.16.0", path = "../gix-date" }
 gix-hashtable = { version = "^0.16.0", path = "../gix-hashtable", optional = true }
 gix-revwalk = { version = "^0.35.0", path = "../gix-revwalk" }

--- a/gix-status/Cargo.toml
+++ b/gix-status/Cargo.toml
@@ -27,8 +27,8 @@ parallel = ["gix-features/parallel"]
 [dependencies]
 gix-index = { version = "^0.55.0", path = "../gix-index" }
 gix-fs = { version = "^0.22.1", path = "../gix-fs" }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 gix-path = { version = "^0.12.5", path = "../gix-path" }
 gix-features = { version = "^0.49.1", path = "../gix-features", features = ["progress"] }
 gix-filter = { version = "^0.34.0", path = "../gix-filter" }

--- a/gix-transport/Cargo.toml
+++ b/gix-transport/Cargo.toml
@@ -96,7 +96,7 @@ gix-path = { version = "^0.12.5", path = "../gix-path" }
 gix-features = { version = "^0.49.1", path = "../gix-features" }
 gix-url = { version = "^0.38.0", path = "../gix-url" }
 gix-sec = { version = "^0.14.2", path = "../gix-sec" }
-gix-packetline = { version = "^0.22.0", path = "../gix-packetline" }
+gix-packetline = { version = "^0.22.1", path = "../gix-packetline" }
 gix-credentials = { version = "^0.40.0", path = "../gix-credentials", optional = true }
 gix-quote = { version = "^0.8.0", path = "../gix-quote" }
 

--- a/gix-worktree-state/Cargo.toml
+++ b/gix-worktree-state/Cargo.toml
@@ -26,7 +26,7 @@ parallel = ["gix-features/parallel"]
 gix-worktree = { version = "^0.56.0", path = "../gix-worktree", default-features = false, features = ["attributes"] }
 gix-index = { version = "^0.55.0", path = "../gix-index" }
 gix-fs = { version = "^0.22.1", path = "../gix-fs" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 gix-path = { version = "^0.12.5", path = "../gix-path" }
 gix-features = { version = "^0.49.1", path = "../gix-features" }
 gix-filter = { version = "^0.34.0", path = "../gix-filter" }

--- a/gix-worktree-stream/Cargo.toml
+++ b/gix-worktree-stream/Cargo.toml
@@ -22,15 +22,15 @@ sha256 = ["gix-hash/sha256"]
 
 [dependencies]
 gix-features = { version = "^0.49.1", path = "../gix-features", features = ["progress", "io-pipe", "parallel"] }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 gix-attributes = { version = "^0.35.0", path = "../gix-attributes", features = ["parallel"] }
 gix-filter = { version = "^0.34.0", path = "../gix-filter" }
 gix-traverse = { version = "^0.61.0", path = "../gix-traverse" }
 gix-fs = { version = "^0.22.1", path = "../gix-fs" }
 gix-path = { version = "^0.12.5", path = "../gix-path" }
 
-gix-error = { version = "^0.3.0", path = "../gix-error" }
+gix-error = { version = "^0.3.1", path = "../gix-error" }
 parking_lot = "0.12.4"
 
 [dev-dependencies]

--- a/gix/Cargo.toml
+++ b/gix/Cargo.toml
@@ -328,10 +328,10 @@ progress-tree = ["prodash/progress-tree"]
 cache-efficiency-debug = ["gix-features/cache-efficiency-debug"]
 
 [dependencies]
-gix-error = { version = "^0.3.0", path = "../gix-error" }
+gix-error = { version = "^0.3.1", path = "../gix-error" }
 gix-utils = { version = "^0.3.6", path = "../gix-utils", features = ["bstr"] }
 gix-fs = { version = "^0.22.1", path = "../gix-fs" }
-gix-ref = { version = "^0.67.0", path = "../gix-ref" }
+gix-ref = { version = "^0.67.1", path = "../gix-ref" }
 gix-discover = { version = "^0.55.0", path = "../gix-discover" }
 gix-tempfile = { version = "^24.0.0", path = "../gix-tempfile", default-features = false }
 gix-lock = { version = "^24.0.0", path = "../gix-lock" }
@@ -345,11 +345,11 @@ gix-dir = { version = "^0.29.0", path = "../gix-dir", optional = true }
 gix-config = { version = "^0.60.0", path = "../gix-config" }
 gix-odb = { version = "^0.84.0", path = "../gix-odb" }
 gix-zlib = { version = "^0.1.0", path = "../gix-zlib" }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
 gix-shallow = { version = "^0.13.0", path = "../gix-shallow" }
-gix-object = { version = "^0.64.0", path = "../gix-object" }
+gix-object = { version = "^0.64.1", path = "../gix-object" }
 gix-actor = { version = "^0.42.0", path = "../gix-actor" }
-gix-pack = { version = "^0.74.0", path = "../gix-pack", default-features = false, features = [
+gix-pack = { version = "^0.74.1", path = "../gix-pack", default-features = false, features = [
     "object-cache-dynamic",
 ] }
 gix-revision = { version = "^0.49.0", path = "../gix-revision", default-features = false }
@@ -423,7 +423,7 @@ document-features = { version = "0.2.0", optional = true }
 gix = { path = ".", default-features = false, features = [
     "merge", "tree-error", "sha1", "sha256"
 ] }
-gix-hash = { version = "^0.26.1", path = "../gix-hash" }
+gix-hash = { version = "^0.26.2", path = "../gix-hash" }
 pretty_assertions = "1.4.0"
 gix-testtools = { path = "../tests/tools", features = ["sha1", "sha256"] }
 is_ci = "1.1.1"

--- a/gix/src/head/mod.rs
+++ b/gix/src/head/mod.rs
@@ -55,7 +55,7 @@ impl<'repo> Head<'repo> {
     /// # let repo = doctest::open_repo(doctest::basic_repo_dir()?)?;
     /// let head = repo.head()?;
     ///
-    /// assert_eq!(head.referent_name().expect("branch head").as_bstr(), "refs/heads/main");
+    /// assert_eq!(head.referent_name().expect("branch head"), "refs/heads/main");
     /// # Ok(()) }
     /// ```
     pub fn referent_name(&self) -> Option<&FullNameRef> {
@@ -111,7 +111,7 @@ impl<'repo> Head<'repo> {
     /// # let repo = doctest::open_repo(doctest::basic_repo_dir()?)?;
     /// let branch = repo.head()?.try_into_referent().expect("symbolic head");
     ///
-    /// assert_eq!(branch.name().as_bstr(), "refs/heads/main");
+    /// assert_eq!(branch, "refs/heads/main");
     /// # Ok(()) }
     /// ```
     pub fn try_into_referent(self) -> Option<crate::Reference<'repo>> {

--- a/gix/src/id.rs
+++ b/gix/src/id.rs
@@ -116,6 +116,22 @@ mod impls {
 
     use crate::{Id, Object, ObjectDetached};
 
+    macro_rules! impl_partial_eq_text {
+        ($text:ty) => {
+            impl PartialEq<$text> for Id<'_> {
+                fn eq(&self, other: &$text) -> bool {
+                    self.inner.eq(other)
+                }
+            }
+
+            impl<'repo> PartialEq<Id<'repo>> for $text {
+                fn eq(&self, other: &Id<'repo>) -> bool {
+                    self.eq(&other.inner)
+                }
+            }
+        };
+    }
+
     // Eq, Hash, Ord, PartialOrd,
 
     impl std::hash::Hash for Id<'_> {
@@ -147,6 +163,10 @@ mod impls {
             self == &other.inner
         }
     }
+
+    impl_partial_eq_text!(str);
+    impl_partial_eq_text!(&str);
+    impl_partial_eq_text!(String);
 
     impl PartialEq<oid> for Id<'_> {
         fn eq(&self, other: &oid) -> bool {

--- a/gix/src/reference/mod.rs
+++ b/gix/src/reference/mod.rs
@@ -263,7 +263,7 @@ impl<'repo> Reference<'repo> {
     /// let head = repo.find_reference("HEAD")?;
     /// let branch = head.follow().expect("symbolic")?;
     ///
-    /// assert_eq!(branch.name().as_bstr(), "refs/heads/main");
+    /// assert_eq!(branch, "refs/heads/main");
     /// # Ok(()) }
     /// ```
     pub fn follow(&self) -> Option<Result<Reference<'repo>, gix_ref::file::find::existing::Error>> {

--- a/gix/src/reference/mod.rs
+++ b/gix/src/reference/mod.rs
@@ -1,9 +1,13 @@
 //!
 #![allow(clippy::empty_docs)]
 
+use crate::ext::ObjectIdExt;
+use gix_ref::file;
 use gix_ref::file::ReferenceExt;
 
 use crate::{Blob, Commit, Id, Object, Reference, Tag, Tree};
+
+pub use gix_ref::{Category, Kind};
 
 pub mod iter;
 ///
@@ -12,11 +16,10 @@ pub mod remote;
 mod errors;
 pub use errors::{edit, find, follow, head_commit, head_id, head_tree, head_tree_id, peel};
 
-use crate::ext::ObjectIdExt;
-
 pub mod log;
 
-pub use gix_ref::{Category, Kind};
+mod edits;
+pub use edits::{delete, set_target_id};
 
 /// Access
 impl<'repo> Reference<'repo> {
@@ -59,12 +62,6 @@ impl<'repo> Reference<'repo> {
     /// Turn this instances into a stand-alone reference.
     pub fn detach(self) -> gix_ref::Reference {
         self.inner
-    }
-}
-
-impl std::fmt::Debug for Reference<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(&self.inner, f)
     }
 }
 
@@ -279,6 +276,37 @@ impl<'repo> Reference<'repo> {
     }
 }
 
-mod edits;
-pub use edits::{delete, set_target_id};
-use gix_ref::file;
+mod impls {
+    use gix_ref::{
+        FullName, FullNameRef,
+        bstr::{BStr, BString},
+    };
+
+    use crate::Reference;
+
+    macro_rules! impl_partial_eq {
+        ($other:ty) => {
+            impl PartialEq<$other> for Reference<'_> {
+                fn eq(&self, other: &$other) -> bool {
+                    self.inner.eq(other)
+                }
+            }
+        };
+    }
+
+    impl_partial_eq!(str);
+    impl_partial_eq!(&str);
+    impl_partial_eq!(String);
+    impl_partial_eq!(BStr);
+    impl_partial_eq!(&BStr);
+    impl_partial_eq!(BString);
+    impl_partial_eq!(FullName);
+    impl_partial_eq!(FullNameRef);
+    impl_partial_eq!(&FullNameRef);
+
+    impl std::fmt::Debug for Reference<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            std::fmt::Debug::fmt(&self.inner, f)
+        }
+    }
+}

--- a/gix/src/reference/remote.rs
+++ b/gix/src/reference/remote.rs
@@ -2,7 +2,7 @@ use gix_ref::{Category, FullName};
 
 use crate::{
     Reference,
-    bstr::ByteSlice,
+    bstr::{BStr, ByteSlice},
     remote,
     repository::{branch_remote_ref_name, branch_remote_tracking_ref_name},
 };
@@ -17,23 +17,14 @@ impl<'repo> Reference<'repo> {
         let (category, shortname) = self.name().category_and_short_name()?;
         match category {
             Category::RemoteBranch => {
-                if shortname.find_iter("/").take(2).count() == 1 {
-                    let slash_pos = shortname.find_byte(b'/').expect("it was just found");
-                    shortname[..slash_pos]
-                        .as_bstr()
-                        .to_str()
-                        .ok()
-                        .map(|n| remote::Name::Symbol(n.into()))
-                } else {
-                    let remotes = self.repo.remote_names();
-                    for slash_pos in shortname.rfind_iter("/") {
-                        let candidate = shortname[..slash_pos].as_bstr();
-                        if remotes.contains(candidate) {
-                            return candidate.to_str().ok().map(|n| remote::Name::Symbol(n.into()));
-                        }
-                    }
-                    None
-                }
+                let mut remotes = None;
+                remote_name_from_tracking_branch(shortname, |candidate| {
+                    remotes
+                        .get_or_insert_with(|| self.repo.remote_names())
+                        .contains(candidate)
+                })
+                .and_then(|name| name.to_str().ok())
+                .map(|name| remote::Name::Symbol(name.into()))
             }
             Category::LocalBranch => self.repo.branch_remote_name(shortname, direction),
             _ => None,
@@ -71,4 +62,25 @@ impl<'repo> Reference<'repo> {
     ) -> Option<Result<FullName, branch_remote_tracking_ref_name::Error>> {
         self.repo.branch_remote_tracking_ref_name(self.name(), direction)
     }
+}
+
+/// Infer the remote name from a remote-tracking branch name without its `refs/remotes/` prefix.
+///
+/// A name with exactly one slash, like `origin/main`, is unambiguous and yields `origin` even if that remote is not
+/// configured. With multiple slashes, both remote and branch names may contain slashes, so configured remote names are
+/// considered from longest to shortest: for `team/origin/topic`, `team/origin` wins over `team` when both exist.
+/// A name without a slash, or a multi-slash name without a matching configured remote prefix, yields `None`.
+/// `is_configured_remote` is only called for multi-slash names, for which configuration is needed to disambiguate.
+pub(crate) fn remote_name_from_tracking_branch(
+    shortname: &BStr,
+    mut is_configured_remote: impl FnMut(&BStr) -> bool,
+) -> Option<&BStr> {
+    if shortname.find_iter("/").take(2).count() == 1 {
+        let slash_pos = shortname.find_byte(b'/').expect("it was just found");
+        return Some(shortname[..slash_pos].as_bstr());
+    }
+    shortname
+        .rfind_iter("/")
+        .map(|slash_pos| shortname[..slash_pos].as_bstr())
+        .find(|candidate| is_configured_remote(candidate))
 }

--- a/gix/src/remote/connection/fetch/update_refs/tests.rs
+++ b/gix/src/remote/connection/fetch/update_refs/tests.rs
@@ -752,8 +752,7 @@ mod update {
             _ => unreachable!("only updates"),
         }
         assert_eq!(
-            edit.name.as_bstr(),
-            "refs/heads/HEAD",
+            edit.name, "refs/heads/HEAD",
             "it's not possible to refer to the local HEAD with refspecs"
         );
     }
@@ -811,7 +810,7 @@ mod update {
             }
             _ => unreachable!("only updates"),
         }
-        assert_eq!(edit.name.as_bstr(), "refs/remotes/origin/new-HEAD");
+        assert_eq!(edit.name, "refs/remotes/origin/new-HEAD");
     }
 
     #[test]

--- a/gix/src/remote/name.rs
+++ b/gix/src/remote/name.rs
@@ -90,3 +90,54 @@ impl AsRef<BStr> for Name<'_> {
         self.as_bstr()
     }
 }
+
+mod impls {
+    use crate::{
+        bstr::{BStr, BString, ByteSlice},
+        remote::Name,
+    };
+
+    macro_rules! impl_partial_eq {
+        ($left_type:ty, $right_type:ty, $left:ident => $left_bytes:expr, $right:ident => $right_bytes:expr) => {
+            impl PartialEq<$right_type> for $left_type {
+                fn eq(&self, other: &$right_type) -> bool {
+                    let $left = self;
+                    let $right = other;
+                    $left_bytes == $right_bytes
+                }
+            }
+        };
+    }
+
+    macro_rules! impl_partial_eq_pair {
+        ($left_type:ty, $right_type:ty, $left:ident => $left_bytes:expr, $right:ident => $right_bytes:expr) => {
+            impl_partial_eq!($left_type, $right_type, $left => $left_bytes, $right => $right_bytes);
+            impl_partial_eq!($right_type, $left_type, $right => $right_bytes, $left => $left_bytes);
+        };
+    }
+
+    macro_rules! impl_partial_eq_bytes {
+        ($type:ty, $value:ident => $bytes:expr) => {
+            impl_partial_eq_pair!($type, str, $value => $bytes.as_bytes(), other => other.as_bytes());
+            impl_partial_eq_pair!($type, &str, $value => $bytes.as_bytes(), other => other.as_bytes());
+            impl_partial_eq_pair!($type, String, $value => $bytes.as_bytes(), other => other.as_bytes());
+            impl_partial_eq_pair!($type, BStr, $value => $bytes.as_bytes(), other => other.as_bytes());
+            impl_partial_eq_pair!($type, &BStr, $value => $bytes.as_bytes(), other => other.as_bytes());
+            impl_partial_eq_pair!($type, BString, $value => $bytes.as_bytes(), other => other.as_bytes());
+        };
+    }
+
+    impl_partial_eq_bytes!(Name<'_>, value => value.as_bstr());
+    impl_partial_eq_pair!(
+        &Name<'_>,
+        String,
+        name => name.as_bstr().as_bytes(),
+        text => text.as_bytes()
+    );
+    impl_partial_eq_pair!(
+        &Name<'_>,
+        BString,
+        name => name.as_bstr().as_bytes(),
+        text => text.as_bytes()
+    );
+}

--- a/gix/src/repository/config/branch.rs
+++ b/gix/src/repository/config/branch.rs
@@ -141,11 +141,8 @@ impl crate::Repository {
     /// the side of the remote, also called upstream branch.
     ///
     /// Return `Ok(None)` if there is no remote with fetch-refspecs that would match `tracking_branch` on the right-hand side,
-    /// or `Err` if the matches were ambiguous.
-    ///
-    /// ### Limitations
-    ///
-    /// A single valid mapping is required as fine-grained matching isn't implemented yet. This means that
+    /// or `Err` if the matches were ambiguous. All configured remotes are searched, and their fetch refspecs are reverse-mapped.
+    /// A single valid mapping is required: mappings from multiple remotes or multiple mappings within one remote are ambiguous.
     pub fn upstream_branch_and_remote_for_tracking_branch(
         &self,
         tracking_branch: &FullNameRef,
@@ -183,15 +180,10 @@ impl crate::Repository {
 
         if candidates.len() == 1 {
             let (remote, candidate) = candidates.pop().expect("just checked for one entry");
-            let upstream_branch = match candidate {
-                gix_refspec::match_group::SourceRef::FullName(name) => gix_ref::FullName::try_from(name.into_owned())?,
-                gix_refspec::match_group::SourceRef::ObjectId(_) => {
-                    unreachable!("Such a reverse mapping isn't ever produced")
-                }
-            };
+            let upstream_branch = source_ref_to_full_name(candidate)?;
             return Ok(Some((upstream_branch, remote)));
         }
-        if ambiguous_remotes.len() + candidates.len() > 1 {
+        if !ambiguous_remotes.is_empty() || candidates.len() > 1 {
             return Err(Error::AmbiguousRemotes {
                 remotes: ambiguous_remotes
                     .into_iter()
@@ -259,6 +251,15 @@ impl crate::Repository {
                     .into(),
                 remote::Name::Symbol(_) => None,
             })
+    }
+}
+
+fn source_ref_to_full_name(source: gix_refspec::match_group::SourceRef<'_>) -> Result<FullName, gix_ref::name::Error> {
+    match source {
+        gix_refspec::match_group::SourceRef::FullName(name) => gix_ref::FullName::try_from(name.into_owned()),
+        gix_refspec::match_group::SourceRef::ObjectId(_) => {
+            unreachable!("Such a reverse mapping isn't ever produced")
+        }
     }
 }
 

--- a/gix/src/repository/config/remote.rs
+++ b/gix/src/repository/config/remote.rs
@@ -6,8 +6,8 @@ use crate::{
 
 /// Query configuration related to remotes.
 impl crate::Repository {
-    /// Returns a sorted list unique of symbolic names of remotes that
-    /// we deem [trustworthy][crate::open::Options::filter_config_section()].
+    /// Returns the unique symbolic names of remotes that we deem
+    /// [trustworthy][crate::open::Options::filter_config_section()], in ascending bytewise lexicographic order.
     ///
     /// # Examples
     ///

--- a/gix/src/repository/reference.rs
+++ b/gix/src/repository/reference.rs
@@ -179,7 +179,7 @@ impl crate::Repository {
     /// # let repo = doctest::open_repo(doctest::basic_repo_dir()?)?;
     /// let head = repo.head()?;
     ///
-    /// assert_eq!(head.referent_name().expect("born").as_bstr(), "refs/heads/main");
+    /// assert_eq!(head.referent_name().expect("born"), "refs/heads/main");
     /// assert!(!head.is_detached());
     /// assert!(!head.is_unborn());
     /// # Ok(()) }
@@ -316,7 +316,7 @@ impl crate::Repository {
     /// # let repo = doctest::open_repo(doctest::basic_repo_dir()?)?;
     /// let mut reference = repo.find_reference("main")?;
     ///
-    /// assert_eq!(reference.name().as_bstr(), "refs/heads/main");
+    /// assert_eq!(reference, "refs/heads/main");
     /// assert_eq!(reference.peel_to_commit()?.message()?.title, "c2\n");
     /// # Ok(()) }
     /// ```
@@ -351,7 +351,6 @@ impl crate::Repository {
     /// let branches = repo
     ///     .references()?
     ///     .local_branches()?
-    ///     .map(|reference| reference.map(|reference| reference.name().as_bstr().to_string()))
     ///     .collect::<Result<Vec<_>, _>>()?;
     ///
     /// assert_eq!(branches, vec!["refs/heads/main".to_owned()]);

--- a/gix/tests/gix/clone.rs
+++ b/gix/tests/gix/clone.rs
@@ -241,16 +241,14 @@ mod blocking_io {
 
         let checked_out_ref = repo.head_ref()?.expect("head points to ref");
         assert_eq!(
-            checked_out_ref.name().as_bstr(),
-            "refs/heads/b",
+            checked_out_ref, "refs/heads/b",
             "branches win over same-named tags, matching git clone --branch"
         );
         assert_eq!(
             checked_out_ref
                 .remote_ref_name(gix::remote::Direction::Fetch)
                 .transpose()?
-                .unwrap()
-                .as_bstr(),
+                .unwrap(),
             "refs/heads/b",
             "branch merge configuration records the chosen branch"
         );
@@ -633,8 +631,8 @@ mod blocking_io {
             "the object pointed to by HEAD was fetched as well"
         );
         assert_eq!(
-            referent.name().as_bstr(),
-            remote_repo.head_name()?.expect("symbolic").as_bstr(),
+            referent,
+            remote_repo.head_name()?.expect("symbolic"),
             "local clone always adopts the name of the remote"
         );
 
@@ -649,8 +647,7 @@ mod blocking_io {
         );
         assert_eq!(
             repo.branch_remote_ref_name(ref_name, gix::remote::Direction::Fetch)
-                .expect("present")?
-                .as_bstr(),
+                .expect("present")?,
             "refs/heads/main"
         );
 
@@ -897,8 +894,7 @@ mod blocking_io {
         let checked_out_ref = repo.head_ref()?.expect("head points to ref");
         let remote_ref_name = format!("refs/heads/{ref_to_checkout}");
         assert_eq!(
-            checked_out_ref.name().as_bstr(),
-            remote_ref_name,
+            checked_out_ref, remote_ref_name,
             "it's possible to checkout anything with that name, but here we have an ordinary branch"
         );
 
@@ -906,8 +902,7 @@ mod blocking_io {
             checked_out_ref
                 .remote_ref_name(gix::remote::Direction::Fetch)
                 .transpose()?
-                .unwrap()
-                .as_bstr(),
+                .unwrap(),
             remote_ref_name,
             "the merge configuration is using the given name"
         );
@@ -1154,11 +1149,7 @@ mod blocking_io {
             }
 
             let checked_out_ref = repo.head_ref()?.expect("head points to ref");
-            assert_eq!(
-                checked_out_ref.name().as_bstr(),
-                remote_ref_name,
-                "it also works with tags"
-            );
+            assert_eq!(checked_out_ref, remote_ref_name, "it also works with tags");
 
             assert_eq!(
                 checked_out_ref
@@ -1212,13 +1203,13 @@ mod blocking_io {
                 .is_some_and(|cap| cap.supports("unborn").unwrap_or(false));
             if supports_unborn {
                 assert_eq!(
-                    head.referent_name().expect("present").as_bstr(),
+                    head.referent_name().expect("present"),
                     "refs/heads/special",
                     "we pick up the name as present on the server, not the one we default to"
                 );
             } else {
                 assert_eq!(
-                    head.referent_name().expect("present").as_bstr(),
+                    head.referent_name().expect("present"),
                     "refs/heads/main",
                     "we simply keep our own post-init HEAD which defaults to the branch name we configured locally"
                 );

--- a/gix/tests/gix/id.rs
+++ b/gix/tests/gix/id.rs
@@ -69,6 +69,21 @@ fn display_and_debug() -> crate::Result {
     Ok(())
 }
 
+#[test]
+fn compares_with_text() -> crate::Result {
+    let repo = crate::basic_repo()?;
+    let id = repo.head_id()?;
+    let text = id.to_string();
+
+    assert_eq!(id, text.as_str(), "an attached ID matches str");
+    assert_eq!(text.as_str(), id, "str comparison is symmetric");
+    assert_eq!(id, text, "an attached ID matches String");
+    assert_eq!(text, id, "String comparison is symmetric");
+    assert_ne!(id, "not an object ID", "invalid text does not match an attached ID");
+    assert_ne!("not an object ID", id, "invalid-text comparison is symmetric");
+    Ok(())
+}
+
 mod ancestors {
     use crate::util::hex_to_id;
 

--- a/gix/tests/gix/init.rs
+++ b/gix/tests/gix/init.rs
@@ -70,10 +70,7 @@ mod non_bare {
             ]),
         )?
         .into();
-        assert_eq!(
-            repo.head()?.referent_name().expect("name").as_bstr(),
-            "refs/heads/special"
-        );
+        assert_eq!(repo.head()?.referent_name().expect("name"), "refs/heads/special");
         Ok(())
     }
 
@@ -91,10 +88,7 @@ mod non_bare {
             ]),
         )?
         .into();
-        assert_eq!(
-            repo.head()?.referent_name().expect("name").as_bstr(),
-            "refs/heads/special"
-        );
+        assert_eq!(repo.head()?.referent_name().expect("name"), "refs/heads/special");
         assert_eq!(
             repo.is_pristine(),
             Some(true),

--- a/gix/tests/gix/reference/mod.rs
+++ b/gix/tests/gix/reference/mod.rs
@@ -76,8 +76,8 @@ fn remote_name() -> crate::Result {
     ] {
         let r = repo.find_reference(ref_name)?;
         assert_eq!(
-            r.remote_name(Direction::Fetch).map(|name| name.as_bstr().to_owned()),
-            Some(expected_remote.into())
+            r.remote_name(Direction::Fetch).expect("remote name can be inferred"),
+            expected_remote
         );
     }
     Ok(())

--- a/gix/tests/gix/reference/mod.rs
+++ b/gix/tests/gix/reference/mod.rs
@@ -97,7 +97,7 @@ mod find {
         let repo = repo()?;
         let mut packed_tag_ref = repo.try_find_reference("dt1")?.expect("tag to exist");
         let expected: &FullNameRef = "refs/tags/dt1".try_into()?;
-        assert_eq!(packed_tag_ref.name(), expected);
+        assert_eq!(packed_tag_ref, expected);
 
         assert_eq!(
             packed_tag_ref.inner.target,
@@ -117,11 +117,11 @@ mod find {
         let mut symbolic_ref = repo.find_reference("multi-link-target1")?;
 
         let expected: &FullNameRef = "refs/heads/multi-link-target1".try_into()?;
-        assert_eq!(symbolic_ref.name(), expected);
+        assert_eq!(symbolic_ref, expected);
         assert_eq!(symbolic_ref.peel_to_id()?, the_commit);
 
         let expected: &FullNameRef = "refs/remotes/origin/multi-link-target3".try_into()?;
-        assert_eq!(symbolic_ref.name(), expected, "it follows symbolic refs, too");
+        assert_eq!(symbolic_ref, expected, "it follows symbolic refs, too");
         assert_eq!(symbolic_ref.into_fully_peeled_id()?, the_commit, "idempotency");
 
         let mut tag_ref = repo.find_reference("dt3")?;

--- a/gix/tests/gix/reference/mod.rs
+++ b/gix/tests/gix/reference/mod.rs
@@ -1,5 +1,44 @@
 use gix::remote::Direction;
 
+#[test]
+fn compares_with_name_representations() -> crate::Result {
+    use gix::{
+        bstr::{BString, ByteSlice},
+        refs::{FullName, FullNameRef, Target},
+    };
+
+    let repo = crate::basic_repo()?;
+    let reference = repo.find_reference("main")?;
+    let text = "refs/heads/main";
+    let string = text.to_owned();
+    let bytes = text.as_bytes().as_bstr();
+    let byte_string: BString = text.into();
+    let name: FullName = text.try_into()?;
+    let name_ref: &FullNameRef = name.as_ref();
+
+    assert_eq!(reference, text, "an attached reference matches str");
+    // Note that the following doesn't compile as this breaks symmetry
+    // (as always when a lesser type is compared to one that has more data)
+    // assert_eq!(text, reference, "an attached reference matches str");
+    assert_eq!(reference, string, "an attached reference matches String");
+    assert_eq!(reference, bytes, "an attached reference matches BStr");
+    assert_eq!(reference, byte_string, "an attached reference matches BString");
+    assert_eq!(reference, name, "an attached reference matches FullName");
+    assert_eq!(reference, name_ref, "an attached reference matches FullNameRef");
+
+    let mut other_target = reference.clone();
+    other_target.inner.target = Target::Symbolic(FullName::try_from("refs/heads/other")?);
+    assert_eq!(
+        other_target, text,
+        "reference-name equality is independent of the target"
+    );
+    assert_ne!(
+        other_target, "refs/heads/other",
+        "a target name does not compare as the reference name"
+    );
+    Ok(())
+}
+
 mod log {
 
     #[test]

--- a/gix/tests/gix/reference/remote.rs
+++ b/gix/tests/gix/reference/remote.rs
@@ -17,16 +17,14 @@ fn push_defaults_to_fetch() -> crate::Result {
             .remote(gix::remote::Direction::Push)
             .expect("configured")?
             .name()
-            .expect("set")
-            .as_bstr(),
+            .expect("set"),
         "origin"
     );
     assert_eq!(
         head.into_remote(gix::remote::Direction::Push)
             .expect("same with branch")?
             .name()
-            .expect("set")
-            .as_bstr(),
+            .expect("set"),
         "origin"
     );
     Ok(())
@@ -39,20 +37,9 @@ fn separate_push_and_fetch() -> crate::Result {
         let head = repo.head()?;
         let branch = head.clone().try_into_referent().expect("history");
 
+        assert_eq!(branch.remote_name(gix::remote::Direction::Push).expect("set"), "myself");
         assert_eq!(
-            branch
-                .remote_name(gix::remote::Direction::Push)
-                .expect("set")
-                .as_symbol()
-                .unwrap(),
-            "myself"
-        );
-        assert_eq!(
-            branch
-                .remote_name(gix::remote::Direction::Fetch)
-                .expect("set")
-                .as_symbol()
-                .unwrap(),
+            branch.remote_name(gix::remote::Direction::Fetch).expect("set"),
             "new-origin"
         );
 
@@ -96,19 +83,10 @@ fn dot_remote_behind_symbol() -> crate::Result {
     let branch = head.clone().try_into_referent().expect("history");
 
     assert_eq!(
-        branch
-            .remote_name(gix::remote::Direction::Push)
-            .expect("derived push")
-            .as_url(),
-        Some(".".into())
+        branch.remote_name(gix::remote::Direction::Push).expect("derived push"),
+        "."
     );
-    assert_eq!(
-        branch
-            .remote_name(gix::remote::Direction::Fetch)
-            .expect("fetch")
-            .as_url(),
-        Some(".".into())
-    );
+    assert_eq!(branch.remote_name(gix::remote::Direction::Fetch).expect("fetch"), ".");
 
     {
         let remote = branch
@@ -129,20 +107,12 @@ fn url_as_remote_name() -> crate::Result {
     let branch = repo.head_ref()?.expect("history");
 
     assert_eq!(
-        branch
-            .remote_name(gix::remote::Direction::Push)
-            .expect("set")
-            .as_url()
-            .unwrap(),
+        branch.remote_name(gix::remote::Direction::Push).expect("set"),
         "https://example.com/push-path.git",
         "remote names can also be urls"
     );
     assert_eq!(
-        branch
-            .remote_name(gix::remote::Direction::Fetch)
-            .expect("set")
-            .as_url()
-            .unwrap(),
+        branch.remote_name(gix::remote::Direction::Fetch).expect("set"),
         "https://example.com/fetch-path.git"
     );
     {

--- a/gix/tests/gix/remote/fetch.rs
+++ b/gix/tests/gix/remote/fetch.rs
@@ -824,13 +824,13 @@ mod blocking_and_async_io {
                         assert_eq!(update_refs.edits.len(), 2);
 
                         let edit = &update_refs.edits[0];
-                        assert_eq!(edit.name.as_bstr(), "refs/remotes/changes-on-top-of-origin/main");
+                        assert_eq!(edit.name, "refs/remotes/changes-on-top-of-origin/main");
                         assert!(
                             edit.change.new_value().expect("no deletion").try_id().is_some(),
                             "a simple peeled ref"
                         );
                         let edit = &update_refs.edits[1];
-                        assert_eq!(edit.name.as_bstr(), "refs/remotes/changes-on-top-of-origin/symbolic");
+                        assert_eq!(edit.name, "refs/remotes/changes-on-top-of-origin/symbolic");
                         match version.unwrap_or_default() {
                             gix::protocol::transport::Protocol::V2 => {
                                 assert!(
@@ -896,7 +896,7 @@ mod blocking_and_async_io {
                                 assert_eq!(id, mapping.remote.as_id().expect("no unborn"));
                             }
                             gix_ref::TargetRef::Symbolic(target) => {
-                                assert_eq!(target.as_bstr(), mapping.remote.as_target().expect("no direct ref"));
+                                assert_eq!(target, mapping.remote.as_target().expect("no direct ref"));
                             }
                         }
                         assert!(
@@ -914,7 +914,7 @@ mod blocking_and_async_io {
                                 );
                             }
                             gix_ref::TargetRef::Symbolic(target) => {
-                                assert_eq!(target.as_bstr(), mapping.remote.as_target().expect("no direct ref"));
+                                assert_eq!(target, mapping.remote.as_target().expect("no direct ref"));
                             }
                         }
                     }

--- a/gix/tests/gix/remote/mod.rs
+++ b/gix/tests/gix/remote/mod.rs
@@ -69,6 +69,57 @@ pub(crate) mod fetch;
 mod ref_map;
 mod save;
 mod name {
+    use std::borrow::Cow;
+
+    use gix::bstr::{BStr, BString, ByteSlice};
+
+    macro_rules! assert_natural_equality {
+        ($value:ident, $matching:literal, $different:literal) => {{
+            let matching = $matching;
+            let matching_string = matching.to_owned();
+            let matching_bstr: &BStr = matching.as_bytes().as_bstr();
+            let matching_bstring: BString = matching.as_bytes().into();
+
+            assert_eq!($value, matching, "the name matches str");
+            assert_eq!(matching, $value, "str comparison is symmetric");
+            assert_eq!($value, matching_string, "the name matches String");
+            assert_eq!(matching_string, $value, "String comparison is symmetric");
+            assert_eq!($value, matching_bstr, "the name matches BStr");
+            assert_eq!(matching_bstr, $value, "BStr comparison is symmetric");
+            assert_eq!($value, matching_bstring, "the name matches BString");
+            assert_eq!(matching_bstring, $value, "BString comparison is symmetric");
+
+            let different = $different;
+            let different_string = different.to_owned();
+            let different_bstr: &BStr = different.as_bytes().as_bstr();
+            let different_bstring: BString = different.as_bytes().into();
+
+            assert_ne!($value, different, "the name differs from str");
+            assert_ne!(different, $value, "str inequality is symmetric");
+            assert_ne!($value, different_string, "the name differs from String");
+            assert_ne!(different_string, $value, "String inequality is symmetric");
+            assert_ne!($value, different_bstr, "the name differs from BStr");
+            assert_ne!(different_bstr, $value, "BStr inequality is symmetric");
+            assert_ne!($value, different_bstring, "the name differs from BString");
+            assert_ne!(different_bstring, $value, "BString inequality is symmetric");
+        }};
+    }
+
+    #[test]
+    fn compares_with_text_and_byte_strings() {
+        let symbol = gix::remote::Name::Symbol("origin".into());
+        assert_natural_equality!(symbol, "origin", "upstream");
+        let symbol_ref = &symbol;
+        assert_natural_equality!(symbol_ref, "origin", "upstream");
+
+        let url = gix::remote::Name::Url(Cow::Borrowed(b"https://example.com/repo.git".as_bstr()));
+        assert_natural_equality!(url, "https://example.com/repo.git", "https://example.com/other.git");
+
+        let raw_url = b"https://example.com/\xff".as_bstr();
+        let raw_url_name = gix::remote::Name::Url(Cow::Borrowed(raw_url));
+        assert_eq!(raw_url_name, raw_url, "URLs compare as exact bytes");
+        assert_eq!(raw_url, raw_url_name, "byte comparison is symmetric");
+    }
 
     #[test]
     fn origin_is_valid() {

--- a/gix/tests/gix/repository/config/remote.rs
+++ b/gix/tests/gix/repository/config/remote.rs
@@ -110,10 +110,7 @@ mod branch_remote {
             .upstream_branch_and_remote_for_tracking_branch("refs/remotes/remote_repo/main".try_into()?)?
             .expect("mapping exists");
         assert_eq!(upstream, "refs/heads/main");
-        assert_eq!(
-            remote_name.name().expect("non-anonymous remote").as_bstr(),
-            "remote_repo"
-        );
+        assert_eq!(remote_name.name().expect("non-anonymous remote"), "remote_repo");
 
         assert_eq!(
             repo.upstream_branch_and_remote_for_tracking_branch("refs/remotes/missing-remote/main".try_into()?)?,
@@ -123,15 +120,12 @@ mod branch_remote {
 
         for direction in [remote::Direction::Fetch, remote::Direction::Push] {
             assert_eq!(
-                repo.branch_remote_name("main", direction)
-                    .expect("Remote name exists")
-                    .as_ref(),
+                repo.branch_remote_name("main", direction).expect("Remote name exists"),
                 "remote_repo"
             );
             assert_eq!(
                 repo.branch_remote_name("broken", direction)
-                    .expect("Remote name exists")
-                    .as_ref(),
+                    .expect("Remote name exists"),
                 "remote_repo"
             );
         }
@@ -149,7 +143,7 @@ mod branch_remote {
         );
         for direction in [remote::Direction::Fetch, remote::Direction::Push] {
             assert_eq!(
-                repo.branch_remote_name("broken", direction).expect("is set").as_bstr(),
+                repo.branch_remote_name("broken", direction).expect("is set"),
                 "remote_repo"
             );
         }
@@ -166,7 +160,7 @@ mod branch_remote {
 
     #[test]
     fn upstream_branch_and_remote_name_for_tracking_branch() -> crate::Result {
-        let repo = repo("multiple-remotes")?;
+        let mut repo = repo("multiple-remotes")?;
         for expected_remote_name in ["other", "with/two"] {
             let (upstream, remote) = repo
                 .upstream_branch_and_remote_for_tracking_branch(
@@ -175,25 +169,60 @@ mod branch_remote {
                         .try_into()?,
                 )?
                 .expect("mapping exists");
-            assert_eq!(remote.name().expect("named remote").as_bstr(), expected_remote_name);
+            assert_eq!(remote.name().expect("named remote"), expected_remote_name);
             assert_eq!(upstream, "refs/heads/main");
         }
         let err = repo
             .upstream_branch_and_remote_for_tracking_branch("refs/remotes/with/two/slashes/main".try_into()?)
-            .unwrap_err();
+            .expect_err("both remotes reverse-map the tracking branch");
         assert_eq!(
             err.to_string(),
             "Found ambiguous remotes without 1:1 mapping or more than one match: with/two, with/two/slashes",
-            "we aren't very specific report an error just like Git does in case of multi-remote ambiguity"
+            "the name is ambiguous because both remotes have fetch refspecs mapping to it"
         );
 
         let (upstream, remote) = repo
             .upstream_branch_and_remote_for_tracking_branch("refs/remotes/with/two/special".try_into()?)?
             .expect("mapping exists");
-        assert_eq!(remote.name().expect("non-anonymous remote").as_bstr(), "with/two");
+        assert_eq!(remote.name().expect("non-anonymous remote"), "with/two");
         assert_eq!(
             upstream, "refs/heads/special",
             "it finds a single mapping even though there are two refspecs"
+        );
+
+        repo.config_snapshot_mut().append_config(
+            [
+                "remote.prefix.url=../fetch",
+                "remote.prefix.fetch=+refs/heads/*:refs/remotes/prefix/unrelated/*",
+                "remote.fallback.url=../fetch",
+                "remote.fallback.fetch=+refs/heads/*:refs/remotes/prefix/*",
+            ],
+            gix_config::Source::Api,
+        )?;
+        let (upstream, remote) = repo
+            .upstream_branch_and_remote_for_tracking_branch("refs/remotes/prefix/main".try_into()?)?
+            .expect("a remote maps the tracking branch");
+        assert_eq!(upstream.as_bstr(), "refs/heads/main");
+        assert_eq!(
+            remote.name().expect("named remote"),
+            "fallback",
+            "a matching remote-name prefix does not override the actual refspec mapping"
+        );
+
+        repo.config_snapshot_mut().append_config(
+            [
+                "remote.also-fallback.url=../fetch",
+                "remote.also-fallback.fetch=+refs/heads/*:refs/remotes/prefix/*",
+            ],
+            gix_config::Source::Api,
+        )?;
+        let err = repo
+            .upstream_branch_and_remote_for_tracking_branch("refs/remotes/prefix/main".try_into()?)
+            .expect_err("multiple remotes are ambiguous");
+        assert_eq!(
+            err.to_string(),
+            "Found ambiguous remotes without 1:1 mapping or more than one match: also-fallback, fallback",
+            "all remotes mapping the same tracking branch are reported"
         );
         Ok(())
     }

--- a/gix/tests/gix/repository/config/remote.rs
+++ b/gix/tests/gix/repository/config/remote.rs
@@ -103,14 +103,13 @@ mod branch_remote {
         assert_eq!(
             repo.branch_remote_tracking_ref_name("refs/heads/main".try_into()?, remote::Direction::Fetch)
                 .expect("Remote Merge ref exists")
-                .expect("Remote Merge ref is valid")
-                .as_bstr(),
+                .expect("Remote Merge ref is valid"),
             "refs/remotes/remote_repo/main"
         );
         let (upstream, remote_name) = repo
             .upstream_branch_and_remote_for_tracking_branch("refs/remotes/remote_repo/main".try_into()?)?
             .expect("mapping exists");
-        assert_eq!(upstream.as_bstr(), "refs/heads/main");
+        assert_eq!(upstream, "refs/heads/main");
         assert_eq!(
             remote_name.name().expect("non-anonymous remote").as_bstr(),
             "remote_repo"
@@ -140,8 +139,7 @@ mod branch_remote {
         assert_eq!(
             repo.branch_remote_ref_name("refs/heads/broken".try_into()?, remote::Direction::Fetch)
                 .expect("Remote Merge ref exists")
-                .expect("merge ref is turned into a full-name")
-                .as_bstr(),
+                .expect("merge ref is turned into a full-name"),
             "refs/heads/not_a_valid_merge_ref",
             "short names are simply turned into branch names - this doesn't always work, but sometimes."
         );
@@ -158,8 +156,7 @@ mod branch_remote {
         assert_eq!(
             repo.branch_remote_tracking_ref_name("refs/heads/broken".try_into()?, remote::Direction::Fetch)
                 .expect("no error")
-                .expect("valid result")
-                .as_bstr(),
+                .expect("valid result"),
             "refs/remotes/remote_repo/not_a_valid_merge_ref",
             "the merge ref is broken, but we turned it into a full ref name from which everything else was derived",
         );
@@ -179,7 +176,7 @@ mod branch_remote {
                 )?
                 .expect("mapping exists");
             assert_eq!(remote.name().expect("named remote").as_bstr(), expected_remote_name);
-            assert_eq!(upstream.as_bstr(), "refs/heads/main");
+            assert_eq!(upstream, "refs/heads/main");
         }
         let err = repo
             .upstream_branch_and_remote_for_tracking_branch("refs/remotes/with/two/slashes/main".try_into()?)
@@ -195,8 +192,7 @@ mod branch_remote {
             .expect("mapping exists");
         assert_eq!(remote.name().expect("non-anonymous remote").as_bstr(), "with/two");
         assert_eq!(
-            upstream.as_bstr(),
-            "refs/heads/special",
+            upstream, "refs/heads/special",
             "it finds a single mapping even though there are two refspecs"
         );
         Ok(())
@@ -217,8 +213,7 @@ mod branch_remote {
         for direction in [remote::Direction::Fetch, remote::Direction::Push] {
             assert_eq!(
                 repo.branch_remote_tracking_ref_name("refs/heads/main".try_into()?, direction)
-                    .expect("exists")?
-                    .as_bstr(),
+                    .expect("exists")?,
                 "refs/remotes/remote_repo/main",
                 "this is a 'simple' mapping of an existing branch, using push.default=simple and the default refspec"
             );
@@ -247,15 +242,13 @@ mod branch_remote {
 
         assert_eq!(
             repo.branch_remote_tracking_ref_name("refs/heads/main".try_into()?, remote::Direction::Push)
-                .expect("exists")?
-                .as_bstr(),
+                .expect("exists")?,
             "refs/remotes/origin/remapped-main",
             "the first matching push-spec maps the branch to another head, then it's mapped with fetch-specs"
         );
         assert_eq!(
             repo.branch_remote_tracking_ref_name("refs/heads/main".try_into()?, remote::Direction::Fetch)
-                .expect("exists")?
-                .as_bstr(),
+                .expect("exists")?,
             "refs/remotes/origin/main",
             "push.simple is set (or the default), hence it's a one-one mapping along with the standard refspec"
         );
@@ -278,15 +271,13 @@ mod branch_remote {
 
         assert_eq!(
             repo.branch_remote_tracking_ref_name("refs/heads/feature".try_into()?, remote::Direction::Push)
-                .expect("exists")?
-                .as_bstr(),
+                .expect("exists")?,
             "refs/remotes/origin/remapped-feature",
             "this branch is mapped with push-specs, then it's mapped with fetch-specs as well"
         );
         assert_eq!(
             repo.branch_remote_tracking_ref_name("refs/heads/feature".try_into()?, remote::Direction::Fetch)
-                .expect("exists")?
-                .as_bstr(),
+                .expect("exists")?,
             "refs/remotes/origin/main",
             "remapping by branch.feature.merge=main, then mapped by refspec"
         );

--- a/gix/tests/gix/repository/mod.rs
+++ b/gix/tests/gix/repository/mod.rs
@@ -32,22 +32,19 @@ mod worktree;
 
 #[cfg(feature = "revision")]
 mod revision {
-    use crate::util::hex_to_id_sha1_only;
-
     #[test]
     fn date() -> crate::Result {
         let repo = crate::named_repo("make_rev_parse_repo.sh")?;
         let actual = repo
             .rev_parse_single("old@{20 years ago}")
             .expect("it returns the oldest possible rev when overshooting");
-        assert_eq!(actual, hex_to_id_sha1_only("be2f093f0588eaeb71e1eff7451b18c2a9b1d765"));
+        assert_eq!(actual, "be2f093f0588eaeb71e1eff7451b18c2a9b1d765");
 
         let actual = repo
             .rev_parse_single("old@{1732184844}")
             .expect("it finds something in the middle");
         assert_eq!(
-            actual,
-            hex_to_id_sha1_only("b29405fe9147a3a366c4048fbe295ea04de40fa6"),
+            actual, "b29405fe9147a3a366c4048fbe295ea04de40fa6",
             "It also figures out that we don't mean an index, but a date"
         );
         Ok(())

--- a/gix/tests/gix/repository/object.rs
+++ b/gix/tests/gix/repository/object.rs
@@ -649,7 +649,7 @@ mod tag {
             message,
             gix_ref::transaction::PreviousValue::MustNotExist,
         )?;
-        assert_eq!(tag_ref.name().as_bstr(), "refs/tags/v1.0.0");
+        assert_eq!(tag_ref, "refs/tags/v1.0.0");
         assert_ne!(tag_ref.id(), current_head_id, "it points to the tag object");
         let tag = tag_ref.id().object()?;
         let tag = tag.try_to_tag_ref()?;
@@ -725,10 +725,7 @@ mod commit {
             gix_hash::Kind::Sha256 => expected_sha256,
             _ => unreachable!(),
         };
-        assert_eq!(
-            actual,
-            gix_hash::ObjectId::from_hex(expected_hash.as_bytes()).expect("valid sha1")
-        );
+        assert_eq!(actual, expected_hash);
     }
 
     #[test]
@@ -778,7 +775,7 @@ mod commit {
         );
 
         let head = repo.head()?.try_into_referent().expect("born");
-        assert_eq!(head.name().as_bstr(), "refs/heads/main", "'main' is the default name");
+        assert_eq!(head, "refs/heads/main", "'main' is the default name");
         assert_eq!(
             head.log_iter()
                 .rev()?
@@ -894,8 +891,7 @@ fn new_commit_as() -> crate::Result {
         _ => unreachable!(),
     };
     assert_eq!(
-        commit.id,
-        gix_hash::ObjectId::from_hex(expected_hex.as_bytes()).expect("valid object id"),
+        commit.id, expected_hex,
         "The commit-id is stable as the author/committer is controlled"
     );
 

--- a/gix/tests/gix/repository/reference.rs
+++ b/gix/tests/gix/repository/reference.rs
@@ -33,11 +33,7 @@ mod set_namespace {
         )?;
 
         assert_eq!(
-            repo.references()?
-                .all()?
-                .filter_map(Result::ok)
-                .map(|r| r.name().as_bstr().to_owned())
-                .collect::<Vec<_>>(),
+            repo.references()?.all()?.filter_map(Result::ok).collect::<Vec<_>>(),
             vec!["refs/heads/new-branch", "refs/tags/new-tag"],
             "namespaced references appear like normal ones"
         );
@@ -46,25 +42,24 @@ mod set_namespace {
             repo.references()?
                 .prefixed("refs/tags/")?
                 .filter_map(Result::ok)
-                .map(|r| r.name().as_bstr().to_owned())
                 .collect::<Vec<_>>(),
             vec!["refs/tags/new-tag"],
             "namespaced references appear like normal ones"
         );
         let fully_qualified_tag_name = "refs/tags/new-tag";
         assert_eq!(
-            repo.find_reference(fully_qualified_tag_name)?.name().as_bstr(),
+            repo.find_reference(fully_qualified_tag_name)?,
             fully_qualified_tag_name,
             "fully qualified (yet namespaced) names work"
         );
         assert_eq!(
-            repo.find_reference("new-tag")?.name().as_bstr(),
+            repo.find_reference("new-tag")?,
             fully_qualified_tag_name,
             "namespaces are transparent"
         );
 
         let previous_ns = repo.clear_namespace().expect("namespace set");
-        assert_eq!(previous_ns.as_bstr(), "refs/namespaces/foo/");
+        assert_eq!(previous_ns, "refs/namespaces/foo/");
         assert!(repo.clear_namespace().is_none(), "it doesn't invent namespaces");
 
         assert_eq!(
@@ -103,11 +98,7 @@ mod iter_references {
     fn all() -> crate::Result {
         let repo = repo()?;
         assert_eq!(
-            repo.references()?
-                .all()?
-                .filter_map(Result::ok)
-                .map(|r| r.name().as_bstr().to_owned())
-                .collect::<Vec<_>>(),
+            repo.references()?.all()?.filter_map(Result::ok).collect::<Vec<_>>(),
             vec![
                 "refs/d1",
                 "refs/heads/d1",
@@ -207,7 +198,7 @@ mod iter_references {
             .filter_map(Result::ok)
             .max_by_key(|tag| tag.name().shorten().to_owned())
             .ok_or(std::io::Error::other("latest tag not found"))?;
-        assert_eq!(actual.name().as_bstr(), "refs/tags/t1");
+        assert_eq!(actual, "refs/tags/t1");
         Ok(())
     }
 }
@@ -231,7 +222,7 @@ mod head {
             }
             _ => panic!("unexpected head kind"),
         }
-        assert_eq!(head.referent_name().expect("born").as_bstr(), "refs/heads/main");
+        assert_eq!(head.referent_name().expect("born"), "refs/heads/main");
         assert!(!head.is_detached());
         Ok(())
     }

--- a/gix/tests/gix/repository/remote.rs
+++ b/gix/tests/gix/repository/remote.rs
@@ -201,7 +201,7 @@ mod find_remote {
         for (name, (url, refspec)) in repo.remote_names().into_iter().zip(expected) {
             count += 1;
             let remote = repo.find_remote(&name)?;
-            assert_eq!(remote.name().expect("set").as_bstr(), name);
+            assert_eq!(remote.name().expect("set"), name);
 
             assert_eq!(
                 remote.fetch_tags(),

--- a/gix/tests/gix/repository/worktree.rs
+++ b/gix/tests/gix/repository/worktree.rs
@@ -409,7 +409,7 @@ fn run_assertions(main_repo: gix::Repository, should_be_bare: bool) {
         );
         assert_eq!(main_repo.head_id().unwrap(), expected_main.peeled);
         assert_eq!(
-            main_repo.head_name().unwrap().expect("no detached head").as_bstr(),
+            main_repo.head_name().unwrap().expect("no detached head"),
             expected_main.branch.unwrap()
         );
         let worktree = main_repo.worktree().expect("not bare");

--- a/gix/tests/gix/revision/spec/from_bytes/mod.rs
+++ b/gix/tests/gix/revision/spec/from_bytes/mod.rs
@@ -24,10 +24,7 @@ mod sibling_branch {
         for op in ["upstream", "push"] {
             for branch in ["", "main"] {
                 let actual = parse_spec(format!("{branch}@{{{op}}}"), &repo)?;
-                assert_eq!(
-                    actual.first_reference().expect("set").name.as_bstr(),
-                    "refs/remotes/origin/main"
-                );
+                assert_eq!(actual.first_reference().expect("set"), "refs/remotes/origin/main");
                 assert_eq!(actual.second_reference(), None);
                 assert_eq!(
                     actual.single().expect("just one"),

--- a/gix/tests/gix/revision/spec/from_bytes/reflog.rs
+++ b/gix/tests/gix/revision/spec/from_bytes/reflog.rs
@@ -17,7 +17,7 @@ fn nth_prior_checkout() {
         ("@{-5}", "refs/heads/h"),
     ] {
         let parsed = parse_spec(spec, &repo).unwrap_or_else(|_| panic!("{spec} to be parsed successfully"));
-        assert_eq!(parsed.first_reference().expect("present").name.as_bstr(), prior_branch);
+        assert_eq!(parsed.first_reference().expect("present"), prior_branch);
         assert_eq!(parsed.second_reference(), None);
     }
 
@@ -71,7 +71,7 @@ fn by_index() {
             Spec::from_id(hex_to_id_sha1_only("55e825ebe8fd2ff78cad3826afb696b96b576a7e").attach(repo))
         );
         assert_eq!(
-            spec.first_reference().expect("set").name.as_bstr(),
+            spec.first_reference().expect("set"),
             "refs/heads/main",
             "it sets the reference name even if it is implied"
         );

--- a/tests/tools/Cargo.toml
+++ b/tests/tools/Cargo.toml
@@ -60,15 +60,15 @@ sha256 = [
 xz = ["dep:xz2"]
 
 [dependencies]
-gix-hash = { version = "^0.26.1", path = "../../gix-hash" }
+gix-hash = { version = "^0.26.2", path = "../../gix-hash" }
 gix-lock = { version = "^24.0.0", path = "../../gix-lock" }
 gix-path = { version = "^0.12.5", path = "../../gix-path" }
 gix-config = { version = "^0.60.0", path = "../../gix-config", optional = true, default-features = false }
 gix-discover = { version = "^0.55.0", path = "../../gix-discover", optional = true }
 gix-index = { version = "^0.55.0", path = "../../gix-index", optional = true, default-features = false }
-gix-object = { version = "^0.64.0", path = "../../gix-object", optional = true, default-features = false }
+gix-object = { version = "^0.64.1", path = "../../gix-object", optional = true, default-features = false }
 gix-odb = { version = "^0.84.0", path = "../../gix-odb", optional = true, default-features = false }
-gix-ref = { version = "^0.67.0", path = "../../gix-ref", optional = true, default-features = false }
+gix-ref = { version = "^0.67.1", path = "../../gix-ref", optional = true, default-features = false }
 gix-shallow = { version = "^0.13.0", path = "../../gix-shallow", optional = true }
 gix-worktree = { version = "^0.56.0", path = "../../gix-worktree", optional = true, features = ["parallel"] }
 gix-fs = { version = "^0.22.1", path = "../../gix-fs", optional = true }


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew
- [x] release `gix-testtools`: follow-up

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

### Initial report

```text
$issue-full-auto Let fundamental types like `gix-ref::FullName*`, and `gix-object::ObjectId` compare directly to their natural counterparts, particularly for testing. All they do is to compare their internal representation, or their typical representation (like they hex/reverse hex value). This shuold also be implemenated for their connected types.
```

### Follow-up

```text
> - gix: make repository-attached Id delegate textual equality to its ObjectId.

The `Reference` type is missing, even though it (and related types maybe) shouldn't.

Also have a separate commit for actually making use of these new comparisons in the test suite everywhere.
```

## Summary

- Add direct comparisons between hash IDs and canonical lowercase hexadecimal text.
- Add comparisons between reference names/references and their byte or string representations.
- Add repository-attached `gix::Id` and `gix::Reference` comparisons.
- Preserve `PartialEq` symmetry and transitivity by limiting prefix, truncated, and reference comparisons to law-preserving directions.
- Adopt the new comparisons throughout the test suite in a separate commit.

## Commits

- `77f28a89d9` feat(gix-hash): compare hash types with text
- `24b200e878` feat(gix-ref): compare names and references with natural counterparts
- `a3c1c8d355` Preserve PartialEq transitivity for reference comparisons
- `60aa0c806b` Preserve PartialEq laws for hash text comparisons
- `5e83f39167` feat(gix): compare attached IDs and references with text
- `d1c3e249d7` Use fundamental-type comparisons throughout tests

## Validation

- Focused `gix-ref`, `gix`, hash-crate, and `gix-object` tag-target tests.
- Formatting, diff checks, cargo-machete, and all local clippy configurations.
- `cargo deny --workspace --all-features check bans licenses sources`.
- `env GIX_TEST_IGNORE_ARCHIVES=1 just ci-test`.
- `just doc-tests`.
- `env GIX_TEST_CREATE_ARCHIVES_EVEN_ON_CI=1 cargo nextest run --workspace --no-fail-fast --exclude gix-error` (3,710 passed, one existing leaky annotation, five configured skips).
- `just ci-journey-tests`.
