### PR TITLE
fix(gix-pack): retain additions from all merge parents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,6 +2294,7 @@ dependencies = [
  "gix-testtools",
  "gix-traverse",
  "gix-zlib",
+ "insta",
  "maplit",
  "memmap2",
  "parking_lot",

--- a/gix-pack/Cargo.toml
+++ b/gix-pack/Cargo.toml
@@ -41,6 +41,8 @@ serde = ["dep:serde", "gix-object/serde", "gix-zlib/serde"]
 parallel = ["gix-features/parallel", "dep:crossbeam-deque"]
 ## Make it possible to compile to the `wasm32-unknown-unknown` target.
 wasm = ["gix-diff?/wasm"]
+## Add test-utilities for tests and benchmarks.
+testing = []
 
 [dependencies]
 gix-features = { version = "^0.49.1", path = "../gix-features", features = ["crc32", "progress"] }
@@ -75,14 +77,16 @@ document-features = { version = "0.2.0", optional = true }
 gix-tempfile = { version = "^24.0.0", default-features = false, path = "../gix-tempfile", optional = true }
 
 [dev-dependencies]
-gix-pack = { path = ".", features = ["sha1", "sha256", "pack-cache-lru-dynamic", "pack-cache-lru-static", "object-cache-dynamic", "serde"] }
+gix-pack = { path = ".", features = ["sha1", "sha256", "pack-cache-lru-dynamic", "pack-cache-lru-static", "object-cache-dynamic", "serde", "testing"] }
 gix-testtools = { path = "../tests/tools", default-features = false, features = ["sha1", "sha256"] }
 gix-odb = { path = "../gix-odb", features = ["sha1", "sha256"] }
 gix-object = { path = "../gix-object" }
 gix-traverse = { path = "../gix-traverse" }
+
 bstr = { version = "1.12.0", default-features = false, features = ["std"] }
 maplit = "1.0.2"
 criterion = "0.8.2"
+insta = "1.46.3"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gix-pack/benches/pack_create.rs
+++ b/gix-pack/benches/pack_create.rs
@@ -7,68 +7,22 @@
 //!
 //! Note that the discovery phase is as fast as the object database can traverse objects, so nothing to test here
 //! and we use in-memory speeds for this.
-use std::{
-    io,
-    sync::{Arc, atomic::AtomicBool},
-};
+use std::{io, sync::atomic::AtomicBool};
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group};
 use gix_features::{parallel::InOrderIter, progress};
 use gix_object::Write as _;
-use gix_pack::data::output::{self, bytes::FromEntriesIter, count, entry};
+use gix_pack::{
+    data::output::{self, bytes::FromEntriesIter, count, entry},
+    testing::Memory,
+};
 
 /// Object counts to exercise. Kept modest so the benchmark stays runnable while still showing how
 /// the phases scale; raise locally to probe larger, more degenerate repositories.
 const OBJECT_COUNTS: &[usize] = &[1_000, 10_000, 50_000];
 
-/// Adapt in-memory objects to `gix_pack::Find`. `gix_odb::memory::Proxy` is still used to populate
-/// the storage, but `count` and `write` need pack-location APIs as well as cheap clones for write
-/// workers.
-#[derive(Clone)]
-struct MemoryOdb {
-    objects: Arc<gix_odb::memory::Storage>,
-}
-
-impl gix_pack::Find for MemoryOdb {
-    fn contains(&self, id: &gix_hash::oid) -> bool {
-        self.objects.contains_key(id)
-    }
-
-    fn try_find_cached<'a>(
-        &self,
-        id: &gix_hash::oid,
-        buffer: &'a mut Vec<u8>,
-        _pack_cache: &mut dyn gix_pack::cache::DecodeEntry,
-    ) -> Result<Option<(gix_object::Data<'a>, Option<gix_pack::data::entry::Location>)>, gix_object::find::Error> {
-        Ok(self.objects.get(id).map(|(kind, data)| {
-            buffer.clear();
-            buffer.extend_from_slice(data);
-            (
-                gix_object::Data {
-                    kind: *kind,
-                    object_hash: id.kind(),
-                    data: buffer,
-                },
-                None,
-            )
-        }))
-    }
-
-    fn location_by_oid(&self, _id: &gix_hash::oid, _buf: &mut Vec<u8>) -> Option<gix_pack::data::entry::Location> {
-        None
-    }
-
-    fn pack_offsets_and_oid(&self, _pack_id: u32) -> Option<Vec<(gix_pack::data::Offset, gix_hash::ObjectId)>> {
-        None
-    }
-
-    fn entry_by_location(&self, _location: &gix_pack::data::entry::Location) -> Option<gix_pack::find::Entry> {
-        None
-    }
-}
-
 /// Create a fresh in-memory object database populated with `count` unique blobs.
-fn memory_odb(count: usize) -> (MemoryOdb, Vec<gix_hash::ObjectId>) {
+fn memory_odb(count: usize) -> (Memory, Vec<gix_hash::ObjectId>) {
     let mut odb = gix_odb::memory::Proxy::new(gix_odb::sink(gix_hash::Kind::Sha1), gix_hash::Kind::Sha1);
     let mut ids = Vec::with_capacity(count);
     for i in 0..count {
@@ -78,19 +32,14 @@ fn memory_odb(count: usize) -> (MemoryOdb, Vec<gix_hash::ObjectId>) {
             .expect("can write an in-memory object");
         ids.push(id);
     }
-    let objects = odb
+    let mut objects = odb
         .take_object_memory()
         .expect("in-memory object storage is still enabled");
-    (
-        MemoryOdb {
-            objects: Arc::new(objects),
-        },
-        ids,
-    )
+    (Memory::new(objects.drain()), ids)
 }
 
 /// Phase 1: collect the counts for `ids` without object expansion - exactly the objects given.
-fn count_objects_unthreaded(odb: &MemoryOdb, ids: &[gix_hash::ObjectId]) -> Vec<output::Count> {
+fn count_objects_unthreaded(odb: &Memory, ids: &[gix_hash::ObjectId]) -> Vec<output::Count> {
     let mut input = ids.iter().copied().map(Ok);
     let (counts, _outcome) = count::objects_unthreaded(
         odb,
@@ -120,7 +69,7 @@ impl io::Write for CountingSink {
 }
 
 /// Phase 2: resolve, sort and encode `counts` into a pack stream, returning the pack size in bytes.
-fn write_pack(odb: &MemoryOdb, counts: Vec<output::Count>) -> u64 {
+fn write_pack(odb: &Memory, counts: Vec<output::Count>) -> u64 {
     let num_objects = counts.len() as u32;
     let entries = InOrderIter::from(entry::iter_from_counts(
         counts,

--- a/gix-pack/src/data/output/count/objects/mod.rs
+++ b/gix-pack/src/data/output/count/objects/mod.rs
@@ -220,6 +220,7 @@ mod expand {
                                     out = objects.dissolve(stats);
                                     &traverse_delegate.non_trees
                                 } else {
+                                    changes_delegate.clear();
                                     for commit_id in &parent_commit_ids {
                                         let parent_tree_id = {
                                             let (parent_commit_obj, location) = db.find(commit_id, buf2)?;
@@ -251,7 +252,6 @@ mod expand {
                                             )
                                         };
 
-                                        changes_delegate.clear();
                                         let objects = CountingObjects::new(db);
                                         gix_diff::tree(
                                             parent_tree,

--- a/gix-pack/src/lib.rs
+++ b/gix-pack/src/lib.rs
@@ -57,6 +57,10 @@ pub mod multi_index;
 ///
 pub mod verify;
 
+///
+#[cfg(feature = "testing")]
+pub mod testing;
+
 mod mmap {
     use std::path::Path;
 

--- a/gix-pack/src/testing.rs
+++ b/gix-pack/src/testing.rs
@@ -1,0 +1,51 @@
+use crate::find::Entry;
+
+/// An in-memory object database without pack locations.
+#[derive(Clone)]
+pub struct Memory {
+    objects: std::sync::Arc<gix_hashtable::HashMap<gix_hash::ObjectId, (gix_object::Kind, Vec<u8>)>>,
+}
+
+impl Memory {
+    /// Create a database containing all `objects`.
+    ///
+    /// Each item is `(id, (kind, data))`, where `data` is the uncompressed object body without a
+    /// loose-object header. IDs are trusted rather than recomputed. If an ID occurs more than once,
+    /// the last item wins.
+    pub fn new(objects: impl IntoIterator<Item = (gix_hash::ObjectId, (gix_object::Kind, Vec<u8>))>) -> Self {
+        Self {
+            objects: std::sync::Arc::new(objects.into_iter().collect()),
+        }
+    }
+}
+
+impl crate::Find for Memory {
+    fn contains(&self, id: &gix_hash::oid) -> bool {
+        self.objects.contains_key(id)
+    }
+
+    fn try_find_cached<'a>(
+        &self,
+        id: &gix_hash::oid,
+        buffer: &'a mut Vec<u8>,
+        _pack_cache: &mut dyn crate::cache::DecodeEntry,
+    ) -> Result<Option<(gix_object::Data<'a>, Option<crate::data::entry::Location>)>, gix_object::find::Error> {
+        Ok(self.objects.get(id).map(|(kind, data)| {
+            buffer.clear();
+            buffer.extend_from_slice(data);
+            (gix_object::Data::new(buffer, *kind, id.kind()), None)
+        }))
+    }
+
+    fn location_by_oid(&self, _id: &gix_hash::oid, _buf: &mut Vec<u8>) -> Option<crate::data::entry::Location> {
+        None
+    }
+
+    fn pack_offsets_and_oid(&self, _pack_id: u32) -> Option<Vec<(crate::data::Offset, gix_hash::ObjectId)>> {
+        None
+    }
+
+    fn entry_by_location(&self, _location: &crate::data::entry::Location) -> Option<Entry> {
+        None
+    }
+}

--- a/gix-pack/tests/pack/data/output/count_and_entries.rs
+++ b/gix-pack/tests/pack/data/output/count_and_entries.rs
@@ -367,6 +367,81 @@ fn traversals() -> crate::Result {
     Ok(())
 }
 
+#[test]
+fn tree_additions_from_each_merge_parent_are_kept() -> crate::Result {
+    use gix_object::Write;
+
+    let object_hash = object_hash();
+    let mut db = gix_odb::memory::Proxy::new(gix_odb::sink(object_hash), object_hash);
+    let added_blob_id = db.write_buf(gix_object::Kind::Blob, b"added")?;
+    let base_tree_id = db.write(&gix_object::Tree::empty())?;
+    let merged_tree_id = db.write(&gix_object::Tree {
+        entries: vec![gix_object::tree::Entry {
+            mode: gix_object::tree::EntryKind::Blob.into(),
+            oid: added_blob_id,
+            filename: "added".into(),
+        }],
+    })?;
+    let write_commit = |tree, parents: &[gix_hash::ObjectId]| {
+        db.write(&gix_object::Commit {
+            tree,
+            parents: parents.iter().copied().collect(),
+            author: Default::default(),
+            committer: Default::default(),
+            encoding: None,
+            message: "commit".into(),
+            extra_headers: Vec::new(),
+        })
+    };
+    let base_commit_id = write_commit(base_tree_id, &[])?;
+    let feature_commit_id = write_commit(merged_tree_id, &[base_commit_id])?;
+    let merge_commit_id = write_commit(merged_tree_id, &[base_commit_id, feature_commit_id])?;
+    let mut objects = db
+        .take_object_memory()
+        .expect("in-memory object storage is still enabled");
+    let db = gix_pack::testing::Memory::new(objects.drain());
+    let mut input = std::iter::once(Ok::<_, Box<dyn std::error::Error + Send + Sync>>(merge_commit_id));
+
+    let (counts, stats) = output::count::objects_unthreaded(
+        &db,
+        &mut input,
+        &progress::Discard,
+        &AtomicBool::new(false),
+        count::objects::ObjectExpansion::TreeAdditionsComparedToAncestor,
+    )?;
+
+    let expected_ids = std::collections::BTreeSet::from([
+        added_blob_id,
+        base_tree_id,
+        merged_tree_id,
+        base_commit_id,
+        feature_commit_id,
+        merge_commit_id,
+    ]);
+    assert_eq!(
+        counts.len(),
+        expected_ids.len(),
+        "each expected object must be counted exactly once"
+    );
+    assert_eq!(
+        counts
+            .iter()
+            .map(|count| count.id)
+            .collect::<std::collections::BTreeSet<_>>(),
+        expected_ids,
+        "additions found against every merge parent must remain in the pack"
+    );
+    insta::assert_debug_snapshot!(stats, @"
+    Outcome {
+        input_objects: 1,
+        expanded_objects: 5,
+        decoded_objects: 5,
+        total_objects: 6,
+    }
+    ");
+    Ok(())
+}
+
 /// Reproduces https://github.com/GitoxideLabs/gitoxide/issues/2024: with the default backend's
 /// level 1 being much weaker than it used to be, entries have to be compressed with the
 /// configured level, defaulting to what `git` uses.


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #2935

## Summary

- retain tree additions found against every parent of a merge commit
- cover the parent-order regression with an isolated object-database test

## Validation

- `cargo fmt --all -- --check`
- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix-pack`
- `cargo clippy -p gix-pack --all-targets -- -D warnings`
- focused regression with `GIX_TEST_FIXTURE_HASH=sha256`
- Codex review of `614fa7b4ec`: no findings

## Git baseline

Git `15c6308cf7ad276b306aa5b3ababfbdebfb1a917`; `list-objects.c:add_edge_parents` accounts for every merge parent tree during object traversal.

## Commit

- `614fa7b4ec` fix(gix-pack): retain additions from all merge parents (#2935)