### PR TITLE
fix: skip only consecutive same-path conflict stages

### DIFF
--- a/gix-status/src/index_as_worktree/function.rs
+++ b/gix-status/src/index_as_worktree/function.rs
@@ -685,11 +685,14 @@ impl Conflict {
         let mut seen: [Option<&gix_index::Entry>; 3] = Default::default();
 
         let mut num_consumed_entries = 0_usize;
-        for (stage, entry) in (start_index..(start_index + 3).min(entries.len())).filter_map(|idx| {
-            let entry = &entries[idx];
+        for entry in entries
+            .get(start_index..(start_index + 3).min(entries.len()))
+            .unwrap_or_default()
+        {
             let stage = entry.stage_raw();
-            (stage > 0 && entry.path_in(path_backing) == entry_path).then_some((stage, entry))
-        }) {
+            if stage == 0 || entry.path_in(path_backing) != entry_path {
+                break;
+            }
             // This could be `1 << (stage - 1)` but let's be specific.
             *mask.get_or_insert(0) |= match stage {
                 1 => 0b001,
@@ -697,9 +700,10 @@ impl Conflict {
                 3 => 0b100,
                 _ => 0,
             };
-            num_consumed_entries = stage as usize - 1;
-            seen[num_consumed_entries] = Some(entry);
+            seen[stage as usize - 1] = Some(entry);
+            num_consumed_entries += 1;
         }
+        num_consumed_entries = num_consumed_entries.saturating_sub(1);
 
         mask.map(|mask| {
             (

--- a/gix-status/src/index_as_worktree/function.rs
+++ b/gix-status/src/index_as_worktree/function.rs
@@ -667,13 +667,16 @@ impl<'a, T> Iterator for OffsetIter<'a, T> {
 }
 
 impl Conflict {
-    /// Given `entries` and `path_backing`, both values obtained from an [index](gix_index::State), use `start_index` and enumerate
-    /// all conflict stages that still match `entry_path` to produce a conflict description.
-    /// Also return the amount of extra-entries that were part of the conflict declaration (not counting the entry at `start_index`)
+    /// Given `entries` and `path_backing` obtained from an [index](gix_index::State), inspect up to three consecutive
+    /// conflict-stage entries starting at `start_index` whose path equals `entry_path`.
     ///
-    /// If for some reason entry at `start_index` isn't in conflicting state, `None` is returned.
+    /// Returns `(conflict, num_extra_entries, entries_by_stage)`, where:
     ///
-    /// Return `(Self, num_consumed_entries, three_possibly_entries)`.
+    /// * `conflict` describes the conflict formed by the matching stages (this instance).
+    /// * `num_extra_entries` is the number of matching entries after the one at `start_index`.
+    /// * `entries_by_stage` contains base, ours, and theirs at indexes 0, 1, and 2 respectively; absent stages are `None`.
+    ///
+    /// Returns `None` if no matching conflict entry is found at `start_index`.
     pub fn try_from_entry<'entry>(
         entries: &'entry [gix_index::Entry],
         path_backing: &gix_index::PathStorageRef,
@@ -703,6 +706,7 @@ impl Conflict {
             seen[stage as usize - 1] = Some(entry);
             num_consumed_entries += 1;
         }
+        // It's always assumed we consume one entry, so deduct it.
         num_consumed_entries = num_consumed_entries.saturating_sub(1);
 
         mask.map(|mask| {

--- a/gix-status/tests/status/index_as_worktree.rs
+++ b/gix-status/tests/status/index_as_worktree.rs
@@ -592,6 +592,145 @@ fn conflict_both_deleted_and_added_by_them_and_added_by_us() {
     );
 }
 
+fn index_with_stages(stages: &[(gix_index::entry::Stage, &str)]) -> gix_index::State {
+    let object_hash = gix_testtools::object_hash();
+    let mut state = gix_index::State::new(object_hash);
+    let id = object_hash.null();
+    for &(stage, path) in stages {
+        state.dangerously_push_entry(
+            Default::default(),
+            id,
+            Flags::from_stage(stage),
+            Mode::FILE,
+            BStr::new(path.as_bytes()),
+        );
+    }
+    state
+}
+
+fn assert_conflict_skip_count(stages: &[(gix_index::entry::Stage, &str)], summary: Conflict, extra: usize) {
+    let index = index_with_stages(stages);
+    let path = index.entry(0).path(&index);
+    let (got_summary, got_extra, _) = Conflict::try_from_entry(index.entries(), index.path_backing(), 0, path)
+        .expect("the first entry is a conflict stage");
+    assert_eq!(got_summary, summary, "{summary:?} classification");
+    assert_eq!(
+        got_extra, extra,
+        "{summary:?} extra skip count must be consecutive same-path stages after start, not stage-1"
+    );
+}
+
+/// Extra entries `try_from_entry` tells the status worker to skip after `start_index`.
+/// This must be consecutive same-path conflict stages, not `stage - 1`.
+#[test]
+fn conflict_try_from_entry_skip_count_is_consecutive_same_path_stages() {
+    use Conflict::*;
+    use gix_index::entry::Stage::{Base, Ours, Theirs, Unconflicted};
+
+    assert_conflict_skip_count(
+        &[(Theirs, "ua"), (Unconflicted, "next"), (Unconflicted, "next2")],
+        AddedByThem,
+        0,
+    );
+    assert_conflict_skip_count(&[(Ours, "au"), (Unconflicted, "next")], AddedByUs, 0);
+    assert_conflict_skip_count(&[(Ours, "aa"), (Theirs, "aa"), (Unconflicted, "next")], BothAdded, 1);
+    assert_conflict_skip_count(&[(Base, "du"), (Theirs, "du"), (Unconflicted, "next")], DeletedByUs, 1);
+    assert_conflict_skip_count(&[(Base, "bm"), (Ours, "bm"), (Theirs, "bm")], BothModified, 2);
+}
+
+fn pad_count_for_chunk_size_gt_one() -> usize {
+    // `optimize_chunk_size` uses `(n / (threads * 2)).clamp(1, 1000)`.
+    // Need `n >= threads * 6` so chunk_size >= 3 and the two paths after AddedByThem share its chunk.
+    let threads = std::thread::available_parallelism().map_or(1, std::num::NonZero::get);
+    threads.saturating_mul(6).max(32)
+}
+
+#[test]
+fn conflict_added_by_them_does_not_skip_following_dirty_path_when_chunked() {
+    use Conflict::*;
+    let pad = pad_count_for_chunk_size_gt_one();
+    assert_eq!(
+        fixture_filtered_detailed(
+            "conflicts",
+            "both-deleted",
+            &[],
+            &[
+                (
+                    BStr::new(b"added-by-them"),
+                    0,
+                    EntryStatus::Conflict {
+                        summary: AddedByThem,
+                        entries: Box::new([
+                            None,
+                            None,
+                            Some(ConflictIndexEntry {
+                                id: hex_to_id("9daeafb9864cf43055ae93beb0afd6c7d144bfa4"),
+                                flags: Flags::STAGE_MASK,
+                                mode: Mode::FILE,
+                            }),
+                        ])
+                    }
+                ),
+                (BStr::new(b"added-by-them-dirty"), 1, status_removed()),
+                (
+                    BStr::new(b"added-by-us"),
+                    2,
+                    EntryStatus::Conflict {
+                        summary: AddedByUs,
+                        entries: Box::new([
+                            None,
+                            Some(ConflictIndexEntry {
+                                id: hex_to_id("9daeafb9864cf43055ae93beb0afd6c7d144bfa4"),
+                                flags: Flags::from_bits_retain(0x2000),
+                                mode: Mode::FILE,
+                            }),
+                            None,
+                        ])
+                    }
+                ),
+                (
+                    BStr::new(b"file"),
+                    3,
+                    EntryStatus::Conflict {
+                        summary: BothDeleted,
+                        entries: Box::new([
+                            Some(ConflictIndexEntry {
+                                id: hex_to_id("9daeafb9864cf43055ae93beb0afd6c7d144bfa4"),
+                                flags: Flags::from_bits_retain(0x1000),
+                                mode: Mode::FILE,
+                            }),
+                            None,
+                            None,
+                        ])
+                    }
+                ),
+            ],
+            |index| {
+                let proto = index.entry(0);
+                let (stat, id, mode) = (proto.stat, proto.id, proto.mode);
+                index.dangerously_push_entry(stat, id, Flags::empty(), mode, BStr::new(b"added-by-them-dirty"));
+                for i in 0..pad {
+                    let path = format!("z-pad-{i:03}");
+                    index.dangerously_push_entry(stat, id, Flags::SKIP_WORKTREE, mode, BStr::new(path.as_bytes()));
+                }
+                index.sort_entries();
+            },
+            false,
+            Default::default(),
+            false,
+            None,
+        ),
+        Outcome {
+            entries_to_process: 4 + pad,
+            entries_processed: 4 + pad,
+            entries_skipped_by_entry_flags: pad,
+            symlink_metadata_calls: 1,
+            ..Default::default()
+        },
+        "every conflict and dirty entry must be processed; only SKIP_WORKTREE padding entries are skipped",
+    );
+}
+
 #[test]
 fn conflict_both_added_and_deleted_by_them() {
     use Conflict::*;

--- a/gix-status/tests/status/index_as_worktree.rs
+++ b/gix-status/tests/status/index_as_worktree.rs
@@ -592,34 +592,6 @@ fn conflict_both_deleted_and_added_by_them_and_added_by_us() {
     );
 }
 
-fn index_with_stages(stages: &[(gix_index::entry::Stage, &str)]) -> gix_index::State {
-    let object_hash = gix_testtools::object_hash();
-    let mut state = gix_index::State::new(object_hash);
-    let id = object_hash.null();
-    for &(stage, path) in stages {
-        state.dangerously_push_entry(
-            Default::default(),
-            id,
-            Flags::from_stage(stage),
-            Mode::FILE,
-            BStr::new(path.as_bytes()),
-        );
-    }
-    state
-}
-
-fn assert_conflict_skip_count(stages: &[(gix_index::entry::Stage, &str)], summary: Conflict, extra: usize) {
-    let index = index_with_stages(stages);
-    let path = index.entry(0).path(&index);
-    let (got_summary, got_extra, _) = Conflict::try_from_entry(index.entries(), index.path_backing(), 0, path)
-        .expect("the first entry is a conflict stage");
-    assert_eq!(got_summary, summary, "{summary:?} classification");
-    assert_eq!(
-        got_extra, extra,
-        "{summary:?} extra skip count must be consecutive same-path stages after start, not stage-1"
-    );
-}
-
 /// Extra entries `try_from_entry` tells the status worker to skip after `start_index`.
 /// This must be consecutive same-path conflict stages, not `stage - 1`.
 #[test]
@@ -627,27 +599,82 @@ fn conflict_try_from_entry_skip_count_is_consecutive_same_path_stages() {
     use Conflict::*;
     use gix_index::entry::Stage::{Base, Ours, Theirs, Unconflicted};
 
+    fn assert_conflict_skip_count(
+        stages: &[(gix_index::entry::Stage, &str)],
+        (expected_conflict, expected_extra, diagnostic): (Conflict, usize, Option<&str>),
+    ) {
+        fn index_with_stages(stages: &[(gix_index::entry::Stage, &str)]) -> gix_index::State {
+            let object_hash = gix_testtools::object_hash();
+            let mut state = gix_index::State::new(object_hash);
+            let id = object_hash.null();
+            for &(stage, path) in stages {
+                state.dangerously_push_entry(
+                    Default::default(),
+                    id,
+                    Flags::from_stage(stage),
+                    Mode::FILE,
+                    BStr::new(path.as_bytes()),
+                );
+            }
+            state
+        }
+
+        let index = index_with_stages(stages);
+        let path = index.entry(0).path(&index);
+        let (actual_summary, actual_extra, _) =
+            Conflict::try_from_entry(index.entries(), index.path_backing(), 0, path)
+                .expect("the first entry is a conflict stage");
+        assert_eq!(
+            actual_summary,
+            expected_conflict,
+            "{}",
+            diagnostic.unwrap_or("conflict classification")
+        );
+        assert_eq!(
+            actual_extra, expected_extra,
+            "{expected_conflict:?} extra skip count must be consecutive same-path stages after start, not stage-1"
+        );
+    }
+
     assert_conflict_skip_count(
         &[(Theirs, "ua"), (Unconflicted, "next"), (Unconflicted, "next2")],
-        AddedByThem,
-        0,
+        (AddedByThem, 0, None),
     );
-    assert_conflict_skip_count(&[(Ours, "au"), (Unconflicted, "next")], AddedByUs, 0);
-    assert_conflict_skip_count(&[(Ours, "aa"), (Theirs, "aa"), (Unconflicted, "next")], BothAdded, 1);
-    assert_conflict_skip_count(&[(Base, "du"), (Theirs, "du"), (Unconflicted, "next")], DeletedByUs, 1);
-    assert_conflict_skip_count(&[(Base, "bm"), (Ours, "bm"), (Theirs, "bm")], BothModified, 2);
-}
-
-fn pad_count_for_chunk_size_gt_one() -> usize {
-    // `optimize_chunk_size` uses `(n / (threads * 2)).clamp(1, 1000)`.
-    // Need `n >= threads * 6` so chunk_size >= 3 and the two paths after AddedByThem share its chunk.
-    let threads = std::thread::available_parallelism().map_or(1, std::num::NonZero::get);
-    threads.saturating_mul(6).max(32)
+    assert_conflict_skip_count(
+        &[(Ours, "au"), (Unconflicted, "next")],
+        (AddedByUs, 0, Some("an unconflicted entry terminates the conflict")),
+    );
+    assert_conflict_skip_count(
+        &[(Ours, "a"), (Theirs, "b")],
+        (
+            AddedByUs,
+            0,
+            Some("a conflict entry for another path terminates the current conflict"),
+        ),
+    );
+    assert_conflict_skip_count(&[(Base, "dd")], (BothDeleted, 0, None));
+    assert_conflict_skip_count(&[(Base, "dt"), (Ours, "dt")], (DeletedByThem, 1, None));
+    assert_conflict_skip_count(
+        &[(Base, "du"), (Theirs, "du"), (Unconflicted, "next")],
+        (DeletedByUs, 1, None),
+    );
+    assert_conflict_skip_count(
+        &[(Ours, "aa"), (Theirs, "aa"), (Unconflicted, "next")],
+        (BothAdded, 1, None),
+    );
+    assert_conflict_skip_count(&[(Base, "bm"), (Ours, "bm"), (Theirs, "bm")], (BothModified, 2, None));
 }
 
 #[test]
 fn conflict_added_by_them_does_not_skip_following_dirty_path_when_chunked() {
     use Conflict::*;
+
+    fn pad_count_for_chunk_size_gt_one() -> usize {
+        // `optimize_chunk_size` uses `(n / (threads * 2)).clamp(1, 1000)`.
+        // Need `n >= threads * 6` so chunk_size >= 3 and the two paths after AddedByThem share its chunk.
+        let threads = std::thread::available_parallelism().map_or(1, std::num::NonZero::get);
+        threads.saturating_mul(6).max(32)
+    }
     let pad = pad_count_for_chunk_size_gt_one();
     assert_eq!(
         fixture_filtered_detailed(


### PR DESCRIPTION
## Summary

`Conflict::try_from_entry` now skips only later conflict stages of the same path, so `index_as_worktree` (and `gix status`) no longer drops unrelated dirty files after a lone stage-3 AddedByThem entry.

## Problem

The status worker uses the extra count from `try_from_entry` to jump over later stages of the same conflict. That count was `stage - 1`, which is the slot index in `seen`, not the number of extra index entries.

For a lone stage-3 AddedByThem entry the extra count was 2. The worker then skipped the next two index entries in the same chunk, even when those entries were different paths.

Existing conflict fixtures have 2-4 entries. `optimize_chunk_size` with the default `parallel` feature then yields `chunk_size = 1`, so the skip is a no-op and the existing tests stay green. With about 32 or more index entries, `chunk_size` is greater than 1. A UA / AU / DU / AA conflict in that situation can hide following dirty files from `index_as_worktree` and from `gix status`.

Correct extra counts:

| Conflict | Stages | Old extra | New extra |
|---|---|---|---|
| AddedByThem | 3 only | 2 | 0 |
| AddedByUs | 2 only | 1 | 0 |
| BothAdded | 2+3 | 2 | 1 |
| DeletedByUs | 1+3 | 2 | 1 |
| BothModified | 1+2+3 | 2 | 2 (already correct) |

This came in with [#2119](https://github.com/GitoxideLabs/gitoxide/pull/2119) ([`38b28c6e77`](https://github.com/GitoxideLabs/gitoxide/commit/38b28c6e778a9a35472b3703e72e2e5e1ade3c7c), 2025-08-17), when `try_from_entry` started returning the three stage slots and reused `stage - 1` as both the slot index and the skip count.

## Change

In `gix-status/src/index_as_worktree/function.rs`, walk consecutive same-path `stage > 0` entries after `start_index` and return that count minus one. Keep `seen[stage - 1]` for the three stage slots.

No new fixture archive. The integration case pads an in-memory copy of the existing `both-deleted` index.

## Validation

Red (production still on `main`):

```
cargo test -p gix-status --test status -- conflict_try_from_entry_skip_count
  AddedByThem extra skip count ... left 2 / right 0

cargo test -p gix-status --test status -- conflict_added_by_them_does_not_skip
  actual records: added-by-them, file
  missing: added-by-them-dirty (Removed), added-by-us (AddedByUs)
```

Green (this commit):

```
cargo test -p gix-status --test status -- conflict_try_from_entry_skip_count conflict_added_by_them_does_not_skip
  2 passed

cargo test -p gix-status --test status
  33 passed

cargo clippy -p gix-status --all-targets -- -D warnings
  ok (gix-status)
```

`GIX_TEST_IGNORE_ARCHIVES=1` on macOS.

## Public repro

`Conflict::try_from_entry` is public. With a 32+ entry index and default `gix-features/parallel`, `gix_status::index_as_worktree` (used by `gix status`) omits a dirty path that sorts immediately after a UA conflict.

The new unit test asserts the five extra counts above. The new `index_as_worktree` case injects a missing `added-by-them-dirty` path plus enough `SKIP_WORKTREE` pads that `chunk_size >= 3`, and checks that the dirty path and the following AddedByUs conflict are still reported.
