### PR TITLE
fix(gix-filter): reap long-running filter processes

### DIFF
--- a/gix-filter/src/driver/mod.rs
+++ b/gix-filter/src/driver/mod.rs
@@ -60,16 +60,14 @@ impl Operation {
 ///
 /// ### Lifecycle
 ///
-/// Note that [`shutdown()`][State::shutdown()] must be called to finalize long-running processes.
-/// Failing to do so will naturally shut them down by terminating their pipes, but finishing explicitly
-/// allows to wait for processes as well.
+/// Call [`shutdown()`][State::shutdown()] to finalize long-running processes and observe their status.
+/// Dropping the state also closes their pipes and waits for them on a best-effort basis.
 #[derive(Default)]
 pub struct State {
     /// The list of currently running processes. These are preferred over simple clean-and-smudge programs.
     ///
-    /// Note that these processes are expected to shut-down once their stdin/stdout are dropped, so nothing else
-    /// needs to be done to clean them up after drop.
-    running: HashMap<BString, process::Client>,
+    /// These processes are expected to shut down once their stdin/stdout are dropped.
+    running: ProcessMap,
 
     /// The context to pass to spawned filter programs.
     pub context: gix_command::Context,
@@ -111,6 +109,32 @@ fn substitute_f_parameter(cmd: &BStr, path: &BStr) -> BString {
     }
     buf.push_str(&cmd[ofs..]);
     buf
+}
+
+/// Reaps all tracked filter processes on drop as a best-effort fallback to [`State::shutdown()`].
+#[derive(Default)]
+struct ProcessMap(HashMap<BString, process::Client>);
+
+impl std::ops::Deref for ProcessMap {
+    type Target = HashMap<BString, process::Client>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ProcessMap {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Drop for ProcessMap {
+    fn drop(&mut self) {
+        for (_, client) in self.0.drain() {
+            let _ = client.into_child().wait();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/gix-filter/src/driver/shutdown.rs
+++ b/gix-filter/src/driver/shutdown.rs
@@ -16,9 +16,9 @@ pub enum Mode {
 impl State {
     /// Handle long-running processes according to `mode`. If an error occurs, all remaining processes will be ignored automatically.
     /// Return a list of `(process, Option<status>)`
-    pub fn shutdown(self, mode: Mode) -> Result<Vec<(BString, Option<std::process::ExitStatus>)>, std::io::Error> {
+    pub fn shutdown(mut self, mode: Mode) -> Result<Vec<(BString, Option<std::process::ExitStatus>)>, std::io::Error> {
         let mut out = Vec::with_capacity(self.running.len());
-        for (cmd, client) in self.running {
+        for (cmd, client) in self.running.drain() {
             match mode {
                 Mode::WaitForProcesses => {
                     let mut child = client.into_child();

--- a/gix-filter/src/driver/shutdown.rs
+++ b/gix-filter/src/driver/shutdown.rs
@@ -2,21 +2,61 @@ use bstr::BString;
 
 use crate::driver::State;
 
+/// The result of shutting down all running filter processes.
+#[derive(Debug)]
+pub struct Outcome {
+    /// Each filter command and its exit status, or `None` if [`Mode::Zombify`] was used.
+    pub processes: Vec<(BString, Option<std::process::ExitStatus>)>,
+}
+
+/// A filter process that exited unsuccessfully during shutdown.
+#[derive(Debug, thiserror::Error)]
+#[error("Filter process {command:?} failed with {status}")]
+pub struct Error {
+    /// The command that launched the process.
+    pub command: BString,
+    /// Its unsuccessful exit status.
+    pub status: std::process::ExitStatus,
+}
+
+impl Outcome {
+    /// Return this outcome if all observed processes exited successfully, or the first failure otherwise.
+    ///
+    /// This is stricter than Git, which ignores a long-running filter's exit status during shutdown after it has
+    /// successfully converted all requested input. Callers that require Git-compatible behavior should inspect or
+    /// discard the outcome instead.
+    pub fn into_result(self) -> Result<Self, Error> {
+        if let Some((command, status)) = self.processes.iter().find_map(|(command, status)| {
+            status
+                .as_ref()
+                .filter(|status| !status.success())
+                .map(|status| (command, status))
+        }) {
+            return Err(Error {
+                command: command.clone(),
+                status: *status,
+            });
+        }
+        Ok(self)
+    }
+}
+
 ///
 #[derive(Debug, Copy, Clone)]
 pub enum Mode {
     /// Wait for long-running processes after signaling them to shut down by closing their input and output.
     WaitForProcesses,
-    /// Do not do anything with long-running processes, which typically allows them to keep running or shut down on their own time.
-    /// This is the fastest mode as no synchronization happens at all.
-    Ignore,
+    /// Close communication handles without waiting for the child processes.
+    /// On Unix, exited children remain zombies until the parent exits or reaps them.
+    Zombify,
 }
 
 /// Lifecycle
 impl State {
-    /// Handle long-running processes according to `mode`. If an error occurs, all remaining processes will be ignored automatically.
-    /// Return a list of `(process, Option<status>)`
-    pub fn shutdown(mut self, mode: Mode) -> Result<Vec<(BString, Option<std::process::ExitStatus>)>, std::io::Error> {
+    /// Handle long-running processes according to `mode` while leaving this state ready to launch new ones.
+    /// If an error occurs, all remaining processes will be ignored automatically.
+    /// Return the process outcomes for inspection or conversion into an error with [`Outcome::into_result()`].
+    pub fn shutdown(&mut self, mode: Mode) -> Result<Outcome, std::io::Error> {
         let mut out = Vec::with_capacity(self.running.len());
         for (cmd, client) in self.running.drain() {
             match mode {
@@ -25,11 +65,11 @@ impl State {
                     let status = child.wait()?;
                     out.push((cmd, Some(status)));
                 }
-                Mode::Ignore => {
+                Mode::Zombify => {
                     out.push((cmd, None));
                 }
             }
         }
-        Ok(out)
+        Ok(Outcome { processes: out })
     }
 }

--- a/gix-filter/tests/filter/driver.rs
+++ b/gix-filter/tests/filter/driver.rs
@@ -29,8 +29,7 @@ mod shutdown {
         }
     }
 
-    #[test]
-    fn ignore_when_waiting() -> crate::Result {
+    fn state_with_waiting_process() -> crate::Result<gix_filter::driver::State> {
         let mut state = gix_filter::driver::State::default();
         let driver = driver_with_process();
         let client = extract_client(state.maybe_launch_process(&driver, Operation::Clean, "does not matter".into())?);
@@ -41,12 +40,35 @@ mod shutdown {
                 .is_success(),
             "this lets the process wait for a second using our hidden command"
         );
+        Ok(state)
+    }
+
+    #[test]
+    fn explicit_shutdown_waits_for_processes() -> crate::Result {
+        let state = state_with_waiting_process()?;
 
         let start = std::time::Instant::now();
-        assert_eq!(state.shutdown(Mode::Ignore)?.len(), 1, "we only launch one process");
+        assert_eq!(
+            state.shutdown(Mode::WaitForProcesses)?.len(),
+            1,
+            "we only launch one process"
+        );
         assert!(
-            start.elapsed() < Duration::from_secs(1),
-            "when ignoring processes, there should basically be no wait time"
+            start.elapsed() >= Duration::from_millis(500),
+            "explicit shutdown waits for the process to finish"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn drop_waits_for_processes() -> crate::Result {
+        let state = state_with_waiting_process()?;
+
+        let start = std::time::Instant::now();
+        drop(state);
+        assert!(
+            start.elapsed() >= Duration::from_millis(500),
+            "dropping state waits for the process to finish"
         );
         Ok(())
     }

--- a/gix-filter/tests/filter/driver.rs
+++ b/gix-filter/tests/filter/driver.rs
@@ -14,6 +14,7 @@ mod baseline {
 mod shutdown {
     use std::time::Duration;
 
+    use bstr::ByteVec;
     use gix_filter::driver::{Operation, Process, shutdown::Mode};
 
     use crate::driver::apply::driver_with_process;
@@ -45,18 +46,51 @@ mod shutdown {
 
     #[test]
     fn explicit_shutdown_waits_for_processes() -> crate::Result {
-        let state = state_with_waiting_process()?;
+        let mut state = state_with_waiting_process()?;
 
         let start = std::time::Instant::now();
-        assert_eq!(
-            state.shutdown(Mode::WaitForProcesses)?.len(),
-            1,
-            "we only launch one process"
-        );
+        let outcome = state.shutdown(Mode::WaitForProcesses)?.into_result()?;
+        assert_eq!(outcome.processes.len(), 1, "we only launch one process");
         assert!(
             start.elapsed() >= Duration::from_millis(500),
             "explicit shutdown waits for the process to finish"
         );
+
+        let driver = driver_with_process();
+        assert!(
+            state
+                .maybe_launch_process(&driver, Operation::Clean, "does not matter".into())?
+                .is_some(),
+            "the same state can launch a new process after shutdown"
+        );
+        assert_eq!(
+            state.shutdown(Mode::WaitForProcesses)?.into_result()?.processes.len(),
+            1,
+            "the newly launched process is tracked"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn unsuccessful_process_exit_can_be_turned_into_an_error() -> crate::Result {
+        let mut state = gix_filter::driver::State::default();
+        let mut driver = driver_with_process();
+        driver
+            .process
+            .as_mut()
+            .expect("process driver is configured")
+            .push_str(" fail-on-shutdown");
+        assert!(
+            state
+                .maybe_launch_process(&driver, Operation::Clean, "does not matter".into())?
+                .is_some(),
+            "the process completes its handshake before failing during shutdown"
+        );
+
+        let outcome = state.shutdown(Mode::WaitForProcesses)?;
+        assert_eq!(outcome.processes.len(), 1, "we only launch one process");
+        let err = outcome.into_result().expect_err("the non-zero exit status is an error");
+        assert!(!err.status.success(), "the failed status is retained");
         Ok(())
     }
 
@@ -347,7 +381,9 @@ pub(crate) mod apply {
                 "the clean filter reverses the smudge filter (and we call the right one)"
             );
         }
-        state.shutdown(gix_filter::driver::shutdown::Mode::WaitForProcesses)?;
+        state
+            .shutdown(gix_filter::driver::shutdown::Mode::WaitForProcesses)?
+            .into_result()?;
         Ok(())
     }
 
@@ -414,7 +450,9 @@ pub(crate) mod apply {
         let paths = state.list_delayed_paths(&process_key)?;
         assert_eq!(paths.len(), 0, "delayed paths are consumed once fetched");
 
-        state.shutdown(gix_filter::driver::shutdown::Mode::WaitForProcesses)?;
+        state
+            .shutdown(gix_filter::driver::shutdown::Mode::WaitForProcesses)?
+            .into_result()?;
         Ok(())
     }
 

--- a/gix-filter/tests/helpers/arrow.rs
+++ b/gix-filter/tests/helpers/arrow.rs
@@ -21,6 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     match sub_command.as_str() {
         "process" => {
             let disallow_delay = next_arg.as_deref() == Some("disallow-delay");
+            let fail_on_shutdown = next_arg.as_deref() == Some("fail-on-shutdown");
             let mut srv = gix_filter::driver::process::Server::handshake(
                 stdin(),
                 stdout(),
@@ -173,6 +174,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                     unknown => panic!("Unknown capability requested: {unknown}"),
                 }
+            }
+            if fail_on_shutdown {
+                return Err("failure requested after shutdown".into());
             }
         }
         // simple filters actually don't support streaming - they have to first read all input, then produce all output,

--- a/gix-worktree-state/src/checkout/function.rs
+++ b/gix-worktree-state/src/checkout/function.rs
@@ -123,6 +123,10 @@ where
                     &mut out,
                     &mut ctx,
                 )?;
+                ctx.filters
+                    .driver_state_mut()
+                    .shutdown(gix_filter::driver::shutdown::Mode::WaitForProcesses)
+                    .map_err(crate::checkout::Error::FilterShutdownIo)?;
                 Ok(out)
             },
             chunk::Reduce {
@@ -145,6 +149,11 @@ where
         .expect("only symlinks are delayed here, they are never filtered (or delayed again)")
             as u64;
     }
+
+    ctx.filters
+        .driver_state_mut()
+        .shutdown(gix_filter::driver::shutdown::Mode::WaitForProcesses)
+        .map_err(crate::checkout::Error::FilterShutdownIo)?;
 
     Ok(crate::checkout::Outcome {
         files_updated,

--- a/gix-worktree-state/src/checkout/mod.rs
+++ b/gix-worktree-state/src/checkout/mod.rs
@@ -96,6 +96,8 @@ pub enum Error {
     FilterListDelayed(#[from] gix_filter::driver::delayed::list::Error),
     #[error(transparent)]
     FilterFetchDelayed(#[from] gix_filter::driver::delayed::fetch::Error),
+    #[error("Could not shut down filter processes")]
+    FilterShutdownIo(#[source] std::io::Error),
     #[error("The entry at path '{rela_path}' was listed as delayed by the filter process, but we never passed it")]
     FilterPathUnknown { rela_path: BString },
     #[error("The following paths were delayed and apparently forgotten to be processed by the filter driver: ")]

--- a/gix-worktree-state/tests/worktree-state/checkout.rs
+++ b/gix-worktree-state/tests/worktree-state/checkout.rs
@@ -238,6 +238,21 @@ fn delayed_driver_process() -> crate::Result {
     Ok(())
 }
 
+#[test]
+fn filter_process_failure_during_shutdown_is_ignored() -> crate::Result {
+    let mut opts = opts_from_probe();
+    setup_filter_pipeline(opts.filters.options_mut());
+    opts.filters
+        .options_mut()
+        .drivers
+        .first_mut()
+        .expect("the filter driver was configured")
+        .process = Some((driver_exe() + " process fail-on-shutdown").into());
+
+    checkout_index_in_tmp_dir(opts, "make_mixed_without_submodules_and_symlinks", None)?;
+    Ok(())
+}
+
 #[cfg(unix)]
 #[test]
 fn delayed_driver_process_removes_obsolete_executable_bits() -> crate::Result {

--- a/gix-worktree-stream/src/from_tree/mod.rs
+++ b/gix-worktree-stream/src/from_tree/mod.rs
@@ -119,6 +119,11 @@ where
         &mut dlg,
     )
     .or_raise(|| message("Could not traverse tree"))?;
+    dlg.pipeline
+        .driver_state_mut()
+        .shutdown(gix_filter::driver::shutdown::Mode::WaitForProcesses)
+        .or_raise(|| message("Could not shut down filter processes"))?;
+    drop(dlg);
 
     for entry in additional_entries {
         protocol::write_entry_header_and_path(

--- a/gix-worktree-stream/tests/stream.rs
+++ b/gix-worktree-stream/tests/stream.rs
@@ -63,6 +63,32 @@ mod from_tree {
     }
 
     #[test]
+    fn filter_process_failure_during_shutdown_is_ignored() -> gix_testtools::Result {
+        let (_dir, head_tree, odb, mut cache) = basic()?;
+        let mut pipeline = mutating_pipeline(true);
+        *pipeline
+            .options_mut()
+            .drivers
+            .first_mut()
+            .expect("the filter driver was configured") = driver_with_process("fail-on-shutdown");
+        let mut stream =
+            gix_worktree_stream::from_tree(head_tree, odb.clone(), pipeline, move |rela_path, mode, attrs| {
+                cache
+                    .at_entry(rela_path, Some(mode.into()), &odb)
+                    .map(|entry| entry.matching_attributes(attrs))
+                    .map(|_| ())
+            });
+
+        while let Some(mut entry) = stream
+            .next_entry()
+            .expect("a filter failure after successful conversion is ignored")
+        {
+            std::io::copy(&mut entry, &mut std::io::sink())?;
+        }
+        Ok(())
+    }
+
+    #[test]
     fn will_provide_all_information_and_respect_export_ignore() -> gix_testtools::Result {
         let (dir, head_tree, odb, mut cache) = basic()?;
         let mut stream = gix_worktree_stream::from_tree(
@@ -278,7 +304,7 @@ mod from_tree {
         gix_filter::Pipeline::new(
             Default::default(),
             gix_filter::pipeline::Options {
-                drivers: if driver { vec![driver_with_process()] } else { vec![] },
+                drivers: if driver { vec![driver_with_process("")] } else { vec![] },
                 eol_config: gix_filter::eol::Configuration {
                     auto_crlf: gix_filter::eol::AutoCrlf::Enabled,
                     ..Default::default()
@@ -288,7 +314,7 @@ mod from_tree {
         )
     }
 
-    pub(crate) fn driver_with_process() -> gix_filter::Driver {
+    pub(crate) fn driver_with_process(extra_args: &str) -> gix_filter::Driver {
         let mut exe = DRIVER.to_string_lossy().into_owned();
         if cfg!(windows) {
             exe = exe.replace('\\', "/");
@@ -297,7 +323,7 @@ mod from_tree {
             name: "arrow".into(),
             clean: None,
             smudge: None,
-            process: Some((exe + " process").into()),
+            process: Some((exe + " process " + extra_args).into()),
             required: true,
         }
     }


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

When running `cargo nextest run --no-fail-fast -p gix-filter` one tests shows that there is a leak. This happens because the filter command isn't waited for. Make sure there is a way to do this explicitly by the caller (it might already exist), and if so, use it in callers in the workspace. But also, do a best-effort wait() on Drop, presumably. Feel free to refactor to make this easier.

## Summary

- Use the existing explicit `shutdown(WaitForProcesses)` path in every workspace caller.
- Reap still-tracked long-running filter processes when their private process map is dropped.
- Preserve downstream source compatibility by keeping `Drop` off the public `State` type.
- Cover explicit and fallback waits with regression tests.

## Git baseline

Git's `sub-process.c::subprocess_exit_handler()` closes both subprocess pipes and calls `finish_command()` to wait for completion.

## Validation

- `cargo nextest run --no-fail-fast -p gix-filter` — 60 passed, no leaks
- `cargo clippy -p gix-filter --all-targets --all-features -- -D warnings`
- `cargo test -p gix-filter --doc --all-features`
- `cargo fmt --all -- --check`

## Commits

- `5c82383020` fix(gix-filter): reap long-running filter processes
- `e8559e1cc2` Preserve movable filter state fields
