### PR TITLE
fix(gix-filter): reap `process` filter children instead of orphaning them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,6 +1967,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "gix-worktree",
+ "libc",
  "smallvec",
  "thiserror 2.0.18",
 ]

--- a/gix-filter/Cargo.toml
+++ b/gix-filter/Cargo.toml
@@ -63,5 +63,9 @@ gix-quote = { path = "../gix-quote" }
 gix-testtools = { path = "../tests/tools" }
 gix-worktree = { path = "../gix-worktree", default-features = false, features = ["attributes"] }
 
+# Used by tests that observe whether a filter's child process was reaped, which `std` cannot express.
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2.186"
+
 [package.metadata.docs.rs]
 features = ["sha1"]

--- a/gix-filter/src/driver/mod.rs
+++ b/gix-filter/src/driver/mod.rs
@@ -60,15 +60,20 @@ impl Operation {
 ///
 /// ### Lifecycle
 ///
-/// Note that [`shutdown()`][State::shutdown()] must be called to finalize long-running processes.
-/// Failing to do so will naturally shut them down by terminating their pipes, but finishing explicitly
-/// allows to wait for processes as well.
+/// Long-running processes are terminated and waited for when this instance is dropped, so they never
+/// linger in the process table of the operating system. Call
+/// [`shutdown()`][State::shutdown()] or [`shutdown_mut()`][State::shutdown_mut()] explicitly to learn
+/// how each of them exited, or to opt out of waiting with [`shutdown::Mode::Ignore`].
+///
+/// Note that [`clone()`][Clone::clone()] does *not* clone the running processes, so each clone owns and
+/// terminates only the processes that it launched itself.
 #[derive(Default)]
 pub struct State {
     /// The list of currently running processes. These are preferred over simple clean-and-smudge programs.
     ///
-    /// Note that these processes are expected to shut-down once their stdin/stdout are dropped, so nothing else
-    /// needs to be done to clean them up after drop.
+    /// Note that these processes shut down once their stdin/stdout are dropped, but on Unix they keep
+    /// occupying a slot in the process table until they are waited for, which is what dropping this
+    /// instance does.
     running: HashMap<BString, process::Client>,
 
     /// The context to pass to spawned filter programs.
@@ -92,6 +97,14 @@ impl Clone for State {
             running: Default::default(),
             context: self.context.clone(),
         }
+    }
+}
+
+impl Drop for State {
+    fn drop(&mut self) {
+        // Waiting is expected to be brief: dropping a client closes the input and output of its process,
+        // which is how it is told to exit. Errors are of no use here as there is nothing left to retry.
+        let _ = self.shutdown_mut(shutdown::Mode::WaitForProcesses);
     }
 }
 

--- a/gix-filter/src/driver/process/client.rs
+++ b/gix-filter/src/driver/process/client.rs
@@ -292,6 +292,14 @@ impl Client {
     pub fn version(&self) -> usize {
         self.version
     }
+
+    /// Return the process id of the child process we are communicating with.
+    ///
+    /// This is enough to observe the child's lifetime, for instance to assert that it was waited for,
+    /// without taking ownership of it like [`into_child()`][Client::into_child()] does.
+    pub fn id(&self) -> u32 {
+        self.child.id()
+    }
 }
 
 /// Lifecycle

--- a/gix-filter/src/driver/shutdown.rs
+++ b/gix-filter/src/driver/shutdown.rs
@@ -9,27 +9,56 @@ pub enum Mode {
     WaitForProcesses,
     /// Do not do anything with long-running processes, which typically allows them to keep running or shut down on their own time.
     /// This is the fastest mode as no synchronization happens at all.
+    ///
+    /// Note that on Unix this leaves each child in the process table until this process exits, as nobody
+    /// waits for it. Prefer [`WaitForProcesses`][Mode::WaitForProcesses] in long-running applications.
     Ignore,
 }
 
 /// Lifecycle
 impl State {
-    /// Handle long-running processes according to `mode`. If an error occurs, all remaining processes will be ignored automatically.
+    /// Handle long-running processes according to `mode`.
     /// Return a list of `(process, Option<status>)`
-    pub fn shutdown(self, mode: Mode) -> Result<Vec<(BString, Option<std::process::ExitStatus>)>, std::io::Error> {
-        let mut out = Vec::with_capacity(self.running.len());
-        for (cmd, client) in self.running {
+    ///
+    /// This is the owned form of [`shutdown_mut()`][State::shutdown_mut()], which is also what
+    /// [`drop`](Drop) uses so no child process is ever left behind.
+    pub fn shutdown(mut self, mode: Mode) -> Result<Vec<(BString, Option<std::process::ExitStatus>)>, std::io::Error> {
+        self.shutdown_mut(mode)
+    }
+
+    /// Handle long-running processes according to `mode`, leaving `self` without any of them.
+    /// Return a list of `(process, Option<status>)`
+    ///
+    /// Under [`Mode::WaitForProcesses`], every process is waited for even if waiting for one of them
+    /// fails, so a single failure can't leave the remaining ones unreaped. The first error is returned
+    /// once all of them were dealt with.
+    pub fn shutdown_mut(
+        &mut self,
+        mode: Mode,
+    ) -> Result<Vec<(BString, Option<std::process::ExitStatus>)>, std::io::Error> {
+        let running = std::mem::take(&mut self.running);
+        let mut out = Vec::with_capacity(running.len());
+        let mut first_err = None;
+        for (cmd, client) in running {
             match mode {
                 Mode::WaitForProcesses => {
                     let mut child = client.into_child();
-                    let status = child.wait()?;
-                    out.push((cmd, Some(status)));
+                    match child.wait() {
+                        Ok(status) => out.push((cmd, Some(status))),
+                        Err(err) => {
+                            out.push((cmd, None));
+                            first_err = first_err.or(Some(err));
+                        }
+                    }
                 }
                 Mode::Ignore => {
                     out.push((cmd, None));
                 }
             }
         }
-        Ok(out)
+        match first_err {
+            Some(err) => Err(err),
+            None => Ok(out),
+        }
     }
 }

--- a/gix-filter/tests/filter/driver.rs
+++ b/gix-filter/tests/filter/driver.rs
@@ -52,11 +52,11 @@ mod shutdown {
     }
 
     /// A `State` that goes out of scope closes the input and output of each of its long-running
-    /// processes, which makes them exit, but it never waits for them. On Unix, a child that exited
-    /// without being waited for keeps its slot in the process table - see the [`crate::reap`] module.
+    /// processes, which makes them exit, and then waits for them. On Unix, only a child that was waited
+    /// for releases its slot in the process table - see the [`crate::reap`] module.
     #[cfg(unix)]
     #[test]
-    fn a_dropped_state_does_not_reap_its_process_children() -> crate::Result {
+    fn a_dropped_state_reaps_its_process_children() -> crate::Result {
         let pid = {
             let mut state = gix_filter::driver::State::default();
             let driver = driver_with_process();
@@ -72,16 +72,35 @@ mod shutdown {
         };
 
         assert_eq!(
+            crate::reap::observe(pid),
+            crate::reap::Child::Reaped,
+            "dropping the state waited for the filter, so it is gone from the process table right away"
+        );
+        Ok(())
+    }
+
+    /// Waiting is what `Mode::Ignore` exists to avoid, so it is also the one way to still end up with a
+    /// child nobody waited for. Pinned here so the documented opt-out can't be lost by accident.
+    #[cfg(unix)]
+    #[test]
+    fn an_ignored_shutdown_leaves_its_process_children_unreaped() -> crate::Result {
+        let mut state = gix_filter::driver::State::default();
+        let driver = driver_with_process();
+        let pid = extract_client(state.maybe_launch_process(&driver, Operation::Clean, "does not matter".into())?).id();
+
+        assert_eq!(state.shutdown(Mode::Ignore)?.len(), 1, "we only launch one process");
+        assert_eq!(
             crate::reap::settle(pid),
             crate::reap::Child::Unreaped,
-            "the filter exits once its pipes close, but nothing waits for it so it stays in the process table"
+            "the filter still exits as its pipes were closed, but this mode explicitly doesn't wait for it"
         );
         Ok(())
     }
 
     /// `gix-status` and `gix-worktree-state` clone their pipeline once per worker thread, and cloning a
-    /// `State` resets the set of running processes. Hence each clone launches, owns and abandons filter
-    /// processes of its own, which is what turns one leaked child per operation into `threads + 2` of them.
+    /// `State` resets the set of running processes. Hence each clone launches and owns filter processes of
+    /// its own, which is what used to turn one leaked child per operation into `threads + 2` of them, and
+    /// is why each clone has to reap what it started.
     #[cfg(unix)]
     #[test]
     fn each_clone_of_a_state_owns_its_own_process_children() -> crate::Result {
@@ -107,9 +126,9 @@ mod shutdown {
 
         for (pid, whose) in [(original, "original"), (clone, "clone")] {
             assert_eq!(
-                crate::reap::settle(pid),
-                crate::reap::Child::Unreaped,
-                "the child of the {whose} was left in the process table"
+                crate::reap::observe(pid),
+                crate::reap::Child::Reaped,
+                "the child of the {whose} was waited for by the state that launched it"
             );
         }
         Ok(())

--- a/gix-filter/tests/filter/driver.rs
+++ b/gix-filter/tests/filter/driver.rs
@@ -50,6 +50,70 @@ mod shutdown {
         );
         Ok(())
     }
+
+    /// A `State` that goes out of scope closes the input and output of each of its long-running
+    /// processes, which makes them exit, but it never waits for them. On Unix, a child that exited
+    /// without being waited for keeps its slot in the process table - see the [`crate::reap`] module.
+    #[cfg(unix)]
+    #[test]
+    fn a_dropped_state_does_not_reap_its_process_children() -> crate::Result {
+        let pid = {
+            let mut state = gix_filter::driver::State::default();
+            let driver = driver_with_process();
+            let client =
+                extract_client(state.maybe_launch_process(&driver, Operation::Clean, "does not matter".into())?);
+            let pid = client.id();
+            assert_eq!(
+                crate::reap::observe(pid),
+                crate::reap::Child::Running,
+                "the filter is up and is a child of ours, which is what makes its fate observable at all"
+            );
+            pid
+        };
+
+        assert_eq!(
+            crate::reap::settle(pid),
+            crate::reap::Child::Unreaped,
+            "the filter exits once its pipes close, but nothing waits for it so it stays in the process table"
+        );
+        Ok(())
+    }
+
+    /// `gix-status` and `gix-worktree-state` clone their pipeline once per worker thread, and cloning a
+    /// `State` resets the set of running processes. Hence each clone launches, owns and abandons filter
+    /// processes of its own, which is what turns one leaked child per operation into `threads + 2` of them.
+    #[cfg(unix)]
+    #[test]
+    fn each_clone_of_a_state_owns_its_own_process_children() -> crate::Result {
+        let driver = driver_with_process();
+        let (original, clone) = {
+            let mut state = gix_filter::driver::State::default();
+            let original =
+                extract_client(state.maybe_launch_process(&driver, Operation::Clean, "does not matter".into())?).id();
+
+            let mut cloned_state = state.clone();
+            let clone = extract_client(cloned_state.maybe_launch_process(
+                &driver,
+                Operation::Clean,
+                "does not matter".into(),
+            )?)
+            .id();
+            assert_ne!(
+                original, clone,
+                "the clone starts out with no running processes, so it launches a filter of its own for the same driver"
+            );
+            (original, clone)
+        };
+
+        for (pid, whose) in [(original, "original"), (clone, "clone")] {
+            assert_eq!(
+                crate::reap::settle(pid),
+                crate::reap::Child::Unreaped,
+                "the child of the {whose} was left in the process table"
+            );
+        }
+        Ok(())
+    }
 }
 
 pub(crate) mod apply {

--- a/gix-filter/tests/filter/main.rs
+++ b/gix-filter/tests/filter/main.rs
@@ -2,6 +2,9 @@ pub(crate) mod driver;
 pub(crate) mod eol;
 mod ident;
 mod pipeline;
+/// Only Unix keeps unreaped children in its process table, so only there can their absence be asserted.
+#[cfg(unix)]
+pub(crate) mod reap;
 mod worktree;
 
 pub use gix_testtools::Result;

--- a/gix-filter/tests/filter/pipeline/convert_to_git.rs
+++ b/gix-filter/tests/filter/pipeline/convert_to_git.rs
@@ -113,12 +113,13 @@ fn only_driver_means_streaming_is_possible() -> gix_testtools::Result {
 }
 
 /// The whole point of a `process` filter is that it stays alive for the next file, so the `Pipeline` is
-/// the only handle to it. That makes this the shape in which the defect reaches users: `gix` owns its
+/// the only handle to it. That makes this the shape in which the defect reached users: `gix` owns its
 /// pipelines privately - `Repository::status()` and checkout never hand one back - so nobody is in a
-/// position to call [`shutdown()`][gix_filter::driver::State::shutdown()] on what they launched.
+/// position to call [`shutdown()`][gix_filter::driver::State::shutdown()] on what they launched, and
+/// dropping the pipeline has to be enough.
 #[cfg(unix)]
 #[test]
-fn a_dropped_pipeline_does_not_reap_the_filter_it_launched() -> gix_testtools::Result {
+fn a_dropped_pipeline_reaps_the_filter_it_launched() -> gix_testtools::Result {
     let (mut cache, mut pipe) = pipeline("driver-only", || {
         (
             vec![driver_with_process()],
@@ -159,9 +160,9 @@ fn a_dropped_pipeline_does_not_reap_the_filter_it_launched() -> gix_testtools::R
     drop(pipe);
 
     assert_eq!(
-        crate::reap::settle(pid),
-        crate::reap::Child::Unreaped,
-        "dropping the pipeline terminates its filter, but leaves it in the process table"
+        crate::reap::observe(pid),
+        crate::reap::Child::Reaped,
+        "dropping the pipeline terminated its filter and waited for it"
     );
     Ok(())
 }

--- a/gix-filter/tests/filter/pipeline/convert_to_git.rs
+++ b/gix-filter/tests/filter/pipeline/convert_to_git.rs
@@ -112,6 +112,60 @@ fn only_driver_means_streaming_is_possible() -> gix_testtools::Result {
     Ok(())
 }
 
+/// The whole point of a `process` filter is that it stays alive for the next file, so the `Pipeline` is
+/// the only handle to it. That makes this the shape in which the defect reaches users: `gix` owns its
+/// pipelines privately - `Repository::status()` and checkout never hand one back - so nobody is in a
+/// position to call [`shutdown()`][gix_filter::driver::State::shutdown()] on what they launched.
+#[cfg(unix)]
+#[test]
+fn a_dropped_pipeline_does_not_reap_the_filter_it_launched() -> gix_testtools::Result {
+    let (mut cache, mut pipe) = pipeline("driver-only", || {
+        (
+            vec![driver_with_process()],
+            Vec::new(),
+            CrlfRoundTripCheck::Skip,
+            Default::default(),
+        )
+    })?;
+
+    let mut out = pipe.convert_to_git(
+        "➡a\n".as_bytes(),
+        Path::new("any.txt"),
+        &mut |path, attrs| {
+            cache
+                .at_entry(path, None, &gix_object::find::Never)
+                .expect("cannot fail")
+                .matching_attributes(attrs);
+        },
+        &mut no_object_in_index,
+    )?;
+    let mut buf = Vec::new();
+    out.read_to_end(&mut buf)?;
+    assert_eq!(
+        buf.as_bstr(),
+        "a\n",
+        "the `process` filter did its work, so it is definitely running"
+    );
+    drop(out);
+
+    let pid = match pipe.driver_state_mut().maybe_launch_process(
+        &driver_with_process(),
+        gix_filter::driver::Operation::Clean,
+        "any.txt".into(),
+    )? {
+        Some(gix_filter::driver::Process::MultiFile { client, .. }) => client.id(),
+        _ => unreachable!("the driver declares a `process` filter, which is still running"),
+    };
+    drop(pipe);
+
+    assert_eq!(
+        crate::reap::settle(pid),
+        crate::reap::Child::Unreaped,
+        "dropping the pipeline terminates its filter, but leaves it in the process table"
+    );
+    Ok(())
+}
+
 #[test]
 fn no_filter_means_reader_is_returned_unchanged() -> gix_testtools::Result {
     let (mut cache, mut pipe) = pipeline("no-filters", || {

--- a/gix-filter/tests/filter/reap.rs
+++ b/gix-filter/tests/filter/reap.rs
@@ -1,0 +1,62 @@
+//! Observe whether a child process was reaped, to pin the lifecycle of long-running `process` filters.
+//!
+//! On Unix a child that exits but is never `wait()`ed for stays in the process table as a zombie,
+//! owned by its parent until the parent itself exits. Nothing in `std` can observe that: `try_wait()`
+//! needs the `Child` handle, and holding one means the process wasn't abandoned in the first place.
+//! Hence these helpers, which ask the kernel by process id instead.
+
+use std::time::{Duration, Instant};
+
+/// What the operating system knows about a process that was launched by this test binary.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum Child {
+    /// It is still running as it didn't exit yet.
+    Running,
+    /// It exited, but nobody waited for it, so it still occupies a slot in the process table.
+    ///
+    /// Note that observing this state is also what collects the process, as `waitpid()` has no way
+    /// to ask without reaping.
+    Unreaped,
+    /// It isn't a child of this process anymore because it was waited for.
+    Reaped,
+}
+
+/// How long to give a child to notice that its input and output were closed.
+///
+/// Only a leaked child is ever waited for here, so this is a failure timeout, not a delay we pay
+/// on the happy path.
+const EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Ask the kernel about `pid` without blocking.
+pub(crate) fn observe(pid: u32) -> Child {
+    let mut status = 0;
+    // SAFETY: `waitpid()` writes to `status` only, and it is valid for the duration of the call.
+    let res = unsafe { libc::waitpid(pid as libc::pid_t, &mut status, libc::WNOHANG) };
+    match res {
+        0 => Child::Running,
+        res if res > 0 => Child::Unreaped,
+        _ => {
+            let err = std::io::Error::last_os_error();
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::ECHILD),
+                "`waitpid({pid})` may only fail because the process isn't ours to wait for, but failed with {err}"
+            );
+            Child::Reaped
+        }
+    }
+}
+
+/// Ask the kernel about `pid` until it stops [running][Child::Running], and return what it settled on.
+///
+/// A child that the library waited for is observable right away, as reaping implies it had already
+/// exited. A leaked one first needs a moment to notice that its input was closed, hence the polling.
+pub(crate) fn settle(pid: u32) -> Child {
+    let start = Instant::now();
+    loop {
+        match observe(pid) {
+            Child::Running if start.elapsed() < EXIT_TIMEOUT => std::thread::sleep(Duration::from_millis(5)),
+            state => return state,
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2947, from discussion #2945. Thanks for turning it into an issue.

## What is wrong

`driver::State::shutdown()` (`gix-filter/src/driver/shutdown.rs:19`) is the only code in the workspace that `wait()`s a long-running `process` filter child, and nothing calls it. It also takes `self` by value, so `State` could not reap from `Drop` as written. Closing a child's pipes terminates it but does not reap it, so on Unix every `process` filter keeps a slot in the process table until the parent exits — the doc-comment on `State::running` currently claims the opposite.

`impl Clone for State` resets `running`, so each per-thread clone in `gix-status`'s `index_as_worktree{,_with_renames}` and in `gix-worktree-state`'s checkout owns and abandons children of its own: on the order of `thread_limit + 2` per `Repository::status()`.

Callers cannot compensate: `Repository::status()` takes no pipeline and returns none, `index_as_worktree`'s `Outcome` cannot hand the `resource_cache` back (it derives `Clone, Eq, Ord`), and `Repository::worktree_stream()` has no public reach to its pipeline at all.

## The two commits

Tests first, and each one is self-contained and green on its own, per `DEVELOPMENT.md`.

**1/2 — `feat(gix-filter): add \`process::Client::id()\` (#2947)`**

Pinning the lifecycle needs the child's pid without consuming the subject, and `into_child()` consumes it, so `Client::id()` is added. Then three `cfg(unix)` tests that assert the behaviour **as it is today**, i.e. the leak, so this commit passes CI by itself:

- `driver::shutdown::a_dropped_state_does_not_reap_its_process_children`
- `driver::shutdown::each_clone_of_a_state_owns_its_own_process_children`
- `pipeline::convert_to_git::a_dropped_pipeline_does_not_reap_the_filter_it_launched` — a real `convert_to_git()` over the `driver-only` fixture, which is the shape users hit

Observation goes through `waitpid(pid, WNOHANG)`, the only way to distinguish a zombie from a reaped child, hence a `[target.'cfg(unix)'.dev-dependencies] libc` entry following `gix-ref/tests/transaction_fd_limit.rs`. `libc 0.2.186` was already in `Cargo.lock`. No new fixture program: `tests/helpers/arrow.rs` already is a long-running `process` filter that exits when its stdin closes.

**2/2 — `fix(gix-filter): reap \`process\` filter children instead of orphaning them (#2947)`**

- `State::shutdown_mut(&mut self, mode)` drains `running` via `mem::take`; the existing `shutdown(self, mode)` delegates to it. No signature changes, no caller adaptations — `driver_state_mut()` is already used in production at `gix-worktree-state/src/checkout/chunk.rs:182`.
- `impl Drop for State` → `shutdown_mut(WaitForProcesses)`. One place that covers `status`, `checkout`, `diff`, `merge`, `worktree_stream` and every clone site, including future ones.
- `shutdown` no longer abandons the remaining children when one `wait()` fails; errors are collected and the first is returned after all of them were handled.
- Doc corrections on `State`, `State::running` and `Mode::Ignore`.
- The three tests above are flipped to the reaped expectation, and `an_ignored_shutdown_leaves_its_process_children_unreaped` is added to pin `Mode::Ignore` as the deliberate opt-out.

30 lines of non-doc source across three files; the rest is tests and docs.

## Evidence

Field report — desktop app on `gix 0.86.0`, macOS, two repositories with `filter.lfs.process`: **274 zombie children after 10 h 29 m**, 95 live helpers, `kern.maxprocperuid` 2666. At ~26/hour the host eventually cannot `fork()` at all; the visible symptoms were the browser failing to open tabs and keyboard shortcuts dying.

Reproduced on Linux 6.17 while preparing this: 200 ms after dropping the `State` the child is at `state=Z` in `/proc/<pid>/stat`, and `waitpid(pid, WNOHANG)` returns the pid rather than `ECHILD`. With the fix, the `/proc` entry is gone by the next statement — which is also the answer to "does waiting in `Drop` cost anything".

**Mutation check**: with `impl Drop for State` deleted and nothing else changed, all three lifecycle tests fail at `assertion left == right … left: Running, right: Reaped`. `an_ignored_shutdown_…` stays green under that mutation, which is what makes it a pin of the opt-out rather than of the fix.

## Checks run

- `cargo test -p gix-filter --test filter`: 61 pass on commit 1, 62 on commit 2, under both `--features sha1` and `GIX_TEST_FIXTURE_HASH=sha256 --features sha256`.
- `cargo check -p gix-filter -p gix-status -p gix-worktree-state -p gix-diff -p gix-merge --all-targets` clean on both commits — adding `Drop` breaks no partial move. `gix-status` and `gix-worktree-state` suites: 56 pass.
- `cargo fmt --check` clean, `clippy --all-targets` no warnings of ours in two feature configurations, `RUSTDOCFLAGS=-D warnings cargo doc -p gix-filter` clean.
- Not run: `just test` in full and `cargo check --workspace`, because `openssl-sys` cannot build in my environment (no system libssl). `just fmt` was skipped deliberately: nightly `rustfmt 1.10.0-nightly (2026-08-25)` wants to reformat 290 files on unmodified `main`, so it is not usable here. The added code introduces no new nightly-rustfmt diff.
