### PR TITLE
fix(gix-pack): make metadata-driven reservations fallible

### DIFF
--- a/gix-pack/src/bundle/write/types.rs
+++ b/gix-pack/src/bundle/write/types.rs
@@ -12,8 +12,8 @@ pub struct Options {
     pub iteration_mode: crate::data::input::Mode,
     /// The version of pack index to write, should be [`crate::index::Version::default()`]
     pub index_version: crate::index::Version,
-    /// If `Some`, rejects individual allocations above the given number of bytes while resolving streamed pack
-    /// entries into decoded object and delta result buffers to write the index.
+    /// If `Some`, rejects individual allocations above the given number of bytes while building the delta tree or resolving
+    /// streamed pack entries into decoded object and delta result buffers to write the index.
     /// `Some(0)` rejects all non-empty allocations.
     pub alloc_limit_bytes: Option<usize>,
     /// The compression level to use when deflating base objects that are added to the pack to complete a thin pack.

--- a/gix-pack/src/cache/delta/from_offsets.rs
+++ b/gix-pack/src/cache/delta/from_offsets.rs
@@ -64,7 +64,7 @@ impl<T> Tree<T> {
                 progress.init(Some(num_objects), progress::count("objects"));
             })
             .unwrap_or_default();
-        let mut tree = Tree::with_capacity(anticipated_num_objects)?;
+        let mut tree = Tree::with_capacity(anticipated_num_objects, None)?;
 
         {
             // safety check - assure ourselves it's a pack we can handle

--- a/gix-pack/src/cache/delta/mod.rs
+++ b/gix-pack/src/cache/delta/mod.rs
@@ -2,6 +2,8 @@
 #[derive(thiserror::Error, Debug)]
 #[allow(missing_docs)]
 pub enum Error {
+    #[error("The pack delta tree is too large to fit in memory")]
+    OutOfMemory,
     #[error(
         "Pack offsets must only increment. The previous pack offset was {last_pack_offset}, the current one is {pack_offset}"
     )]
@@ -11,6 +13,12 @@ pub enum Error {
         /// The invariant violating offset
         pack_offset: crate::data::Offset,
     },
+}
+
+impl From<std::collections::TryReserveError> for Error {
+    fn from(_: std::collections::TryReserveError) -> Self {
+        Error::OutOfMemory
+    }
 }
 ///
 /// A tree that allows one-time iteration over all nodes and their children, consuming it in the process,

--- a/gix-pack/src/cache/delta/traverse/resolve.rs
+++ b/gix-pack/src/cache/delta/traverse/resolve.rs
@@ -684,7 +684,7 @@ mod tests {
         let first_leaf = append_delta(&mut pack, first_child, b'D');
         let second_leaf = append_delta(&mut pack, second_child, b'E');
 
-        let mut tree = Tree::with_capacity(5).expect("capacity is small");
+        let mut tree = Tree::with_capacity(5, None).expect("capacity is small");
         tree.add_root(root_offset, ()).expect("offsets are increasing");
         tree.add_child(root_offset, first_child, ())
             .expect("offsets are increasing");
@@ -730,7 +730,7 @@ mod tests {
             .map(|byte| append_delta(&mut pack, root_offset, byte))
             .collect();
 
-        let mut tree = Tree::with_capacity(1 + child_offsets.len()).expect("capacity is small");
+        let mut tree = Tree::with_capacity(1 + child_offsets.len(), None).expect("capacity is small");
         tree.add_root(root_offset, ()).expect("offsets are increasing");
         for child_offset in child_offsets {
             tree.add_child(root_offset, child_offset, ())
@@ -768,7 +768,7 @@ mod tests {
     fn traversal_rejects_declared_decompressed_size_over_alloc_limit() {
         let mut pack = Vec::new();
         let root_offset = append_entry(&mut pack, data::entry::Header::Blob, 1, b"");
-        let mut tree = Tree::with_capacity(1).expect("capacity is small");
+        let mut tree = Tree::with_capacity(1, None).expect("capacity is small");
         tree.add_root(root_offset, ()).expect("offsets are increasing");
 
         let err = traverse_with_limit(tree, &pack).expect_err("entry size exceeds the allocation cap");
@@ -795,7 +795,7 @@ mod tests {
             &delta,
         );
 
-        let mut tree = Tree::with_capacity(2).expect("capacity is small");
+        let mut tree = Tree::with_capacity(2, None).expect("capacity is small");
         tree.add_root(root_offset, ()).expect("offsets are increasing");
         tree.add_child(root_offset, child_offset, ())
             .expect("offsets are increasing");
@@ -824,7 +824,7 @@ mod tests {
             &delta,
         );
 
-        let mut tree = Tree::with_capacity(2).expect("capacity is small");
+        let mut tree = Tree::with_capacity(2, None).expect("capacity is small");
         tree.add_root(root_offset, ()).expect("offsets are increasing");
         tree.add_child(root_offset, child_offset, ())
             .expect("offsets are increasing");

--- a/gix-pack/src/cache/delta/tree.rs
+++ b/gix-pack/src/cache/delta/tree.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use super::{Error, Tree, traverse};
-use crate::exact_vec;
 
 /// Maps each referenced base object ID to indices in `Tree::child_items` of ref-deltas waiting for it.
 pub(super) type RefDeltaChildren = BTreeMap<gix_hash::ObjectId, Vec<u32>>;
@@ -48,10 +47,22 @@ pub(super) enum NodeKind {
 
 impl<T> Tree<T> {
     /// Instantiate a empty tree capable of storing `num_objects` amounts of items.
-    pub(crate) fn with_capacity(num_objects: usize) -> Result<Self, Error> {
+    pub(crate) fn with_capacity(num_objects: usize, alloc_limit_bytes: Option<usize>) -> Result<Self, Error> {
+        let capacity = num_objects / 2;
+        let allocation_bytes = capacity
+            .checked_mul(std::mem::size_of::<Item<T>>())
+            .ok_or(Error::OutOfMemory)?;
+        if alloc_limit_bytes.is_some_and(|limit| allocation_bytes > limit) {
+            return Err(Error::OutOfMemory);
+        }
+
+        let mut root_items = Vec::new();
+        root_items.try_reserve_exact(capacity)?;
+        let mut child_items = Vec::new();
+        child_items.try_reserve_exact(capacity)?;
         Ok(Tree {
-            root_items: exact_vec(num_objects / 2),
-            child_items: exact_vec(num_objects / 2),
+            root_items,
+            child_items,
             last_seen: None,
             future_child_offsets: Vec::new(),
             ref_child_indices: BTreeMap::new(),
@@ -200,6 +211,22 @@ impl<T> Tree<T> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn allocation_failure_is_reported() {
+        let result = super::Tree::<()>::with_capacity(usize::MAX, None);
+        assert!(
+            matches!(result, Err(super::Error::OutOfMemory)),
+            "an impossible attacker-controlled capacity must return an allocation error"
+        );
+        assert!(
+            matches!(
+                super::Tree::<()>::with_capacity(2, Some(0)),
+                Err(super::Error::OutOfMemory)
+            ),
+            "the configured allocation limit must apply to delta-tree storage"
+        );
+    }
+
     mod from_offsets_in_pack {
         use std::sync::atomic::AtomicBool;
 

--- a/gix-pack/src/data/input/lookup_ref_delta_objects.rs
+++ b/gix-pack/src/data/input/lookup_ref_delta_objects.rs
@@ -182,7 +182,7 @@ where
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (min, max) = self.inner.size_hint();
-        max.map_or_else(|| (min * 2, None), |max| (min, Some(max * 2)))
+        (min, max.map(|max| max.saturating_mul(2)))
     }
 }
 

--- a/gix-pack/src/index/write/mod.rs
+++ b/gix-pack/src/index/write/mod.rs
@@ -84,8 +84,8 @@ pub(super) mod function {
     /// * `root_progress` is the top-level progress to stay informed about the progress of this potentially long-running
     ///   computation.
     /// * `object_hash` defines what kind of object hash we write into the index file.
-    /// * `alloc_limit_bytes` limits the maximum size of individual allocations while resolving pack entries to compute
-    ///   object ids. `None` means no limit is applied.
+    /// * `alloc_limit_bytes` limits the maximum size of individual allocations for the delta tree and while resolving pack
+    ///   entries to compute object ids. `None` means no limit is applied.
     /// * `pack_version` is the version of the underlying pack for which `entries` are read. It's used in case none of these objects are provided
     ///   to compute a pack-hash.
     ///
@@ -120,7 +120,7 @@ pub(super) mod function {
         let mut last_seen_trailer = None;
         let (anticipated_num_objects, upper_bound) = entries.size_hint();
         let worst_case_num_objects_after_thin_pack_resolution = upper_bound.unwrap_or(anticipated_num_objects);
-        let mut tree = Tree::with_capacity(worst_case_num_objects_after_thin_pack_resolution)?;
+        let mut tree = Tree::with_capacity(worst_case_num_objects_after_thin_pack_resolution, alloc_limit_bytes)?;
         let indexing_start = std::time::Instant::now();
 
         root_progress.init(Some(4), progress::steps());

--- a/gix-pack/src/lib.rs
+++ b/gix-pack/src/lib.rs
@@ -99,11 +99,25 @@ fn read_u64(b: &[u8]) -> u64 {
 
 fn exact_vec<T>(capacity: usize) -> Vec<T> {
     let mut v = Vec::new();
-    v.reserve_exact(capacity);
+    _ = v.try_reserve_exact(capacity);
     v
 }
 
 #[inline]
 fn fan_is_monotonically_increasing(fan: &[u32]) -> bool {
     !fan.windows(2).any(|window| window[0] > window[1])
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn exact_capacity_is_only_an_optimization() {
+        let result = std::panic::catch_unwind(|| super::exact_vec::<u8>(usize::MAX));
+        assert!(result.is_ok(), "failure to preallocate an optimization must not panic");
+        assert_eq!(
+            result.expect("preallocation does not panic").capacity(),
+            0,
+            "a failed preallocation leaves the vector empty"
+        );
+    }
 }

--- a/gix-pack/src/multi_index/write.rs
+++ b/gix-pack/src/multi_index/write.rs
@@ -13,6 +13,8 @@ mod error {
         Interrupted,
         #[error(transparent)]
         OpenIndex(#[from] crate::index::init::Error),
+        #[error("Too many index entries to fit in memory")]
+        OutOfMemory,
     }
 }
 pub use error::Error;
@@ -118,7 +120,9 @@ pub(super) mod function {
                     .unwrap_or(SystemTime::UNIX_EPOCH);
                 let index = crate::index::File::at(index, object_hash)?;
 
-                entries.reserve(index.num_objects() as usize);
+                entries
+                    .try_reserve(index.num_objects() as usize)
+                    .map_err(|_| Error::OutOfMemory)?;
                 entries.extend(index.iter().map(|e| Entry {
                     id: e.oid,
                     pack_index: index_id as u32,

--- a/gix-pack/tests/pack/bundle.rs
+++ b/gix-pack/tests/pack/bundle.rs
@@ -276,10 +276,10 @@ mod write_to_directory {
                 compression: gix_zlib::Compression::BEST_SPEED,
             },
         )
-        .expect_err("a zero allocation limit rejects the first non-empty decoded object");
+        .expect_err("a zero allocation limit rejects non-empty delta-tree storage");
 
         assert!(
-            error_chain_contains_message(&err, "Entry too large to fit in memory"),
+            error_chain_contains_message(&err, "The pack delta tree is too large to fit in memory"),
             "bundle writing must forward its allocation limit to index writing"
         );
         Ok(())

--- a/gix-pack/tests/pack/data/input.rs
+++ b/gix-pack/tests/pack/data/input.rs
@@ -223,4 +223,29 @@ mod lookup_ref_delta_objects {
             assert_eq!(format!("{actual:?}"), format!("{expected:?}"));
         }
     }
+
+    #[test]
+    fn size_hint_does_not_overflow() {
+        struct MaxSizeHint;
+
+        impl Iterator for MaxSizeHint {
+            type Item = Result<input::Entry, input::Error>;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                None
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                (usize::MAX, Some(usize::MAX))
+            }
+        }
+
+        let iter =
+            LookupRefDeltaObjectsIter::new(MaxSizeHint, gix_object::find::Never, gix_zlib::Compression::BEST_SPEED);
+        assert_eq!(
+            iter.size_hint(),
+            (usize::MAX, Some(usize::MAX)),
+            "doubling the upper bound must saturate"
+        );
+    }
 }

--- a/gix-pack/tests/pack/index.rs
+++ b/gix-pack/tests/pack/index.rs
@@ -256,11 +256,11 @@ mod version {
                 prevent_allocation,
                 pack_version,
             )
-            .expect_err("a zero allocation limit rejects the first non-empty decoded object");
+            .expect_err("a zero allocation limit rejects non-empty delta-tree storage");
 
             assert!(
-                crate::error_chain_contains_message(&err, "Entry too large to fit in memory"),
-                "index writing must forward the allocation limit into delta-tree traversal"
+                crate::error_chain_contains_message(&err, "The pack delta tree is too large to fit in memory"),
+                "index writing must apply the allocation limit to delta-tree storage"
             );
             Ok(())
         }


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Advisory

https://github.com/GitoxideLabs/gitoxide/security/advisories/GHSA-x862-c2wj-4mwr

### Advisory summary

- GHSA: GHSA-x862-c2wj-4mwr
- Severity: Medium
- Package/ecosystem: `gix-pack` / Other
- Vulnerable versions: `<= 0.74.2`
- Patched versions: not yet assigned
- CVE: not yet assigned

The detailed reproducer remains in the private advisory. This PR makes delta-tree capacity derived from pack metadata fallible and applies the existing per-allocation ceiling throughout initial allocation and later item-vector growth.

## Additional audit fixes

A separate commit makes the remaining shared exact-capacity hints best-effort, makes multi-index accumulation return an allocation error, and prevents overflow while deriving thin-pack iterator bounds.

## Commits

- `53c22d586a` — make delta-tree allocation fallible
- `9338390a38` — keep delta-tree growth fallible
- `e0a83ae7a4` — reserve exact capacity during limited growth
- `500bd1bbd1` — retain amortized unlimited tree growth
- `1a0937029f` — avoid aborts in remaining capacity hints

## Git baseline

Git reads the advertised object count in `builtin/index-pack.c::parse_pack_header()` and allocates its object tables with `CALLOC_ARRAY`; gitoxide retains eager sizing while returning allocation failures through its error path and honoring its configured limit.

## Validation

- `cargo test -p gix-pack`
- `cargo clippy -p gix-pack --all-targets --all-features -- -D warnings`
- One `codex review --commit` run per commit; review findings were addressed in follow-up commits.