### PR TITLE
fix(gix-pack): reject invalid OFS_DELTA base offsets

### DIFF
--- a/gix-pack/src/cache/delta/from_offsets.rs
+++ b/gix-pack/src/cache/delta/from_offsets.rs
@@ -25,8 +25,6 @@ pub enum Error {
     Interrupted,
 }
 
-const PACK_HEADER_LEN: usize = 12;
-
 /// Generate tree from certain input
 impl<T> Tree<T> {
     /// Create a new `Tree` from any data sorted by offset, ascending as returned by the `data_sorted_by_offsets` iterator.
@@ -68,7 +66,7 @@ impl<T> Tree<T> {
 
         {
             // safety check - assure ourselves it's a pack we can handle
-            let mut buf = [0u8; PACK_HEADER_LEN];
+            let mut buf = [0u8; data::header::SIZE];
             r.read_exact(&mut buf).map_err(|err| Error::Io {
                 source: err,
                 message: "reading header buffer with at least 12 bytes failed - pack file truncated?",

--- a/gix-pack/src/cache/delta/from_offsets.rs
+++ b/gix-pack/src/cache/delta/from_offsets.rs
@@ -105,9 +105,19 @@ impl<T> Tree<T> {
                         })?;
                 }
                 OfsDelta { base_distance } => {
-                    let base_pack_offset = pack_offset
-                        .checked_sub(base_distance)
-                        .expect("in bound distance for deltas");
+                    let Some(base_pack_offset) =
+                        crate::data::entry::Header::verified_base_pack_offset(pack_offset, base_distance)
+                    else {
+                        return Err(Error::Io {
+                            source: io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!(
+                                    "OFS_DELTA base distance {base_distance} is invalid for pack offset {pack_offset}"
+                                ),
+                            ),
+                            message: "invalid OFS_DELTA base distance",
+                        });
+                    };
                     tree.add_child(base_pack_offset, pack_offset, data)?;
                 }
             }

--- a/gix-pack/src/cache/delta/tree.rs
+++ b/gix-pack/src/cache/delta/tree.rs
@@ -223,6 +223,27 @@ mod tests {
             tree(SMALL_PACK_INDEX, SMALL_PACK)
         }
 
+        #[test]
+        fn invalid_ofs_delta_base_distance_is_reported() -> Result<(), Box<dyn std::error::Error>> {
+            let pack_file = gix_testtools::tempfile::NamedTempFile::new()?;
+            let mut pack_data = pack::data::header::encode(pack::data::Version::V2, 1).to_vec();
+            pack::data::entry::Header::OfsDelta { base_distance: 12 + 1 }.write_to(0, &mut pack_data)?;
+            std::fs::write(pack_file.path(), pack_data)?;
+
+            let result = crate::cache::delta::Tree::from_offsets_in_pack(
+                pack_file.path(),
+                std::iter::once(()),
+                &|_| 12,
+                &|_| None,
+                &mut gix_features::progress::Discard,
+                &AtomicBool::new(false),
+                gix_hash::Kind::Sha1,
+            );
+
+            assert!(result.is_err(), "an out-of-bounds delta base is corrupt pack data");
+            Ok(())
+        }
+
         fn tree(index_path: &str, pack_path: &str) -> Result<(), Box<dyn std::error::Error>> {
             let idx = pack::index::File::at(fixture_path(index_path), gix_hash::Kind::Sha1)?;
             crate::cache::delta::Tree::from_offsets_in_pack(

--- a/gix-pack/src/cache/delta/tree.rs
+++ b/gix-pack/src/cache/delta/tree.rs
@@ -225,15 +225,19 @@ mod tests {
 
         #[test]
         fn invalid_ofs_delta_base_distance_is_reported() -> Result<(), Box<dyn std::error::Error>> {
+            let first_entry_offset = pack::data::header::SIZE as pack::data::Offset;
             let pack_file = gix_testtools::tempfile::NamedTempFile::new()?;
             let mut pack_data = pack::data::header::encode(pack::data::Version::V2, 1).to_vec();
-            pack::data::entry::Header::OfsDelta { base_distance: 12 + 1 }.write_to(0, &mut pack_data)?;
+            pack::data::entry::Header::OfsDelta {
+                base_distance: first_entry_offset + 1,
+            }
+            .write_to(0, &mut pack_data)?;
             std::fs::write(pack_file.path(), pack_data)?;
 
             let result = crate::cache::delta::Tree::from_offsets_in_pack(
                 pack_file.path(),
                 std::iter::once(()),
-                &|_| 12,
+                &|_| first_entry_offset,
                 &|_| None,
                 &mut gix_features::progress::Discard,
                 &AtomicBool::new(false),

--- a/gix-pack/src/data/entry/header.rs
+++ b/gix-pack/src/data/entry/header.rs
@@ -32,12 +32,14 @@ pub enum Header {
 }
 
 impl Header {
-    /// Subtract `distance` from `pack_offset` safely, returning only offsets beyond the 12-byte pack header.
+    /// Subtract `distance` from `pack_offset` safely, returning only offsets beyond the pack header.
     pub fn verified_base_pack_offset(pack_offset: data::Offset, distance: u64) -> Option<data::Offset> {
         if distance == 0 {
             return None;
         }
-        pack_offset.checked_sub(distance).filter(|offset| *offset >= 12)
+        pack_offset
+            .checked_sub(distance)
+            .filter(|offset| *offset >= data::header::SIZE as data::Offset)
     }
     /// Convert the header's object kind into [`gix_object::Kind`] if possible
     pub fn as_kind(&self) -> Option<gix_object::Kind> {
@@ -149,8 +151,17 @@ mod tests {
 
     #[test]
     fn verified_base_pack_offset_rejects_the_pack_header() {
-        assert_eq!(Header::verified_base_pack_offset(13, 1), Some(12));
-        for (pack_offset, distance) in [(13, 0), (12, 1), (12, 12), (12, 13)] {
+        let first_entry_offset = data::header::SIZE as data::Offset;
+        assert_eq!(
+            Header::verified_base_pack_offset(first_entry_offset + 1, 1),
+            Some(first_entry_offset)
+        );
+        for (pack_offset, distance) in [
+            (first_entry_offset + 1, 0),
+            (first_entry_offset, 1),
+            (first_entry_offset, first_entry_offset),
+            (first_entry_offset, first_entry_offset + 1),
+        ] {
             assert_eq!(
                 Header::verified_base_pack_offset(pack_offset, distance),
                 None,

--- a/gix-pack/src/data/entry/header.rs
+++ b/gix-pack/src/data/entry/header.rs
@@ -32,12 +32,12 @@ pub enum Header {
 }
 
 impl Header {
-    /// Subtract `distance` from `pack_offset` safely without the chance for overflow or no-ops if `distance` is 0.
+    /// Subtract `distance` from `pack_offset` safely, returning only offsets beyond the 12-byte pack header.
     pub fn verified_base_pack_offset(pack_offset: data::Offset, distance: u64) -> Option<data::Offset> {
         if distance == 0 {
             return None;
         }
-        pack_offset.checked_sub(distance)
+        pack_offset.checked_sub(distance).filter(|offset| *offset >= 12)
     }
     /// Convert the header's object kind into [`gix_object::Kind`] if possible
     pub fn as_kind(&self) -> Option<gix_object::Kind> {
@@ -145,5 +145,17 @@ mod tests {
         let mut buf = [0u8; 10];
         let buf = leb64_encode(u64::MAX, &mut buf);
         assert_eq!(buf.len(), 10, "10 bytes should be used when 64bits are encoded");
+    }
+
+    #[test]
+    fn verified_base_pack_offset_rejects_the_pack_header() {
+        assert_eq!(Header::verified_base_pack_offset(13, 1), Some(12));
+        for (pack_offset, distance) in [(13, 0), (12, 1), (12, 12), (12, 13)] {
+            assert_eq!(
+                Header::verified_base_pack_offset(pack_offset, distance),
+                None,
+                "offset {pack_offset} and distance {distance} cannot point to a pack entry"
+            );
+        }
     }
 }

--- a/gix-pack/src/data/file/init.rs
+++ b/gix-pack/src/data/file/init.rs
@@ -34,17 +34,19 @@ where
     /// This constructor leaves allocation limiting disabled, allowing allocations of any size dictated by pack data.
     /// Call [`File::with_alloc_limit_bytes()`][crate::data::File::with_alloc_limit_bytes()] before decoding entries from untrusted input.
     pub fn from_data(data: T, path: PathBuf, object_hash: gix_hash::Kind) -> Result<Self, data::header::decode::Error> {
-        use crate::data::header::N32_SIZE;
         let hash_len = object_hash.len_in_bytes();
         let pack_len = data.len();
         let id = gix_features::hash::crc32(path.as_os_str().to_string_lossy().as_bytes());
-        if pack_len < N32_SIZE * 3 + hash_len {
+        if pack_len < data::header::SIZE + hash_len {
             return Err(data::header::decode::Error::Corrupt(format!(
                 "Pack data of size {pack_len} is too small for even an empty pack with shortest hash"
             )));
         }
-        let (kind, num_objects) =
-            data::header::decode(&data[..12].try_into().expect("enough data after previous check"))?;
+        let (kind, num_objects) = data::header::decode(
+            &data[..data::header::SIZE]
+                .try_into()
+                .expect("enough data after previous check"),
+        )?;
         Ok(Self {
             data,
             path,

--- a/gix-pack/src/data/file/mod.rs
+++ b/gix-pack/src/data/file/mod.rs
@@ -6,4 +6,4 @@ pub mod verify;
 pub mod decode;
 
 /// The bytes used as header in a pack data file.
-pub type Header = [u8; 12];
+pub type Header = [u8; super::header::SIZE];

--- a/gix-pack/src/data/header.rs
+++ b/gix-pack/src/data/header.rs
@@ -2,8 +2,11 @@ use crate::data;
 
 pub(crate) const N32_SIZE: usize = std::mem::size_of::<u32>();
 
+/// The number of bytes in a pack file header.
+pub const SIZE: usize = b"PACK".len() + N32_SIZE * 2;
+
 /// Parses the first 12 bytes of a pack file, returning the pack version as well as the number of objects contained in the pack.
-pub fn decode(data: &[u8; 12]) -> Result<(data::Version, u32), decode::Error> {
+pub fn decode(data: &[u8; SIZE]) -> Result<(data::Version, u32), decode::Error> {
     let mut ofs = 0;
     if &data[ofs..ofs + b"PACK".len()] != b"PACK" {
         return Err(decode::Error::Corrupt("Pack data type not recognized".into()));
@@ -21,9 +24,9 @@ pub fn decode(data: &[u8; 12]) -> Result<(data::Version, u32), decode::Error> {
 }
 
 /// Write a pack data header at `version` with `num_objects` and return a buffer.
-pub fn encode(version: data::Version, num_objects: u32) -> [u8; 12] {
+pub fn encode(version: data::Version, num_objects: u32) -> [u8; SIZE] {
     use crate::data::Version::*;
-    let mut buf = [0u8; 12];
+    let mut buf = [0u8; SIZE];
     buf[..4].copy_from_slice(b"PACK");
     buf[4..8].copy_from_slice(
         &match version {

--- a/gix-pack/src/data/input/bytes_to_entries.rs
+++ b/gix-pack/src/data/input/bytes_to_entries.rs
@@ -51,7 +51,7 @@ where
         compressed: input::EntryDataMode,
         object_hash: gix_hash::Kind,
     ) -> Result<BytesToEntriesIter<BR>, input::Error> {
-        let mut header_data = [0u8; 12];
+        let mut header_data = [0u8; crate::data::header::SIZE];
         read.read_exact(&mut header_data).map_err(gix_hash::io::Error::from)?;
 
         let (version, num_objects) = crate::data::header::decode(&header_data)?;
@@ -59,7 +59,7 @@ where
             read,
             decompressor: Decompress::new(),
             compressed,
-            offset: 12,
+            offset: crate::data::header::SIZE as u64,
             had_error: false,
             version,
             objects_left: num_objects,

--- a/gix-pack/src/data/input/lookup_ref_delta_objects.rs
+++ b/gix-pack/src/data/input/lookup_ref_delta_objects.rs
@@ -130,10 +130,14 @@ where
                         if let Header::OfsDelta { base_distance } = entry.header {
                             // We have to find the new distance based on the previous distance to the base, using the absolute
                             // pack offset computed from it as stored in `base_pack_offset`.
-                            let base_pack_offset = entry
-                                .pack_offset
-                                .checked_sub(base_distance)
-                                .expect("distance to be in range of pack");
+                            let Some(base_pack_offset) =
+                                Header::verified_base_pack_offset(entry.pack_offset, base_distance)
+                            else {
+                                return Some(Err(input::Error::InvalidBaseDistance {
+                                    pack_offset: entry.pack_offset,
+                                    distance: base_distance,
+                                }));
+                            };
                             match self
                                 .inserted_entry_length_at_offset
                                 .binary_search_by_key(&base_pack_offset, |c| c.pack_offset)

--- a/gix-pack/src/data/input/types.rs
+++ b/gix-pack/src/data/input/types.rs
@@ -13,6 +13,8 @@ pub enum Error {
     IncompletePack { actual: u64, expected: u64 },
     #[error("The object {object_id} could not be decoded or wasn't found")]
     NotFound { object_id: gix_hash::ObjectId },
+    #[error("The OFS_DELTA base distance {distance} is invalid for pack offset {pack_offset}")]
+    InvalidBaseDistance { pack_offset: u64, distance: u64 },
 }
 
 /// Iteration Mode

--- a/gix-pack/src/data/output/entry/mod.rs
+++ b/gix-pack/src/data/output/entry/mod.rs
@@ -89,10 +89,14 @@ impl output::Entry {
             Tag => Some(output::entry::Kind::Base(gix_object::Kind::Tag)),
             OfsDelta { base_distance } => {
                 let pack_location = count.entry_pack_location.as_ref().expect("packed");
-                let base_offset = pack_location
-                    .pack_offset
-                    .checked_sub(base_distance)
-                    .expect("pack-offset - distance is firmly within the pack");
+                let Some(base_offset) =
+                    crate::data::entry::Header::verified_base_pack_offset(pack_location.pack_offset, base_distance)
+                else {
+                    return Some(Err(crate::data::entry::decode::Error::Corrupt {
+                        message: "an ofs-delta base distance pointing before pack start",
+                    }
+                    .into()));
+                };
                 potential_bases
                     .binary_search_by(|e| {
                         e.entry_pack_location

--- a/gix-pack/tests/pack/data/fuzzed.rs
+++ b/gix-pack/tests/pack/data/fuzzed.rs
@@ -6,6 +6,8 @@ use std::{
 
 use gix_pack::data;
 
+const FIRST_ENTRY_OFFSET: data::Offset = data::header::SIZE as data::Offset;
+
 #[test]
 fn artifact_inputs_can_be_opened_without_panicking() {
     for path in crate::fuzz_artifact_paths("data_file") {
@@ -45,7 +47,7 @@ fn oversized_pack_entry_header_is_reported_without_panicking() {
         gix_hash::Kind::Sha1,
     )
     .expect("pack header is syntactically valid");
-    let result = catch_unwind(AssertUnwindSafe(|| file.entry(12)));
+    let result = catch_unwind(AssertUnwindSafe(|| file.entry(FIRST_ENTRY_OFFSET)));
 
     assert!(
         result
@@ -76,10 +78,14 @@ fn non_canonical_pack_entry_header_is_accepted() {
     )
     .expect("pack header is syntactically valid");
     let entry = file
-        .entry(12)
+        .entry(FIRST_ENTRY_OFFSET)
         .expect("git-compatible non-canonical entry header is accepted");
     assert_eq!(entry.header_size(), 2, "the actual header size is retained");
-    assert_eq!(entry.pack_offset(), 12, "the entry start remains recoverable");
+    assert_eq!(
+        entry.pack_offset(),
+        FIRST_ENTRY_OFFSET,
+        "the entry start remains recoverable"
+    );
 
     let mut out = Vec::new();
     let outcome = file
@@ -111,7 +117,7 @@ fn oversized_declared_object_size_is_reported_without_panicking() {
     let file = data::File::from_data(bytes.as_slice(), PathBuf::from("fuzzed-oom.pack"), gix_hash::Kind::Sha1)
         .expect("pack header is syntactically valid")
         .with_alloc_limit_bytes(Some(4_000_000));
-    let entry = file.entry(12).expect("entry metadata is parseable");
+    let entry = file.entry(FIRST_ENTRY_OFFSET).expect("entry metadata is parseable");
 
     let result = catch_unwind(AssertUnwindSafe(|| {
         file.decode_entry(
@@ -157,7 +163,7 @@ fn declared_object_size_over_alloc_limit_bytes_is_reported_as_out_of_memory() {
     )
     .expect("pack header is syntactically valid")
     .with_alloc_limit_bytes(Some(64));
-    let entry = file.entry(12).expect("entry metadata is parseable");
+    let entry = file.entry(FIRST_ENTRY_OFFSET).expect("entry metadata is parseable");
 
     let result = catch_unwind(AssertUnwindSafe(|| {
         file.decode_entry(
@@ -194,7 +200,7 @@ fn runaway_delta_allocation_is_rejected_with_fuzz_alloc_limit() {
     .expect("pack header is syntactically valid")
     .with_alloc_limit_bytes(Some(64 * 1024 * 1024));
     let len = bytes.len() as u64;
-    let mut offsets = vec![0, 12.min(len - 1), (len - 1) / 2];
+    let mut offsets = vec![0, FIRST_ENTRY_OFFSET.min(len - 1), (len - 1) / 2];
     let mut first_eight = [0u8; 8];
     first_eight.copy_from_slice(&bytes[..8]);
     offsets.push(u64::from_le_bytes(first_eight) % len);
@@ -248,7 +254,7 @@ fn invalid_ofs_delta_base_distance_is_reported_without_panicking() {
     )
     .expect("pack header is syntactically valid")
     .with_alloc_limit_bytes(Some(8 * 1024 * 1024));
-    let entry = file.entry(12).expect("entry metadata is parseable");
+    let entry = file.entry(FIRST_ENTRY_OFFSET).expect("entry metadata is parseable");
 
     let result = catch_unwind(AssertUnwindSafe(|| {
         file.decode_entry(
@@ -296,7 +302,7 @@ fn out_of_bounds_entry_data_offset_is_reported_without_panicking() {
     .expect("pack header is syntactically valid")
     .with_alloc_limit_bytes(Some(8 * 1024 * 1024));
     let len = data.len() as u64;
-    let mut offsets = vec![0, 12.min(len - 1), (len - 1) / 2];
+    let mut offsets = vec![0, FIRST_ENTRY_OFFSET.min(len - 1), (len - 1) / 2];
     let mut first_eight = [0u8; 8];
     first_eight.copy_from_slice(&data[..8]);
     offsets.push(u64::from_le_bytes(first_eight) % len);
@@ -354,7 +360,7 @@ fn malformed_delta_instruction_relocation_is_reported_without_panicking() {
     .with_alloc_limit_bytes(Some(8 * 1024 * 1024));
 
     let len = data.len() as u64;
-    let mut offsets = vec![0, 12.min(len - 1), (len - 1) / 2];
+    let mut offsets = vec![0, FIRST_ENTRY_OFFSET.min(len - 1), (len - 1) / 2];
     let mut first_eight = [0u8; 8];
     first_eight.copy_from_slice(&data[..8]);
     offsets.push(u64::from_le_bytes(first_eight) % len);
@@ -415,7 +421,7 @@ fn runaway_delta_chain_is_reported_without_panicking() {
     .with_alloc_limit_bytes(Some(8 * 1024 * 1024));
 
     let len = data.len() as u64;
-    let mut offsets = vec![0, 12.min(len - 1), (len - 1) / 2];
+    let mut offsets = vec![0, FIRST_ENTRY_OFFSET.min(len - 1), (len - 1) / 2];
     let mut first_eight = [0u8; 8];
     first_eight.copy_from_slice(&data[..8]);
     offsets.push(u64::from_le_bytes(first_eight) % len);
@@ -466,7 +472,7 @@ fn overlong_delta_header_size_is_reported_without_panicking() {
     .with_alloc_limit_bytes(Some(8 * 1024 * 1024));
 
     let len = data.len() as u64;
-    let mut offsets = vec![0, 12.min(len - 1), (len - 1) / 2];
+    let mut offsets = vec![0, FIRST_ENTRY_OFFSET.min(len - 1), (len - 1) / 2];
     let mut first_eight = [0u8; 8];
     first_eight.copy_from_slice(&data[..8]);
     offsets.push(u64::from_le_bytes(first_eight) % len);
@@ -526,7 +532,7 @@ fn short_delta_application_is_reported_without_panicking() {
 
     let delta_pack_offset = bytes.len() as u64;
     data::entry::Header::OfsDelta {
-        base_distance: delta_pack_offset - 12,
+        base_distance: delta_pack_offset - FIRST_ENTRY_OFFSET,
     }
     .write_to(delta_payload.len() as u64, &mut bytes)
     .expect("header write succeeds");

--- a/gix-pack/tests/pack/data/header.rs
+++ b/gix-pack/tests/pack/data/header.rs
@@ -5,7 +5,7 @@ fn encode_decode_roundtrip() -> crate::Result {
     let buf = std::fs::read(fixture_path(
         "objects/pack/pack-11fdfa9e156ab73caae3b6da867192221f2089c2.pack",
     ))?;
-    let expected_encoded_header = &buf[..12];
+    let expected_encoded_header = &buf[..gix_pack::data::header::SIZE];
     let (version, num_objects) = gix_pack::data::header::decode(expected_encoded_header.try_into()?)?;
     let actual_encoded_header = gix_pack::data::header::encode(version, num_objects);
     assert_eq!(actual_encoded_header, expected_encoded_header);

--- a/gix-pack/tests/pack/data/input.rs
+++ b/gix-pack/tests/pack/data/input.rs
@@ -182,6 +182,33 @@ mod lookup_ref_delta_objects {
     }
 
     #[test]
+    fn invalid_ofs_delta_base_distance_is_reported_after_base_insertion() {
+        for distance in [0, u64::MAX] {
+            let input = compute_offsets(vec![
+                entry(delta_ref(gix_hash::Kind::Sha1.null()), D_A),
+                entry(delta_ofs(distance), D_B),
+            ]);
+            let calls = AtomicUsize::default();
+            let db = FindData::new(D_D, &calls);
+
+            let result =
+                LookupRefDeltaObjectsIter::new(into_results_iter(input), &db, gix_zlib::Compression::BEST_SPEED)
+                    .collect::<Result<Vec<_>, _>>();
+
+            assert!(
+                matches!(
+                    result,
+                    Err(input::Error::InvalidBaseDistance {
+                        distance: actual,
+                        ..
+                    }) if actual == distance
+                ),
+                "zero and out-of-bounds base distances are rejected as corrupt pack data"
+            );
+        }
+    }
+
+    #[test]
     fn missing_bases_are_left_for_in_pack_resolution() {
         let input = compute_offsets(vec![
             entry(delta_ref(gix_hash::Kind::Sha1.null()), D_A),

--- a/gix-pack/tests/pack/data/output/count_and_entries.rs
+++ b/gix-pack/tests/pack/data/output/count_and_entries.rs
@@ -16,6 +16,46 @@ use crate::{
 };
 
 #[test]
+fn invalid_ofs_delta_base_distance_is_an_error() -> crate::Result {
+    let mut data = Vec::new();
+    gix_pack::data::entry::Header::OfsDelta {
+        base_distance: u64::MAX,
+    }
+    .write_to(0, &mut data)?;
+    let count = output::Count::from_data(
+        object_hash().null(),
+        Some(gix_pack::data::entry::Location {
+            pack_id: 0,
+            entry_size: data.len(),
+            pack_offset: 12,
+        }),
+    );
+
+    let result = output::Entry::from_pack_entry(
+        gix_pack::find::Entry {
+            data,
+            version: gix_pack::data::Version::V2,
+        },
+        &count,
+        &[],
+        0,
+        None::<fn(u32, u64) -> Option<gix_hash::ObjectId>>,
+        gix_pack::data::Version::V2,
+    );
+
+    assert!(
+        matches!(
+            result,
+            Some(Err(entry::Error::EntryType(
+                gix_pack::data::entry::decode::Error::Corrupt { .. }
+            )))
+        ),
+        "an invalid packed delta is reported as corrupt"
+    );
+    Ok(())
+}
+
+#[test]
 fn traversals() -> crate::Result {
     #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
     struct Count {

--- a/gix-pack/tests/pack/data/output/count_and_entries.rs
+++ b/gix-pack/tests/pack/data/output/count_and_entries.rs
@@ -17,7 +17,8 @@ use crate::{
 
 #[test]
 fn invalid_ofs_delta_base_distance_is_an_error() -> crate::Result {
-    for base_distance in [12, u64::MAX] {
+    let first_entry_offset = gix_pack::data::header::SIZE as gix_pack::data::Offset;
+    for base_distance in [first_entry_offset, u64::MAX] {
         let mut data = Vec::new();
         gix_pack::data::entry::Header::OfsDelta { base_distance }.write_to(0, &mut data)?;
         let count = output::Count::from_data(
@@ -25,7 +26,7 @@ fn invalid_ofs_delta_base_distance_is_an_error() -> crate::Result {
             Some(gix_pack::data::entry::Location {
                 pack_id: 0,
                 entry_size: data.len(),
-                pack_offset: 12,
+                pack_offset: first_entry_offset,
             }),
         );
 

--- a/gix-pack/tests/pack/data/output/count_and_entries.rs
+++ b/gix-pack/tests/pack/data/output/count_and_entries.rs
@@ -17,41 +17,40 @@ use crate::{
 
 #[test]
 fn invalid_ofs_delta_base_distance_is_an_error() -> crate::Result {
-    let mut data = Vec::new();
-    gix_pack::data::entry::Header::OfsDelta {
-        base_distance: u64::MAX,
+    for base_distance in [12, u64::MAX] {
+        let mut data = Vec::new();
+        gix_pack::data::entry::Header::OfsDelta { base_distance }.write_to(0, &mut data)?;
+        let count = output::Count::from_data(
+            object_hash().null(),
+            Some(gix_pack::data::entry::Location {
+                pack_id: 0,
+                entry_size: data.len(),
+                pack_offset: 12,
+            }),
+        );
+
+        let result = output::Entry::from_pack_entry(
+            gix_pack::find::Entry {
+                data,
+                version: gix_pack::data::Version::V2,
+            },
+            &count,
+            &[],
+            0,
+            None::<fn(u32, u64) -> Option<gix_hash::ObjectId>>,
+            gix_pack::data::Version::V2,
+        );
+
+        assert!(
+            matches!(
+                result,
+                Some(Err(entry::Error::EntryType(
+                    gix_pack::data::entry::decode::Error::Corrupt { .. }
+                )))
+            ),
+            "an invalid packed delta is reported as corrupt"
+        );
     }
-    .write_to(0, &mut data)?;
-    let count = output::Count::from_data(
-        object_hash().null(),
-        Some(gix_pack::data::entry::Location {
-            pack_id: 0,
-            entry_size: data.len(),
-            pack_offset: 12,
-        }),
-    );
-
-    let result = output::Entry::from_pack_entry(
-        gix_pack::find::Entry {
-            data,
-            version: gix_pack::data::Version::V2,
-        },
-        &count,
-        &[],
-        0,
-        None::<fn(u32, u64) -> Option<gix_hash::ObjectId>>,
-        gix_pack::data::Version::V2,
-    );
-
-    assert!(
-        matches!(
-            result,
-            Some(Err(entry::Error::EntryType(
-                gix_pack::data::entry::decode::Error::Corrupt { .. }
-            )))
-        ),
-        "an invalid packed delta is reported as corrupt"
-    );
     Ok(())
 }
 

--- a/gix-pack/tests/pack/malformed.rs
+++ b/gix-pack/tests/pack/malformed.rs
@@ -6,6 +6,8 @@ use std::{
 
 use gix_pack::{cache, data};
 
+const FIRST_ENTRY_OFFSET: data::Offset = data::header::SIZE as data::Offset;
+
 /// Reproducer for GHSA-x494-mj8g-cj27: malformed delta copy instructions currently reach
 /// `gix_pack::data::File::decode_entry()` and panic while slicing the base object instead of
 /// returning an error for attacker-controlled pack data.
@@ -13,7 +15,7 @@ use gix_pack::{cache, data};
 fn delta_copy_is_reported_without_panicking() -> crate::Result {
     let pack_data = ref_delta_pack(&[1, 2, 0x90, 0x02])?;
     let pack = data::File::from_data(pack_data, PathBuf::from("malformed.pack"), gix_hash::Kind::Sha1)?;
-    let entry = pack.entry(12)?;
+    let entry = pack.entry(FIRST_ENTRY_OFFSET)?;
     let mut out = Vec::new();
     let mut inflate = gix_zlib::Inflate::default();
 
@@ -41,7 +43,7 @@ fn oversized_delta_result_is_rejected_without_panicking() -> crate::Result {
 
     let pack_data = ref_delta_pack(&delta)?;
     let pack = data::File::from_data(pack_data, PathBuf::from("malformed.pack"), gix_hash::Kind::Sha1)?;
-    let entry = pack.entry(12)?;
+    let entry = pack.entry(FIRST_ENTRY_OFFSET)?;
     let mut out = Vec::new();
     let mut inflate = gix_zlib::Inflate::default();
 
@@ -64,7 +66,7 @@ fn oversized_delta_result_is_rejected_without_panicking() -> crate::Result {
 fn truncated_delta_header_ignores_zero_filled_remainder() -> crate::Result {
     let pack_data = ref_delta_pack_with_declared_size(&[1, 0x80], 3)?;
     let pack = data::File::from_data(pack_data, PathBuf::from("malformed.pack"), gix_hash::Kind::Sha1)?;
-    let entry = pack.entry(12)?;
+    let entry = pack.entry(FIRST_ENTRY_OFFSET)?;
     let mut out = Vec::new();
     let mut inflate = gix_zlib::Inflate::default();
 
@@ -85,7 +87,7 @@ fn complete_delta_with_mismatched_declared_size_is_rejected() -> crate::Result {
     ] {
         let pack_data = ref_delta_pack_with_declared_size(delta, decompressed_size)?;
         let pack = data::File::from_data(pack_data, PathBuf::from("malformed.pack"), gix_hash::Kind::Sha1)?;
-        let entry = pack.entry(12)?;
+        let entry = pack.entry(FIRST_ENTRY_OFFSET)?;
         let mut out = Vec::new();
         let mut inflate = gix_zlib::Inflate::default();
 
@@ -104,7 +106,7 @@ fn plain_object_with_mismatched_declared_size_is_rejected() -> crate::Result {
     for (blob, decompressed_size) in [(b"A".as_slice(), 2), (b"AB".as_slice(), 1)] {
         let pack_data = blob_pack_with_declared_size(blob, decompressed_size)?;
         let pack = data::File::from_data(pack_data, PathBuf::from("malformed.pack"), gix_hash::Kind::Sha1)?;
-        let entry = pack.entry(12)?;
+        let entry = pack.entry(FIRST_ENTRY_OFFSET)?;
         let mut out = Vec::new();
         let mut inflate = gix_zlib::Inflate::default();
 
@@ -122,7 +124,7 @@ fn plain_object_with_mismatched_declared_size_is_rejected() -> crate::Result {
 fn empty_plain_object_is_accepted() -> crate::Result {
     let pack_data = blob_pack_with_declared_size(b"", 0)?;
     let pack = data::File::from_data(pack_data, PathBuf::from("malformed.pack"), gix_hash::Kind::Sha1)?;
-    let entry = pack.entry(12)?;
+    let entry = pack.entry(FIRST_ENTRY_OFFSET)?;
     let mut out = Vec::new();
     let mut inflate = gix_zlib::Inflate::default();
 
@@ -141,7 +143,7 @@ fn delta_with_mismatched_base_size_is_rejected_before_allocating_work_buffers() 
     delta.extend([1, 0x90, 1]);
     let pack_data = ref_delta_pack(&delta)?;
     let pack = data::File::from_data(pack_data, PathBuf::from("malformed.pack"), gix_hash::Kind::Sha1)?;
-    let entry = pack.entry(12)?;
+    let entry = pack.entry(FIRST_ENTRY_OFFSET)?;
     let mut out = Vec::new();
     let mut inflate = gix_zlib::Inflate::default();
 
@@ -183,7 +185,7 @@ fn in_pack_delta_base_with_mismatched_declared_size_is_rejected() -> crate::Resu
 fn decode_header_ignores_zero_filled_delta_remainder() -> crate::Result {
     let pack_data = ref_delta_pack_with_declared_size(&[1, 0x80], 3)?;
     let pack = data::File::from_data(pack_data, PathBuf::from("malformed.pack"), gix_hash::Kind::Sha1)?;
-    let entry = pack.entry(12)?;
+    let entry = pack.entry(FIRST_ENTRY_OFFSET)?;
     let mut inflate = gix_zlib::Inflate::default();
 
     let res = pack.decode_header(entry, &mut inflate, &resolve_external_header_blob);
@@ -211,7 +213,7 @@ fn decode_header_with_mismatched_declared_delta_size_is_rejected() -> crate::Res
     ] {
         let pack_data = ref_delta_pack_with_declared_size(delta, decompressed_size)?;
         let pack = data::File::from_data(pack_data, PathBuf::from("malformed.pack"), gix_hash::Kind::Sha1)?;
-        let entry = pack.entry(12)?;
+        let entry = pack.entry(FIRST_ENTRY_OFFSET)?;
         let mut inflate = gix_zlib::Inflate::default();
 
         let res = pack.decode_header(entry, &mut inflate, &resolve_external_header_blob);
@@ -227,7 +229,7 @@ fn large_mismatched_declared_delta_size_is_rejected_during_full_decode() -> crat
         let delta = padded_delta(delta_len);
         let pack_data = ref_delta_pack_with_declared_size(&delta, decompressed_size)?;
         let pack = data::File::from_data(pack_data, PathBuf::from("malformed.pack"), gix_hash::Kind::Sha1)?;
-        let entry = pack.entry(12)?;
+        let entry = pack.entry(FIRST_ENTRY_OFFSET)?;
         let mut inflate = gix_zlib::Inflate::default();
 
         let outcome = pack.decode_header(entry.clone(), &mut inflate, &resolve_external_header_blob)?;


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Advisory

https://github.com/GitoxideLabs/gitoxide/security/advisories/GHSA-mpf5-465h-mr53

GHSA-mpf5-465h-mr53 reports a reachable panic when malformed `OFS_DELTA` base distances are processed during thin-pack handling.

### Advisory summary

- Severity: medium
- Package: `gix-pack`
- Affected versions: `<= 0.74.2`
- Patched versions: not assigned yet
- CVE: not assigned

## Changes

- Reject invalid delta base distances during thin-pack base insertion.
- Preserve the existing public `input::Error` enum shape.
- Harden the two analogous raw-pack consumers found during audit: delta-tree verification and pack-copy generation.

## Validation

- `cargo test -p gix-pack` — 18 unit and 93 integration tests passed.
- `cargo clippy -p gix-pack --all-targets -- -D warnings` passed; only the existing removed-lint warning was emitted.
- Each commit was reviewed once with `codex review --commit`.

Git baseline: `f78ce2f7b6df702f93d40b85d6bda92a3f65da79`; Git rejects delta base offsets outside the pack prefix in `builtin/index-pack.c` and `packfile.c`.

## Commits

- `48d2c40fa6` fixes the advisory path and adds the regression.
- `db68bae1ca` preserves public error-enum compatibility after review.
- `76e4a3cd38` fixes the analogous consumers in a separate commit.