### PR TITLE
fix(gix-pack): accept pack version 3 without panicking

### DIFF
--- a/gix-pack/src/data/input/bytes_to_entries.rs
+++ b/gix-pack/src/data/input/bytes_to_entries.rs
@@ -55,11 +55,6 @@ where
         read.read_exact(&mut header_data).map_err(gix_hash::io::Error::from)?;
 
         let (version, num_objects) = crate::data::header::decode(&header_data)?;
-        assert_eq!(
-            version,
-            crate::data::Version::V2,
-            "let's stop here if we see undocumented pack formats"
-        );
         Ok(BytesToEntriesIter {
             read,
             decompressor: Decompress::new(),

--- a/gix-pack/src/data/input/entries_to_bytes.rs
+++ b/gix-pack/src/data/input/entries_to_bytes.rs
@@ -34,15 +34,7 @@ where
     /// `output` writer, resembling a pack of `version`. The amount of entries will be dynamically determined and
     /// the pack is completed once the last entry was written.
     /// `object_hash` is the kind of hash to use for the pack checksum and maybe other places, depending on the version.
-    ///
-    /// # Panics
-    ///
-    /// Only [Version::V2](crate::data::Version::V2) is allowed for `version.
     pub fn new(input: I, output: W, version: crate::data::Version, object_hash: gix_hash::Kind) -> Self {
-        assert!(
-            matches!(version, crate::data::Version::V2),
-            "currently only pack version 2 can be written",
-        );
         EntriesToBytesIter {
             input: input.peekable(),
             output,

--- a/gix-pack/src/data/mod.rs
+++ b/gix-pack/src/data/mod.rs
@@ -76,7 +76,7 @@ pub enum Version {
     V2,
     /// A pack data version accepted by Git and recognized by `gix-pack` readers.
     ///
-    /// Git does not generate this version, and `gix-pack` writers currently reject it.
+    /// Git does not generate this version.
     /// Entries are decoded with the same layout as [`V2`](Version::V2); the difference
     /// visible to this crate is the version number stored in the pack header.
     V3,

--- a/gix-pack/src/data/output/bytes.rs
+++ b/gix-pack/src/data/output/bytes.rs
@@ -51,10 +51,6 @@ where
     ///
     /// The input chunks are expected to be sorted already. You can use the [`InOrderIter`][gix_features::parallel::InOrderIter] to assure
     /// this happens on the fly holding entire chunks in memory as long as needed for them to be dispensed in order.
-    ///
-    /// # Panics
-    ///
-    /// Not all combinations of `object_hash` and `version` are supported currently triggering assertion errors.
     pub fn new(
         input: I,
         output: W,
@@ -62,10 +58,6 @@ where
         version: crate::data::Version,
         object_hash: gix_hash::Kind,
     ) -> Self {
-        assert!(
-            matches!(version, crate::data::Version::V2),
-            "currently only pack version 2 can be written",
-        );
         FromEntriesIter {
             input,
             output: gix_hash::io::Write::new(output, object_hash),

--- a/gix-pack/src/data/output/entry/iter_from_counts.rs
+++ b/gix-pack/src/data/output/entry/iter_from_counts.rs
@@ -59,10 +59,6 @@ pub(crate) mod function {
     where
         Find: crate::Find + Send + Clone + 'static,
     {
-        assert!(
-            matches!(version, crate::data::Version::V2),
-            "currently we can only write version 2"
-        );
         let (chunk_size, thread_limit, _) =
             parallel::optimize_chunk_size_and_thread_limit(chunk_size, Some(counts.len()), thread_limit, None);
         {

--- a/gix-pack/src/data/output/entry/mod.rs
+++ b/gix-pack/src/data/output/entry/mod.rs
@@ -61,7 +61,8 @@ impl output::Entry {
     }
 
     /// Create an Entry from a previously counted object which is located in a pack. It's `entry` is provided here.
-    /// The `version` specifies what kind of target `Entry` version the caller desires.
+    /// The `target_version` specifies what kind of target `Entry` version the caller desires. Both supported versions use
+    /// the same entry encoding.
     pub fn from_pack_entry(
         mut entry: find::Entry,
         count: &output::Count,
@@ -158,21 +159,16 @@ impl output::Entry {
         })
     }
 
-    /// Transform ourselves into pack entry header of `version` which can be written into a pack.
+    /// Transform ourselves into a pack entry header which can be written into a pack of `version`.
     ///
     /// `index_to_pack(object_index) -> pack_offset` is a function to convert the base object's index into
     /// the input object array (if each object is numbered) to an offset into the pack.
     /// This information is known to the one calling the method.
     pub fn to_entry_header(
         &self,
-        version: data::Version,
+        _version: data::Version,
         index_to_base_distance: impl FnOnce(usize) -> u64,
     ) -> data::entry::Header {
-        assert!(
-            matches!(version, data::Version::V2),
-            "we can only write V2 pack entries for now"
-        );
-
         use Kind::*;
         match self.kind {
             Base(kind) => {

--- a/gix-pack/tests/pack/bundle.rs
+++ b/gix-pack/tests/pack/bundle.rs
@@ -168,7 +168,7 @@ mod write_to_directory {
                 &[b"A".as_slice(), b"B".as_slice()][..],
                 &[b"A".as_slice(), b"B".as_slice(), b"C".as_slice()][..],
             ] {
-                let pack_data = ref_delta_pack(object_hash, objects)?;
+                let pack_data = ref_delta_pack(object_hash, objects, pack::data::Version::V2)?;
                 for lookup in [None, Some(gix_object::find::Never)] {
                     let dir = TempDir::new()?;
                     let mut input = Cursor::new(pack_data.clone());
@@ -215,6 +215,34 @@ mod write_to_directory {
                 }
             }
         }
+        Ok(())
+    }
+
+    #[test]
+    fn version_3_with_thin_pack_lookup() -> Result<(), Box<dyn std::error::Error>> {
+        let object_hash = gix_hash::Kind::Sha1;
+        let pack_data = ref_delta_pack(
+            object_hash,
+            &[b"A".as_slice(), b"B".as_slice()],
+            pack::data::Version::V3,
+        )?;
+        let outcome = pack::Bundle::write_to_directory(
+            &mut Cursor::new(pack_data),
+            Some(TempDir::new()?.as_ref()),
+            &mut progress::Discard,
+            &AtomicBool::new(false),
+            Some(gix_object::find::Never),
+            object_hash,
+            pack::bundle::write::Options {
+                iteration_mode: pack::data::input::Mode::Verify,
+                ..Default::default()
+            },
+        )?;
+        assert_eq!(
+            outcome.pack_version,
+            pack::data::Version::V3,
+            "the rewritten pack preserves its supported input version"
+        );
         Ok(())
     }
 
@@ -329,8 +357,9 @@ mod write_to_directory {
     fn ref_delta_pack(
         object_hash: gix_hash::Kind,
         objects: &[&'static [u8]],
+        version: pack::data::Version,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-        let mut pack_data = pack::data::header::encode(pack::data::Version::V2, objects.len() as u32).to_vec();
+        let mut pack_data = pack::data::header::encode(version, objects.len() as u32).to_vec();
         for pair in objects.windows(2).rev() {
             let (base, resolved) = (pair[0], pair[1]);
             let base_id = gix_object::compute_hash(object_hash, gix_object::Kind::Blob, base)?;

--- a/gix-pack/tests/pack/iter.rs
+++ b/gix-pack/tests/pack/iter.rs
@@ -103,6 +103,30 @@ mod new_from_header {
     }
 
     #[test]
+    fn version_3_is_accepted() -> Result<(), Box<dyn std::error::Error>> {
+        let mut data = fs::read(fixture_path(SMALL_PACK))?;
+        data[4..8].copy_from_slice(&3u32.to_be_bytes());
+
+        let iter = pack::data::input::BytesToEntriesIter::new_from_header(
+            std::io::BufReader::new(data.as_slice()),
+            Mode::AsIs,
+            EntryDataMode::Ignore,
+            gix_hash::Kind::Sha1,
+        )?;
+        assert_eq!(
+            iter.version(),
+            pack::data::Version::V3,
+            "Git accepts pack version 3 with the version 2 entry layout"
+        );
+        assert_eq!(
+            iter.collect::<Result<Vec<_>, _>>()?.len(),
+            42,
+            "all entries should be readable"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn restore_missing_trailer() -> Result<(), Box<dyn std::error::Error>> {
         let pack = fs::read(fixture_path(SMALL_PACK))?;
         let mut iter = pack::data::input::BytesToEntriesIter::new_from_header(


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Advisory

https://github.com/GitoxideLabs/gitoxide/security/advisories/GHSA-633h-mqjc-8rwg

GHSA-633h-mqjc-8rwg reports a remotely reachable panic while handling a supported pack version.

### Advisory summary

- Severity: medium
- Package: `gix-pack`
- Affected versions: `<= 0.74.2`
- Patched versions: not yet assigned
- CVE: not yet assigned

## Changes

- Accept version 3 in streaming pack input, matching the shared decoder and Git.
- Remove equivalent stale V2-only assertions from pack-writing paths.
- Cover complete V3 iteration and V3 thin-pack rewriting.

Git baseline: `pack_version_ok_native()` in Git at `f78ce2f7b6` accepts pack versions 2 and 3 with the same entry layout.

## Commits

- `f8e6523dae` — `fix(gix-pack): accept version 3 in streaming pack input`
- `7e918e8eb0` — `fix(gix-pack): support version 3 across pack writers`

## Validation

- `cargo test -p gix-pack`
- `cargo clippy -p gix-pack --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- One Codex review per commit; the second commit resolves the first review finding, and its review found no actionable regression.
