### PR TITLE
fix(gix-object): invoke signature programs without a shell

### DIFF
--- a/gix-object/src/signature/sign.rs
+++ b/gix-object/src/signature/sign.rs
@@ -16,7 +16,7 @@ use super::Format;
 pub struct Options {
     /// The signature format.
     pub format: Format,
-    /// The external signing program or command.
+    /// The external signing program.
     pub program: OsString,
     /// Additional arguments passed to the signing program before Git's fixed arguments.
     pub program_arguments: Vec<OsString>,
@@ -111,9 +111,7 @@ fn sign(payload: &[u8], options: &Options) -> Result<BString, Error> {
 
 fn command(options: &Options) -> gix_command::Prepare {
     options.environment.iter().fold(
-        gix_command::prepare(&options.program)
-            .command_may_be_shell_script()
-            .args(&options.program_arguments),
+        gix_command::prepare(&options.program).args(&options.program_arguments),
         |command, (key, value)| command.env(key, value),
     )
 }
@@ -267,4 +265,33 @@ fn strip_cr_before_lf(input: Vec<u8>) -> Vec<u8> {
         }
     }
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn programs_with_spaces_are_invoked_directly() {
+        let program = OsStr::new("a directory/signer");
+        let command: std::process::Command = command(&Options {
+            format: Format::OpenPgp,
+            program: program.into(),
+            program_arguments: vec!["argument with spaces".into()],
+            signing_key: "key".into(),
+            environment: Vec::new(),
+        })
+        .into();
+
+        assert_eq!(
+            command.get_program(),
+            program,
+            "a signer pathname is passed directly instead of being interpreted by a shell"
+        );
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            [OsStr::new("argument with spaces")],
+            "signer arguments remain separate from the program pathname"
+        );
+    }
 }

--- a/gix-object/src/signature/verify.rs
+++ b/gix-object/src/signature/verify.rs
@@ -17,7 +17,7 @@ use super::Format;
 pub enum Options {
     /// Verify an OpenPGP signature.
     OpenPgp {
-        /// The external verification program or command.
+        /// The external verification program.
         program: OsString,
         /// Additional arguments passed before Git's fixed arguments.
         ///
@@ -30,7 +30,7 @@ pub enum Options {
     },
     /// Verify an X.509 signature.
     X509 {
-        /// The external verification program or command.
+        /// The external verification program.
         program: OsString,
         /// Additional arguments passed before Git's fixed arguments, useful for selecting an alternate key store or
         /// configuring a wrapper around the verifier.
@@ -42,7 +42,7 @@ pub enum Options {
     },
     /// Verify an SSH signature.
     Ssh {
-        /// The external verification program or command.
+        /// The external verification program.
         program: OsString,
         /// Additional arguments passed before Git's fixed arguments, useful for selecting an alternate key store or
         /// configuring a wrapper around the verifier.
@@ -437,9 +437,7 @@ fn prepare(
     environment: &[(OsString, OsString)],
 ) -> gix_command::Prepare {
     environment.iter().fold(
-        gix_command::prepare(program)
-            .command_may_be_shell_script()
-            .args(arguments),
+        gix_command::prepare(program).args(arguments),
         |command, (key, value)| command.env(key, value),
     )
 }
@@ -686,8 +684,12 @@ mod tests {
         let outcome = signed.verify(
             BStr::new(b"-----BEGIN SSH SIGNATURE-----\n"),
             Options::Ssh {
-                program: r#"if [ "$2" = find-principals ]; then printf 'fixture\n'; else printf 'Good "git" signature for fixture with ED25519 key SHA256:fixture\n'; exit 1; fi # "$@""#.into(),
-                program_arguments: Vec::new(),
+                program: gix_testtools::bash_program().into(),
+                program_arguments: vec![
+                    "-c".into(),
+                    r#"if [ "$2" = find-principals ]; then printf 'fixture\n'; else printf 'Good "git" signature for fixture with ED25519 key SHA256:fixture\n'; exit 1; fi"#.into(),
+                    "bash".into(),
+                ],
                 environment: Vec::new(),
                 allowed_signers: "unused".into(),
                 revocation_file: None,
@@ -698,6 +700,23 @@ mod tests {
         assert_eq!(outcome.status, Status::Good, "the verifier's text is retained");
         assert!(!outcome.is_valid(), "a failed verifier cannot produce a valid outcome");
         Ok(())
+    }
+
+    #[test]
+    fn programs_with_spaces_are_invoked_directly() {
+        let program = OsStr::new("a directory/verifier");
+        let command: std::process::Command = prepare(program, ["argument with spaces".into()], &[]).into();
+
+        assert_eq!(
+            command.get_program(),
+            program,
+            "a verifier pathname is passed directly instead of being interpreted by a shell"
+        );
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            [OsStr::new("argument with spaces")],
+            "verifier arguments remain separate from the program pathname"
+        );
     }
 
     #[test]

--- a/gix/src/commit/mod.rs
+++ b/gix/src/commit/mod.rs
@@ -10,6 +10,30 @@ pub mod sign;
 #[cfg(feature = "command")]
 pub mod verify;
 
+#[cfg(feature = "command")]
+fn signature_program(
+    config: &crate::config::Snapshot<'_>,
+    format: gix_object::signature::Format,
+) -> Result<std::ffi::OsString, gix_config::path::interpolate::Error> {
+    use crate::config::tree::{Gpg, Key, gpg};
+    use gix_object::signature::Format;
+
+    let (program, default) = match format {
+        Format::OpenPgp => (
+            match config.trusted_path(gpg::OpenPgp::PROGRAM)? {
+                Some(program) => Some(program),
+                None => config.trusted_path(Gpg::PROGRAM)?,
+            },
+            &gpg::OpenPgp::PROGRAM,
+        ),
+        Format::X509 => (config.trusted_path(gpg::X509::PROGRAM)?, &gpg::X509::PROGRAM),
+        Format::Ssh => (config.trusted_path(gpg::Ssh::PROGRAM)?, &gpg::Ssh::PROGRAM),
+    };
+    Ok(program
+        .unwrap_or_else(|| gix_path::from_bstr(default.default_value_or_panic()).into_owned())
+        .into_os_string())
+}
+
 /// An empty array of a type usable with the `gix::easy` API to help declaring no parents should be used
 pub const NO_PARENT_IDS: [gix_hash::ObjectId; 0] = [];
 

--- a/gix/src/commit/sign.rs
+++ b/gix/src/commit/sign.rs
@@ -74,20 +74,7 @@ pub(crate) fn signing_options(repo: &crate::Repository) -> Result<Options, optio
         .string(Gpg::FORMAT)
         .unwrap_or_else(|| Gpg::FORMAT.default_value_or_panic().into());
     let format = parse_format(format.trim()).ok_or(Error::UnsupportedFormat(format))?;
-    let program = match format {
-        Format::OpenPgp => match config.trusted_path(gpg::OpenPgp::PROGRAM)? {
-            Some(program) => program.into_os_string(),
-            None => config
-                .trusted_path(Gpg::PROGRAM)?
-                .map_or_else(|| default_program(&gpg::OpenPgp::PROGRAM), PathBuf::into_os_string),
-        },
-        Format::X509 => config
-            .trusted_path(gpg::X509::PROGRAM)?
-            .map_or_else(|| default_program(&gpg::X509::PROGRAM), PathBuf::into_os_string),
-        Format::Ssh => config
-            .trusted_path(gpg::Ssh::PROGRAM)?
-            .map_or_else(|| default_program(&gpg::Ssh::PROGRAM), PathBuf::into_os_string),
-    };
+    let program = super::signature_program(&config, format)?;
     let signing_key = match config
         .plumbing()
         .string_filter(User::SIGNING_KEY, &mut repo.filter_config_section())
@@ -120,12 +107,6 @@ pub(crate) fn signing_options_if_enabled(repo: &crate::Repository) -> Result<Opt
         .may_sign_commits()?
         .then(|| signing_options(repo))
         .transpose()
-}
-
-fn default_program(key: &crate::config::tree::keys::Program) -> OsString {
-    gix_path::from_bstr(key.default_value_or_panic())
-        .into_owned()
-        .into_os_string()
 }
 
 fn parse_format(value: &[u8]) -> Option<Format> {

--- a/gix/src/commit/verify.rs
+++ b/gix/src/commit/verify.rs
@@ -1,6 +1,6 @@
-use std::{ffi::OsString, path::PathBuf};
+use std::path::PathBuf;
 
-use crate::config::tree::{Gpg, Key, gpg};
+use crate::config::tree::{Gpg, gpg};
 
 pub use gix_object::signature::{
     Format,
@@ -36,20 +36,16 @@ pub(crate) fn verify(commit: &crate::Commit<'_>) -> Result<Option<Outcome>, Erro
         .transpose()?
         .unwrap_or_default();
     let format = Format::from_signature(&signature).ok_or(gix_object::signature::verify::Error::UnsupportedFormat)?;
+    let program = super::signature_program(&config, format)?;
     let options = match format {
         Format::OpenPgp => gix_object::signature::verify::Options::OpenPgp {
-            program: config
-                .trusted_program(gpg::OpenPgp::PROGRAM)
-                .or_else(|| config.trusted_program(Gpg::PROGRAM))
-                .unwrap_or_else(|| default_program(&gpg::OpenPgp::PROGRAM)),
+            program,
             program_arguments: Vec::new(),
             environment: Vec::new(),
             minimum_trust,
         },
         Format::X509 => gix_object::signature::verify::Options::X509 {
-            program: config
-                .trusted_program(gpg::X509::PROGRAM)
-                .unwrap_or_else(|| default_program(&gpg::X509::PROGRAM)),
+            program,
             program_arguments: Vec::new(),
             environment: Vec::new(),
             minimum_trust,
@@ -62,9 +58,7 @@ pub(crate) fn verify(commit: &crate::Commit<'_>) -> Result<Option<Outcome>, Erro
                 .trusted_path(gpg::Ssh::REVOCATION_FILE)?
                 .filter(|path| path.exists());
             gix_object::signature::verify::Options::Ssh {
-                program: config
-                    .trusted_program(gpg::Ssh::PROGRAM)
-                    .unwrap_or_else(|| default_program(&gpg::Ssh::PROGRAM)),
+                program,
                 program_arguments: Vec::new(),
                 environment: Vec::new(),
                 allowed_signers: resolve_relative_to_repository(commit.repo, allowed_signers),
@@ -75,12 +69,6 @@ pub(crate) fn verify(commit: &crate::Commit<'_>) -> Result<Option<Outcome>, Erro
         }
     };
     signed_data.verify(&signature, options).map(Some).map_err(Into::into)
-}
-
-fn default_program(key: &crate::config::tree::keys::Program) -> OsString {
-    gix_path::from_bstr(key.default_value_or_panic())
-        .into_owned()
-        .into_os_string()
 }
 
 fn resolve_relative_to_repository(repo: &crate::Repository, path: PathBuf) -> PathBuf {

--- a/gix/tests/gix/commit.rs
+++ b/gix/tests/gix/commit.rs
@@ -214,6 +214,39 @@ mod signature {
     }
 
     #[test]
+    fn expands_verification_program_paths() -> crate::Result {
+        let home = gix::path::env::home_dir().expect("the test environment has a home directory");
+        let mut permissions = gix::open::Permissions::isolated();
+        permissions.env.home = gix::sec::Permission::Allow;
+        let options = gix::open::Options::isolated()
+            .permissions(permissions)
+            .config_overrides([gpg::OpenPgp::PROGRAM.validated_assignment_fmt(&"~/bin/missing-gpg")?]);
+        let repo = crate::util::repo_opts("make_basic_repo.sh", options)?
+            .to_thread_local()
+            .with_object_memory();
+        let mut commit = repo.head_commit()?.decode()?.into_owned()?;
+        let signature_field = gix_object::commit::signature_field_name(commit.tree.kind());
+        commit
+            .extra_headers
+            .push((signature_field.into(), "-----BEGIN PGP SIGNATURE-----\n".into()));
+        let id = repo.write_object(&commit)?;
+        let err = repo
+            .find_commit(id)?
+            .verify_signature()
+            .expect_err("the configured verifier does not exist");
+        let gix::commit::verify::Error::Verify(gix_object::signature::verify::Error::Spawn { program, .. }) = err
+        else {
+            panic!("expected a verifier spawn failure, got {err:?}");
+        };
+        assert_eq!(
+            program,
+            home.join("bin/missing-gpg"),
+            "the configured verifier path is expanded relative to home"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn resolves_signing_options_only_when_enabled() -> crate::Result {
         let disabled = gix::open_opts(
             gix_testtools::scripted_fixture_read_only("make_basic_repo.sh")?,


### PR DESCRIPTION
### Tasks

* [x] refackiew

---

Treat signing and verification programs as executable paths, matching the argv-based launch used by Git. Shell detection treated paths containing spaces as shell commands, so unquoted Windows paths could fail before reaching the signer.

Keep wrapper customization explicit through `program_arguments` and cover signer and verifier paths containing spaces with regression tests.
