### PR TITLE
fix(gix-note): edit notes trees lazily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,9 +2186,9 @@ dependencies = [
 name = "gix-note"
 version = "0.1.1"
 dependencies = [
+ "criterion",
  "gix-error",
  "gix-hash",
- "gix-hashtable",
  "gix-note",
  "gix-object",
  "gix-odb",

--- a/gix-note/Cargo.toml
+++ b/gix-note/Cargo.toml
@@ -14,22 +14,27 @@ include = ["/src/**/*", "/LICENSE-*"]
 [lib]
 doctest = false
 
+[[bench]]
+name = "read-write"
+harness = false
+path = "./benches/read_write.rs"
+
 [package.metadata.docs.rs]
 features = ["sha1"]
 
 [features]
 ## Enable support for the SHA-1 hash by forwarding it to dependencies.
-sha1 = ["gix-hash/sha1", "gix-object/sha1", "gix-hashtable/sha1" ]
+sha1 = ["gix-hash/sha1", "gix-object/sha1"]
 ## Enable support for the SHA-256 hash by forwarding it to dependencies.
-sha256 = ["gix-hash/sha256", "gix-object/sha256",  "gix-hashtable/sha256" ]
+sha256 = ["gix-hash/sha256", "gix-object/sha256"]
 
 [dependencies]
 gix-error = { version = "^0.3.2", path = "../gix-error" }
 gix-hash = { version = "^0.26.2", path = "../gix-hash" }
-gix-hashtable = { version = "^0.16.0", path = "../gix-hashtable" }
 gix-object = { version = "^0.64.1", path = "../gix-object" }
 
 [dev-dependencies]
+criterion = "0.8.2"
 gix-note = { path = ".", features = ["sha1", "sha256"] }
 gix-odb = { path = "../gix-odb" }
 gix-testtools = { path = "../tests/tools" }

--- a/gix-note/benches/read_write.rs
+++ b/gix-note/benches/read_write.rs
@@ -1,0 +1,133 @@
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use gix_hash::ObjectId;
+use gix_object::{
+    Kind, Tree, Write,
+    tree::{Entry, EntryKind},
+};
+
+const NOTES_PER_BYTE: usize = 256;
+const NOTE_COUNT: usize = NOTES_PER_BYTE * NOTES_PER_BYTE;
+
+type ObjectDb = gix_odb::memory::Proxy<gix_object::find::Never>;
+
+struct Fixture {
+    objects: ObjectDb,
+    root_tree_id: ObjectId,
+    annotated_object_id: ObjectId,
+    replacement_note_blob_id: ObjectId,
+}
+
+fn read_write(c: &mut Criterion) {
+    for (name, fanout, fixture) in [("fanout-expansion", 1, fixture(1)), ("steady-state", 2, fixture(2))] {
+        let mut group = c.benchmark_group(format!("notes/{NOTE_COUNT}-notes/{name}-{fanout}-level-fanout"));
+        group.throughput(Throughput::Elements(1));
+
+        group.bench_function("get", |b| {
+            b.iter(|| {
+                black_box(
+                    gix_note::get(fixture.root_tree_id, &fixture.annotated_object_id, &fixture.objects)
+                        .expect("the benchmark note can be read"),
+                )
+            });
+        });
+        group.bench_function("replace", |b| {
+            b.iter(|| {
+                black_box(
+                    gix_note::replace(
+                        fixture.root_tree_id,
+                        fixture.annotated_object_id,
+                        fixture.replacement_note_blob_id,
+                        &fixture.objects,
+                    )
+                    .expect("the benchmark note can be replaced"),
+                )
+            });
+        });
+        group.finish();
+    }
+}
+
+fn fixture(fanout: usize) -> Fixture {
+    let objects = ObjectDb::new(gix_object::find::Never, gix_hash::Kind::Sha1);
+    let note_blob_id = objects.write_buf(Kind::Blob, b"note").expect("note can be written");
+    let replacement_note_blob_id = objects
+        .write_buf(Kind::Blob, b"replacement")
+        .expect("replacement note can be written");
+
+    let subtree_id = match fanout {
+        1 => objects
+            .write(&Tree {
+                entries: (0..=u8::MAX)
+                    .map(|second_byte| {
+                        let annotated_object_id = object_id(0, second_byte);
+                        Entry {
+                            mode: EntryKind::Blob.into(),
+                            filename: annotated_object_id.to_hex().to_string()[2..].into(),
+                            oid: note_blob_id,
+                        }
+                    })
+                    .collect(),
+            })
+            .expect("fanout subtree can be written"),
+        2 => {
+            let annotated_object_id = object_id(0, 0);
+            let leaf_tree_id = objects
+                .write(&Tree {
+                    entries: vec![Entry {
+                        mode: EntryKind::Blob.into(),
+                        filename: annotated_object_id.to_hex().to_string()[4..].into(),
+                        oid: note_blob_id,
+                    }],
+                })
+                .expect("leaf tree can be written");
+            objects
+                .write(&Tree {
+                    entries: (0..=u8::MAX)
+                        .map(|second_byte| Entry {
+                            mode: EntryKind::Tree.into(),
+                            filename: format!("{second_byte:02x}").into(),
+                            oid: leaf_tree_id,
+                        })
+                        .collect(),
+                })
+                .expect("fanout subtree can be written")
+        }
+        _ => unreachable!("the benchmark only uses one or two fanout levels"),
+    };
+    let root_entries = (0..=u8::MAX)
+        .map(|first_byte| Entry {
+            mode: EntryKind::Tree.into(),
+            filename: format!("{first_byte:02x}").into(),
+            oid: subtree_id,
+        })
+        .collect();
+
+    let root_tree_id = objects
+        .write(&Tree { entries: root_entries })
+        .expect("notes root can be written");
+    let annotated_object_id = object_id(0x80, 0x80);
+    assert_eq!(
+        gix_note::get(root_tree_id, &annotated_object_id, &objects).expect("the fixture can be read"),
+        Some(note_blob_id),
+        "the fixture contains the benchmark note"
+    );
+
+    Fixture {
+        objects,
+        root_tree_id,
+        annotated_object_id,
+        replacement_note_blob_id,
+    }
+}
+
+fn object_id(first_byte: u8, second_byte: u8) -> ObjectId {
+    let mut bytes = [0; gix_hash::Kind::Sha1.len_in_bytes()];
+    bytes[0] = first_byte;
+    bytes[1] = second_byte;
+    ObjectId::from_bytes_or_panic(&bytes)
+}
+
+criterion_group!(benches, read_write);
+criterion_main!(benches);

--- a/gix-note/benches/read_write.rs
+++ b/gix-note/benches/read_write.rs
@@ -9,6 +9,8 @@ use gix_object::{
 
 const NOTES_PER_BYTE: usize = 256;
 const NOTE_COUNT: usize = NOTES_PER_BYTE * NOTES_PER_BYTE;
+// A full replacement sweep is too slow for routine runs; increase this when replacement scaling improves.
+const REPLACEMENT_COUNT: usize = 16;
 
 type ObjectDb = gix_odb::memory::Proxy<gix_object::find::Never>;
 
@@ -16,6 +18,8 @@ struct Fixture {
     objects: ObjectDb,
     root_tree_id: ObjectId,
     annotated_object_id: ObjectId,
+    annotated_object_ids: Vec<ObjectId>,
+    note_blob_id: ObjectId,
     replacement_note_blob_id: ObjectId,
 }
 
@@ -24,25 +28,96 @@ fn read_write(c: &mut Criterion) {
         let mut group = c.benchmark_group(format!("notes/{NOTE_COUNT}-notes/{name}-{fanout}-level-fanout"));
         group.throughput(Throughput::Elements(1));
 
-        group.bench_function("get", |b| {
+        group.bench_function("get/same-note/new-state", |b| {
             b.iter(|| {
+                let mut state = gix_note::State::new(fixture.root_tree_id, &fixture.objects)
+                    .expect("read state can be initialized");
                 black_box(
-                    gix_note::get(fixture.root_tree_id, &fixture.annotated_object_id, &fixture.objects)
+                    state
+                        .get(&fixture.annotated_object_id, &fixture.objects)
                         .expect("the benchmark note can be read"),
                 )
             });
         });
-        group.bench_function("replace", |b| {
+        group.bench_function("replace/same-note/new-state", |b| {
+            b.iter(|| {
+                let mut state = gix_note::State::new(fixture.root_tree_id, &fixture.objects)
+                    .expect("write state can be initialized");
+                black_box(
+                    state
+                        .replace(
+                            fixture.annotated_object_id,
+                            fixture.replacement_note_blob_id,
+                            &fixture.objects,
+                        )
+                        .expect("the benchmark note can be replaced"),
+                )
+            });
+        });
+        let mut read_state =
+            gix_note::State::new(fixture.root_tree_id, &fixture.objects).expect("cached read state can be initialized");
+        group.bench_function("get/same-note/reused-state", |b| {
             b.iter(|| {
                 black_box(
-                    gix_note::replace(
-                        fixture.root_tree_id,
-                        fixture.annotated_object_id,
-                        fixture.replacement_note_blob_id,
-                        &fixture.objects,
-                    )
-                    .expect("the benchmark note can be replaced"),
+                    read_state
+                        .get(&fixture.annotated_object_id, &fixture.objects)
+                        .expect("the cached benchmark note can be read"),
                 )
+            });
+        });
+
+        let mut write_state = gix_note::State::new(fixture.root_tree_id, &fixture.objects)
+            .expect("cached write state can be initialized");
+        write_state
+            .replace(
+                fixture.annotated_object_id,
+                fixture.replacement_note_blob_id,
+                &fixture.objects,
+            )
+            .expect("the write state can be primed outside the measurement");
+        let mut use_replacement = true;
+        group.bench_function("replace/same-note/reused-state", |b| {
+            b.iter(|| {
+                use_replacement = !use_replacement;
+                let note_blob_id = if use_replacement {
+                    fixture.replacement_note_blob_id
+                } else {
+                    fixture.note_blob_id
+                };
+                black_box(
+                    write_state
+                        .replace(fixture.annotated_object_id, note_blob_id, &fixture.objects)
+                        .expect("the cached benchmark note can be replaced"),
+                )
+            });
+        });
+
+        group.throughput(Throughput::Elements(NOTE_COUNT as u64));
+        group.bench_function("get/all-notes/one-state", |b| {
+            b.iter(|| {
+                let mut state = gix_note::State::new(fixture.root_tree_id, &fixture.objects)
+                    .expect("read state can be initialized");
+                for annotated_object_id in &fixture.annotated_object_ids {
+                    black_box(
+                        state
+                            .get(annotated_object_id, &fixture.objects)
+                            .expect("the benchmark note can be read"),
+                    );
+                }
+            });
+        });
+        group.throughput(Throughput::Elements(REPLACEMENT_COUNT as u64));
+        group.bench_function("replace/dispersed-batch/one-state", |b| {
+            b.iter(|| {
+                let mut state = gix_note::State::new(fixture.root_tree_id, &fixture.objects)
+                    .expect("write state can be initialized");
+                for &annotated_object_id in fixture.annotated_object_ids.iter().take(REPLACEMENT_COUNT) {
+                    black_box(
+                        state
+                            .replace(annotated_object_id, fixture.replacement_note_blob_id, &fixture.objects)
+                            .expect("the benchmark note can be replaced"),
+                    );
+                }
             });
         });
         group.finish();
@@ -108,8 +183,18 @@ fn fixture(fanout: usize) -> Fixture {
         .write(&Tree { entries: root_entries })
         .expect("notes root can be written");
     let annotated_object_id = object_id(0x80, 0x80);
+    let annotated_object_ids = (0..NOTE_COUNT)
+        .map(|index| {
+            // This stride visits every ID while spreading adjacent operations across both fanout bytes.
+            let index = index * (NOTES_PER_BYTE + 1) % NOTE_COUNT;
+            object_id((index / NOTES_PER_BYTE) as u8, (index % NOTES_PER_BYTE) as u8)
+        })
+        .collect();
+    let mut state = gix_note::State::new(root_tree_id, &objects).expect("read state can be initialized");
     assert_eq!(
-        gix_note::get(root_tree_id, &annotated_object_id, &objects).expect("the fixture can be read"),
+        state
+            .get(&annotated_object_id, &objects)
+            .expect("the fixture can be read"),
         Some(note_blob_id),
         "the fixture contains the benchmark note"
     );
@@ -118,6 +203,8 @@ fn fixture(fanout: usize) -> Fixture {
         objects,
         root_tree_id,
         annotated_object_id,
+        annotated_object_ids,
+        note_blob_id,
         replacement_note_blob_id,
     }
 }

--- a/gix-note/src/lib.rs
+++ b/gix-note/src/lib.rs
@@ -3,8 +3,7 @@
 #![deny(missing_docs)]
 
 use gix_error::{CorruptionError, ErrorExt, ResultExt, ValidationError, message};
-use gix_hash::{ObjectId, Prefix, oid};
-use gix_hashtable::{HashMap, HashSet};
+use gix_hash::{ObjectId, oid};
 use gix_object::{
     Find, FindExt, Tree, Write,
     bstr::{BStr, BString, ByteSlice},
@@ -71,10 +70,12 @@ pub fn get(root_tree_id: ObjectId, annotated_object_id: &oid, objects: &impl Fin
 /// tree and any previous note.
 ///
 /// The notes tree is rewritten with the same progressive fanout heuristic as
-/// Git while retaining entries that are not notes. `note` is expected to
-/// reference a blob, but its actual object kind is not verified; the mapping is
-/// always written as a blob-mode tree entry. For repeated edits, `objects`
-/// should have a built-in object cache to accelerate tree retrieval.
+/// Git while retaining entries that are not notes. Untouched fanout subtrees
+/// are kept by object ID and loaded only when the edit or a fanout change needs
+/// their contents. `note` is expected to reference a blob, but its actual object
+/// kind is not verified; the mapping is always written as a blob-mode tree
+/// entry. For repeated edits, `objects` should have a built-in object cache to
+/// accelerate tree retrieval.
 pub fn replace(
     root_tree_id: ObjectId,
     annotated_object_id: ObjectId,
@@ -115,93 +116,294 @@ fn edit(
     note_blob_id: Option<ObjectId>,
     objects: &(impl Find + Write),
 ) -> Result<Edit, Error> {
-    let mut notes = HashMap::default();
+    let hash = root_tree_id.kind();
+    let mut root = InternalNode::default();
     let mut non_notes = Vec::new();
-    let mut existing_fanout = HashSet::default();
-    collect(
-        root_tree_id,
-        BString::default(),
-        Vec::new(),
+    load_subtree(
+        Subtree {
+            prefix: ObjectId::null(hash),
+            prefix_len: 0,
+            path: Vec::new(),
+            tree_id: root_tree_id,
+        },
+        &mut root,
+        0,
         objects,
-        &mut notes,
         &mut non_notes,
-        &mut existing_fanout,
     )?;
-    let previous_note_blob_id = match note_blob_id {
-        Some(note_blob_id) => notes.insert(annotated_object_id, note_blob_id),
-        None => notes.remove(&annotated_object_id),
-    };
+    let previous_note_blob_id = root.remove(&annotated_object_id, 0, objects, &mut non_notes)?;
     if note_blob_id.is_none() && previous_note_blob_id.is_none() {
         return Ok(Edit {
             tree: root_tree_id,
             previous: previous_note_blob_id,
         });
     }
-    let root_tree_id = write(notes, non_notes, existing_fanout, root_tree_id.kind(), objects)?;
+    if let Some(note_blob_id) = note_blob_id {
+        root.insert(
+            Node::Note(Note {
+                annotated_object_id,
+                note_blob_id,
+            }),
+            0,
+            objects,
+            &mut non_notes,
+        )?;
+    }
+    let root_tree_id = write(root, non_notes, hash, objects)?;
     Ok(Edit {
         tree: root_tree_id,
         previous: previous_note_blob_id,
     })
 }
 
-#[derive(Clone)]
-struct NonNote {
+struct TreeEntry {
     path: Vec<BString>,
     mode: EntryMode,
     object_id: ObjectId,
 }
 
-fn collect(
+#[derive(Default)]
+struct InternalNode {
+    children: [Option<Box<Node>>; 16],
+}
+
+enum Node {
+    Internal(InternalNode),
+    Note(Note),
+    Subtree(Subtree),
+}
+
+#[derive(Clone, Copy)]
+struct Note {
+    annotated_object_id: ObjectId,
+    note_blob_id: ObjectId,
+}
+
+// An unopened on-disk fanout directory. Keeping it opaque is what makes edits path-local.
+#[derive(Clone)]
+struct Subtree {
+    prefix: ObjectId,
+    prefix_len: usize,
+    path: Vec<BString>,
     tree_id: ObjectId,
-    hex_prefix: BString,
-    path_prefix: Vec<BString>,
+}
+
+impl Node {
+    fn key(&self) -> &oid {
+        match self {
+            Node::Note(note) => &note.annotated_object_id,
+            Node::Subtree(subtree) => &subtree.prefix,
+            Node::Internal(_) => unreachable!("internal nodes have no object ID key"),
+        }
+    }
+}
+
+impl Subtree {
+    fn contains(&self, id: &oid) -> bool {
+        self.prefix.as_bytes()[..self.prefix_len] == id.as_bytes()[..self.prefix_len]
+    }
+}
+
+impl InternalNode {
+    fn insert(
+        &mut self,
+        entry: Node,
+        nibble: usize,
+        objects: &impl Find,
+        non_notes: &mut Vec<TreeEntry>,
+    ) -> Result<(), Error> {
+        if self.load_matching_subtree(entry.key(), nibble, objects, non_notes)? {
+            return self.insert(entry, nibble, objects, non_notes);
+        }
+
+        let index = nibble_at(entry.key(), nibble);
+        let Some(existing) = self.children[index].take() else {
+            self.children[index] = Some(Box::new(entry));
+            return Ok(());
+        };
+
+        match *existing {
+            Node::Internal(mut child) => {
+                let result = child.insert(entry, nibble + 1, objects, non_notes);
+                self.children[index] = Some(Box::new(Node::Internal(child)));
+                result
+            }
+            Node::Note(note) => {
+                if matches!(&entry, Node::Note(incoming) if incoming.annotated_object_id == note.annotated_object_id) {
+                    return Err(CorruptionError::from(format!(
+                        "Multiple notes map to object {}",
+                        note.annotated_object_id
+                    ))
+                    .raise_erased());
+                }
+                if let Node::Subtree(subtree) = &entry
+                    && subtree.contains(&note.annotated_object_id)
+                {
+                    self.children[index] = Some(Box::new(Node::Note(note)));
+                    return load_subtree(subtree.clone(), self, nibble, objects, non_notes);
+                }
+                self.insert_collision(Node::Note(note), entry, index, nibble, objects, non_notes)
+            }
+            Node::Subtree(subtree) => {
+                if subtree.contains(entry.key()) {
+                    load_subtree(subtree, self, nibble, objects, non_notes)?;
+                    self.insert(entry, nibble, objects, non_notes)
+                } else {
+                    self.insert_collision(Node::Subtree(subtree), entry, index, nibble, objects, non_notes)
+                }
+            }
+        }
+    }
+
+    fn insert_collision(
+        &mut self,
+        existing: Node,
+        entry: Node,
+        index: usize,
+        nibble: usize,
+        objects: &impl Find,
+        non_notes: &mut Vec<TreeEntry>,
+    ) -> Result<(), Error> {
+        let mut child = InternalNode::default();
+        child.insert(existing, nibble + 1, objects, non_notes)?;
+        child.insert(entry, nibble + 1, objects, non_notes)?;
+        self.children[index] = Some(Box::new(Node::Internal(child)));
+        Ok(())
+    }
+
+    fn remove(
+        &mut self,
+        annotated_object_id: &oid,
+        nibble: usize,
+        objects: &impl Find,
+        non_notes: &mut Vec<TreeEntry>,
+    ) -> Result<Option<ObjectId>, Error> {
+        if self.load_matching_subtree(annotated_object_id, nibble, objects, non_notes)? {
+            return self.remove(annotated_object_id, nibble, objects, non_notes);
+        }
+
+        let index = nibble_at(annotated_object_id, nibble);
+        let Some(existing) = self.children[index].take() else {
+            return Ok(None);
+        };
+        match *existing {
+            Node::Internal(mut child) => {
+                let previous = child.remove(annotated_object_id, nibble + 1, objects, non_notes)?;
+                self.children[index] = if previous.is_some() {
+                    child.after_removal()
+                } else {
+                    Some(Box::new(Node::Internal(child)))
+                };
+                Ok(previous)
+            }
+            Node::Note(note) if note.annotated_object_id == annotated_object_id => Ok(Some(note.note_blob_id)),
+            Node::Note(note) => {
+                self.children[index] = Some(Box::new(Node::Note(note)));
+                Ok(None)
+            }
+            Node::Subtree(subtree) if subtree.contains(annotated_object_id) => {
+                load_subtree(subtree, self, nibble, objects, non_notes)?;
+                self.remove(annotated_object_id, nibble, objects, non_notes)
+            }
+            Node::Subtree(subtree) => {
+                self.children[index] = Some(Box::new(Node::Subtree(subtree)));
+                Ok(None)
+            }
+        }
+    }
+
+    fn load_matching_subtree(
+        &mut self,
+        key: &oid,
+        nibble: usize,
+        objects: &impl Find,
+        non_notes: &mut Vec<TreeEntry>,
+    ) -> Result<bool, Error> {
+        let is_match = self.children[0]
+            .as_deref()
+            .is_some_and(|node| matches!(node, Node::Subtree(subtree) if subtree.contains(key)));
+        if !is_match {
+            return Ok(false);
+        }
+        let Node::Subtree(subtree) = *self.children[0].take().expect("the matching subtree is present") else {
+            unreachable!("the matching node was checked to be a subtree")
+        };
+        load_subtree(subtree, self, nibble, objects, non_notes)?;
+        Ok(true)
+    }
+
+    fn after_removal(mut self) -> Option<Box<Node>> {
+        let mut occupied = self.children.iter().enumerate().filter(|(_, child)| child.is_some());
+        let (only_index, _) = occupied.next()?;
+        if occupied.next().is_none()
+            && self.children[only_index]
+                .as_deref()
+                .is_some_and(|node| matches!(node, Node::Note(_)))
+        {
+            return self.children[only_index].take();
+        }
+        Some(Box::new(Node::Internal(self)))
+    }
+}
+
+fn load_subtree(
+    subtree: Subtree,
+    node: &mut InternalNode,
+    nibble: usize,
     objects: &impl Find,
-    notes: &mut HashMap<ObjectId, ObjectId>,
-    non_notes: &mut Vec<NonNote>,
-    existing_fanout: &mut HashSet<FanoutPrefix>,
+    non_notes: &mut Vec<TreeEntry>,
 ) -> Result<(), Error> {
     let mut buf = Vec::new();
     let tree = objects
-        .find_tree(&tree_id, &mut buf)
-        .or_raise_erased(|| message!("Could not load notes tree {tree_id}"))?;
-    let hex_len = tree_id.kind().len_in_hex();
+        .find_tree(&subtree.tree_id, &mut buf)
+        .or_raise_erased(|| message!("Could not load notes tree {}", subtree.tree_id))?;
+    let hex_len = subtree.tree_id.kind().len_in_hex();
+    let prefix_hex_len = subtree.prefix_len * 2;
+    let mut prefix_hex = gix_hash::Kind::hex_buf();
+    prefix_hex.fill(b'0');
+    let _ = subtree.prefix.hex_to_buf(&mut prefix_hex);
     for entry in tree.entries {
-        let mut path = path_prefix.clone();
-        path.push(entry.filename.to_owned());
-        if entry.mode.is_blob() && entry.filename.len() + hex_prefix.len() == hex_len {
-            let mut hex = hex_prefix.clone();
-            hex.extend_from_slice(entry.filename);
-            if let Ok(annotated_object_id) = ObjectId::from_hex(&hex) {
-                for offset in 0..hex_prefix.len() / 2 {
-                    existing_fanout.insert(FanoutPrefix(annotated_object_id.to_prefix(0..offset)));
-                }
-                if notes.insert(annotated_object_id, entry.oid.to_owned()).is_some() {
-                    return Err(
-                        CorruptionError::from(format!("Multiple notes map to object {annotated_object_id}"))
-                            .raise_erased(),
-                    );
-                }
+        if entry.mode.is_blob() && entry.filename.len() + prefix_hex_len == hex_len {
+            let mut hex = prefix_hex;
+            hex[prefix_hex_len..hex_len].copy_from_slice(entry.filename);
+            if let Ok(annotated_object_id) = ObjectId::from_hex(&hex[..hex_len]) {
+                node.insert(
+                    Node::Note(Note {
+                        annotated_object_id,
+                        note_blob_id: entry.oid.to_owned(),
+                    }),
+                    nibble,
+                    objects,
+                    non_notes,
+                )?;
                 continue;
             }
         }
         if entry.mode.is_tree()
             && entry.filename.len() == 2
-            && hex_prefix.len() + 2 < hex_len
+            && prefix_hex_len + 2 < hex_len
             && entry.filename.iter().all(u8::is_ascii_hexdigit)
         {
-            let mut prefix = hex_prefix.clone();
-            prefix.extend_from_slice(entry.filename);
-            collect(
-                entry.oid.to_owned(),
-                prefix,
-                path,
+            let mut path = subtree.path.clone();
+            path.push(entry.filename.to_owned());
+            let mut hex = prefix_hex;
+            hex[prefix_hex_len..prefix_hex_len + 2].copy_from_slice(entry.filename);
+            let prefix = ObjectId::from_hex(&hex[..hex_len]).expect("validated hex produces an object ID");
+            node.insert(
+                Node::Subtree(Subtree {
+                    prefix,
+                    prefix_len: subtree.prefix_len + 1,
+                    path,
+                    tree_id: entry.oid.to_owned(),
+                }),
+                nibble,
                 objects,
-                notes,
                 non_notes,
-                existing_fanout,
             )?;
         } else {
-            non_notes.push(NonNote {
+            let mut path = subtree.path.clone();
+            path.push(entry.filename.to_owned());
+            non_notes.push(TreeEntry {
                 path,
                 mode: entry.mode,
                 object_id: entry.oid.to_owned(),
@@ -212,31 +414,22 @@ fn collect(
 }
 
 fn write(
-    notes: HashMap<ObjectId, ObjectId>,
-    non_notes: Vec<NonNote>,
-    existing_fanout: HashSet<FanoutPrefix>,
+    mut root: InternalNode,
+    mut non_notes: Vec<TreeEntry>,
     hash: gix_hash::Kind,
     objects: &(impl Find + Write),
 ) -> Result<ObjectId, Error> {
-    // A notes path contains the full hexadecimal ID plus one slash for each byte consumed as a fanout directory.
-    // At least one byte remains for the leaf name, so allowing one slash per hash byte is a simple one-byte overestimate.
-    const NOTE_PATH_BUFFER_SIZE: usize =
-        gix_hash::Kind::longest().len_in_hex() + gix_hash::Kind::longest().len_in_bytes();
-
+    let mut notes = Vec::new();
+    collect_for_write(&mut root, 0, 0, objects, &mut non_notes, &mut notes)?;
     let mut editor = Editor::new(Tree { entries: Vec::new() }, objects, hash);
     for entry in non_notes {
         editor
             .upsert(entry.path.iter(), entry.mode.kind(), entry.object_id)
             .or_raise_erased(|| message("Could not restore a non-note tree entry"))?;
     }
-
-    let bucket_counts = fanout_bucket_counts(notes.keys());
-    let mut path_buf = [0u8; NOTE_PATH_BUFFER_SIZE];
-    for (annotated_object_id, note_blob_id) in notes {
-        let fanout = fanout(&annotated_object_id, &bucket_counts, &existing_fanout);
-        let path = note_path(&annotated_object_id, fanout, &mut path_buf);
+    for entry in notes {
         editor
-            .upsert(path.split_str("/"), EntryKind::Blob, note_blob_id)
+            .upsert(entry.path.iter(), entry.mode.kind(), entry.object_id)
             .or_raise_erased(|| message("Could not add a note tree entry"))?;
     }
     editor
@@ -244,62 +437,79 @@ fn write(
         .or_raise_erased(|| message("Could not write the notes tree"))
 }
 
-/// Return the next-nibble note counts for every possible two-hex-digit fanout prefix.
-///
-/// `ids` yields the annotated object IDs that will become note-tree entry names; the IDs of their note blobs do not
-/// affect fanout.
-///
-/// The returned map associates each possible byte-aligned hexadecimal prefix with 16 counters, one for each possible value
-/// of the following nibble. Counts saturate at two because Git creates the next fanout level only when all 16 slots at a
-/// candidate level represent internal nodes, which requires at least two distinct notes per slot.
-fn fanout_bucket_counts<'a>(ids: impl Iterator<Item = &'a ObjectId>) -> HashMap<FanoutPrefix, [u8; 16]> {
-    let mut out = HashMap::default();
-    for id in ids {
-        for offset in 0..id.as_bytes().len().saturating_sub(1) {
-            let counts = out.entry(FanoutPrefix(id.to_prefix(0..offset))).or_insert([0u8; 16]);
-            let nibble = id.as_bytes()[offset] >> 4;
-            let index = usize::from(nibble);
-            counts[index] = counts[index].saturating_add(1).min(2);
+fn collect_for_write(
+    node: &mut InternalNode,
+    nibble: usize,
+    fanout: usize,
+    objects: &impl Find,
+    non_notes: &mut Vec<TreeEntry>,
+    notes: &mut Vec<TreeEntry>,
+) -> Result<(), Error> {
+    let fanout = if nibble.is_multiple_of(2)
+        && nibble <= 2 * fanout
+        && node
+            .children
+            .iter()
+            .all(|child| matches!(child.as_deref(), Some(Node::Internal(_) | Node::Subtree(_))))
+    {
+        fanout + 1
+    } else {
+        fanout
+    };
+
+    for index in 0..node.children.len() {
+        while let Some(entry) = node.children[index].take() {
+            match *entry {
+                Node::Internal(mut child) => {
+                    collect_for_write(&mut child, nibble + 1, fanout, objects, non_notes, notes)?;
+                    node.children[index] = Some(Box::new(Node::Internal(child)));
+                    break;
+                }
+                Node::Note(note) => {
+                    notes.push(TreeEntry {
+                        path: note_path_components(&note.annotated_object_id, fanout),
+                        mode: EntryKind::Blob.into(),
+                        object_id: note.note_blob_id,
+                    });
+                    node.children[index] = Some(Box::new(Node::Note(note)));
+                    break;
+                }
+                Node::Subtree(subtree) if nibble < 2 * fanout => {
+                    notes.push(TreeEntry {
+                        path: subtree.path.clone(),
+                        mode: EntryKind::Tree.into(),
+                        object_id: subtree.tree_id,
+                    });
+                    node.children[index] = Some(Box::new(Node::Subtree(subtree)));
+                    break;
+                }
+                Node::Subtree(subtree) => {
+                    load_subtree(subtree, node, nibble, objects, non_notes)?;
+                }
+            }
         }
     }
-    out
+    Ok(())
 }
 
-/// Determine how many leading bytes of `id` become two-hex-digit fanout directories.
-///
-/// `bucket_counts` describes the populated next-nibble buckets below every prefix. `existing_fanout` identifies prefixes
-/// that were already directories before the edit. Git creates a level only once every bucket contains at least two notes,
-/// but retains an existing level while every bucket remains occupied; this hysteresis avoids tree churn around the creation
-/// threshold. The returned number is both the fanout depth and the byte offset at which the remaining hexadecimal ID becomes
-/// the note's leaf name.
-fn fanout(id: &oid, bucket_counts: &HashMap<FanoutPrefix, [u8; 16]>, existing_fanout: &HashSet<FanoutPrefix>) -> usize {
-    let mut fanout = 0;
-    while fanout < id.as_bytes().len().saturating_sub(1) {
-        let prefix = FanoutPrefix(id.to_prefix(0..fanout));
-        let should_fanout = bucket_counts.get(&prefix).is_some_and(|counts| {
-            counts.iter().all(|count| *count == 2)
-                || (existing_fanout.contains(&prefix) && counts.iter().all(|count| *count >= 1))
-        });
-        if !should_fanout {
-            break;
-        }
-        fanout += 1;
-    }
-    fanout
+fn nibble_at(id: &oid, nibble: usize) -> usize {
+    let byte = id.as_bytes()[nibble / 2];
+    usize::from(if nibble.is_multiple_of(2) {
+        byte >> 4
+    } else {
+        byte & 0x0f
+    })
 }
 
-/// A prefix key whose hash is compatible with `gix_hashtable`'s object-ID-specialized hasher.
-///
-/// Equality includes the prefix length through [`Prefix`], while hashing writes only its zero-padded object-ID bytes.
-/// Different lengths can therefore collide when their significant bytes are all zero, but equality still distinguishes
-/// them and avoids requiring a separate hash table for each prefix depth.
-#[derive(Clone, Copy, Eq, PartialEq)]
-struct FanoutPrefix(Prefix);
+fn note_path_components(id: &oid, fanout: usize) -> Vec<BString> {
+    // A notes path contains the full hexadecimal ID plus one slash for each byte consumed as a fanout directory.
+    // At least one byte remains for the leaf name, so allowing one slash per hash byte is a simple one-byte overestimate.
+    const NOTE_PATH_BUFFER_SIZE: usize =
+        gix_hash::Kind::longest().len_in_hex() + gix_hash::Kind::longest().len_in_bytes();
 
-impl std::hash::Hash for FanoutPrefix {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        std::hash::Hash::hash(self.0.as_oid(), state);
-    }
+    let mut path_buf = [0u8; NOTE_PATH_BUFFER_SIZE];
+    let path = note_path(id, fanout, &mut path_buf);
+    path.split_str("/").map(BString::from).collect()
 }
 
 /// Write the notes-tree path for `id` with `fanout` leading bytes represented as directory components.

--- a/gix-note/src/lib.rs
+++ b/gix-note/src/lib.rs
@@ -7,7 +7,7 @@ use gix_hash::{ObjectId, oid};
 use gix_object::{
     Find, FindExt, Tree, Write,
     bstr::{BStr, BString, ByteSlice},
-    tree::{Editor, EntryKind, EntryMode},
+    tree::{Editor, Entry, EntryKind, EntryMode},
 };
 
 /// The type-erased error returned by note operations.
@@ -20,171 +20,232 @@ pub struct Edit {
     pub tree: ObjectId,
     /// The object ID of the note previously associated with the annotated object.
     ///
-    /// This is `Some` when [`replace()`] replaced an existing note or [`remove()`]
+    /// This is `Some` when [`State::replace()`] replaced an existing note or [`State::remove()`]
     /// removed one. It is `None` when adding a new mapping or when removal
     /// found no matching note. Note IDs are expected to reference blobs, but
     /// their object kind is not verified.
     pub previous: Option<ObjectId>,
 }
 
-/// Return the note associated with `object` in the notes tree at `root`.
+/// A caller-owned, lazily materialized notes tree for lookups and edits.
 ///
-/// Git notes are expected to reference blobs. This function verifies that the
-/// notes-tree entry has blob mode, but does not load the referenced object to
-/// verify its actual kind.
+/// Use [`State::get()`], [`State::replace()`], and [`State::remove()`] to keep parsed
+/// tree entries and opened fanout subtrees in memory. A state starts at one root
+/// tree and advances to each tree produced by [`State::replace()`] or [`State::remove()`].
 ///
-/// Trees are loaded lazily along the progressive two-hex-digit fanout path.
-/// Entries that do not conform to Git's notes layout are ignored.
-///
-/// For repeated lookups, `objects` should have a built-in object cache to
-/// accelerate tree retrieval.
-pub fn get(root_tree_id: ObjectId, annotated_object_id: &oid, objects: &impl Find) -> Result<Option<ObjectId>, Error> {
-    let prefix = annotated_object_id.to_prefix(0..annotated_object_id.as_bytes().len());
-    let mut hex = gix_hash::Kind::hex_buf();
-    let mut remaining = prefix.hex_to_buf(&mut hex).as_bytes().as_bstr();
-    let mut tree_id = root_tree_id;
-    let mut buf = Vec::new();
+/// As in Git, the exact fanout can depend on which lazy subtrees were materialized.
+/// If an operation fails after changing materialized data, the state discards that
+/// data and remains usable from its last successfully written root tree.
+#[doc(alias = "notes_tree")]
+pub struct State {
+    root_tree_id: ObjectId,
+    root: InternalNode,
+    non_notes: Vec<TreeEntry>,
+}
 
-    loop {
-        let tree = objects
-            .find_tree(&tree_id, &mut buf)
-            .or_raise_erased(|| message!("Could not load notes tree {tree_id}"))?;
-        if let Some(entry) = tree.bisect_entry(remaining, false).filter(|entry| entry.mode.is_blob()) {
-            return Ok(Some(entry.oid.to_owned()));
+impl State {
+    /// Initialize state from `root_tree_id`, loading only its root tree from `objects`.
+    pub fn new(root_tree_id: ObjectId, objects: &impl Find) -> Result<Self, Error> {
+        let mut root = InternalNode::default();
+        let mut non_notes = Vec::new();
+        load_subtree(
+            Subtree {
+                prefix: ObjectId::null(root_tree_id.kind()),
+                prefix_len: 0,
+                path: BString::default(),
+                tree_id: root_tree_id,
+            },
+            &mut root,
+            0,
+            objects,
+            &mut non_notes,
+        )?;
+        Ok(State {
+            root_tree_id,
+            root,
+            non_notes,
+        })
+    }
+
+    /// Return the current root tree represented by this state.
+    ///
+    /// This initially matches the ID passed to [`State::new()`]. After a successful
+    /// [`Self::replace()`] or [`Self::remove()`], it matches the [`Edit::tree`] returned by that
+    /// operation. Lookups, failed operations, and removal of a missing note leave it unchanged.
+    pub fn root_tree_id(&self) -> ObjectId {
+        self.root_tree_id
+    }
+
+    /// Return the note associated with `annotated_object_id`, loading unopened notes trees from `objects`.
+    ///
+    /// Git notes are expected to reference blobs. This method verifies that the
+    /// notes-tree entry has blob mode, but does not load the referenced object to
+    /// verify its actual kind.
+    ///
+    /// Fanout subtrees on the lookup path are materialized once and retained for
+    /// subsequent operations. Entries that do not conform to Git's notes layout
+    /// are ignored.
+    pub fn get(&mut self, annotated_object_id: &oid, objects: &impl Find) -> Result<Option<ObjectId>, Error> {
+        validate_annotated_object_kind(self.root_tree_id.kind(), annotated_object_id)?;
+        self.reset_on_error(|state| state.root.get(annotated_object_id, 0, objects, &mut state.non_notes))
+    }
+
+    /// Associate `note_blob_id` with `annotated_object_id`, replacing any existing note.
+    ///
+    /// Use `objects` to read and write the notes tree. Return the new root tree and
+    /// any previous note.
+    ///
+    /// The notes tree is rewritten with the same progressive fanout heuristic as
+    /// Git while retaining entries that are not notes. Untouched fanout subtrees
+    /// are kept by object ID and loaded only when the edit or a fanout change needs
+    /// their contents. `note_blob_id` is expected to reference a blob, but its actual
+    /// object kind is not verified; the mapping is always written as a blob-mode tree entry.
+    pub fn replace(
+        &mut self,
+        annotated_object_id: ObjectId,
+        note_blob_id: ObjectId,
+        objects: &(impl Find + Write),
+    ) -> Result<Edit, Error> {
+        validate_replace_kinds(
+            self.root_tree_id.kind(),
+            annotated_object_id.kind(),
+            note_blob_id.kind(),
+        )?;
+        self.edit(annotated_object_id, Some(note_blob_id), objects)
+    }
+
+    /// Remove the note associated with `annotated_object_id`.
+    ///
+    /// Use `objects` to read and write the notes tree. Return the new root tree and
+    /// removed note.
+    ///
+    /// If there is no such note, the root is returned unchanged.
+    pub fn remove(&mut self, annotated_object_id: ObjectId, objects: &(impl Find + Write)) -> Result<Edit, Error> {
+        validate_annotated_object_kind(self.root_tree_id.kind(), &annotated_object_id)?;
+        self.edit(annotated_object_id, None, objects)
+    }
+
+    fn edit(
+        &mut self,
+        annotated_object_id: ObjectId,
+        note_blob_id: Option<ObjectId>,
+        objects: &(impl Find + Write),
+    ) -> Result<Edit, Error> {
+        self.reset_on_error(|state| {
+            let previous_note_blob_id = state
+                .root
+                .remove(&annotated_object_id, 0, objects, &mut state.non_notes)?;
+            if note_blob_id.is_none() && previous_note_blob_id.is_none() {
+                return Ok(Edit {
+                    tree: state.root_tree_id,
+                    previous: previous_note_blob_id,
+                });
+            }
+            if let Some(note_blob_id) = note_blob_id {
+                state.root.insert(
+                    Node::Note(Note {
+                        annotated_object_id,
+                        note_blob_id,
+                    }),
+                    0,
+                    objects,
+                    &mut state.non_notes,
+                )?;
+            }
+            state.root_tree_id = state
+                .root
+                .write(&mut state.non_notes, state.root_tree_id.kind(), objects)?;
+            Ok(Edit {
+                tree: state.root_tree_id,
+                previous: previous_note_blob_id,
+            })
+        })
+    }
+
+    fn reset_on_error<T>(&mut self, operation: impl FnOnce(&mut Self) -> Result<T, Error>) -> Result<T, Error> {
+        let result = operation(self);
+        if result.is_err() {
+            let root_tree_id = self.root_tree_id;
+            self.root = InternalNode::default();
+            self.root.children[0] = Some(Box::new(Node::Subtree(Subtree {
+                prefix: ObjectId::null(root_tree_id.kind()),
+                prefix_len: 0,
+                path: BString::default(),
+                tree_id: root_tree_id,
+            })));
+            self.non_notes.clear();
         }
-        let Some(component) = remaining.get(..2).filter(|_| remaining.len() > 2) else {
-            return Ok(None);
-        };
-        let Some(subtree) = tree
-            .bisect_entry(component.into(), true)
-            .filter(|entry| entry.mode.is_tree())
-        else {
-            return Ok(None);
-        };
-        tree_id = subtree.oid.to_owned();
-        remaining = remaining[2..].as_bstr();
+        result
     }
 }
 
-/// Replace the note for `object`, or add it if absent, returning the new root
-/// tree and any previous note.
-///
-/// The notes tree is rewritten with the same progressive fanout heuristic as
-/// Git while retaining entries that are not notes. Untouched fanout subtrees
-/// are kept by object ID and loaded only when the edit or a fanout change needs
-/// their contents. `note` is expected to reference a blob, but its actual object
-/// kind is not verified; the mapping is always written as a blob-mode tree
-/// entry. For repeated edits, `objects` should have a built-in object cache to
-/// accelerate tree retrieval.
-pub fn replace(
-    root_tree_id: ObjectId,
-    annotated_object_id: ObjectId,
-    note_blob_id: ObjectId,
-    objects: &(impl Find + Write),
-) -> Result<Edit, Error> {
-    if annotated_object_id.kind() != root_tree_id.kind() || note_blob_id.kind() != root_tree_id.kind() {
+fn validate_replace_kinds(
+    root: gix_hash::Kind,
+    annotated_object: gix_hash::Kind,
+    note_blob: gix_hash::Kind,
+) -> Result<(), Error> {
+    if annotated_object != root || note_blob != root {
         return Err(
             ValidationError::from("Notes, annotated objects, and their root tree must use the same hash kind")
                 .raise_erased(),
         );
     }
-    edit(root_tree_id, annotated_object_id, Some(note_blob_id), objects)
+    Ok(())
 }
 
-/// Remove the note for `object`, returning the new root tree and removed note.
-///
-/// If there is no such note, the root is returned unchanged. For repeated
-/// edits, `objects` should have a built-in object cache to accelerate tree
-/// retrieval.
-pub fn remove(
-    root_tree_id: ObjectId,
-    annotated_object_id: ObjectId,
-    objects: &(impl Find + Write),
-) -> Result<Edit, Error> {
-    if annotated_object_id.kind() != root_tree_id.kind() {
+fn validate_annotated_object_kind(root: gix_hash::Kind, annotated_object_id: &oid) -> Result<(), Error> {
+    if annotated_object_id.kind() != root {
         return Err(
             ValidationError::from("The annotated object and notes root tree must use the same hash kind")
                 .raise_erased(),
         );
     }
-    edit(root_tree_id, annotated_object_id, None, objects)
-}
-
-fn edit(
-    root_tree_id: ObjectId,
-    annotated_object_id: ObjectId,
-    note_blob_id: Option<ObjectId>,
-    objects: &(impl Find + Write),
-) -> Result<Edit, Error> {
-    let hash = root_tree_id.kind();
-    let mut root = InternalNode::default();
-    let mut non_notes = Vec::new();
-    load_subtree(
-        Subtree {
-            prefix: ObjectId::null(hash),
-            prefix_len: 0,
-            path: Vec::new(),
-            tree_id: root_tree_id,
-        },
-        &mut root,
-        0,
-        objects,
-        &mut non_notes,
-    )?;
-    let previous_note_blob_id = root.remove(&annotated_object_id, 0, objects, &mut non_notes)?;
-    if note_blob_id.is_none() && previous_note_blob_id.is_none() {
-        return Ok(Edit {
-            tree: root_tree_id,
-            previous: previous_note_blob_id,
-        });
-    }
-    if let Some(note_blob_id) = note_blob_id {
-        root.insert(
-            Node::Note(Note {
-                annotated_object_id,
-                note_blob_id,
-            }),
-            0,
-            objects,
-            &mut non_notes,
-        )?;
-    }
-    let root_tree_id = write(root, non_notes, hash, objects)?;
-    Ok(Edit {
-        tree: root_tree_id,
-        previous: previous_note_blob_id,
-    })
+    Ok(())
 }
 
 struct TreeEntry {
-    path: Vec<BString>,
+    path: BString,
     mode: EntryMode,
     object_id: ObjectId,
 }
 
 #[derive(Default)]
 struct InternalNode {
+    /// One slot per hexadecimal nibble at this trie depth; an empty slot has no matching notes or subtree.
     children: [Option<Box<Node>>; 16],
 }
 
 enum Node {
+    /// A materialized branch that distinguishes the next nibble of an annotated object ID.
     Internal(InternalNode),
+    /// A materialized mapping from an annotated object ID to its note blob.
     Note(Note),
+    /// An on-disk fanout subtree kept unopened until an operation needs its contents.
     Subtree(Subtree),
 }
 
 #[derive(Clone, Copy)]
 struct Note {
+    /// The object receiving the note.
     annotated_object_id: ObjectId,
+    /// The blob containing the note's contents.
     note_blob_id: ObjectId,
 }
 
 // An unopened on-disk fanout directory. Keeping it opaque is what makes edits path-local.
 #[derive(Clone)]
 struct Subtree {
+    /// The decoded object-ID prefix covered by this fanout subtree.
+    ///
+    /// This performance-sensitive trie stores `prefix` and `prefix_len` separately so it can compare whole bytes
+    /// directly. Notes fanout advances by two hexadecimal digits at a time, so it does not need the nibble-granular
+    /// lengths supported by [`gix_hash::Prefix`].
     prefix: ObjectId,
+    /// The number of leading bytes in `prefix` that are significant.
     prefix_len: usize,
-    path: Vec<BString>,
+    /// The slash-separated path from the notes root to this fanout subtree.
+    path: BString,
+    /// The object ID of the on-disk tree represented by this subtree.
     tree_id: ObjectId,
 }
 
@@ -205,6 +266,36 @@ impl Subtree {
 }
 
 impl InternalNode {
+    fn get(
+        &mut self,
+        annotated_object_id: &oid,
+        nibble: usize,
+        objects: &impl Find,
+        non_notes: &mut Vec<TreeEntry>,
+    ) -> Result<Option<ObjectId>, Error> {
+        if self.load_matching_subtree(annotated_object_id, nibble, objects, non_notes)? {
+            return self.get(annotated_object_id, nibble, objects, non_notes);
+        }
+
+        let index = nibble_at(annotated_object_id, nibble);
+        let should_load = self.children[index]
+            .as_deref()
+            .is_some_and(|node| matches!(node, Node::Subtree(subtree) if subtree.contains(annotated_object_id)));
+        if should_load {
+            let Node::Subtree(subtree) = *self.children[index].take().expect("the matching subtree is present") else {
+                unreachable!("the matching node was checked to be a subtree")
+            };
+            load_subtree(subtree, self, nibble, objects, non_notes)?;
+            return self.get(annotated_object_id, nibble, objects, non_notes);
+        }
+
+        match self.children[index].as_deref_mut() {
+            Some(Node::Internal(child)) => child.get(annotated_object_id, nibble + 1, objects, non_notes),
+            Some(Node::Note(note)) if note.annotated_object_id == annotated_object_id => Ok(Some(note.note_blob_id)),
+            _ => Ok(None),
+        }
+    }
+
     fn insert(
         &mut self,
         entry: Node,
@@ -346,6 +437,16 @@ impl InternalNode {
     }
 }
 
+fn path_with_component(path: &BStr, component: &BStr) -> BString {
+    let mut joined = Vec::with_capacity(path.len() + usize::from(!path.is_empty()) + component.len());
+    joined.extend_from_slice(path);
+    if !path.is_empty() {
+        joined.push(b'/');
+    }
+    joined.extend_from_slice(component);
+    joined.into()
+}
+
 fn load_subtree(
     subtree: Subtree,
     node: &mut InternalNode,
@@ -384,8 +485,7 @@ fn load_subtree(
             && prefix_hex_len + 2 < hex_len
             && entry.filename.iter().all(u8::is_ascii_hexdigit)
         {
-            let mut path = subtree.path.clone();
-            path.push(entry.filename.to_owned());
+            let path = path_with_component(subtree.path.as_bstr(), entry.filename);
             let mut hex = prefix_hex;
             hex[prefix_hex_len..prefix_hex_len + 2].copy_from_slice(entry.filename);
             let prefix = ObjectId::from_hex(&hex[..hex_len]).expect("validated hex produces an object ID");
@@ -401,8 +501,7 @@ fn load_subtree(
                 non_notes,
             )?;
         } else {
-            let mut path = subtree.path.clone();
-            path.push(entry.filename.to_owned());
+            let path = path_with_component(subtree.path.as_bstr(), entry.filename);
             non_notes.push(TreeEntry {
                 path,
                 mode: entry.mode,
@@ -413,83 +512,130 @@ fn load_subtree(
     Ok(())
 }
 
-fn write(
-    mut root: InternalNode,
-    mut non_notes: Vec<TreeEntry>,
-    hash: gix_hash::Kind,
-    objects: &(impl Find + Write),
-) -> Result<ObjectId, Error> {
-    let mut notes = Vec::new();
-    collect_for_write(&mut root, 0, 0, objects, &mut non_notes, &mut notes)?;
-    let mut editor = Editor::new(Tree { entries: Vec::new() }, objects, hash);
-    for entry in non_notes {
-        editor
-            .upsert(entry.path.iter(), entry.mode.kind(), entry.object_id)
-            .or_raise_erased(|| message("Could not restore a non-note tree entry"))?;
-    }
-    for entry in notes {
-        editor
-            .upsert(entry.path.iter(), entry.mode.kind(), entry.object_id)
-            .or_raise_erased(|| message("Could not add a note tree entry"))?;
-    }
-    editor
-        .write(|tree| objects.write(tree).map_err(gix_error::Error::from_boxed))
-        .or_raise_erased(|| message("Could not write the notes tree"))
-}
+impl InternalNode {
+    fn write(
+        &mut self,
+        non_notes: &mut Vec<TreeEntry>,
+        hash: gix_hash::Kind,
+        objects: &(impl Find + Write),
+    ) -> Result<ObjectId, Error> {
+        let mut notes = Vec::new();
+        self.collect_for_write(0, 0, objects, non_notes, &mut notes)?;
+        if non_notes.is_empty() {
+            return write_note_entries(&notes, 0, objects);
+        }
 
-fn collect_for_write(
-    node: &mut InternalNode,
-    nibble: usize,
-    fanout: usize,
-    objects: &impl Find,
-    non_notes: &mut Vec<TreeEntry>,
-    notes: &mut Vec<TreeEntry>,
-) -> Result<(), Error> {
-    let fanout = if nibble.is_multiple_of(2)
-        && nibble <= 2 * fanout
-        && node
-            .children
-            .iter()
-            .all(|child| matches!(child.as_deref(), Some(Node::Internal(_) | Node::Subtree(_))))
-    {
-        fanout + 1
-    } else {
-        fanout
-    };
+        let mut editor = Editor::new(Tree { entries: Vec::new() }, objects, hash);
+        for entry in non_notes.iter() {
+            editor
+                .upsert(entry.path.split_str("/"), entry.mode.kind(), entry.object_id)
+                .or_raise_erased(|| message("Could not restore a non-note tree entry"))?;
+        }
+        for entry in notes {
+            editor
+                .upsert(entry.path.split_str("/"), entry.mode.kind(), entry.object_id)
+                .or_raise_erased(|| message("Could not add a note tree entry"))?;
+        }
+        editor
+            .write(|tree| objects.write(tree).map_err(gix_error::Error::from_boxed))
+            .or_raise_erased(|| message("Could not write the notes tree"))
+    }
 
-    for index in 0..node.children.len() {
-        while let Some(entry) = node.children[index].take() {
-            match *entry {
-                Node::Internal(mut child) => {
-                    collect_for_write(&mut child, nibble + 1, fanout, objects, non_notes, notes)?;
-                    node.children[index] = Some(Box::new(Node::Internal(child)));
-                    break;
-                }
-                Node::Note(note) => {
-                    notes.push(TreeEntry {
-                        path: note_path_components(&note.annotated_object_id, fanout),
-                        mode: EntryKind::Blob.into(),
-                        object_id: note.note_blob_id,
-                    });
-                    node.children[index] = Some(Box::new(Node::Note(note)));
-                    break;
-                }
-                Node::Subtree(subtree) if nibble < 2 * fanout => {
-                    notes.push(TreeEntry {
-                        path: subtree.path.clone(),
-                        mode: EntryKind::Tree.into(),
-                        object_id: subtree.tree_id,
-                    });
-                    node.children[index] = Some(Box::new(Node::Subtree(subtree)));
-                    break;
-                }
-                Node::Subtree(subtree) => {
-                    load_subtree(subtree, node, nibble, objects, non_notes)?;
+    /// Collect entries for writing while determining the fanout below `nibble` from the current tree shape.
+    ///
+    /// Subtrees that fit the selected `fanout` remain unopened and are appended to `notes` by tree ID. Subtrees that
+    /// need inspection are loaded from `objects`, with any entries that are not notes appended to `non_notes`.
+    fn collect_for_write(
+        &mut self,
+        nibble: usize,
+        fanout: usize,
+        objects: &impl Find,
+        non_notes: &mut Vec<TreeEntry>,
+        notes: &mut Vec<TreeEntry>,
+    ) -> Result<(), Error> {
+        let fanout = if nibble.is_multiple_of(2)
+            && nibble <= 2 * fanout
+            && self
+                .children
+                .iter()
+                .all(|child| matches!(child.as_deref(), Some(Node::Internal(_) | Node::Subtree(_))))
+        {
+            fanout + 1
+        } else {
+            fanout
+        };
+
+        for index in 0..self.children.len() {
+            while let Some(entry) = self.children[index].take() {
+                match *entry {
+                    Node::Internal(mut child) => {
+                        child.collect_for_write(nibble + 1, fanout, objects, non_notes, notes)?;
+                        self.children[index] = Some(Box::new(Node::Internal(child)));
+                        break;
+                    }
+                    Node::Note(note) => {
+                        notes.push(TreeEntry {
+                            path: owned_note_path(&note.annotated_object_id, fanout),
+                            mode: EntryKind::Blob.into(),
+                            object_id: note.note_blob_id,
+                        });
+                        self.children[index] = Some(Box::new(Node::Note(note)));
+                        break;
+                    }
+                    Node::Subtree(subtree) if nibble < 2 * fanout => {
+                        notes.push(TreeEntry {
+                            path: subtree.path.clone(),
+                            mode: EntryKind::Tree.into(),
+                            object_id: subtree.tree_id,
+                        });
+                        self.children[index] = Some(Box::new(Node::Subtree(subtree)));
+                        break;
+                    }
+                    Node::Subtree(subtree) => {
+                        load_subtree(subtree, self, nibble, objects, non_notes)?;
+                    }
                 }
             }
         }
+        Ok(())
     }
-    Ok(())
+}
+
+/// This is faster than going through the tree editor, whose characteristics are useful enough
+/// to bear worse performance in the uncommon case where non-note entries are present.
+fn write_note_entries(notes: &[TreeEntry], level: usize, objects: &impl Write) -> Result<ObjectId, Error> {
+    let mut entries = Vec::new();
+    let mut start = 0;
+    while start < notes.len() {
+        let mut components = notes[start].path.split_str("/");
+        let name = components.nth(level).expect("a note path has this fanout level");
+        let is_leaf = components.next().is_none();
+        let mut end = start + 1;
+        while end < notes.len() && notes[end].path.split_str("/").nth(level) == Some(name) {
+            end += 1;
+        }
+
+        if is_leaf {
+            debug_assert_eq!(end, start + 1, "a notes path cannot be both a tree and a blob");
+            entries.push(Entry {
+                mode: notes[start].mode,
+                filename: name.into(),
+                oid: notes[start].object_id,
+            });
+        } else {
+            entries.push(Entry {
+                mode: EntryKind::Tree.into(),
+                filename: name.into(),
+                oid: write_note_entries(&notes[start..end], level + 1, objects)?,
+            });
+        }
+        start = end;
+    }
+
+    objects
+        .write(&Tree { entries })
+        .map_err(gix_error::Error::from_boxed)
+        .or_raise_erased(|| message("Could not write the notes tree"))
 }
 
 fn nibble_at(id: &oid, nibble: usize) -> usize {
@@ -501,15 +647,14 @@ fn nibble_at(id: &oid, nibble: usize) -> usize {
     })
 }
 
-fn note_path_components(id: &oid, fanout: usize) -> Vec<BString> {
+fn owned_note_path(id: &oid, fanout: usize) -> BString {
     // A notes path contains the full hexadecimal ID plus one slash for each byte consumed as a fanout directory.
     // At least one byte remains for the leaf name, so allowing one slash per hash byte is a simple one-byte overestimate.
     const NOTE_PATH_BUFFER_SIZE: usize =
         gix_hash::Kind::longest().len_in_hex() + gix_hash::Kind::longest().len_in_bytes();
 
     let mut path_buf = [0u8; NOTE_PATH_BUFFER_SIZE];
-    let path = note_path(id, fanout, &mut path_buf);
-    path.split_str("/").map(BString::from).collect()
+    note_path(id, fanout, &mut path_buf).to_owned()
 }
 
 /// Write the notes-tree path for `id` with `fanout` leading bytes represented as directory components.

--- a/gix-note/tests/note.rs
+++ b/gix-note/tests/note.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::{cell::Cell, collections::BTreeSet, io::Read};
 
 use gix_hash::{Kind, ObjectId, oid};
 use gix_object::{
@@ -8,6 +8,56 @@ use gix_object::{
 };
 
 type ObjectDb = gix_odb::memory::Proxy<gix_object::find::Never>;
+
+struct CountingObjectDb {
+    inner: ObjectDb,
+    reads: Cell<usize>,
+    writes: Cell<usize>,
+}
+
+impl gix_object::Find for CountingObjectDb {
+    fn try_find<'a>(
+        &self,
+        id: &gix_hash::oid,
+        buffer: &'a mut Vec<u8>,
+    ) -> Result<Option<gix_object::Data<'a>>, gix_object::find::Error> {
+        self.reads.set(self.reads.get() + 1);
+        self.inner.try_find(id, buffer)
+    }
+}
+
+impl gix_object::Write for CountingObjectDb {
+    fn write_buf_with_known_id(
+        &self,
+        kind: gix_object::Kind,
+        from: &[u8],
+        id: ObjectId,
+    ) -> Result<ObjectId, gix_object::write::Error> {
+        self.writes.set(self.writes.get() + 1);
+        self.inner.write_buf_with_known_id(kind, from, id)
+    }
+
+    fn write_stream(
+        &self,
+        kind: gix_object::Kind,
+        size: u64,
+        from: &mut dyn Read,
+    ) -> Result<ObjectId, gix_object::write::Error> {
+        self.writes.set(self.writes.get() + 1);
+        self.inner.write_stream(kind, size, from)
+    }
+
+    fn write_stream_with_known_id(
+        &self,
+        kind: gix_object::Kind,
+        size: u64,
+        from: &mut dyn Read,
+        id: ObjectId,
+    ) -> Result<ObjectId, gix_object::write::Error> {
+        self.writes.set(self.writes.get() + 1);
+        self.inner.write_stream_with_known_id(kind, size, from, id)
+    }
+}
 
 #[test]
 fn reads_notes_without_fanout() -> gix_testtools::Result {
@@ -27,6 +77,76 @@ fn reads_notes_with_two_fanout_levels() -> gix_testtools::Result {
 #[test]
 fn reads_notes_with_three_fanout_levels() -> gix_testtools::Result {
     assert_note_at_fanout(3)
+}
+
+#[test]
+fn replacing_a_note_does_not_read_untouched_fanout_subtrees() -> gix_testtools::Result {
+    let kind = gix_testtools::object_hash();
+    let objects = CountingObjectDb {
+        inner: ObjectDb::new(gix_object::find::Never, kind),
+        reads: Cell::new(0),
+        writes: Cell::new(0),
+    };
+    let note = objects.write_buf(gix_object::Kind::Blob, b"note")?;
+    let replacement = objects.write_buf(gix_object::Kind::Blob, b"replacement")?;
+    let mut annotated = Vec::new();
+    let mut root_entries = Vec::new();
+    for high_nibble in b"0123456789abcdef" {
+        for low_nibble in b"01" {
+            let object = object_id_with_nibbles(kind, &[(0, *high_nibble), (1, *low_nibble)])?;
+            let hex = object.to_hex().to_string();
+            let subtree = objects.write(&Tree {
+                entries: vec![Entry {
+                    mode: EntryKind::Blob.into(),
+                    filename: hex[2..].into(),
+                    oid: note,
+                }],
+            })?;
+            annotated.push(object);
+            root_entries.push(Entry {
+                mode: EntryKind::Tree.into(),
+                filename: hex[..2].into(),
+                oid: subtree,
+            });
+        }
+    }
+    let root = objects.write(&Tree {
+        entries: root_entries.clone(),
+    })?;
+    let target_hex = annotated[0].to_hex().to_string();
+    let replacement_subtree = objects.write(&Tree {
+        entries: vec![Entry {
+            mode: EntryKind::Blob.into(),
+            filename: target_hex[2..].into(),
+            oid: replacement,
+        }],
+    })?;
+    root_entries[0].oid = replacement_subtree;
+    let expected_root = objects.write(&Tree { entries: root_entries })?;
+    objects.writes.set(0);
+
+    let outcome = gix_note::replace(root, annotated[0], replacement, &objects)?;
+    assert_eq!(outcome.previous, Some(note), "replacement returns the previous note");
+    assert_eq!(
+        outcome.tree, expected_root,
+        "the rewritten tree matches a path-local edit"
+    );
+    assert_eq!(
+        objects.reads.get(),
+        2,
+        "only the root and the changed fanout subtree are read"
+    );
+    assert_eq!(
+        objects.writes.get(),
+        2,
+        "only the changed fanout subtree and root are written"
+    );
+    assert_eq!(
+        gix_note::get(outcome.tree, &annotated[0], &objects)?,
+        Some(replacement),
+        "the replacement is visible"
+    );
+    Ok(())
 }
 
 fn assert_note_at_fanout(fanout: usize) -> gix_testtools::Result {
@@ -186,8 +306,8 @@ fn mutations_rebalance_when_each_nibble_bucket_has_multiple_notes_and_preserve_n
     let tree = objects.find_tree(&outcome.tree, &mut buf)?;
     assert_eq!(
         tree.entries.iter().filter(|entry| entry.mode.is_tree()).count(),
-        16,
-        "Git's fanout hysteresis retains the existing level while every leading-nibble bucket remains occupied"
+        0,
+        "Git collapses fanout when the edited bucket materializes as a single note"
     );
 
     let outcome = gix_note::remove(outcome.tree, annotated[16], &objects)?;
@@ -406,7 +526,7 @@ fn mutations_create_and_collapse_mixed_deep_fanout() -> gix_testtools::Result {
         None,
         "the deep mapping is removed"
     );
-    assert_note_layout(&objects, outcome.tree, &three_levels, 3, note)?;
+    assert_note_layout(&objects, outcome.tree, &three_levels, 2, note)?;
 
     let outcome = gix_note::remove(outcome.tree, three_levels, &objects)?;
     assert_eq!(
@@ -414,8 +534,7 @@ fn mutations_create_and_collapse_mixed_deep_fanout() -> gix_testtools::Result {
         Some(note),
         "the second deep removal empties its bucket"
     );
-    // Existing fanout survives while every deepest nibble bucket remains occupied. Emptying one bucket collapses the
-    // level, moving the notes in all surviving buckets from three-level paths to two-level paths.
+    // Loading the edited subtree exposes its single remaining note, so Git's lazy heuristic collapses the deepest level.
     assert_note_layout(&objects, outcome.tree, &surviving_after_collapse, 2, note)?;
     assert_note_layout(&objects, outcome.tree, &two_levels, 2, note)?;
     assert_note_layout(&objects, outcome.tree, &one_level, 1, note)?;
@@ -445,14 +564,14 @@ fn mutations_preserve_non_notes_at_root_and_below_hex_trees() -> gix_testtools::
                 oid: kind.empty_tree(),
             },
             Entry {
+                mode: EntryKind::Tree.into(),
+                filename: "CD".into(),
+                oid: nested,
+            },
+            Entry {
                 mode: EntryKind::BlobExecutable.into(),
                 filename: "ab".into(),
                 oid: payload,
-            },
-            Entry {
-                mode: EntryKind::Tree.into(),
-                filename: "cd".into(),
-                oid: nested,
             },
             Entry {
                 mode: EntryKind::Blob.into(),
@@ -471,7 +590,7 @@ fn mutations_preserve_non_notes_at_root_and_below_hex_trees() -> gix_testtools::
     let outcome = gix_note::replace(root, annotated, note, &objects)?;
 
     assert_entry_at_path(&objects, outcome.tree, &["ab"], EntryKind::BlobExecutable, payload)?;
-    assert_entry_at_path(&objects, outcome.tree, &["cd", "README"], EntryKind::Blob, payload)?;
+    assert_entry_at_path(&objects, outcome.tree, &["CD", "README"], EntryKind::Blob, payload)?;
     assert_entry_at_path(
         &objects,
         outcome.tree,

--- a/gix-note/tests/note.rs
+++ b/gix-note/tests/note.rs
@@ -1,4 +1,8 @@
-use std::{cell::Cell, collections::BTreeSet, io::Read};
+use std::{
+    cell::Cell,
+    collections::BTreeSet,
+    io::{self, Read},
+};
 
 use gix_hash::{Kind, ObjectId, oid};
 use gix_object::{
@@ -9,10 +13,63 @@ use gix_object::{
 
 type ObjectDb = gix_odb::memory::Proxy<gix_object::find::Never>;
 
+mod one_shot {
+    use super::*;
+
+    pub fn get(
+        root_tree_id: ObjectId,
+        annotated_object_id: &oid,
+        objects: &impl gix_object::Find,
+    ) -> Result<Option<ObjectId>, gix_note::Error> {
+        let mut state = gix_note::State::new(root_tree_id, objects)?;
+        state.get(annotated_object_id, objects)
+    }
+
+    pub fn replace(
+        root_tree_id: ObjectId,
+        annotated_object_id: ObjectId,
+        note_blob_id: ObjectId,
+        objects: &(impl gix_object::Find + Write),
+    ) -> Result<gix_note::Edit, gix_note::Error> {
+        let mut state = gix_note::State::new(root_tree_id, objects)?;
+        state.replace(annotated_object_id, note_blob_id, objects)
+    }
+
+    pub fn remove(
+        root_tree_id: ObjectId,
+        annotated_object_id: ObjectId,
+        objects: &(impl gix_object::Find + Write),
+    ) -> Result<gix_note::Edit, gix_note::Error> {
+        let mut state = gix_note::State::new(root_tree_id, objects)?;
+        state.remove(annotated_object_id, objects)
+    }
+}
+
 struct CountingObjectDb {
     inner: ObjectDb,
     reads: Cell<usize>,
     writes: Cell<usize>,
+    fail_next_read: Cell<bool>,
+    fail_next_write: Cell<bool>,
+}
+
+impl CountingObjectDb {
+    fn new(kind: Kind) -> Self {
+        Self {
+            inner: ObjectDb::new(gix_object::find::Never, kind),
+            reads: Cell::new(0),
+            writes: Cell::new(0),
+            fail_next_read: Cell::new(false),
+            fail_next_write: Cell::new(false),
+        }
+    }
+
+    fn maybe_fail_write(&self) -> Result<(), gix_object::write::Error> {
+        if self.fail_next_write.replace(false) {
+            return Err(io::Error::other("injected write failure").into());
+        }
+        Ok(())
+    }
 }
 
 impl gix_object::Find for CountingObjectDb {
@@ -22,6 +79,9 @@ impl gix_object::Find for CountingObjectDb {
         buffer: &'a mut Vec<u8>,
     ) -> Result<Option<gix_object::Data<'a>>, gix_object::find::Error> {
         self.reads.set(self.reads.get() + 1);
+        if self.fail_next_read.replace(false) {
+            return Err(io::Error::other("injected read failure").into());
+        }
         self.inner.try_find(id, buffer)
     }
 }
@@ -34,6 +94,7 @@ impl gix_object::Write for CountingObjectDb {
         id: ObjectId,
     ) -> Result<ObjectId, gix_object::write::Error> {
         self.writes.set(self.writes.get() + 1);
+        self.maybe_fail_write()?;
         self.inner.write_buf_with_known_id(kind, from, id)
     }
 
@@ -44,6 +105,7 @@ impl gix_object::Write for CountingObjectDb {
         from: &mut dyn Read,
     ) -> Result<ObjectId, gix_object::write::Error> {
         self.writes.set(self.writes.get() + 1);
+        self.maybe_fail_write()?;
         self.inner.write_stream(kind, size, from)
     }
 
@@ -55,6 +117,7 @@ impl gix_object::Write for CountingObjectDb {
         id: ObjectId,
     ) -> Result<ObjectId, gix_object::write::Error> {
         self.writes.set(self.writes.get() + 1);
+        self.maybe_fail_write()?;
         self.inner.write_stream_with_known_id(kind, size, from, id)
     }
 }
@@ -82,11 +145,7 @@ fn reads_notes_with_three_fanout_levels() -> gix_testtools::Result {
 #[test]
 fn replacing_a_note_does_not_read_untouched_fanout_subtrees() -> gix_testtools::Result {
     let kind = gix_testtools::object_hash();
-    let objects = CountingObjectDb {
-        inner: ObjectDb::new(gix_object::find::Never, kind),
-        reads: Cell::new(0),
-        writes: Cell::new(0),
-    };
+    let objects = CountingObjectDb::new(kind);
     let note = objects.write_buf(gix_object::Kind::Blob, b"note")?;
     let replacement = objects.write_buf(gix_object::Kind::Blob, b"replacement")?;
     let mut annotated = Vec::new();
@@ -125,7 +184,7 @@ fn replacing_a_note_does_not_read_untouched_fanout_subtrees() -> gix_testtools::
     let expected_root = objects.write(&Tree { entries: root_entries })?;
     objects.writes.set(0);
 
-    let outcome = gix_note::replace(root, annotated[0], replacement, &objects)?;
+    let outcome = one_shot::replace(root, annotated[0], replacement, &objects)?;
     assert_eq!(outcome.previous, Some(note), "replacement returns the previous note");
     assert_eq!(
         outcome.tree, expected_root,
@@ -142,9 +201,111 @@ fn replacing_a_note_does_not_read_untouched_fanout_subtrees() -> gix_testtools::
         "only the changed fanout subtree and root are written"
     );
     assert_eq!(
-        gix_note::get(outcome.tree, &annotated[0], &objects)?,
+        one_shot::get(outcome.tree, &annotated[0], &objects)?,
         Some(replacement),
         "the replacement is visible"
+    );
+    Ok(())
+}
+
+#[test]
+fn state_reuses_materialized_trees_across_operations() -> gix_testtools::Result {
+    let kind = gix_testtools::object_hash();
+    let objects = CountingObjectDb::new(kind);
+    let annotated = gix_object::compute_hash(kind, gix_object::Kind::Blob, b"annotated")?;
+    let note = objects.write_buf(gix_object::Kind::Blob, b"note")?;
+    let replacement = objects.write_buf(gix_object::Kind::Blob, b"replacement")?;
+    let root = notes_tree(&objects, &annotated, note, 2)?;
+    objects.reads.set(0);
+
+    let mut state = gix_note::State::new(root, &objects)?;
+    assert_eq!(objects.reads.get(), 1, "initialization reads only the root tree");
+    assert_eq!(state.get(&annotated, &objects)?, Some(note), "the note is found");
+    let reads_after_first_lookup = objects.reads.get();
+    assert_eq!(reads_after_first_lookup, 3, "the first lookup reads both fanout trees");
+    assert_eq!(state.get(&annotated, &objects)?, Some(note), "the cached note is found");
+    assert_eq!(
+        objects.reads.get(),
+        reads_after_first_lookup,
+        "a repeated lookup reuses the materialized trees"
+    );
+
+    let edit = state.replace(annotated, replacement, &objects)?;
+    assert_eq!(edit.previous, Some(note), "replacement returns the cached note");
+    assert_eq!(
+        objects.reads.get(),
+        reads_after_first_lookup,
+        "replacement reuses the materialized trees"
+    );
+    assert_eq!(
+        state.get(&annotated, &objects)?,
+        Some(replacement),
+        "the state contains the replacement"
+    );
+    assert_eq!(
+        objects.reads.get(),
+        reads_after_first_lookup,
+        "looking up the replacement needs no tree reads"
+    );
+    let edit = state.replace(annotated, note, &objects)?;
+    assert_eq!(
+        edit.previous,
+        Some(replacement),
+        "a second edit sees the cached replacement"
+    );
+    assert_eq!(
+        objects.reads.get(),
+        reads_after_first_lookup,
+        "writing the state retains its materialized trees"
+    );
+    let edit = state.remove(annotated, &objects)?;
+    assert_eq!(edit.previous, Some(note), "removal sees the cached note");
+    assert_eq!(state.get(&annotated, &objects)?, None, "the cached note is removed");
+    assert_eq!(
+        objects.reads.get(),
+        reads_after_first_lookup,
+        "removal and its subsequent lookup need no tree reads"
+    );
+    Ok(())
+}
+
+#[test]
+fn state_recovers_after_failed_operations() -> gix_testtools::Result {
+    let kind = gix_testtools::object_hash();
+    let objects = CountingObjectDb::new(kind);
+    let annotated = gix_object::compute_hash(kind, gix_object::Kind::Blob, b"annotated")?;
+    let note = objects.write_buf(gix_object::Kind::Blob, b"note")?;
+    let replacement = objects.write_buf(gix_object::Kind::Blob, b"replacement")?;
+    let root = notes_tree(&objects, &annotated, note, 2)?;
+    let mut state = gix_note::State::new(root, &objects)?;
+
+    objects.fail_next_read.set(true);
+    state
+        .get(&annotated, &objects)
+        .expect_err("the injected subtree read fails");
+    assert_eq!(state.root_tree_id(), root, "a failed lookup retains the current root");
+    assert_eq!(
+        state.get(&annotated, &objects)?,
+        Some(note),
+        "the state reloads from its root after a failed lookup"
+    );
+
+    objects.fail_next_write.set(true);
+    state
+        .replace(annotated, replacement, &objects)
+        .expect_err("the injected tree write fails");
+    assert_eq!(state.root_tree_id(), root, "a failed edit retains the current root");
+    assert_eq!(
+        state.get(&annotated, &objects)?,
+        Some(note),
+        "the state reloads the pre-edit note after a failed edit"
+    );
+    let edit = state.replace(annotated, replacement, &objects)?;
+    assert_eq!(edit.previous, Some(note), "the recovered state can be edited");
+    assert_eq!(
+        state.root_tree_id(),
+        edit.tree,
+        "a successful edit advances the recovered state"
     );
     Ok(())
 }
@@ -157,14 +318,14 @@ fn assert_note_at_fanout(fanout: usize) -> gix_testtools::Result {
     let root = notes_tree(&objects, &annotated, note, fanout)?;
 
     assert_eq!(
-        gix_note::get(root, &annotated, &objects)?,
+        one_shot::get(root, &annotated, &objects)?,
         Some(note),
         "the note is found with {fanout} fanout levels"
     );
     Ok(())
 }
 
-fn notes_tree(objects: &ObjectDb, annotated: &oid, note: ObjectId, fanout: usize) -> gix_testtools::Result<ObjectId> {
+fn notes_tree(objects: &impl Write, annotated: &oid, note: ObjectId, fanout: usize) -> gix_testtools::Result<ObjectId> {
     let hex = annotated.to_hex().to_string();
     let mut tree = objects.write(&Tree {
         entries: vec![Entry {
@@ -201,7 +362,7 @@ fn ignores_entries_that_are_not_notes() -> gix_testtools::Result {
     })?;
 
     assert_eq!(
-        gix_note::get(root, &annotated, &objects)?,
+        one_shot::get(root, &annotated, &objects)?,
         None,
         "the canonical empty-tree ID in a tree-mode entry at the full object-ID path is not a blob note"
     );
@@ -225,7 +386,7 @@ fn mutations_rebalance_when_each_nibble_bucket_has_multiple_notes_and_preserve_n
     for nibble in b"0123456789abcdef" {
         let object = object_id_with_nibble(kind, 0, *nibble)?;
         annotated.push(object);
-        let outcome = gix_note::replace(root, object, note, &objects)?;
+        let outcome = one_shot::replace(root, object, note, &objects)?;
         assert_eq!(outcome.previous, None, "each distinct object receives a new note");
         root = outcome.tree;
     }
@@ -246,7 +407,7 @@ fn mutations_rebalance_when_each_nibble_bucket_has_multiple_notes_and_preserve_n
     for nibble in b"0123456789abcde" {
         let object = object_id_with_nibbles(kind, &[(0, *nibble), (2, b'1')])?;
         annotated.push(object);
-        let outcome = gix_note::replace(root, object, note, &objects)?;
+        let outcome = one_shot::replace(root, object, note, &objects)?;
         assert_eq!(outcome.previous, None, "each bucket receives a second note");
         root = outcome.tree;
     }
@@ -261,7 +422,7 @@ fn mutations_rebalance_when_each_nibble_bucket_has_multiple_notes_and_preserve_n
     let last = object_id_with_nibbles(kind, &[(0, b'f'), (2, b'1')])?;
     annotated.push(last);
 
-    let outcome = gix_note::replace(root, last, note, &objects)?;
+    let outcome = one_shot::replace(root, last, note, &objects)?;
     assert_eq!(outcome.previous, None, "the final bucket receives its second note");
     root = outcome.tree;
 
@@ -281,24 +442,24 @@ fn mutations_rebalance_when_each_nibble_bucket_has_multiple_notes_and_preserve_n
 
     for object in &annotated {
         assert_eq!(
-            gix_note::get(root, object, &objects)?,
+            one_shot::get(root, object, &objects)?,
             Some(note),
             "every note remains readable after fanout"
         );
     }
 
     let replacement = objects.write_buf(gix_object::Kind::Blob, b"replacement")?;
-    let outcome = gix_note::replace(root, annotated[0], replacement, &objects)?;
+    let outcome = one_shot::replace(root, annotated[0], replacement, &objects)?;
     assert_eq!(outcome.previous, Some(note), "replacement returns the previous note");
     assert_eq!(
-        gix_note::get(outcome.tree, &annotated[0], &objects)?,
+        one_shot::get(outcome.tree, &annotated[0], &objects)?,
         Some(replacement),
         "replacement is visible through lookup"
     );
-    let outcome = gix_note::remove(outcome.tree, annotated[0], &objects)?;
+    let outcome = one_shot::remove(outcome.tree, annotated[0], &objects)?;
     assert_eq!(outcome.previous, Some(replacement), "removal returns the removed note");
     assert_eq!(
-        gix_note::get(outcome.tree, &annotated[0], &objects)?,
+        one_shot::get(outcome.tree, &annotated[0], &objects)?,
         None,
         "the removed mapping is no longer visible"
     );
@@ -310,7 +471,7 @@ fn mutations_rebalance_when_each_nibble_bucket_has_multiple_notes_and_preserve_n
         "Git collapses fanout when the edited bucket materializes as a single note"
     );
 
-    let outcome = gix_note::remove(outcome.tree, annotated[16], &objects)?;
+    let outcome = one_shot::remove(outcome.tree, annotated[16], &objects)?;
     assert_eq!(outcome.previous, Some(note), "the second removal empties the bucket");
     let mut buf = Vec::new();
     let tree = objects.find_tree(&outcome.tree, &mut buf)?;
@@ -371,12 +532,12 @@ fn mutation_fanout_matches_git_at_bucket_count_boundaries() -> gix_testtools::Re
                 );
                 if operation == "add" {
                     additions += 1;
-                    let outcome = gix_note::replace(root, annotated_object_id, note, &objects)?;
+                    let outcome = one_shot::replace(root, annotated_object_id, note, &objects)?;
                     assert_eq!(outcome.previous, None, "baseline additions introduce distinct notes");
                     root = outcome.tree;
                 } else {
                     removals += 1;
-                    let outcome = gix_note::remove(root, annotated_object_id, &objects)?;
+                    let outcome = one_shot::remove(root, annotated_object_id, &objects)?;
                     assert_eq!(outcome.previous, Some(note), "baseline removals remove the shared note");
                     root = outcome.tree;
                 }
@@ -426,40 +587,40 @@ fn edit_lifecycle_handles_empty_trees_replacements_and_no_op_removals() -> gix_t
     })?;
 
     assert_eq!(
-        gix_note::get(root, &annotated, &objects)?,
+        one_shot::get(root, &annotated, &objects)?,
         None,
         "an empty notes tree has no mapping"
     );
-    let absent = gix_note::remove(root, annotated, &objects)?;
+    let absent = one_shot::remove(root, annotated, &objects)?;
     assert_eq!(absent.previous, None, "removing an absent mapping has no previous note");
     assert_eq!(
         absent.tree, root,
         "removing an absent mapping leaves the root unchanged"
     );
 
-    let added = gix_note::replace(root, annotated, tree_note, &objects)?;
+    let added = one_shot::replace(root, annotated, tree_note, &objects)?;
     assert_eq!(added.previous, None, "adding the first mapping has no previous note");
     assert_eq!(
-        gix_note::get(added.tree, &annotated, &objects)?,
+        one_shot::get(added.tree, &annotated, &objects)?,
         Some(tree_note),
         "lookup returns a note even when its object is actually a tree"
     );
     assert_note_layout(&objects, added.tree, &annotated, 0, tree_note)?;
 
     let replacement = objects.write_buf(gix_object::Kind::Blob, b"replacement")?;
-    let replaced = gix_note::replace(added.tree, annotated, replacement, &objects)?;
+    let replaced = one_shot::replace(added.tree, annotated, replacement, &objects)?;
     assert_eq!(
         replaced.previous,
         Some(tree_note),
         "replacement returns the tree-valued note"
     );
     assert_eq!(
-        gix_note::get(replaced.tree, &annotated, &objects)?,
+        one_shot::get(replaced.tree, &annotated, &objects)?,
         Some(replacement),
         "lookup observes the replacement"
     );
 
-    let removed = gix_note::remove(replaced.tree, annotated, &objects)?;
+    let removed = one_shot::remove(replaced.tree, annotated, &objects)?;
     assert_eq!(
         removed.previous,
         Some(replacement),
@@ -470,7 +631,7 @@ fn edit_lifecycle_handles_empty_trees_replacements_and_no_op_removals() -> gix_t
         kind.empty_tree(),
         "removing the last note produces the empty tree"
     );
-    let absent = gix_note::remove(removed.tree, annotated, &objects)?;
+    let absent = one_shot::remove(removed.tree, annotated, &objects)?;
     assert_eq!(absent.previous, None, "a repeated removal is a no-op");
     assert_eq!(absent.tree, removed.tree, "a repeated removal retains the empty root");
     Ok(())
@@ -497,7 +658,7 @@ fn mutations_create_and_collapse_mixed_deep_fanout() -> gix_testtools::Result {
         annotated.insert(object_id_with_nibbles(kind, &[(4, *nibble), (6, b'1')])?);
     }
     for object in &annotated {
-        let outcome = gix_note::replace(root, *object, note, &objects)?;
+        let outcome = one_shot::replace(root, *object, note, &objects)?;
         assert_eq!(outcome.previous, None, "every generated object is unique");
         root = outcome.tree;
     }
@@ -513,22 +674,22 @@ fn mutations_create_and_collapse_mixed_deep_fanout() -> gix_testtools::Result {
     assert_note_layout(&objects, root, &last_in_level_three, 3, note)?;
     for object in &annotated {
         assert_eq!(
-            gix_note::get(root, object, &objects)?,
+            one_shot::get(root, object, &objects)?,
             Some(note),
             "mixed fanout depths remain readable"
         );
     }
 
-    let outcome = gix_note::remove(root, last_in_level_three, &objects)?;
+    let outcome = one_shot::remove(root, last_in_level_three, &objects)?;
     assert_eq!(outcome.previous, Some(note), "deep removal returns its note");
     assert_eq!(
-        gix_note::get(outcome.tree, &last_in_level_three, &objects)?,
+        one_shot::get(outcome.tree, &last_in_level_three, &objects)?,
         None,
         "the deep mapping is removed"
     );
     assert_note_layout(&objects, outcome.tree, &three_levels, 2, note)?;
 
-    let outcome = gix_note::remove(outcome.tree, three_levels, &objects)?;
+    let outcome = one_shot::remove(outcome.tree, three_levels, &objects)?;
     assert_eq!(
         outcome.previous,
         Some(note),
@@ -587,7 +748,7 @@ fn mutations_preserve_non_notes_at_root_and_below_hex_trees() -> gix_testtools::
     })?;
     let annotated = gix_object::compute_hash(kind, gix_object::Kind::Blob, b"new")?;
     let note = objects.write_buf(gix_object::Kind::Blob, b"note")?;
-    let outcome = gix_note::replace(root, annotated, note, &objects)?;
+    let outcome = one_shot::replace(root, annotated, note, &objects)?;
 
     assert_entry_at_path(&objects, outcome.tree, &["ab"], EntryKind::BlobExecutable, payload)?;
     assert_entry_at_path(&objects, outcome.tree, &["CD", "README"], EntryKind::Blob, payload)?;
@@ -607,7 +768,7 @@ fn mutations_preserve_non_notes_at_root_and_below_hex_trees() -> gix_testtools::
     )?;
     assert_entry_at_path(&objects, outcome.tree, &["zz"], EntryKind::Tree, nested)?;
     assert_eq!(
-        gix_note::get(outcome.tree, &annotated, &objects)?,
+        one_shot::get(outcome.tree, &annotated, &objects)?,
         Some(note),
         "the new note coexists with all preserved entries"
     );
@@ -615,14 +776,14 @@ fn mutations_preserve_non_notes_at_root_and_below_hex_trees() -> gix_testtools::
 }
 
 #[test]
-fn mutations_reject_mixed_hash_kinds_before_reading_objects() -> gix_testtools::Result {
+fn mutations_reject_mixed_hash_kinds() -> gix_testtools::Result {
     let objects = ObjectDb::new(gix_object::find::Never, Kind::Sha1);
     let root = objects.write(&Tree { entries: Vec::new() })?;
     let sha1 = ObjectId::null(Kind::Sha1);
     let sha256 = ObjectId::null(Kind::Sha256);
 
     let err =
-        gix_note::replace(root, sha256, sha1, &objects).expect_err("the annotated object has the wrong hash kind");
+        one_shot::replace(root, sha256, sha1, &objects).expect_err("the annotated object has the wrong hash kind");
     let err = err.into_error();
     assert!(
         err.is_validation(),
@@ -633,7 +794,7 @@ fn mutations_reject_mixed_hash_kinds_before_reading_objects() -> gix_testtools::
         "Notes, annotated objects, and their root tree must use the same hash kind",
         "replace reports an annotated-object hash mismatch"
     );
-    let err = gix_note::replace(root, sha1, sha256, &objects).expect_err("the note has the wrong hash kind");
+    let err = one_shot::replace(root, sha1, sha256, &objects).expect_err("the note has the wrong hash kind");
     let err = err.into_error();
     assert!(err.is_validation(), "a note hash mismatch is a validation error");
     assert_eq!(
@@ -641,7 +802,7 @@ fn mutations_reject_mixed_hash_kinds_before_reading_objects() -> gix_testtools::
         "Notes, annotated objects, and their root tree must use the same hash kind",
         "replace reports a note hash mismatch"
     );
-    let err = gix_note::remove(root, sha256, &objects).expect_err("the annotated object has the wrong hash kind");
+    let err = one_shot::remove(root, sha256, &objects).expect_err("the annotated object has the wrong hash kind");
     let err = err.into_error();
     assert!(
         err.is_validation(),
@@ -664,15 +825,15 @@ fn edits_support_sha256_notes_trees() -> gix_testtools::Result {
     let annotated = gix_object::compute_hash(kind, gix_object::Kind::Blob, b"annotated")?;
     let note = objects.write_buf(gix_object::Kind::Blob, b"note")?;
 
-    let added = gix_note::replace(root, annotated, note, &objects)?;
+    let added = one_shot::replace(root, annotated, note, &objects)?;
     assert_eq!(added.previous, None, "the SHA-256 mapping is new");
     assert_eq!(added.tree.kind(), kind, "the rewritten root retains its hash kind");
     assert_eq!(
-        gix_note::get(added.tree, &annotated, &objects)?,
+        one_shot::get(added.tree, &annotated, &objects)?,
         Some(note),
         "SHA-256 notes can be read after insertion"
     );
-    let removed = gix_note::remove(added.tree, annotated, &objects)?;
+    let removed = one_shot::remove(added.tree, annotated, &objects)?;
     assert_eq!(removed.previous, Some(note), "SHA-256 removal returns the note");
     assert_eq!(
         removed.tree,
@@ -713,7 +874,7 @@ fn mutations_reject_duplicate_mappings_across_layouts() -> gix_testtools::Result
     })?;
     let other = gix_object::compute_hash(kind, gix_object::Kind::Blob, b"other")?;
 
-    let err = gix_note::replace(root, other, flat_note, &objects)
+    let err = one_shot::replace(root, other, flat_note, &objects)
         .expect_err("ambiguous existing mappings cannot be rewritten losslessly");
     let err = err.into_error();
     assert!(err.is_corrupted(), "duplicate mappings indicate a corrupt notes tree");

--- a/gix-odb/src/memory.rs
+++ b/gix-odb/src/memory.rs
@@ -210,6 +210,19 @@ impl<T> gix_object::Write for Proxy<T>
 where
     T: gix_object::Write,
 {
+    fn write(&self, object: &dyn gix_object::WriteTo) -> Result<gix_hash::ObjectId, gix_object::write::Error> {
+        let Some(map) = self.memory.as_ref() else {
+            return self.inner.write(object);
+        };
+
+        let mut buf = Vec::with_capacity(2048);
+        object.write_to(&mut buf)?;
+        let kind = object.kind();
+        let id = gix_object::compute_hash(self.object_hash, kind, &buf)?;
+        map.borrow_mut().entry(id).or_insert((kind, buf));
+        Ok(id)
+    }
+
     fn write_stream(
         &self,
         kind: gix_object::Kind,
@@ -224,7 +237,7 @@ where
         from.read_to_end(&mut buf)?;
 
         let id = gix_object::compute_hash(self.object_hash, kind, &buf)?;
-        map.borrow_mut().insert(id, (kind, buf));
+        map.borrow_mut().entry(id).or_insert((kind, buf));
         Ok(id)
     }
 
@@ -238,7 +251,7 @@ where
             return self.inner.write_buf_with_known_id(kind, from, id);
         };
 
-        map.borrow_mut().insert(id, (kind, from.to_owned()));
+        map.borrow_mut().entry(id).or_insert_with(|| (kind, from.to_owned()));
         Ok(id)
     }
 
@@ -256,7 +269,7 @@ where
         let mut buf = Vec::new();
         from.read_to_end(&mut buf)?;
 
-        map.borrow_mut().insert(id, (kind, buf));
+        map.borrow_mut().entry(id).or_insert((kind, buf));
         Ok(id)
     }
 }

--- a/gix-tix/src/edit/rebase.rs
+++ b/gix-tix/src/edit/rebase.rs
@@ -2295,16 +2295,23 @@ fn note_rewrite_edits(
         }
         None => (ObjectId::empty_tree(repo.object_hash()), None),
     };
-    let mut root = original_root;
+    let mut source_state = gix::note::plumbing::State::new(original_root, repo)
+        .map_err(gix::Exn::into_error)
+        .context("could not initialize the source Git notes tree")?;
+    let mut destination_state = gix::note::plumbing::State::new(original_root, repo)
+        .map_err(gix::Exn::into_error)
+        .context("could not initialize the destination Git notes tree")?;
     for &(old, new) in rewrites {
-        let Some(source) = gix::note::plumbing::get(original_root, &old, repo)
+        let Some(source) = source_state
+            .get(&old, repo)
             .map_err(gix::Exn::into_error)
             .context("could not find a Git note to copy")?
         else {
             continue;
         };
         let source = repo.find_blob(source).context("could not read a Git note to copy")?;
-        let destination = gix::note::plumbing::get(root, &new, repo)
+        let destination = destination_state
+            .get(&new, repo)
             .map_err(gix::Exn::into_error)
             .context("could not inspect the successor Git note")?;
         let data = match destination {
@@ -2320,11 +2327,12 @@ fn note_rewrite_edits(
             None => source.data.clone(),
         };
         let note = repo.write_blob(data)?.detach();
-        root = gix::note::plumbing::replace(root, new, note, repo)
+        destination_state
+            .replace(new, note, repo)
             .map_err(gix::Exn::into_error)
-            .context("could not copy a Git note onto its successor")?
-            .tree;
+            .context("could not copy a Git note onto its successor")?;
     }
+    let root = destination_state.root_tree_id();
     if root == original_root {
         return Ok(empty());
     }
@@ -2363,7 +2371,11 @@ fn enrichment_edits(
         None => (ObjectId::empty_tree(repo.object_hash()), None),
     };
     let note = repo.write_blob(data)?.detach();
-    let tree = gix::note::plumbing::replace(root, object, note, repo)
+    let mut state = gix::note::plumbing::State::new(root, repo)
+        .map_err(gix::Exn::into_error)
+        .context("could not initialize the tix enrichment tree")?;
+    let tree = state
+        .replace(object, note, repo)
         .map_err(gix::Exn::into_error)
         .context("could not prepare the tix enrichment")?
         .tree;

--- a/gix/src/note.rs
+++ b/gix/src/note.rs
@@ -25,10 +25,15 @@ pub struct Note<'platform, 'repo> {
 
 /// Cached access to one or more notes references.
 pub struct Platform<'repo> {
-    // TODO(ST): make this owned once there is a cache, so it's easier to use reliably.
     pub(crate) repo: &'repo Repository,
     pub(crate) default_ref: Option<FullName>,
+    // Selected references in lookup order. Each caches its resolved notes-tree ID until a successful local edit
+    // invalidates all resolutions. The selection lives until `with_refs()` replaces it or the platform is dropped.
     roots: Vec<Root>,
+    // Lazily materialized notes trees, searched by their current root tree ID rather than aligned with `roots`.
+    // Multiple roots resolving to the same tree share one state. States survive root invalidation and selection changes
+    // for the platform's lifetime; a successful edit advances its state so the re-resolved root finds it again.
+    states: Vec<gix_note::State>,
     commit_message: Option<String>,
 }
 
@@ -66,6 +71,7 @@ impl<'repo> Platform<'repo> {
             repo,
             default_ref,
             roots: refs.into_iter().map(Root::new).collect(),
+            states: Vec::new(),
             commit_message: None,
         })
     }
@@ -130,16 +136,19 @@ impl<'repo> Platform<'repo> {
     ) -> Result<Vec<Note<'platform, 'repo>>, crate::Error> {
         let annotated_object_id = object.into();
         let mut out = Vec::new();
-        for selected in &mut self.roots {
-            let Some(root_tree_id) = selected.tree_id(self.repo)? else {
+        let repo = self.repo;
+        let (roots, states) = (&mut self.roots, &mut self.states);
+        for selected in roots {
+            let Some(root_tree_id) = selected.tree_id(repo)? else {
                 continue;
             };
-            if let Some(note_blob_id) = gix_note::get(root_tree_id, &annotated_object_id, &self.repo)
+            let state = state_for(states, root_tree_id, repo)?;
+            if let Some(note_blob_id) = state
+                .get(&annotated_object_id, repo)
                 .or_raise(|| message!("Could not find notes for {annotated_object_id}"))?
             {
                 let reference = selected.reference.as_ref();
-                let blob = self
-                    .repo
+                let blob = repo
                     .find_blob(note_blob_id)
                     .or_raise(|| message!("Could not load note {note_blob_id} from {reference}"))?;
                 out.push(Note { reference, blob });
@@ -194,8 +203,11 @@ impl<'repo> Platform<'repo> {
             .write_blob(data.as_ref())
             .or_raise(|| message("Could not write note blob"))?
             .detach();
-        let edit = gix_note::replace(root_tree_id, annotated_object_id, note_blob_id, &self.repo)
-            .or_raise(|| message!("Could not replace note for {annotated_object_id}"))?;
+        let edit = {
+            let state = state_for(&mut self.states, root_tree_id, self.repo)?;
+            state.replace(annotated_object_id, note_blob_id, self.repo)
+        }
+        .or_raise(|| message!("Could not replace note for {annotated_object_id}"))?;
         self.commit_edit(
             update_ref.as_ref(),
             parent_commit_id,
@@ -233,8 +245,11 @@ impl<'repo> Platform<'repo> {
             update_ref,
         } = self.lookup_edit_root(notes_ref.as_ref())?;
         let annotated_object_id = object.into();
-        let edit = gix_note::remove(root_tree_id, annotated_object_id, &self.repo)
-            .or_raise(|| message!("Could not remove note for {annotated_object_id}"))?;
+        let edit = {
+            let state = state_for(&mut self.states, root_tree_id, self.repo)?;
+            state.remove(annotated_object_id, self.repo)
+        }
+        .or_raise(|| message!("Could not remove note for {annotated_object_id}"))?;
         if edit.previous.is_some() {
             self.commit_edit(update_ref.as_ref(), parent_commit_id, edit, "Notes removed by gitoxide")?;
         }
@@ -305,6 +320,22 @@ impl<'repo> Platform<'repo> {
         }
         Ok(())
     }
+}
+
+fn state_for<'a>(
+    states: &'a mut Vec<gix_note::State>,
+    root_tree_id: gix_hash::ObjectId,
+    repo: &Repository,
+) -> Result<&'a mut gix_note::State, crate::Error> {
+    if let Some(index) = states.iter().position(|state| state.root_tree_id() == root_tree_id) {
+        return Ok(&mut states[index]);
+    }
+    let index = states.len();
+    states.push(
+        gix_note::State::new(root_tree_id, repo)
+            .or_raise(|| message!("Could not initialize notes tree {root_tree_id}"))?,
+    );
+    Ok(&mut states[index])
 }
 
 /// A selected notes reference and its lazily resolved root tree.


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- Keep unopened notes fanout subtrees as opaque tree IDs and materialize only the edited path.
- Reuse untouched subtrees while applying Git’s lazy radix-tree fanout heuristic, including its local-materialization trade-off.
- Preserve non-note entries and remove the now-unused `gix-hashtable` dependency.

## Reported issue

Compare this with how Git does it in /Users/byron/dev/github.com/git/git
- I have a feeling that we over-corrected for something, and lost performance on the way.

---

The `edit()` path does a full traversal and reconstruction:

- [`gix-note/src/lib.rs:121`](/Users/byron/dev/github.com/GitoxideLabs/gitoxide/gix-note/src/lib.rs:121) calls `collect()` on the root.
- [`collect()` at line 168](/Users/byron/dev/github.com/GitoxideLabs/gitoxide/gix-note/src/lib.rs:168) visits every entry and recursively descends into every notes fanout subtree at line 194.
- The resulting `HashMap` contains every note; only one entry is changed at lines 130–133.
- [`write()` at line 226](/Users/byron/dev/github.com/GitoxideLabs/gitoxide/gix-note/src/lib.rs:226) starts with an empty tree.
- It recalculates fanout for all note IDs at line 233, reinserts every note at lines 235–240, then writes the reconstructed tree.

So the CPU/allocation work is O(number of notes), and the full notes tree is read.

My wording was slightly imprecise: it reconstructs the complete logical tree, but content addressing means unchanged tree objects may hash identically and already exist in the ODB. It does not necessarily add N fresh Git objects on every edit. A path-local editor would avoid the full traversal, but matching Git’s global fanout heuristic makes that less trivial than my earlier answer suggested.

## Requested direction

`$issue-full-auto  Do it like Git does, accepting the trade-off that comes with it.`

## Git baseline

Compared with git.git `1630431f326e15fcde608827b5ff38422528eb59`, especially `notes.c` functions `note_tree_search()`, `load_subtree()`, `determine_fanout()`, `for_each_note_helper()`, and `write_notes_tree()`.

Like Git, the implementation keeps untouched subtrees opaque. A fanout decision can therefore change when editing materializes one sparse bucket instead of after a global note recount.

## Validation

- `cargo +1.88 test -p gix-note --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy -p gix-note --all-targets --all-features --no-deps -- -D warnings`
- `cargo test -p gix --test gix repository::note`
- SHA-1-only and SHA-256-only feature checks
- Git-generated fanout-boundary fixture with exact tree-ID comparisons

Commit: `d149d746f2fa0951c5db5b812e6caa15e28e02e7`