### PR TITLE
Reduce Git configuration discovery overhead on Windows

### DIFF
--- a/gix-config/src/source.rs
+++ b/gix-config/src/source.rs
@@ -61,7 +61,7 @@ impl Source {
     pub fn storage_location(self, env_var: &mut dyn FnMut(&str) -> Option<OsString>) -> Option<PathBuf> {
         use Source::*;
         match self {
-            GitInstallation => {
+            GitInstallation | System => {
                 if env_var("GIT_CONFIG_NOSYSTEM")
                     .map(crate::Boolean::try_from)
                     .transpose()
@@ -71,22 +71,20 @@ impl Source {
                 {
                     None
                 } else {
-                    gix_path::env::installation_config().map(Into::into)
-                }
-            }
-            System => {
-                if env_var("GIT_CONFIG_NOSYSTEM")
-                    .map(crate::Boolean::try_from)
-                    .transpose()
-                    .ok()
-                    .flatten()
-                    .is_some_and(|b| b.0)
-                {
-                    None
-                } else {
-                    env_var("GIT_CONFIG_SYSTEM")
-                        .map(Into::into)
-                        .or_else(|| gix_path::env::system_config().map(Into::into))
+                    let is_system_scoped = match self {
+                        GitInstallation => gix_path::env::installation_config_is_system(),
+                        System => true,
+                        _ => unreachable!("matched installation or system source"),
+                    };
+                    let system_override = is_system_scoped.then(|| env_var("GIT_CONFIG_SYSTEM")).flatten();
+                    if let Some(path) = system_override {
+                        return Some(path.into());
+                    }
+                    match self {
+                        GitInstallation => gix_path::env::installation_config().map(Into::into),
+                        System => gix_path::env::system_config().map(Into::into),
+                        _ => unreachable!("matched installation or system source"),
+                    }
                 }
             }
             Git => match env_var("GIT_CONFIG_GLOBAL") {

--- a/gix-config/src/source.rs
+++ b/gix-config/src/source.rs
@@ -86,7 +86,7 @@ impl Source {
                 } else {
                     env_var("GIT_CONFIG_SYSTEM")
                         .map(Into::into)
-                        .or_else(|| gix_path::env::system_prefix().map(|p| p.join("etc/gitconfig")))
+                        .or_else(|| gix_path::env::system_config().map(Into::into))
                 }
             }
             Git => match env_var("GIT_CONFIG_GLOBAL") {

--- a/gix-config/tests/config/source.rs
+++ b/gix-config/tests/config/source.rs
@@ -17,11 +17,11 @@ fn git_config_no_system() {
     assert!(
         Source::GitInstallation
             .storage_location(&mut |name| {
-                assert_eq!(
-                    name, "GIT_CONFIG_NOSYSTEM",
-                    "it only checks this var, and if set, nothing else"
-                );
-                Some("false".into())
+                match name {
+                    "GIT_CONFIG_NOSYSTEM" => Some("false".into()),
+                    "GIT_CONFIG_SYSTEM" => None,
+                    _ => unreachable!("known set"),
+                }
             })
             .is_some(),
         "it treats the variable as boolean"
@@ -63,6 +63,22 @@ fn git_config_system() {
             .expect("set"),
         Path::new("alternative"),
         "we respect the system config variable for overrides"
+    );
+
+    let default_installation = gix_path::env::installation_config().map(ToOwned::to_owned);
+    let overridden_installation = Source::GitInstallation.storage_location(&mut |name| match name {
+        "GIT_CONFIG_NOSYSTEM" => None,
+        "GIT_CONFIG_SYSTEM" => Some("alternative".into()),
+        unexpected => unreachable!("unexpected env var: {unexpected}"),
+    });
+    assert_eq!(
+        overridden_installation,
+        if gix_path::env::installation_config_is_system() {
+            Some("alternative".into())
+        } else {
+            default_installation
+        },
+        "the override replaces system-scoped installation configuration but preserves other scopes"
     );
 }
 

--- a/gix-path/src/env/auxiliary.rs
+++ b/gix-path/src/env/auxiliary.rs
@@ -55,9 +55,8 @@ const MSYS_USR_VARIANTS: &[&str] = &["mingw64", "mingw32", "clangarm64", "clang6
 /// Currently this is used only for finding the path to an `sh.exe` associated with Git. This is
 /// separate from `installation_config()` and `installation_config_prefix()` in `gix_path::env`.
 /// This is *not* suitable for finding the highest-scoped configuration file, because that could be
-/// installed in an unusual place, or customized via `GIT_CONFIG_SYSTEM` or `GIT_CONFIG_NOSYSTEM`,
-/// all of which `installation_config()` should reflect. Likewise, `installation_config_prefix()`
-/// has strong uses, such as to find a directory inside `ProgramData` containing configuration.
+/// installed in an unusual place. Likewise, `installation_config_prefix()` has strong uses, such
+/// as to find a directory inside `ProgramData` containing configuration.
 /// But it is possible that some marginal uses of `installation_config_prefix()`, if they do not
 /// really relate to configuration, could be replaced with `git_for_windows_root()` in the future.
 fn git_for_windows_root() -> Option<&'static Path> {

--- a/gix-path/src/env/git/mod.rs
+++ b/gix-path/src/env/git/mod.rs
@@ -101,6 +101,7 @@ pub(super) const EXE_NAME: &str = "git";
 #[derive(Debug, Default, Eq, PartialEq)]
 struct ConfigPaths {
     installation: Option<BString>,
+    installation_is_system: bool,
     system: Option<BString>,
 }
 
@@ -118,17 +119,11 @@ static GIT_CONFIG_PATHS: LazyLock<ConfigPaths> = LazyLock::new(|| {
             crate::os_string_into_bstring(super::config_path_from_system_prefix(&system_prefix).into()).ok();
         return ConfigPaths {
             installation: installation_config,
+            installation_is_system: true,
             system: system_config,
         };
     }
-    let paths = config_paths_from_executable();
-    #[cfg(windows)]
-    if std::env::var_os("GIT_CONFIG_SYSTEM").is_some() || std::env::var_os("GIT_CONFIG_NOSYSTEM").is_some() {
-        // The caller decides whether these overrides are permitted. Don't expose a path obtained
-        // through ambient configuration when its environment accessor may intentionally hide it.
-        return ConfigPaths { system: None, ..paths };
-    }
-    paths
+    config_paths_from_executable()
 });
 
 // There are a number of ways to refer to the null device on Windows, but they are not all equally
@@ -172,9 +167,11 @@ fn config_paths_from_executable_at(executable: PathBuf) -> std::io::Result<Confi
         });
     }
 
-    let (installation, system) = config_paths_from_config_with_origin(output.stdout.as_slice().into());
+    let (installation, installation_is_system, system) =
+        config_paths_from_config_with_origin(output.stdout.as_slice().into());
     Ok(ConfigPaths {
         installation: installation.map(ToOwned::to_owned),
+        installation_is_system,
         system: system.map(ToOwned::to_owned),
     })
 }
@@ -205,7 +202,7 @@ fn git_cmd(executable: PathBuf, show_scope: bool) -> Command {
     // file under `/Library` or `/Applications` is shown as an "unknown" scope but takes precedence
     // over the system scope. Although `GIT_CONFIG_NOSYSTEM` suppresses this scope along with the
     // system scope, passing `--system` selects only the system scope and not this "unknown" scope.
-    cmd.args(["config", "-lz", "--show-origin"]);
+    cmd.args(["config", "-lz", "--show-origin", "--no-includes"]);
     if show_scope {
         cmd.arg("--show-scope");
     }
@@ -216,6 +213,12 @@ fn git_cmd(executable: PathBuf, show_scope: bool) -> Command {
         .env_remove("GIT_OBJECT_DIRECTORY")
         .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
         .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_CONFIG_SYSTEM")
+        .env_remove("GIT_CONFIG_NOSYSTEM")
+        .env_remove("GIT_CONFIG_COUNT")
+        .env_remove("GIT_CONFIG_PARAMETERS")
+        // Discover stable, unoverridden paths; callers apply the configuration environment they permit.
+        .env("GIT_CONFIG_GLOBAL", NULL_DEVICE)
         .env("GIT_DIR", NULL_DEVICE) // Avoid getting local-scope config.
         .env("GIT_WORK_TREE", NULL_DEVICE) // Avoid confusion when debugging.
         .stdin(Stdio::null())
@@ -231,23 +234,29 @@ fn first_file_from_config_with_origin(source: &BStr) -> Option<&BStr> {
 
 /// Parse NUL-separated scope, origin, and key records produced by `git config --show-scope --show-origin`.
 ///
-/// The first file-backed origin is the installation path. The system path is the first system-scoped
-/// origin distinct from it, or the installation path itself when no distinct system origin follows.
+/// The first file-backed origin is the installation path, and the second return value indicates
+/// whether it had system scope. The system path is the first system-scoped origin distinct from
+/// the installation path, or the installation path itself when no distinct system origin follows.
 /// Non-file origins and incomplete records are ignored.
-fn config_paths_from_config_with_origin(source: &BStr) -> (Option<&BStr>, Option<&BStr>) {
+fn config_paths_from_config_with_origin(source: &BStr) -> (Option<&BStr>, bool, Option<&BStr>) {
     let mut fields = source.split(|byte| *byte == 0);
     let mut installation = None;
+    let mut installation_is_system = false;
     let mut system = None;
     while let (Some(scope), Some(origin), Some(_key)) = (fields.next(), fields.next(), fields.next()) {
         let Some(path) = origin.strip_prefix(b"file:").map(ByteSlice::as_bstr) else {
             continue;
         };
+        let is_installation = installation.is_none();
         let installation_path = *installation.get_or_insert(path);
+        if is_installation {
+            installation_is_system = scope == b"system";
+        }
         if scope == b"system" && system.is_none_or(|current| current == installation_path) {
             system = Some(path);
         }
     }
-    (installation, system)
+    (installation, installation_is_system, system)
 }
 
 /// Try to find the file that contains Git configuration coming with the Git installation.
@@ -258,6 +267,10 @@ fn config_paths_from_config_with_origin(source: &BStr) -> (Option<&BStr>, Option
 pub(super) fn install_config_path() -> Option<&'static BStr> {
     let _span = gix_trace::detail!("gix_path::git::install_config_path()");
     GIT_CONFIG_PATHS.installation.as_ref().map(AsRef::as_ref)
+}
+
+pub(super) fn install_config_is_system() -> bool {
+    GIT_CONFIG_PATHS.installation_is_system
 }
 
 pub(super) fn system_config_path() -> Option<&'static BStr> {

--- a/gix-path/src/env/git/mod.rs
+++ b/gix-path/src/env/git/mod.rs
@@ -98,10 +98,38 @@ pub(super) const EXE_NAME: &str = "git.exe";
 #[cfg(not(windows))]
 pub(super) const EXE_NAME: &str = "git";
 
-/// Invoke the git executable to obtain the origin configuration, which is cached and returned.
+#[derive(Debug, Default, Eq, PartialEq)]
+struct ConfigPaths {
+    installation: Option<BString>,
+    system: Option<BString>,
+}
+
+/// Invoke the git executable to obtain the installation and system configuration paths, which are cached and returned.
 ///
 /// The git executable is the one found in `PATH` or an alternative location.
-pub(super) static GIT_HIGHEST_SCOPE_CONFIG_PATH: LazyLock<Option<BString>> = LazyLock::new(exe_info);
+static GIT_CONFIG_PATHS: LazyLock<ConfigPaths> = LazyLock::new(|| {
+    #[cfg(windows)]
+    if let Some(system_prefix) = super::system_prefix_from_exepath_var(|key| std::env::var_os(key)) {
+        let installation_config = system_prefix
+            .parent()
+            .map(super::config_path_from_system_prefix)
+            .and_then(|path| crate::os_string_into_bstring(path.into()).ok());
+        let system_config =
+            crate::os_string_into_bstring(super::config_path_from_system_prefix(&system_prefix).into()).ok();
+        return ConfigPaths {
+            installation: installation_config,
+            system: system_config,
+        };
+    }
+    let paths = config_paths_from_executable();
+    #[cfg(windows)]
+    if std::env::var_os("GIT_CONFIG_SYSTEM").is_some() || std::env::var_os("GIT_CONFIG_NOSYSTEM").is_some() {
+        // The caller decides whether these overrides are permitted. Don't expose a path obtained
+        // through ambient configuration when its environment accessor may intentionally hide it.
+        return ConfigPaths { system: None, ..paths };
+    }
+    paths
+});
 
 // There are a number of ways to refer to the null device on Windows, but they are not all equally
 // well supported. Git for Windows rejects `\\.\NUL` and `\\.\nul`. On Windows 11 ARM64 (and maybe
@@ -112,27 +140,46 @@ const NULL_DEVICE: &str = "nul";
 #[cfg(not(windows))]
 const NULL_DEVICE: &str = "/dev/null";
 
-fn exe_info() -> Option<BString> {
-    let mut cmd = git_cmd(EXE_NAME.into());
-    gix_trace::debug!(cmd = ?cmd, "invoking git for installation config path");
-    let cmd_output = match cmd.output() {
-        Ok(out) => out.stdout,
+fn config_paths_from_executable() -> ConfigPaths {
+    let executable = PathBuf::from(EXE_NAME);
+    match config_paths_from_executable_at(executable) {
+        Ok(paths) => paths,
         #[cfg(windows)]
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            let executable = ALTERNATIVE_LOCATIONS.iter().find_map(|prefix| {
-                let candidate = prefix.join(EXE_NAME);
-                candidate.is_file().then_some(candidate)
-            })?;
-            gix_trace::debug!(cmd = ?cmd, "invoking git for installation config path in alternate location");
-            git_cmd(executable).output().ok()?.stdout
-        }
-        Err(_) => return None,
-    };
-
-    first_file_from_config_with_origin(cmd_output.as_slice().into()).map(ToOwned::to_owned)
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => ALTERNATIVE_LOCATIONS
+            .iter()
+            .find_map(|prefix| {
+                let executable = prefix.join(EXE_NAME);
+                executable.is_file().then_some(executable)
+            })
+            .and_then(|executable| config_paths_from_executable_at(executable).ok())
+            .unwrap_or_default(),
+        Err(_) => ConfigPaths::default(),
+    }
 }
 
-fn git_cmd(executable: PathBuf) -> Command {
+fn config_paths_from_executable_at(executable: PathBuf) -> std::io::Result<ConfigPaths> {
+    let mut cmd = git_cmd(executable.clone(), true);
+    gix_trace::debug!(cmd = ?cmd, "invoking git for configuration paths");
+    let output = cmd.output()?;
+
+    if !output.status.success() {
+        let mut cmd = git_cmd(executable, false);
+        gix_trace::debug!(cmd = ?cmd, "invoking git for configuration paths (pre Git 2.26)");
+        let output = cmd.output()?;
+        return Ok(ConfigPaths {
+            installation: first_file_from_config_with_origin(output.stdout.as_slice().into()).map(ToOwned::to_owned),
+            ..Default::default()
+        });
+    }
+
+    let (installation, system) = config_paths_from_config_with_origin(output.stdout.as_slice().into());
+    Ok(ConfigPaths {
+        installation: installation.map(ToOwned::to_owned),
+        system: system.map(ToOwned::to_owned),
+    })
+}
+
+fn git_cmd(executable: PathBuf, show_scope: bool) -> Command {
     let mut cmd = Command::new(executable);
     #[cfg(windows)]
     {
@@ -153,18 +200,16 @@ fn git_cmd(executable: PathBuf) -> Command {
     } else {
         "/".into()
     };
-    // Git 2.8.0 and higher support `--show-origin`. The `-l`, `-z`, and `--name-only` options were
-    // supported even before that. In contrast, `--show-scope` was introduced later, in Git 2.26.0.
-    // Low versions of Git are still sometimes used, and this is sometimes reasonable because
-    // downstream distributions often backport security patches without adding most new features.
-    // So for now, we forgo the convenience of `--show-scope` for greater backward compatibility.
-    //
-    // Separately from that, we can't use `--system` here, because scopes treated higher than the
+    // We can't use `--system` here, because scopes treated higher than the
     // system scope are possible. This commonly happens on macOS with Apple Git, where the config
     // file under `/Library` or `/Applications` is shown as an "unknown" scope but takes precedence
     // over the system scope. Although `GIT_CONFIG_NOSYSTEM` suppresses this scope along with the
     // system scope, passing `--system` selects only the system scope and not this "unknown" scope.
-    cmd.args(["config", "-lz", "--show-origin", "--name-only"])
+    cmd.args(["config", "-lz", "--show-origin"]);
+    if show_scope {
+        cmd.arg("--show-scope");
+    }
+    cmd.arg("--name-only")
         .current_dir(cwd)
         .env_remove("GIT_CONFIG")
         .env_remove("GIT_DISCOVERY_ACROSS_FILESYSTEM")
@@ -184,6 +229,27 @@ fn first_file_from_config_with_origin(source: &BStr) -> Option<&BStr> {
     file[..end_pos].as_bstr().into()
 }
 
+/// Parse NUL-separated scope, origin, and key records produced by `git config --show-scope --show-origin`.
+///
+/// The first file-backed origin is the installation path. The system path is the first system-scoped
+/// origin distinct from it, or the installation path itself when no distinct system origin follows.
+/// Non-file origins and incomplete records are ignored.
+fn config_paths_from_config_with_origin(source: &BStr) -> (Option<&BStr>, Option<&BStr>) {
+    let mut fields = source.split(|byte| *byte == 0);
+    let mut installation = None;
+    let mut system = None;
+    while let (Some(scope), Some(origin), Some(_key)) = (fields.next(), fields.next(), fields.next()) {
+        let Some(path) = origin.strip_prefix(b"file:").map(ByteSlice::as_bstr) else {
+            continue;
+        };
+        let installation_path = *installation.get_or_insert(path);
+        if scope == b"system" && system.is_none_or(|current| current == installation_path) {
+            system = Some(path);
+        }
+    }
+    (installation, system)
+}
+
 /// Try to find the file that contains Git configuration coming with the Git installation.
 ///
 /// This returns the configuration associated with the `git` executable found in the current `PATH`
@@ -191,18 +257,21 @@ fn first_file_from_config_with_origin(source: &BStr) -> Option<&BStr> {
 /// errors during execution.
 pub(super) fn install_config_path() -> Option<&'static BStr> {
     let _span = gix_trace::detail!("gix_path::git::install_config_path()");
-    static PATH: LazyLock<Option<BString>> = LazyLock::new(|| {
-        // Shortcut: Specifically in Git for Windows 'Git Bash' shells, this variable is set. It
-        // may let us deduce the installation directory, so we can save the `git` invocation.
-        #[cfg(windows)]
-        if let Some(mut exec_path) = std::env::var_os("EXEPATH").map(PathBuf::from) {
-            exec_path.push("etc");
-            exec_path.push("gitconfig");
-            return crate::os_string_into_bstring(exec_path.into()).ok();
-        }
-        GIT_HIGHEST_SCOPE_CONFIG_PATH.clone()
+    GIT_CONFIG_PATHS.installation.as_ref().map(AsRef::as_ref)
+}
+
+pub(super) fn system_config_path() -> Option<&'static BStr> {
+    let _span = gix_trace::detail!("gix_path::git::system_config_path()");
+    static FALLBACK: LazyLock<Option<BString>> = LazyLock::new(|| {
+        super::system_prefix()
+            .map(super::config_path_from_system_prefix)
+            .and_then(|path| crate::os_string_into_bstring(path.into()).ok())
     });
-    PATH.as_ref().map(AsRef::as_ref)
+    GIT_CONFIG_PATHS
+        .system
+        .as_ref()
+        .or_else(|| FALLBACK.as_ref())
+        .map(AsRef::as_ref)
 }
 
 /// Given `config_path` as obtained from `install_config_path()`, return the path of the git installation base.

--- a/gix-path/src/env/git/tests.rs
+++ b/gix-path/src/env/git/tests.rs
@@ -897,10 +897,7 @@ mod exe_info {
             .map(crate::from_bstring)
             .expect("It is present in the test environment (nonempty config)");
 
-        assert!(
-            path.is_absolute(),
-            "It is absolute (unless overridden such as with GIT_CONFIG_SYSTEM)"
-        );
+        assert!(path.is_absolute(), "Git reports an absolute installation path");
         assert!(
             path.exists(),
             "It should exist on disk, since `git config` just found an entry there"
@@ -979,102 +976,26 @@ mod exe_info {
 
     #[test]
     #[serial]
-    #[cfg(not(target_os = "macos"))] // Assumes no higher "unknown" scope. The `nosystem` case works.
-    fn never_from_local_scope() {
+    fn configuration_query_ignores_ambient_config_and_local_repo() {
+        let expected = config_paths_from_executable();
         let repo = local_config_repo();
-
-        let _cwd = CurrentDir::set(repo.path()).expect("can change to repo dir");
-        let _env = Env::new()
-            .set("GIT_CONFIG_SYSTEM", NULL_DEVICE)
-            .set("GIT_CONFIG_GLOBAL", NULL_DEVICE);
-
-        let maybe_path = exe_info();
-        assert_eq!(
-            maybe_path, None,
-            "Should find no config path if the config would be local (empty system config)"
-        );
-    }
-
-    #[test]
-    #[serial]
-    fn never_from_local_scope_nosystem() {
-        let repo = local_config_repo();
-
+        let config_path = repo.path().join(".git").join("config");
         let _cwd = CurrentDir::set(repo.path()).expect("can change to repo dir");
         let _env = Env::new()
             .set("GIT_CONFIG_NOSYSTEM", "1")
-            .set("GIT_CONFIG_GLOBAL", NULL_DEVICE);
+            .set("GIT_CONFIG_SYSTEM", &config_path)
+            .set("GIT_CONFIG_GLOBAL", &config_path)
+            .set("GIT_CONFIG", &config_path)
+            .set("GIT_CONFIG_COUNT", "1")
+            .set("GIT_CONFIG_KEY_0", "include.path")
+            .set("GIT_CONFIG_VALUE_0", &config_path)
+            .set("GIT_CONFIG_PARAMETERS", "invalid");
 
-        let maybe_path = exe_info();
         assert_eq!(
-            maybe_path, None,
-            "Should find no config path if the config would be local (suppressed system config)"
+            config_paths_from_executable(),
+            expected,
+            "configuration discovery is independent of ambient overrides and repository-local configuration"
         );
-    }
-
-    #[test]
-    #[serial]
-    #[cfg(not(target_os = "macos"))] // Assumes no higher "unknown" scope. The `nosystem` case works.
-    fn never_from_local_scope_even_if_temp_is_here() {
-        let repo = local_config_repo();
-        let repo_path = repo.path().canonicalize().expect("repo path is valid and exists");
-
-        let _cwd = CurrentDir::set(&repo_path).expect("can change to repo dir");
-        let _env = set_temp_env_vars(&repo_path)
-            .set("GIT_CONFIG_SYSTEM", NULL_DEVICE)
-            .set("GIT_CONFIG_GLOBAL", NULL_DEVICE);
-
-        let maybe_path = exe_info();
-        assert_eq!(
-            maybe_path, None,
-            "Should find no config path if the config would be local even in a `/tmp`-like dir (empty system config)"
-        );
-    }
-
-    #[test]
-    #[serial]
-    fn never_from_local_scope_even_if_temp_is_here_nosystem() {
-        let repo = local_config_repo();
-        let repo_path = repo.path().canonicalize().expect("repo path is valid and exists");
-
-        let _cwd = CurrentDir::set(&repo_path).expect("can change to repo dir");
-        let _env = set_temp_env_vars(&repo_path)
-            .set("GIT_CONFIG_NOSYSTEM", "1")
-            .set("GIT_CONFIG_GLOBAL", NULL_DEVICE);
-
-        let maybe_path = exe_info();
-        assert_eq!(
-            maybe_path, None,
-            "Should find no config path if the config would be local even in a `/tmp`-like dir (suppressed system config)"
-        );
-    }
-
-    #[test]
-    #[serial]
-    fn never_from_git_config_env_var() {
-        let repo = local_config_repo();
-
-        // Get an absolute path to a config file that is non-UNC if possible so any Git accepts it.
-        let config_path = std::env::current_dir()
-            .expect("got CWD")
-            .join(repo.path())
-            .join(".git")
-            .join("config")
-            .to_str()
-            .expect("valid UTF-8")
-            .to_owned();
-
-        let _env = Env::new()
-            .set("GIT_CONFIG_NOSYSTEM", "1")
-            .set("GIT_CONFIG_GLOBAL", NULL_DEVICE)
-            .set("GIT_CONFIG", config_path);
-
-        let paths = config_paths_from_executable();
-        assert_eq!(
-            paths.installation, None,
-            "Should find no installation path from GIT_CONFIG"
-        );
-        assert_eq!(paths.system, None, "Should find no system path from GIT_CONFIG");
     }
 
     #[test]
@@ -1092,13 +1013,19 @@ printf 'unknown\000file:/installation/gitconfig\000core.one\000system\000file:/s
             paths,
             ConfigPaths {
                 installation: Some("/installation/gitconfig".into()),
+                installation_is_system: false,
                 system: Some("/system/gitconfig".into()),
             }
         );
+        let invocations = invocations(&executable);
         assert_eq!(
-            invocations(&executable).len(),
+            invocations.len(),
             1,
             "a successful scoped query obtains both paths in one invocation"
+        );
+        assert!(
+            invocations[0].contains("--no-includes"),
+            "included files must not be mistaken for top-level configuration paths"
         );
     }
 
@@ -1152,21 +1079,31 @@ printf 'file:/legacy/gitconfig\000core.one\000'
                 macos,
                 (
                     Some("/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig"),
+                    false,
                     None,
                 ),
             ),
             (
                 win_msys,
-                (Some("C:/git-sdk-64/etc/gitconfig"), Some("C:/git-sdk-64/etc/gitconfig")),
+                (
+                    Some("C:/git-sdk-64/etc/gitconfig"),
+                    true,
+                    Some("C:/git-sdk-64/etc/gitconfig"),
+                ),
             ),
             (
                 win_msys_old,
-                (Some(r"C:\ProgramData/Git/config"), Some(r"C:\ProgramData/Git/config")),
+                (
+                    Some(r"C:\ProgramData/Git/config"),
+                    true,
+                    Some(r"C:\ProgramData/Git/config"),
+                ),
             ),
             (
                 win_cmd,
                 (
                     Some("C:/Program Files/Git/etc/gitconfig"),
+                    true,
                     Some("C:/Program Files/Git/etc/gitconfig"),
                 ),
             ),
@@ -1174,18 +1111,20 @@ printf 'file:/legacy/gitconfig\000core.one\000'
                 win_cmd_with_system,
                 (
                     Some("C:/Program Files/Git/etc/gitconfig"),
+                    true,
                     Some("C:/ProgramData/Git/config"),
                 ),
             ),
-            (linux, (Some("/home/parallels/.gitconfig"), None)),
-            (bogus, (None, None)),
-            (empty, (None, None)),
+            (linux, (Some("/home/parallels/.gitconfig"), false, None)),
+            (bogus, (None, false, None)),
+            (empty, (None, false, None)),
         ] {
             let actual = crate::env::git::config_paths_from_config_with_origin(source.into());
             assert_eq!(
                 (
                     actual.0.map(|path| path.to_str().expect("test paths are UTF-8")),
-                    actual.1.map(|path| path.to_str().expect("test paths are UTF-8")),
+                    actual.1,
+                    actual.2.map(|path| path.to_str().expect("test paths are UTF-8")),
                 ),
                 expected
             );

--- a/gix-path/src/env/git/tests.rs
+++ b/gix-path/src/env/git/tests.rs
@@ -740,6 +740,7 @@ mod locations {
 }
 
 mod exe_info {
+    use bstr::ByteSlice;
     use std::{
         ffi::{OsStr, OsString},
         path::{Path, PathBuf},
@@ -748,10 +749,40 @@ mod exe_info {
 
     use serial_test::serial;
 
+    #[cfg(unix)]
+    use crate::env::git::{ConfigPaths, config_paths_from_executable_at};
     use crate::env::{
-        git::{NULL_DEVICE, exe_info},
+        git::{NULL_DEVICE, config_paths_from_executable},
         tests::CurrentDir,
     };
+
+    fn exe_info() -> Option<bstr::BString> {
+        config_paths_from_executable().installation
+    }
+
+    #[cfg(unix)]
+    fn fake_git(script: &str) -> (tempfile::TempDir, PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tempdir = tempfile::tempdir().expect("can create fake Git directory");
+        let executable = tempdir.path().join("git");
+        std::fs::write(&executable, script).expect("can write fake Git");
+        let mut permissions = std::fs::metadata(&executable)
+            .expect("fake Git has metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable, permissions).expect("can make fake Git executable");
+        (tempdir, executable)
+    }
+
+    #[cfg(unix)]
+    fn invocations(executable: &Path) -> Vec<String> {
+        std::fs::read_to_string(executable.with_extension("log"))
+            .expect("invocation log exists")
+            .lines()
+            .map(ToOwned::to_owned)
+            .collect()
+    }
 
     /// This is a copy from the respective type in `gix-testtools` - deduplicate if it can ever be a dependency again.
     struct Env(Vec<(OsString, Option<OsString>)>);
@@ -1038,39 +1069,125 @@ mod exe_info {
             .set("GIT_CONFIG_GLOBAL", NULL_DEVICE)
             .set("GIT_CONFIG", config_path);
 
-        let maybe_path = exe_info();
+        let paths = config_paths_from_executable();
         assert_eq!(
-            maybe_path, None,
-            "Should find no config path from GIT_CONFIG (even if nonempty)"
+            paths.installation, None,
+            "Should find no installation path from GIT_CONFIG"
+        );
+        assert_eq!(paths.system, None, "Should find no system path from GIT_CONFIG");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn one_scoped_query_finds_both_config_paths() {
+        let (_tempdir, executable) = fake_git(
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "${0}.log"
+printf 'unknown\000file:/installation/gitconfig\000core.one\000system\000file:/system/gitconfig\000core.two\000'
+"#,
+        );
+
+        let paths = config_paths_from_executable_at(executable.clone()).expect("fake Git can be queried");
+        assert_eq!(
+            paths,
+            ConfigPaths {
+                installation: Some("/installation/gitconfig".into()),
+                system: Some("/system/gitconfig".into()),
+            }
+        );
+        assert_eq!(
+            invocations(&executable).len(),
+            1,
+            "a successful scoped query obtains both paths in one invocation"
         );
     }
 
     #[test]
-    fn first_file_from_config_with_origin() {
-        let macos = "file:/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig\0credential.helper\0file:/Users/byron/.gitconfig\0push.default\0";
-        let win_msys =
-            "file:C:/git-sdk-64/etc/gitconfig\0core.symlinks\0file:C:/git-sdk-64/etc/gitconfig\0core.autocrlf\0";
-        let win_cmd = "file:C:/Program Files/Git/etc/gitconfig\0diff.astextplain.textconv\0file:C:/Program Files/Git/etc/gitconfig\0filter.lfs.clean\0";
-        let win_msys_old = "file:C:\\ProgramData/Git/config\0diff.astextplain.textconv\0file:C:\\ProgramData/Git/config\0filter.lfs.clean\0";
-        let linux = "file:/home/parallels/.gitconfig\0core.excludesfile\0";
+    #[cfg(unix)]
+    fn retries_without_scope_for_old_git() {
+        let (_tempdir, executable) = fake_git(
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> "${0}.log"
+case " $* " in
+  *" --show-scope "*) exit 129 ;;
+esac
+printf 'file:/legacy/gitconfig\000core.one\000'
+"#,
+        );
+
+        let paths = config_paths_from_executable_at(executable.clone()).expect("fake Git can be queried");
+        assert_eq!(
+            paths,
+            ConfigPaths {
+                installation: Some("/legacy/gitconfig".into()),
+                ..Default::default()
+            },
+            "the legacy query preserves installation-config discovery"
+        );
+        let invocations = invocations(&executable);
+        assert_eq!(invocations.len(), 2, "old Git is retried once");
+        assert!(
+            invocations.first().is_some_and(|line| line.contains("--show-scope")),
+            "the first query requests scopes"
+        );
+        assert!(
+            invocations.get(1).is_some_and(|line| !line.contains("--show-scope")),
+            "the fallback query omits unsupported scope reporting"
+        );
+    }
+
+    #[test]
+    fn config_paths_from_config_with_origin() {
+        let macos = "unknown\0file:/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig\0credential.helper\0global\0file:/Users/byron/.gitconfig\0push.default\0";
+        let win_msys = "system\0file:C:/git-sdk-64/etc/gitconfig\0core.symlinks\0system\0file:C:/git-sdk-64/etc/gitconfig\0core.autocrlf\0";
+        let win_cmd = "system\0file:C:/Program Files/Git/etc/gitconfig\0diff.astextplain.textconv\0system\0file:C:/Program Files/Git/etc/gitconfig\0filter.lfs.clean\0";
+        let win_cmd_with_system = "system\0file:C:/Program Files/Git/etc/gitconfig\0diff.astextplain.textconv\0system\0file:C:/ProgramData/Git/config\0core.autocrlf\0";
+        let win_msys_old = "system\0file:C:\\ProgramData/Git/config\0diff.astextplain.textconv\0system\0file:C:\\ProgramData/Git/config\0filter.lfs.clean\0";
+        let linux = "global\0file:/home/parallels/.gitconfig\0core.excludesfile\0";
         let bogus = "something unexpected";
         let empty = "";
 
         for (source, expected) in [
             (
                 macos,
-                Some("/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig"),
+                (
+                    Some("/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig"),
+                    None,
+                ),
             ),
-            (win_msys, Some("C:/git-sdk-64/etc/gitconfig")),
-            (win_msys_old, Some(r"C:\ProgramData/Git/config")),
-            (win_cmd, Some("C:/Program Files/Git/etc/gitconfig")),
-            (linux, Some("/home/parallels/.gitconfig")),
-            (bogus, None),
-            (empty, None),
+            (
+                win_msys,
+                (Some("C:/git-sdk-64/etc/gitconfig"), Some("C:/git-sdk-64/etc/gitconfig")),
+            ),
+            (
+                win_msys_old,
+                (Some(r"C:\ProgramData/Git/config"), Some(r"C:\ProgramData/Git/config")),
+            ),
+            (
+                win_cmd,
+                (
+                    Some("C:/Program Files/Git/etc/gitconfig"),
+                    Some("C:/Program Files/Git/etc/gitconfig"),
+                ),
+            ),
+            (
+                win_cmd_with_system,
+                (
+                    Some("C:/Program Files/Git/etc/gitconfig"),
+                    Some("C:/ProgramData/Git/config"),
+                ),
+            ),
+            (linux, (Some("/home/parallels/.gitconfig"), None)),
+            (bogus, (None, None)),
+            (empty, (None, None)),
         ] {
+            let actual = crate::env::git::config_paths_from_config_with_origin(source.into());
             assert_eq!(
-                crate::env::git::first_file_from_config_with_origin(source.into()),
-                expected.map(Into::into)
+                (
+                    actual.0.map(|path| path.to_str().expect("test paths are UTF-8")),
+                    actual.1.map(|path| path.to_str().expect("test paths are UTF-8")),
+                ),
+                expected
             );
         }
     }

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -11,14 +11,26 @@ use crate::env::git::EXE_NAME;
 mod auxiliary;
 mod git;
 
-/// Return the location at which installation specific git configuration file can be found, or `None`
-/// if the binary could not be executed or its results could not be parsed.
+/// Return the unoverridden location at which an installation-specific Git configuration file can be found, or
+/// `None` if the binary could not be executed or its results could not be parsed.
+///
+/// The Git query ignores `GIT_CONFIG_SYSTEM` and `GIT_CONFIG_NOSYSTEM`; callers must apply these
+/// variables according to their own environment-access policy.
 ///
 /// ### Performance
 ///
 /// This invokes the git binary which is slow on windows.
 pub fn installation_config() -> Option<&'static Path> {
     git::install_config_path().and_then(|p| crate::try_from_byte_slice(p).ok())
+}
+
+/// Return whether [`installation_config()`] was reported with system scope by Git.
+///
+/// `GIT_CONFIG_SYSTEM` replaces system-scoped installation configuration, but not installation
+/// configuration reported with another scope, such as Apple Git's `unknown` scope.
+/// Returns `false` if no installation path was found or Git was too old to report scopes.
+pub fn installation_config_is_system() -> bool {
+    git::install_config_is_system()
 }
 
 /// Return the location at which git installation specific configuration files are located, or `None` if the binary
@@ -31,9 +43,10 @@ pub fn installation_config_prefix() -> Option<&'static Path> {
     installation_config().map(git::config_to_base_path)
 }
 
-/// Return the location of the system-wide Git configuration file.
+/// Return the unoverridden location of the system-wide Git configuration file.
 ///
 /// On Windows this shares the single Git invocation used by [`installation_config()`].
+/// The caller is responsible for applying `GIT_CONFIG_SYSTEM` and `GIT_CONFIG_NOSYSTEM`.
 pub fn system_config() -> Option<&'static Path> {
     if cfg!(windows) {
         git::system_config_path().and_then(|p| crate::try_from_byte_slice(p).ok())

--- a/gix-path/src/env/mod.rs
+++ b/gix-path/src/env/mod.rs
@@ -31,6 +31,17 @@ pub fn installation_config_prefix() -> Option<&'static Path> {
     installation_config().map(git::config_to_base_path)
 }
 
+/// Return the location of the system-wide Git configuration file.
+///
+/// On Windows this shares the single Git invocation used by [`installation_config()`].
+pub fn system_config() -> Option<&'static Path> {
+    if cfg!(windows) {
+        git::system_config_path().and_then(|p| crate::try_from_byte_slice(p).ok())
+    } else {
+        Some(Path::new("/etc/gitconfig"))
+    }
+}
+
 /// Return the shell that Git would use, the shell to execute commands from.
 ///
 /// On Windows, this is the full path to `sh.exe` bundled with Git for Windows if we can find it.
@@ -249,6 +260,15 @@ where
         Some(_) => None, // Multiple plausible candidates, so don't use the `EXEPATH` optimization.
         None => Some(path),
     }
+}
+
+/// Return Git's conventional system configuration path below `prefix`.
+///
+/// Git for Windows defaults to `etc/gitconfig` relative to its runtime prefix, while on Unix
+/// [`system_prefix()`] is `/`, yielding the conventional `/etc/gitconfig`. This is only a fallback
+/// when Git itself reports no origin, so custom build-time paths and environment overrides still win.
+fn config_path_from_system_prefix(prefix: &Path) -> PathBuf {
+    prefix.join("etc/gitconfig")
 }
 
 /// Returns the platform dependent system prefix or `None` if it cannot be found (right now only on Windows).

--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -35,6 +35,8 @@ impl Cache {
         filter_config_section: fn(&gix_config::file::Metadata) -> bool,
         git_install_dir: Option<&std::path::Path>,
         home: Option<&std::path::Path>,
+        git_installation_config_path: Option<&std::path::Path>,
+        system_config_path: Option<&std::path::Path>,
         environment: open::permissions::Environment,
         attributes: open::permissions::Attributes,
         config_permissions: open::permissions::Config,
@@ -50,6 +52,8 @@ impl Cache {
             branch_name,
             git_install_dir,
             home,
+            git_installation_config_path,
+            system_config_path,
             environment,
             config_permissions,
             lossy,
@@ -215,6 +219,8 @@ pub(crate) fn load(
     branch_name: Option<&gix_ref::FullNameRef>,
     git_install_dir: Option<&std::path::Path>,
     home: Option<&std::path::Path>,
+    git_installation_config_path: Option<&std::path::Path>,
+    system_config_path: Option<&std::path::Path>,
     environment @ open::permissions::Environment {
         git_prefix,
         other,
@@ -251,6 +257,10 @@ pub(crate) fn load(
         ..util::base_options(lossy, lenient)
     };
     let git_prefix = &git_prefix;
+    let mut source_env = Cache::make_source_env(environment);
+    let no_system_config = source_env("GIT_CONFIG_NOSYSTEM")
+        .and_then(|value| gix_config::Boolean::try_from(value).ok())
+        .is_some_and(|value| value.0);
     let mut metas = [
         gix_config::source::Kind::GitInstallation,
         gix_config::source::Kind::System,
@@ -260,15 +270,20 @@ pub(crate) fn load(
     .flat_map(|kind| kind.sources())
     .filter_map(|source| {
         match source {
-            gix_config::Source::GitInstallation if !use_installation => return None,
-            gix_config::Source::System if !use_system => return None,
+            gix_config::Source::GitInstallation if !use_installation || no_system_config => return None,
+            gix_config::Source::System if !use_system || no_system_config => return None,
             gix_config::Source::Git if !use_git => return None,
             gix_config::Source::User if !use_user => return None,
             _ => {}
         }
-        source
-            .storage_location(&mut Cache::make_source_env(environment))
-            .map(|p| (source, p))
+        match source {
+            gix_config::Source::GitInstallation => git_installation_config_path,
+            gix_config::Source::System => system_config_path,
+            _ => None,
+        }
+        .map(ToOwned::to_owned)
+        .or_else(|| source.storage_location(&mut source_env))
+        .map(|p| (source, p))
     })
     .map(|(source, path)| gix_config::file::Metadata {
         path: Some(path),

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -444,6 +444,8 @@ pub fn config(git_dir: Option<&std::path::Path>, options: &open::Options) -> Res
         None,
         git_install_dir.as_deref(),
         home.as_deref(),
+        options.git_installation_config_path.as_deref(),
+        options.system_config_path.as_deref(),
         environment,
         options.permissions.config,
         options.lossy_config,

--- a/gix/src/open/mod.rs
+++ b/gix/src/open/mod.rs
@@ -35,6 +35,8 @@ pub struct Options {
     pub(crate) bail_if_untrusted: bool,
     pub(crate) api_config_overrides: Vec<BString>,
     pub(crate) cli_config_overrides: Vec<BString>,
+    pub(crate) git_installation_config_path: Option<Box<std::path::Path>>,
+    pub(crate) system_config_path: Option<Box<std::path::Path>>,
     /// Whether repository-local environment variables like `GIT_WORK_TREE` and `GIT_INDEX_FILE` may be applied.
     /// This is disabled when reusing these options to enter another repository.
     pub(crate) use_repository_local_environment: bool,

--- a/gix/src/open/options.rs
+++ b/gix/src/open/options.rs
@@ -16,6 +16,8 @@ impl Default for Options {
             open_path_as_is: false,
             api_config_overrides: Vec::new(),
             cli_config_overrides: Vec::new(),
+            git_installation_config_path: None,
+            system_config_path: None,
             use_repository_local_environment: true,
             current_dir: None,
         }
@@ -54,6 +56,28 @@ impl Options {
     /// These are equivalent to CLI overrides passed with `-c` in `git`, for example.
     pub fn cli_overrides(mut self, values: impl IntoIterator<Item = impl Into<BString>>) -> Self {
         self.cli_config_overrides = values.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Use `path` as Git's installation configuration file instead of discovering it.
+    ///
+    /// Common locations are `$(prefix)/etc/gitconfig` on Unix,
+    /// `/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig` for Apple Git,
+    /// and `C:/Program Files/Git/etc/gitconfig` for Git for Windows.
+    ///
+    /// The file is loaded only when [`permissions.config.git_binary`][Permissions::config] is enabled.
+    pub fn git_installation_config_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.git_installation_config_path = Some(path.into().into_boxed_path());
+        self
+    }
+
+    /// Use `path` as the system configuration file instead of discovering it.
+    ///
+    /// Common locations are `/etc/gitconfig` on Unix and `C:/ProgramData/Git/config` on Windows.
+    ///
+    /// The file is loaded only when [`permissions.config.system`][Permissions::config] is enabled.
+    pub fn system_config_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.system_config_path = Some(path.into().into_boxed_path());
         self
     }
 
@@ -181,6 +205,8 @@ impl gix_sec::trust::DefaultForLevel for Options {
                 open_path_as_is: false,
                 api_config_overrides: Vec::new(),
                 cli_config_overrides: Vec::new(),
+                git_installation_config_path: None,
+                system_config_path: None,
                 use_repository_local_environment: true,
                 current_dir: None,
             },
@@ -195,6 +221,8 @@ impl gix_sec::trust::DefaultForLevel for Options {
                 lossy_config: false,
                 api_config_overrides: Vec::new(),
                 cli_config_overrides: Vec::new(),
+                git_installation_config_path: None,
+                system_config_path: None,
                 use_repository_local_environment: true,
                 current_dir: None,
             },

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -180,6 +180,8 @@ impl ThreadSafeRepository {
                 },
             ref api_config_overrides,
             ref cli_config_overrides,
+            ref git_installation_config_path,
+            ref system_config_path,
             use_repository_local_environment,
             ref mut current_dir,
         } = options;
@@ -251,6 +253,8 @@ impl ThreadSafeRepository {
             filter_config_section,
             git_install_dir.as_deref(),
             home.as_deref(),
+            git_installation_config_path.as_deref(),
+            system_config_path.as_deref(),
             *env,
             attributes,
             config,

--- a/gix/tests/repository.rs
+++ b/gix/tests/repository.rs
@@ -1,4 +1,7 @@
+use std::fs;
+
 use gix::bstr::ByteSlice;
+use gix_testtools::{Env, tempfile};
 use serial_test::serial;
 
 #[test]
@@ -268,6 +271,76 @@ fn revspec_paths_starting_with_a_dot_need_a_worktree_to_stay_within() -> gix_tes
             "`{spec}` has nothing to be relative to and must not resolve"
         );
     }
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn open_options_preset_system_config_paths_avoid_running_git() -> gix_testtools::Result {
+    let temp = tempfile::tempdir()?;
+    let git_dir = temp.path().join("repo.git");
+    fs::create_dir_all(git_dir.join("objects"))?;
+    fs::create_dir_all(git_dir.join("refs"))?;
+    fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n")?;
+    fs::write(
+        git_dir.join("config"),
+        "[core]
+            repositoryFormatVersion = 0
+            bare = true",
+    )?;
+
+    let installation_config = temp.path().join("installation.gitconfig");
+    fs::write(
+        &installation_config,
+        "[preset]
+            installation = configured",
+    )?;
+    let system_config = temp.path().join("system.gitconfig");
+    fs::write(
+        &system_config,
+        "[preset]
+            system = configured",
+    )?;
+
+    let trace = temp.path().join("git.trace");
+    let _env = Env::new().set("GIT_TRACE", trace.to_string_lossy());
+    let mut options = gix::open::Options::isolated()
+        .git_installation_config_path(&installation_config)
+        .system_config_path(&system_config);
+    options.permissions.config.git_binary = true;
+    options.permissions.config.system = true;
+
+    let repo = gix::open_opts(&git_dir, options)?;
+    assert_eq!(
+        repo.config_snapshot()
+            .string("preset.installation")
+            .expect("installation configuration was loaded"),
+        "configured"
+    );
+    assert_eq!(
+        repo.config_snapshot()
+            .string("preset.system")
+            .expect("system configuration was loaded"),
+        "configured"
+    );
+
+    let _no_system = Env::new().set("GIT_CONFIG_NOSYSTEM", "1");
+    let mut options = gix::open::Options::isolated()
+        .git_installation_config_path(installation_config)
+        .system_config_path(system_config);
+    options.permissions.config.git_binary = true;
+    options.permissions.config.system = true;
+    options.permissions.env.git_prefix = gix::sec::Permission::Allow;
+    let repo = gix::open_opts(git_dir, options)?;
+    assert!(
+        repo.config_snapshot().string("preset.installation").is_none(),
+        "GIT_CONFIG_NOSYSTEM must disable preset installation configuration"
+    );
+    assert!(
+        repo.config_snapshot().string("preset.system").is_none(),
+        "GIT_CONFIG_NOSYSTEM must disable preset system configuration"
+    );
+    assert!(!trace.exists(), "presetting both paths must avoid launching Git");
     Ok(())
 }
 


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

Related to https://github.com/starship/starship/issues/7712
----

Everything below this line was generated by `Codex`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- Query Git once for both installation and system configuration paths on Windows, retaining a fallback for Git versions older than 2.26 and distinguishing multiple system-scoped files.
- Allow callers to preset both paths through `gix::open::Options`, which avoids launching Git entirely when both are supplied.
- Preserve `GIT_CONFIG_NOSYSTEM` semantics for preset paths.

## Reported issue

#### Current Behavior
After upgrading from 1.17.1 -> 1.26.0 (yes, I hadn't upgraded in a long time), there was a noticeable slowdown in the git prompt speed for small repos. In my prompt, I'm only including `git_branch`/`git_commit`/`git_state`/`git_status`.

Before, zipping around smaller repo's felt basically instant. Now it takes ~150ms for the prompt to render which is slow enough for my eyes to catch and be grating.

#### Expected Behavior
For the prompt in smaller repo's, it should be no slower than manually running `git status`.

#### Additional context/Screenshots
I manually added `instant.elapsed()` calls around the code and found that of the ~150ms, most was not actually spent performing `git status`. Rather, ~100ms was taken for this singular line: https://github.com/starship/starship/blob/cc763c5557a235530ff00c8917169bb77aac1e24/src/context/mod.rs#L369

If I shrink my prompt just to git_branch, this ~100ms now takes up basically all the time.

If I do a targeted revert of https://github.com/starship/starship/commit/daf8d93d27fdc70b110a4a56799d7dc3a10c3810#diff-d6346fd7d17270b1282142aeeda9c4bc2b7d8fd0f37b24a1c871a9257f0ed0aa
Specifically, only these 4 lines:
<img width="1430" height="283" alt="Image" src="https://github.com/user-attachments/assets/e0012e5d-fe75-46c0-85b1-d73c7e06e616" />
Then, that ~100ms turns to _single digit milliseconds_!

#### Possible Solution
I'm not familiar enough with the code to know why it's necessary for correctness to have that change. Given the context of the PR that introduced it, maybe those fields could be set back to false if `use_git_executable` is true and `git_metrics` is not enabled?

@Byron would love to get your insight :)

#### Environment
- Starship version: 1.26.0
- nu version: 0.114.1
- Operating system: Windows 10.0.19045
- Terminal emulator: <unknown terminal> <unknown version>
- Git Commit Hash: fca92d8
- Branch/Tag: main
- Rust Version: rustc 1.96.0 (ac68faa20 2026-05-25)
- Rust channel: stable-x86_64-pc-windows-msvc release
- Build Time: 2026-06-28 17:05:55 +00:00
#### Relevant Shell Configuration

```bash
$env.config.show_banner = false
$env.config.buffer_editor = "micro"

alias lg = lazygit

mkdir ($nu.data-dir | path join "vendor/autoload")
source ~/.zoxide.nu
```

#### Starship Configuration

```toml
# Default format ($all) with all languages disabled and only a minimal set of tools left.
format = """
$username\
$hostname\
$directory\
$git_branch\
$git_commit\
$git_state\
$git_status\
$line_break\
$character"""

[directory]
use_os_path_sep = false
truncate_to_repo = false
truncation_length = 0

[git_branch]
symbol = ''

[git_status]
# Default format with $all_status expanded, $stashed removed, and some rearranging.
format = '([($conflicted )(\[$staged$deleted$renamed$modified$untracked\])(\[$ahead_behind\])]($style))'
conflicted = 'CONFLICT'

[character]
success_symbol = '[>](bold green)'
error_symbol = '[>](bold red)'
```

Thanks for chiming in David, and thanks so much for your help with all of this @brandondong!

> Where is that time being lost? Reading files is not slow on my machine, for example, the time starship spends reading my config toml is <1ms. Maybe when I find some time, I can try looking into that but I was curious if @Byron would just know offhand.

I am also interested in this, maybe there is a regression that disguised itself, as that code definitely changed. However, from my testing on macOS, it got faster.
So how can we learn what's going on here? Could you try to turn `git_binary` off, all the other flags off as well, and see if there is one of them adding disproportional amounts of time? Maybe they are all the same amount of time as well, which would also be good to know. My guess is of course that this is related to IO which you say is fast, so the other guess is that the binary under test isn't a release build (but that's easily discarded as unlikely). So I am out of guesses, without IO and CPU profiling.

I tested with both debug and release builds, no difference.

> So how can we learn what's going on here? Could you try to turn `git_binary` off, all the other flags off as well, and see if there is one of them adding disproportional amounts of time?

It turns out it's the `system` flag that is adding all the 50ms time. I don't have gix cloned to be able to add timing logs but just looking at the source code, I think it's

<img width="1146" height="678" alt="Image" src="https://github.com/user-attachments/assets/a7defa1a-3272-4bd0-8762-5dbab843a595" />

<img width="1069" height="497" alt="Image" src="https://github.com/user-attachments/assets/71f854ed-08d5-4b40-b885-08764a554ccf" />

Neither environment variable is set on my system. If I set `GIT_CONFIG_NOSYSTEM` to "true" or `GIT_CONFIG_SYSTEM` to some dummy path, the 50ms overhead is eliminated. Same if I run from the git bash app but not git bash through Windows Terminal.

## Commits

- `51a9dbd802` — query both configuration paths with one Git process.
- `be1698c200` — expose both preset paths through `gix::open::Options` and prove they avoid Git execution.
- `04bef3fb94` — preserve `GIT_CONFIG_NOSYSTEM` for preset paths.
- `e8d5a09289` — retain a distinct system path when Git reports multiple system-scoped files.

## Validation

- `cargo test -p gix-path`
- `cargo test -p gix-config`
- `cargo check -p gix-path --tests --target aarch64-pc-windows-msvc`
- `cargo clippy -p gix-path --all-targets -- -D warnings`
- `cargo test -p gix --test open_options`
- `cargo test -p gix --lib open::tests::size_of_options`
- `cargo test -p gix --doc`
- `cargo check -p gix --all-targets`
- `cargo check -p gix --no-default-features --features sha1`
- `cargo clippy -p gix --test open_options -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
