### PR TITLE
fix(gix-ref)!: explain unsupported reftable storage when reading HEAD

### DIFF
--- a/gix-ref/src/store/file/loose/reference/decode.rs
+++ b/gix-ref/src/store/file/loose/reference/decode.rs
@@ -12,6 +12,9 @@ enum MaybeUnsafeState {
 #[derive(Debug, thiserror::Error)]
 #[expect(missing_docs)]
 pub enum Error {
+    /// Git's placeholder for an unsupported backend, such as reftable, was encountered.
+    #[error("This reference uses an unsupported storage backend, such as reftable")]
+    UnsupportedStorage,
     #[error("{content:?} could not be parsed")]
     Parse { content: BString },
     #[error("The path {path:?} to a symbolic reference within a ref file is invalid")]
@@ -30,6 +33,7 @@ impl TryFrom<MaybeUnsafeState> for Target {
             MaybeUnsafeState::UnvalidatedPath(name) => {
                 Target::Symbolic(match gix_validate::reference::name(name.as_ref()) {
                     Ok(_) => FullName(name),
+                    Err(_) if name == "refs/heads/.invalid" => return Err(Error::UnsupportedStorage),
                     Err(err) => {
                         return Err(Error::RefnameValidation {
                             source: err,

--- a/gix-ref/tests/refs/file/reference.rs
+++ b/gix-ref/tests/refs/file/reference.rs
@@ -220,14 +220,28 @@ mod parse {
                         $input,
                         gix_hash::Kind::Sha1,
                     )
-                    .unwrap_err();
-                    assert_eq!(err.to_string(), $err);
+                    .expect_err("the loose reference content is invalid or unsupported");
+                    assert_eq!(
+                        err.to_string(),
+                        $err,
+                        "the error identifies why decoding failed"
+                    );
                 }
             };
         }
 
         mktest!(hex_id, b"foobar", "\"foobar\" could not be parsed");
         mktest!(ref_tag, b"reff: hello", "\"reff: hello\" could not be parsed");
+        mktest!(
+            reftable_placeholder,
+            b"ref: refs/heads/.invalid\n",
+            "This reference uses an unsupported storage backend, such as reftable"
+        );
+        mktest!(
+            other_invalid_symbolic_target,
+            b"ref: refs/heads/.invalid-other\n",
+            "The path \"refs/heads/.invalid-other\" to a symbolic reference within a ref file is invalid"
+        );
         mktest!(
             sha256_sized_id_for_sha1,
             b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",

--- a/gix/tests/gix/repository/open.rs
+++ b/gix/tests/gix/repository/open.rs
@@ -115,9 +115,11 @@ fn non_bare_reftable() -> crate::Result {
         return Ok(());
     };
     let repo = gix::open_opts(root.join("reftable-clone"), gix::open::Options::isolated())?;
-    assert!(
-        repo.head_id().is_err(),
-        "Trying to do anything with head will fail as we don't support reftables yet"
+    let err = repo.head_id().expect_err("reftable references are not supported");
+    assert_eq!(
+        err.source().expect("reference decoding error").to_string(),
+        "This reference uses an unsupported storage backend, such as reftable",
+        "accessing HEAD explains that the reference storage backend is unsupported"
     );
     assert!(!repo.is_bare());
     assert_eq!(repo.kind(), gix::repository::Kind::Common);


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-6`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Reading `HEAD` in a reftable repository now reports “This reference uses an unsupported storage backend, such as reftable” instead of an invalid symbolic-reference name. `gix-ref` recognizes Git's exact `refs/heads/.invalid` placeholder in the shared loose-reference decoder; other invalid targets keep their existing validation errors.

The commit adds `file::loose::reference::decode::Error::UnsupportedStorage`, a new public enum variant, and is marked as a breaking change.

## Validation

- The new decoder regression failed with the original error before the fix and passes afterward. A nearby invalid target retains its existing diagnostic.
- All 187 `gix-ref` tests pass with all features, with both SHA-1 and SHA-256 fixtures.
- The existing `gix` test `repository::open::non_bare_reftable` now checks the error cause and passes.
- Formatting, `gix-ref` Clippy, and the `small` CLI build pass.
- `gix status` on the real reftable fixture produces the new diagnostic; Git reports the same repository as clean.
- One `codex review --commit` run for `9d2ed85721` found no actionable regressions.

Git reference: `1630431f326e15fcde608827b5ff38422528eb59` in the local Git checkout, particularly `refs.c::refs_create_refdir_stubs()` and `t/t0610-reftable-basics.sh`. Git uses this placeholder for reftable, including linked worktrees, and newer alternate storage. Local Git `2.50.1` resolves the fixture's `HEAD` to `refs/heads/main` despite the placeholder on disk.

## Reported issue

$issue-full-auto When head is read in a repository that uses the ref table backend, the error message currently, it fails to acknowledge that ref table is not supported. Instead, it prints this:

```
> gix status
Error: The reference at "HEAD" could not be instantiated

Caused by:
    0: The path "refs/heads/.invalid" to a symbolic reference within a ref file is invalid
    1: Reference name cannot start with a dot
```

Ideally, in `gix-ref`, handle this case specifically and mention the lack of reftable support, when HEAD is accessed.
