### PR TITLE
Avoid null-ID filter lookups and extend configuration and branch APIs

### DIFF
--- a/gix-diff/src/blob/pipeline.rs
+++ b/gix-diff/src/blob/pipeline.rs
@@ -214,8 +214,10 @@ impl Pipeline {
     /// `attributes` must be returning the attributes at `rela_path`, and `objects` must be usable if `kind` is
     /// a resource in the object database, i.e. has no worktree root available.
     ///
-    /// If `id` [is null](gix_hash::ObjectId::is_null()) or the file in question doesn't exist in the worktree in case
-    /// [a root](WorktreeRoots) is present, then `out` will be left cleared and [Outcome::data] will be `None`.
+    /// If a [worktree root](WorktreeRoots) is present, read the file from there. A non-null `id` is used to look up
+    /// its index version for line-ending conversion. Null IDs are never looked up in `objects`.
+    /// If the worktree file doesn't exist, or no root is present and `id` [is null](gix_hash::ObjectId::is_null()),
+    /// then `out` will be left cleared and [Outcome::data] will be `None`.
     ///
     /// Note that `mode` is trusted, and we will not re-validate that the entry in the worktree actually is of that mode.
     ///
@@ -343,7 +345,12 @@ impl Pipeline {
                                                     file,
                                                     gix_path::from_bstr(rela_path).as_ref(),
                                                     attributes,
-                                                    &mut |buf| objects.try_find(id, buf).map(|obj| obj.map(|_| ())),
+                                                    &mut |buf| {
+                                                        if id.is_null() {
+                                                            return Ok(None);
+                                                        }
+                                                        objects.try_find(id, buf).map(|obj| obj.map(|_| ()))
+                                                    },
                                                 )?;
 
                                                 match res {

--- a/gix-diff/tests/diff/blob/pipeline.rs
+++ b/gix-diff/tests/diff/blob/pipeline.rs
@@ -435,26 +435,6 @@ pub(crate) mod convert_to_diffable {
 
     #[test]
     fn worktree_filter_skips_null_id_lookups() -> crate::Result {
-        struct NonNullObjects(crate::util::ObjectDb);
-
-        impl gix_object::Find for NonNullObjects {
-            fn try_find<'a>(
-                &self,
-                id: &gix_hash::oid,
-                buffer: &'a mut Vec<u8>,
-            ) -> Result<Option<gix_object::Data<'a>>, gix_object::find::Error> {
-                assert!(!id.is_null(), "null IDs must not be looked up in the object database");
-                gix_object::Find::try_find(&self.0, id, buffer)
-            }
-        }
-
-        impl gix_object::FindHeader for NonNullObjects {
-            fn try_header(&self, id: &gix_hash::oid) -> Result<Option<gix_object::Header>, gix_object::find::Error> {
-                assert!(!id.is_null(), "null IDs must not be looked up in the object database");
-                gix_object::FindHeader::try_header(&self.0, id)
-            }
-        }
-
         let tmp = gix_testtools::tempfile::TempDir::new()?;
         std::fs::write(tmp.path().join("a"), "worktree\r\n")?;
         let mut filter = gix_diff::blob::Pipeline::new(
@@ -475,21 +455,26 @@ pub(crate) mod convert_to_diffable {
             vec![],
             default_options(),
         );
-        let objects = NonNullObjects(object_db());
-        let index_id = insert(&objects.0, "index\r\n")?;
+        let objects = object_db();
+        let index_id = insert(&objects, "index\r\n")?;
         let mut buf = Vec::new();
         for mode in [pipeline::Mode::ToGit, pipeline::Mode::ToGitUnlessBinaryToTextIsPresent] {
             for (id, expected) in [
                 (crate::fixture_hash_kind().null(), "worktree\n"),
                 (index_id, "worktree\r\n"),
             ] {
+                let objects: &dyn gix_object::FindObjectOrHeader = if id.is_null() {
+                    &gix_object::find::Never::panic_on_access()
+                } else {
+                    &objects
+                };
                 let out = filter.convert_to_diffable(
                     &id,
                     EntryKind::Blob,
                     "a".into(),
                     ResourceKind::NewOrDestination,
                     &mut |_, _| {},
-                    &objects,
+                    objects,
                     mode,
                     &mut buf,
                 )?;

--- a/gix-diff/tests/diff/blob/pipeline.rs
+++ b/gix-diff/tests/diff/blob/pipeline.rs
@@ -434,6 +434,81 @@ pub(crate) mod convert_to_diffable {
     }
 
     #[test]
+    fn worktree_filter_skips_null_id_lookups() -> crate::Result {
+        struct NonNullObjects(crate::util::ObjectDb);
+
+        impl gix_object::Find for NonNullObjects {
+            fn try_find<'a>(
+                &self,
+                id: &gix_hash::oid,
+                buffer: &'a mut Vec<u8>,
+            ) -> Result<Option<gix_object::Data<'a>>, gix_object::find::Error> {
+                assert!(!id.is_null(), "null IDs must not be looked up in the object database");
+                gix_object::Find::try_find(&self.0, id, buffer)
+            }
+        }
+
+        impl gix_object::FindHeader for NonNullObjects {
+            fn try_header(&self, id: &gix_hash::oid) -> Result<Option<gix_object::Header>, gix_object::find::Error> {
+                assert!(!id.is_null(), "null IDs must not be looked up in the object database");
+                gix_object::FindHeader::try_header(&self.0, id)
+            }
+        }
+
+        let tmp = gix_testtools::tempfile::TempDir::new()?;
+        std::fs::write(tmp.path().join("a"), "worktree\r\n")?;
+        let mut filter = gix_diff::blob::Pipeline::new(
+            WorktreeRoots {
+                old_root: None,
+                new_root: Some(tmp.path().to_owned()),
+            },
+            gix_filter::Pipeline::new(
+                Default::default(),
+                gix_filter::pipeline::Options {
+                    eol_config: eol::Configuration {
+                        auto_crlf: AutoCrlf::Input,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            ),
+            vec![],
+            default_options(),
+        );
+        let objects = NonNullObjects(object_db());
+        let index_id = insert(&objects.0, "index\r\n")?;
+        let mut buf = Vec::new();
+        for mode in [pipeline::Mode::ToGit, pipeline::Mode::ToGitUnlessBinaryToTextIsPresent] {
+            for (id, expected) in [
+                (crate::fixture_hash_kind().null(), "worktree\n"),
+                (index_id, "worktree\r\n"),
+            ] {
+                let out = filter.convert_to_diffable(
+                    &id,
+                    EntryKind::Blob,
+                    "a".into(),
+                    ResourceKind::NewOrDestination,
+                    &mut |_, _| {},
+                    &objects,
+                    mode,
+                    &mut buf,
+                )?;
+                assert_eq!(
+                    out.data,
+                    Some(pipeline::Data::Buffer { is_derived: false }),
+                    "worktree content remains available for diffing"
+                );
+                assert_eq!(
+                    buf.as_bstr(),
+                    expected,
+                    "only a known index object can prevent CRLF normalization"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
     fn binary_by_buffer_inspection() -> crate::Result {
         let tmp = gix_testtools::tempfile::TempDir::new()?;
         let root = crate::scripted_fixture_read_only("make_blob_repo.sh")?;

--- a/gix-merge/src/blob/pipeline.rs
+++ b/gix-merge/src/blob/pipeline.rs
@@ -145,16 +145,18 @@ impl Pipeline {
     /// Convert the object at `id`, `mode`, `rela_path` and `kind`, providing access to `attributes` and `objects`.
     /// The resulting merge-able data is written into `out`, if it's not too large.
     /// The returned [`Data`] contains information on how to use `out`, which will be cleared if it is `None`, indicating
-    /// that no object was found at the location *on disk* - it's always an error to provide an object ID that doesn't exist
-    /// in the object database.
+    /// that no object was found at the location *on disk*. If no worktree root is available, a non-null object ID
+    /// must exist in the object database.
     ///
     /// `attributes` must be returning the attributes at `rela_path` and is used for obtaining worktree filter settings,
     /// and `objects` must be usable if `kind` is a resource in the object database,
     /// i.e. if no worktree root is available. It's notable that if a worktree root is present for `kind`,
     /// then a `rela_path` is used to access it on disk.
     ///
-    /// If `id` [is null](gix_hash::ObjectId::is_null()) or the file in question doesn't exist in the worktree in case
-    /// [a root](WorktreeRoots) is present, then `out` will be left cleared and the output data will be `None`.
+    /// If a [worktree root](WorktreeRoots) is present, read the file from there. A non-null `id` may be used to look up
+    /// its index version for line-ending conversion. Null IDs are never looked up in `objects`.
+    /// If the worktree file doesn't exist, or no root is present and `id` [is null](gix_hash::ObjectId::is_null()),
+    /// then `out` will be left cleared and the output data will be `None`.
     /// This is useful to simplify the calling code as empty buffers signal that nothing is there.
     ///
     /// Note that `mode` is trusted, and we will not re-validate that the entry in the worktree actually is of that mode.
@@ -215,7 +217,7 @@ impl Pipeline {
                                         gix_path::from_bstr(rela_path).as_ref(),
                                         attributes,
                                         &mut |buf| {
-                                            if convert == Mode::Renormalize {
+                                            if convert == Mode::Renormalize || id.is_null() {
                                                 Ok(None)
                                             } else {
                                                 objects.try_find(id, buf).map(|obj| obj.map(|_| ()))

--- a/gix-merge/tests/merge/blob/pipeline.rs
+++ b/gix-merge/tests/merge/blob/pipeline.rs
@@ -310,24 +310,6 @@ fn non_existing() -> crate::Result {
 
 #[test]
 fn worktree_filter() -> crate::Result {
-    struct NoObjectLookups;
-
-    impl gix_object::Find for NoObjectLookups {
-        fn try_find<'a>(
-            &self,
-            _id: &gix_hash::oid,
-            _buffer: &'a mut Vec<u8>,
-        ) -> Result<Option<gix_object::Data<'a>>, gix_object::find::Error> {
-            panic!("null-ID worktree resources must not look up objects");
-        }
-    }
-
-    impl gix_object::FindHeader for NoObjectLookups {
-        fn try_header(&self, _id: &gix_hash::oid) -> Result<Option<gix_object::Header>, gix_object::find::Error> {
-            panic!("null-ID worktree resources must not look up object headers");
-        }
-    }
-
     let tmp = gix_testtools::tempfile::TempDir::new()?;
     let filter = gix_filter::Pipeline::new(
         Default::default(),
@@ -361,7 +343,7 @@ fn worktree_filter() -> crate::Result {
             a_name.into(),
             ResourceKind::CommonAncestorOrBase,
             &mut |_, _| {},
-            &NoObjectLookups,
+            &gix_object::find::Never::panic_on_access(),
             mode,
             &mut buf,
         )?;

--- a/gix-merge/tests/merge/blob/pipeline.rs
+++ b/gix-merge/tests/merge/blob/pipeline.rs
@@ -310,6 +310,24 @@ fn non_existing() -> crate::Result {
 
 #[test]
 fn worktree_filter() -> crate::Result {
+    struct NoObjectLookups;
+
+    impl gix_object::Find for NoObjectLookups {
+        fn try_find<'a>(
+            &self,
+            _id: &gix_hash::oid,
+            _buffer: &'a mut Vec<u8>,
+        ) -> Result<Option<gix_object::Data<'a>>, gix_object::find::Error> {
+            panic!("null-ID worktree resources must not look up objects");
+        }
+    }
+
+    impl gix_object::FindHeader for NoObjectLookups {
+        fn try_header(&self, _id: &gix_hash::oid) -> Result<Option<gix_object::Header>, gix_object::find::Error> {
+            panic!("null-ID worktree resources must not look up object headers");
+        }
+    }
+
     let tmp = gix_testtools::tempfile::TempDir::new()?;
     let filter = gix_filter::Pipeline::new(
         Default::default(),
@@ -343,7 +361,7 @@ fn worktree_filter() -> crate::Result {
             a_name.into(),
             ResourceKind::CommonAncestorOrBase,
             &mut |_, _| {},
-            &gix_object::find::Never,
+            &NoObjectLookups,
             mode,
             &mut buf,
         )?;

--- a/gix-object/src/find.rs
+++ b/gix-object/src/find.rs
@@ -63,8 +63,74 @@ pub mod existing_iter {
 }
 
 /// An implementation of object access traits that stores nothing and finds nothing.
+/// Use [`Never::panic_on_access()`] to panic on object access instead.
 #[derive(Debug, Copy, Clone)]
 pub struct Never;
+
+impl Never {
+    /// Return an implementation that panics whenever an object access trait method is called.
+    /// Useful for asserting that an operation does not access the object database.
+    pub const fn panic_on_access() -> PanicAlways {
+        PanicAlways
+    }
+}
+
+/// An implementation of object access traits that panics on every call.
+/// Obtain it with [`Never::panic_on_access()`].
+#[derive(Debug, Copy, Clone)]
+pub struct PanicAlways;
+
+impl super::FindHeader for PanicAlways {
+    fn try_header(&self, _id: &gix_hash::oid) -> Result<Option<crate::Header>, Error> {
+        panic!("object header lookups are forbidden");
+    }
+}
+
+impl super::Find for PanicAlways {
+    fn try_find<'a>(&self, _id: &gix_hash::oid, _buffer: &'a mut Vec<u8>) -> Result<Option<crate::Data<'a>>, Error> {
+        panic!("object lookups are forbidden");
+    }
+}
+
+impl super::Exists for PanicAlways {
+    fn exists(&self, _id: &gix_hash::oid) -> bool {
+        panic!("object existence checks are forbidden");
+    }
+}
+
+impl super::Write for PanicAlways {
+    fn write(&self, _object: &dyn crate::WriteTo) -> Result<gix_hash::ObjectId, crate::write::Error> {
+        panic!("object writes are forbidden");
+    }
+
+    fn write_buf_with_known_id(
+        &self,
+        _object: crate::Kind,
+        _from: &[u8],
+        _id: gix_hash::ObjectId,
+    ) -> Result<gix_hash::ObjectId, crate::write::Error> {
+        panic!("object writes are forbidden");
+    }
+
+    fn write_stream(
+        &self,
+        _kind: crate::Kind,
+        _size: u64,
+        _from: &mut dyn std::io::Read,
+    ) -> Result<gix_hash::ObjectId, crate::write::Error> {
+        panic!("object writes are forbidden");
+    }
+
+    fn write_stream_with_known_id(
+        &self,
+        _kind: crate::Kind,
+        _size: u64,
+        _from: &mut dyn std::io::Read,
+        _id: gix_hash::ObjectId,
+    ) -> Result<gix_hash::ObjectId, crate::write::Error> {
+        panic!("object writes are forbidden");
+    }
+}
 
 impl super::FindHeader for Never {
     fn try_header(&self, _id: &gix_hash::oid) -> Result<Option<crate::Header>, Error> {

--- a/gix-object/tests/object/main.rs
+++ b/gix-object/tests/object/main.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, sync::atomic::AtomicBool};
 
 use gix_hash::ObjectId;
-use gix_object::{Find, FindHeader, Write, WriteTo};
+use gix_object::{Exists, Find, FindHeader, Write, WriteTo};
 
 mod commit;
 mod encode;
@@ -94,8 +94,49 @@ fn never_writes_to_nowhere_and_finds_nothing() -> Result {
         db.try_header(&expected)?.is_none(),
         "discarded writes must not make headers readable"
     );
+    assert!(!db.exists(&expected), "discarded writes must not exist");
 
     Ok(())
+}
+
+#[test]
+fn never_fail_always_panics_on_all_object_access() {
+    let assert_panics = |operation: fn(gix_object::find::PanicAlways, ObjectId)| {
+        assert!(
+            std::panic::catch_unwind(|| {
+                operation(
+                    gix_object::find::Never::panic_on_access(),
+                    ObjectId::empty_blob(gix_hash::Kind::default()),
+                );
+            })
+            .is_err(),
+            "every object-access operation must panic"
+        );
+    };
+    assert_panics(|db, blob_id| {
+        let _ = db.try_find(&blob_id, &mut Vec::new());
+    });
+    assert_panics(|db, blob_id| {
+        let _ = db.try_header(&blob_id);
+    });
+    assert_panics(|db, blob_id| {
+        db.exists(&blob_id);
+    });
+    assert_panics(|db, _| {
+        let _ = db.write(&gix_object::Tree::default());
+    });
+    assert_panics(|db, _| {
+        let _ = db.write_buf(gix_object::Kind::Blob, b"");
+    });
+    assert_panics(|db, blob_id| {
+        let _ = db.write_buf_with_known_id(gix_object::Kind::Blob, b"", blob_id);
+    });
+    assert_panics(|db, _| {
+        let _ = db.write_stream(gix_object::Kind::Blob, 0, &mut std::io::empty());
+    });
+    assert_panics(|db, blob_id| {
+        let _ = db.write_stream_with_known_id(gix_object::Kind::Blob, 0, &mut std::io::empty(), blob_id);
+    });
 }
 
 use gix_testtools::Result;

--- a/gix-tix/src/lib.rs
+++ b/gix-tix/src/lib.rs
@@ -1948,10 +1948,10 @@ fn event_loop(
                                         });
                                     let message = result.as_ref().map_or_else(
                                         |err| format!("delete {label}: {err}"),
-                                        |()| format!("deleted {label}"),
+                                        |_| format!("deleted {label}"),
                                     );
                                     match (result, recorded) {
-                                        (Ok(()), Ok(())) => ref_tree.leave_success(message),
+                                        (Ok(_), Ok(())) => ref_tree.leave_success(message),
                                         (_, Ok(())) => ref_tree.leave_attention(message),
                                         (_, Err(err)) => {
                                             ref_tree.leave_attention(format!("{message}; undo history: {err:#}"));

--- a/gix/src/config/cache/access.rs
+++ b/gix/src/config/cache/access.rs
@@ -253,13 +253,7 @@ impl Cache {
     }
 
     pub(crate) fn config_lock_timeout(&self) -> Result<gix_lock::acquire::Fail, config::lock_timeout::Error> {
-        Core::CONFIG_LOCK_TIMEOUT
-            .try_into_lock_timeout(
-                self.resolved
-                    .integer_filter(Core::CONFIG_LOCK_TIMEOUT, &mut self.filter_config_section.clone()),
-            )
-            .with_leniency(self.lenient_config)
-            .map(|value| value.unwrap_or_else(|| Fail::from(Duration::from_millis(1000))))
+        config_lock_timeout(&self.resolved, self.lenient_config, self.filter_config_section)
     }
 
     /// The path to the user-level excludes file to ignore certain files in the worktree.
@@ -528,6 +522,17 @@ impl Cache {
     pub(crate) fn home_dir(&self) -> Option<PathBuf> {
         home_dir(self.environment)
     }
+}
+
+pub(crate) fn config_lock_timeout(
+    config: &gix_config::File,
+    lenient: bool,
+    mut filter_config_section: fn(&gix_config::file::Metadata) -> bool,
+) -> Result<Fail, config::lock_timeout::Error> {
+    Core::CONFIG_LOCK_TIMEOUT
+        .try_into_lock_timeout(config.integer_filter(Core::CONFIG_LOCK_TIMEOUT, &mut filter_config_section))
+        .with_leniency(lenient)
+        .map(|value| value.unwrap_or_else(|| Fail::from(Duration::from_millis(1000))))
 }
 
 fn compression(

--- a/gix/src/config/cache/init.rs
+++ b/gix/src/config/cache/init.rs
@@ -209,6 +209,40 @@ impl Cache {
     }
 }
 
+/// Resolve a permitted repository-independent configuration source, including explicit and environment path overrides.
+pub(crate) fn source_path(
+    source: gix_config::Source,
+    git_installation_config_path: Option<&std::path::Path>,
+    system_config_path: Option<&std::path::Path>,
+    permissions: open::permissions::Config,
+    source_env: &mut dyn FnMut(&str) -> Option<OsString>,
+) -> Option<std::path::PathBuf> {
+    let permitted = match source {
+        gix_config::Source::GitInstallation => permissions.git_binary,
+        gix_config::Source::System => permissions.system,
+        gix_config::Source::Git => permissions.git,
+        gix_config::Source::User => permissions.user,
+        _ => false,
+    };
+    if !permitted {
+        return None;
+    }
+    if matches!(source, gix_config::Source::GitInstallation | gix_config::Source::System)
+        && source_env("GIT_CONFIG_NOSYSTEM")
+            .and_then(|value| gix_config::Boolean::try_from(value).ok())
+            .is_some_and(|value| value.0)
+    {
+        return None;
+    }
+    match source {
+        gix_config::Source::GitInstallation => git_installation_config_path,
+        gix_config::Source::System => system_config_path,
+        _ => None,
+    }
+    .map(ToOwned::to_owned)
+    .or_else(|| source.storage_location(source_env))
+}
+
 /// Load global configuration and optional repository-local configuration using the same ordering and overrides as
 /// repository opening.
 #[expect(clippy::too_many_arguments)]
@@ -231,13 +265,10 @@ pub(crate) fn load(
         identity,
         objects,
     }: open::permissions::Environment,
-    open::permissions::Config {
-        git_binary: use_installation,
-        system: use_system,
-        git: use_git,
-        user: use_user,
+    config_permissions @ open::permissions::Config {
         env: use_env,
         includes: use_includes,
+        ..
     }: open::permissions::Config,
     lossy: bool,
     lenient: bool,
@@ -258,9 +289,6 @@ pub(crate) fn load(
     };
     let git_prefix = &git_prefix;
     let mut source_env = Cache::make_source_env(environment);
-    let no_system_config = source_env("GIT_CONFIG_NOSYSTEM")
-        .and_then(|value| gix_config::Boolean::try_from(value).ok())
-        .is_some_and(|value| value.0);
     let mut metas = [
         gix_config::source::Kind::GitInstallation,
         gix_config::source::Kind::System,
@@ -268,28 +296,19 @@ pub(crate) fn load(
     ]
     .iter()
     .flat_map(|kind| kind.sources())
-    .filter_map(|source| {
-        match source {
-            gix_config::Source::GitInstallation if !use_installation || no_system_config => return None,
-            gix_config::Source::System if !use_system || no_system_config => return None,
-            gix_config::Source::Git if !use_git => return None,
-            gix_config::Source::User if !use_user => return None,
-            _ => {}
-        }
-        match source {
-            gix_config::Source::GitInstallation => git_installation_config_path,
-            gix_config::Source::System => system_config_path,
-            _ => None,
-        }
-        .map(ToOwned::to_owned)
-        .or_else(|| source.storage_location(&mut source_env))
-        .map(|p| (source, p))
-    })
-    .map(|(source, path)| gix_config::file::Metadata {
-        path: Some(path),
-        source: *source,
-        level: 0,
-        trust: gix_sec::Trust::Full,
+    .filter_map(|&source| {
+        source_path(
+            source,
+            git_installation_config_path,
+            system_config_path,
+            config_permissions,
+            &mut source_env,
+        )
+        .map(|path| {
+            gix_config::file::Metadata::from(source)
+                .at(path)
+                .with(gix_sec::Trust::Full)
+        })
     });
 
     let err_on_nonexisting_paths = false;

--- a/gix/src/config/cache/mod.rs
+++ b/gix/src/config/cache/mod.rs
@@ -4,7 +4,7 @@ mod incubate;
 pub(crate) use incubate::StageOne;
 
 mod init;
-pub(crate) use init::load;
+pub(crate) use init::{load, source_path};
 
 impl std::fmt::Debug for Cache {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/gix/src/config/file_mut.rs
+++ b/gix/src/config/file_mut.rs
@@ -11,6 +11,14 @@ use super::FileTransaction;
 #[derive(Debug, thiserror::Error)]
 #[expect(missing_docs)]
 pub enum Error {
+    #[error("Configuration source {0:?} requires a repository or has no physical file")]
+    UnsupportedSource(gix_config::Source),
+    #[error("Configuration source {0:?} has no available path with these options")]
+    SourceUnavailable(gix_config::Source),
+    #[error("Could not load global configuration")]
+    Config(#[from] super::Error),
+    #[error("Could not obtain the current directory for a relative configuration path")]
+    CurrentDir(#[source] std::io::Error),
     #[error(transparent)]
     LockTimeout(#[from] super::lock_timeout::Error),
     #[error(transparent)]
@@ -44,6 +52,7 @@ pub enum Error {
 impl FileTransaction {
     pub(crate) fn open(
         path: std::path::PathBuf,
+        source: gix_config::Source,
         trust: gix_sec::Trust,
         lock_mode: gix_lock::acquire::Fail,
         shared_repository_permissions: i32,
@@ -59,7 +68,6 @@ impl FileTransaction {
             Some(&gix_lock::acquire::resolve_symlink),
             adjust_permissions,
         )?;
-        let source = gix_config::Source::Local;
         let path = lock.resource_path();
         let config = match std::fs::File::open(&path) {
             Ok(mut file) => {

--- a/gix/src/config/mod.rs
+++ b/gix/src/config/mod.rs
@@ -18,8 +18,9 @@ pub use tree::root::Tree;
 
 /// A locked, mutable physical configuration file.
 ///
+/// Create one with [`crate::config_mut()`] or [`Repository::config_file_mut()`].
 /// Includes are not expanded. Dropping this value releases the lock and discards all changes;
-/// [`commit()`](Self::commit()) writes them atomically. The owning repository is not updated.
+/// [`commit()`](Self::commit()) writes them atomically. Existing repository instances are not updated.
 pub struct FileTransaction {
     pub(crate) lock: gix_lock::File,
     pub(crate) config: gix_config::File,

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -456,6 +456,69 @@ pub fn config(git_dir: Option<&std::path::Path>, options: &open::Options) -> Res
     )
 }
 
+/// Lock and open one configuration file available without a repository, selected by its source.
+///
+/// Supported sources are [`GitInstallation`](config::Source::GitInstallation), [`System`](config::Source::System),
+/// [`Git`](config::Source::Git) (the XDG Git configuration), and [`User`](config::Source::User).
+/// Path selection honors the configuration permissions, environment permissions and explicit paths in `options`,
+/// just like [`config()`]. Disabled sources and sources without an available path return an error.
+/// Relative paths are resolved against the current directory when called.
+///
+/// The lock timeout comes from `core.configLockTimeout` in [`config(None, options)`](config()), honoring section filtering
+/// and leniency, and defaults to one second. Includes and runtime overrides can affect the timeout, but the returned file
+/// contains only the selected physical file, parsed strictly and losslessly even with `lossy_config` enabled.
+///
+/// Missing files start empty; their parent directories must already exist. Existing file permissions are preserved, and
+/// new files apply `core.sharedRepository` from the same resolved configuration, honoring section filtering.
+/// Invalid sharing policies return an error.
+/// Dropping the transaction discards edits and releases its lock; [`commit()`](config::FileTransaction::commit()) writes
+/// the file atomically without updating existing repository instances.
+///
+/// ```no_run
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut file = gix::config_mut(gix::config::Source::User, &gix::open::Options::default())?;
+/// file.set_raw_value("user.name", "Ada Lovelace")?;
+/// file.commit()?;
+/// # Ok(()) }
+/// ```
+pub fn config_mut(
+    source: config::Source,
+    options: &open::Options,
+) -> Result<config::FileTransaction, config::file_mut::Error> {
+    use config::file_mut::Error;
+
+    if !matches!(
+        source,
+        config::Source::GitInstallation | config::Source::System | config::Source::Git | config::Source::User
+    ) {
+        return Err(Error::UnsupportedSource(source));
+    }
+    let path = config::cache::source_path(
+        source,
+        options.git_installation_config_path.as_deref(),
+        options.system_config_path.as_deref(),
+        options.permissions.config,
+        &mut config::Cache::make_source_env(options.permissions.env),
+    )
+    .ok_or(Error::SourceUnavailable(source))?;
+    let path = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir().map_err(Error::CurrentDir)?.join(path)
+    };
+    let resolved = config(None, options)?;
+    let filter = options.filter_config_section.unwrap_or(config::section::is_trusted);
+    let lock_mode = config::cache::access::config_lock_timeout(&resolved, options.lenient_config, filter)?;
+    let shared_repository_permissions = config::file_mut::shared_repository_permissions(&resolved, filter)?;
+    config::FileTransaction::open(
+        path,
+        source,
+        gix_sec::Trust::Full,
+        lock_mode,
+        shared_repository_permissions,
+    )
+}
+
 ///
 pub mod create;
 

--- a/gix/src/repository/branch.rs
+++ b/gix/src/repository/branch.rs
@@ -52,6 +52,10 @@ pub mod delete {
             /// All of these references and their reflogs are guaranteed to be absent. Their `branch.<name>` configuration
             /// sections may remain; inspect `source` to determine which cleanup phase failed.
             references: Vec<FullName>,
+            /// The branches actually deleted, as would have been returned on success.
+            ///
+            /// Names are sorted and deduplicated; branches missing when locked for deletion are excluded.
+            deleted: Vec<FullName>,
             /// The configuration cleanup phase that failed.
             #[source]
             source: CleanupError,
@@ -67,19 +71,23 @@ impl crate::Repository {
     /// associated local configuration is still removed. **It deliberately performs no merged-state check**.
     ///
     /// On success, every requested reference and its reflog is absent, and every matching `branch.<name>` section has been
-    /// removed from the local configuration. A requested reference which was already missing is treated as successfully absent,
-    /// and its configuration is still removed.
+    /// removed from the local configuration. Return the sorted, deduplicated names of branches that existed when locked for
+    /// deletion. Missing branches are omitted from the returned vector, but their configuration is still removed.
     ///
     /// Reference deletion and configuration cleanup cannot be one atomic transaction. Once reference deletion succeeds, a
     /// configuration write or commit failure is returned as [`delete::Error::Cleanup`]. Its `references` field contains
     /// every requested name—including names which were missing initially—and guarantees only that their references and reflogs
-    /// are absent. See [`delete::CleanupError`] to determine whether the on-disk configuration was updated.
-    pub fn delete_local_branches(&mut self, names: impl IntoIterator<Item = FullName>) -> Result<(), delete::Error> {
+    /// are absent. Its `deleted` field contains the branches actually deleted, just as in the success case.
+    /// See [`delete::CleanupError`] to determine whether the on-disk configuration was updated.
+    pub fn delete_local_branches(
+        &mut self,
+        names: impl IntoIterator<Item = FullName>,
+    ) -> Result<Vec<FullName>, delete::Error> {
         let mut names: Vec<_> = names.into_iter().collect();
         names.sort();
         names.dedup();
         if names.is_empty() {
-            return Ok(());
+            return Ok(names);
         }
 
         for name in &names {
@@ -125,7 +133,11 @@ impl crate::Repository {
             .as_mut()
             .is_some_and(|config| remove_branch_config(config, &names, |_| true));
 
-        self.edit_references(edits)?;
+        let deleted: Vec<_> = self
+            .edit_references(edits)?
+            .into_iter()
+            .filter_map(|edit| edit.change.previous_value().is_some().then_some(edit.name))
+            .collect();
 
         if removed_config {
             let config = config.expect("configuration was present when sections were removed");
@@ -133,10 +145,12 @@ impl crate::Repository {
                 .write_to(&mut config_lock)
                 .map_err(|source| delete::Error::Cleanup {
                     references: names.clone(),
+                    deleted: deleted.clone(),
                     source: delete::CleanupError::Write(source),
                 })?;
             config_lock.commit().map_err(|err| delete::Error::Cleanup {
                 references: names.clone(),
+                deleted: deleted.clone(),
                 source: delete::CleanupError::Commit(err.error),
             })?;
             remove_branch_config(
@@ -149,7 +163,7 @@ impl crate::Repository {
                 },
             );
         }
-        Ok(())
+        Ok(deleted)
     }
 }
 

--- a/gix/src/repository/config/mod.rs
+++ b/gix/src/repository/config/mod.rs
@@ -42,7 +42,13 @@ impl crate::Repository {
         let lock_mode = self.config.config_lock_timeout()?;
         let shared_repository_permissions =
             config::file_mut::shared_repository_permissions(&self.config.resolved, self.filter_config_section())?;
-        config::FileTransaction::open(path, self.git_dir_trust(), lock_mode, shared_repository_permissions)
+        config::FileTransaction::open(
+            path,
+            config::Source::Local,
+            self.git_dir_trust(),
+            lock_mode,
+            shared_repository_permissions,
+        )
     }
 
     /// Return the editor program selected by Git's precedence rules.

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -32,88 +32,558 @@ fn discover_with_environment_overrides_isolated(
     .map(|repo| repo.to_thread_local())
 }
 
-#[test]
-#[serial]
-fn globals_from_open_options_match_repository_opening() -> gix_testtools::Result {
-    let temp = gix_testtools::tempfile::TempDir::new()?;
-    let _cwd = gix_testtools::set_current_dir(temp.path())?;
+mod config {
+    use gix_sec::Permission;
+    use serial_test::serial;
 
-    let repo_path = std::env::current_dir()?.join("project");
-    let git_dir = repo_path.join(".git");
-    let included = temp.path().join("included.config");
-    let global = temp.path().join("global.config");
-    std::fs::write(
-        &included,
-        "[marker]
-            included = true",
-    )?;
-    std::fs::write(
-        &global,
-        format!(
+    #[test]
+    #[serial]
+    fn globals_from_open_options_match_repository_opening() -> gix_testtools::Result {
+        let temp = gix_testtools::tempfile::TempDir::new()?;
+        let _cwd = gix_testtools::set_current_dir(temp.path())?;
+
+        let repo_path = std::env::current_dir()?.join("project");
+        let git_dir = repo_path.join(".git");
+        let included = temp.path().join("included.config");
+        let global = temp.path().join("global.config");
+        std::fs::write(
+            &included,
             "[marker]
+            included = true",
+        )?;
+        std::fs::write(
+            &global,
+            format!(
+                "[marker]
                 global = true
             [includeIf \"gitdir:{git_dir}\"]
                 path = {included}
             [includeIf \"gitdir:**/unrelated/.git\"]
                 path = {included}",
-            git_dir = git_dir.display().to_string().replace('\\', "/"),
-            included = included.display().to_string().replace('\\', "/"),
-        ),
-    )?;
-    let _env = gix_testtools::Env::new().set("GIT_CONFIG_GLOBAL", global.display().to_string());
+                git_dir = git_dir.display().to_string().replace('\\', "/"),
+                included = included.display().to_string().replace('\\', "/"),
+            ),
+        )?;
+        let _env = gix_testtools::Env::new().set("GIT_CONFIG_GLOBAL", global.display().to_string());
 
-    let mut permissions = gix::open::Permissions::isolated();
-    permissions.config.user = true;
-    permissions.config.includes = true;
-    permissions.env.git_prefix = Permission::Allow;
-    let options = gix::open::Options::isolated()
-        .permissions(permissions)
-        .cli_overrides(["marker.precedence=cli"])
-        .config_overrides(["marker.precedence=api"]);
+        let mut permissions = gix::open::Permissions::isolated();
+        permissions.config.user = true;
+        permissions.config.includes = true;
+        permissions.env.git_prefix = Permission::Allow;
+        let options = gix::open::Options::isolated()
+            .permissions(permissions)
+            .cli_overrides(["marker.precedence=cli"])
+            .config_overrides(["marker.precedence=api"]);
 
-    let globals = gix::config(Some(std::path::Path::new("project/.git")), &options)?;
-    assert_eq!(globals.boolean("marker.global")?, Some(true), "global files are loaded");
-    assert_eq!(
-        globals.boolean("marker.included")?,
-        Some(true),
-        "git-dir conditional includes use the provided future repository path"
-    );
-    assert_eq!(
-        globals.string("marker.precedence").expect("API override is present"),
-        "api",
-        "API overrides retain repository-opening precedence"
-    );
-
-    let globals_without_repo = gix::config(None, &options)?;
-    assert_eq!(
-        globals_without_repo.boolean("marker.global")?,
-        Some(true),
-        "global files are loaded without repository context"
-    );
-    assert_eq!(
-        globals_without_repo.boolean("marker.included")?,
-        None,
-        "git-dir conditional includes aren't loaded without repository context"
-    );
-
-    let repo =
-        gix::ThreadSafeRepository::init_opts(&repo_path, gix::create::Kind::WithWorktree, Default::default(), options)?
-            .to_thread_local();
-    let repo = repo.config_snapshot();
-
-    for key in ["marker.global", "marker.included"] {
+        let globals = gix::config(Some(std::path::Path::new("project/.git")), &options)?;
+        assert_eq!(globals.boolean("marker.global")?, Some(true), "global files are loaded");
         assert_eq!(
-            globals.boolean(key)?,
-            repo.try_boolean(key)?,
-            "{key} is loaded identically before and during repository opening"
+            globals.boolean("marker.included")?,
+            Some(true),
+            "git-dir conditional includes use the provided future repository path"
         );
+        assert_eq!(
+            globals.string("marker.precedence").expect("API override is present"),
+            "api",
+            "API overrides retain repository-opening precedence"
+        );
+
+        let globals_without_repo = gix::config(None, &options)?;
+        assert_eq!(
+            globals_without_repo.boolean("marker.global")?,
+            Some(true),
+            "global files are loaded without repository context"
+        );
+        assert_eq!(
+            globals_without_repo.boolean("marker.included")?,
+            None,
+            "git-dir conditional includes aren't loaded without repository context"
+        );
+
+        let repo = gix::ThreadSafeRepository::init_opts(
+            &repo_path,
+            gix::create::Kind::WithWorktree,
+            Default::default(),
+            options,
+        )?
+        .to_thread_local();
+        let repo = repo.config_snapshot();
+
+        for key in ["marker.global", "marker.included"] {
+            assert_eq!(
+                globals.boolean(key)?,
+                repo.try_boolean(key)?,
+                "{key} is loaded identically before and during repository opening"
+            );
+        }
+        assert_eq!(
+            globals.string("marker.precedence"),
+            repo.string("marker.precedence"),
+            "overrides are loaded identically before and during repository opening"
+        );
+        Ok(())
     }
-    assert_eq!(
-        globals.string("marker.precedence"),
-        repo.string("marker.precedence"),
-        "overrides are loaded identically before and during repository opening"
-    );
-    Ok(())
+}
+
+mod config_mut {
+    use gix::config::{Source, file_mut::Error};
+    use gix_sec::Permission;
+    use gix_testtools::{Env, Result};
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn edits_one_physical_file_losslessly_without_a_repository() -> Result {
+        let temp = gix_testtools::tempfile::tempdir()?;
+        let _cwd = gix_testtools::set_current_dir(temp.path())?;
+        let path = std::env::current_dir()?.join("global.config");
+        let included = path.with_file_name("included.config");
+        let original = "# leading comment
+[include]
+    path = included.config
+[marker]
+    value = before
+# trailing comment
+";
+        let included_contents = "[marker]
+    included = true
+";
+        std::fs::write(&path, original)?;
+        std::fs::write(&included, included_contents)?;
+        let _env = Env::new().set("GIT_CONFIG_GLOBAL", path.display().to_string());
+        let mut options = options_for(Source::User)
+            .lossy_config(true)
+            .cli_overrides(["marker.cli=transient"])
+            .config_overrides(["marker.api=transient"]);
+        options.permissions.config.includes = true;
+        options.permissions.env.git_prefix = Permission::Allow;
+
+        let mut file = gix::config_mut(Source::User, &options)?;
+        assert_eq!(
+            file.meta().source,
+            Source::User,
+            "metadata identifies the requested source"
+        );
+        assert_eq!(
+            file.meta().path.as_deref(),
+            Some(path.as_path()),
+            "metadata identifies the physical file"
+        );
+        assert_eq!(
+            file.meta().trust,
+            gix_sec::Trust::Full,
+            "global configuration is fully trusted"
+        );
+        for key in ["marker.included", "marker.cli", "marker.api"] {
+            assert!(file.string(key).is_none(), "{key} is not part of the physical file");
+        }
+        file.set_raw_value("marker.value", "after")?;
+        assert_eq!(
+            std::fs::read_to_string(&path)?,
+            original,
+            "changes wait for an explicit commit"
+        );
+        file.commit()?;
+        let written = original.replace("value = before", "value = after");
+        assert_eq!(
+            std::fs::read_to_string(&path)?,
+            written,
+            "comments, whitespace and includes survive lossy options"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&included)?,
+            included_contents,
+            "included files are untouched"
+        );
+        assert_eq!(
+            gix::config(None, &options)?
+                .string("marker.value")
+                .expect("committed marker"),
+            "after",
+            "standalone reads see the committed value"
+        );
+
+        let mut file = gix::config_mut(Source::User, &options)?;
+        file.set_raw_value("marker.value", "discarded")?;
+        drop(file);
+        assert_eq!(std::fs::read_to_string(&path)?, written, "dropping discards edits");
+        assert!(
+            !path.with_extension("config.lock").exists(),
+            "dropping releases the lock"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn source_paths_match_standalone_reads() -> Result {
+        let temp = gix_testtools::tempfile::tempdir()?;
+        let home = temp.path();
+        let xdg = home.join("xdg");
+        std::fs::create_dir_all(xdg.join("git"))?;
+        std::fs::create_dir_all(home.join(".config/git"))?;
+        let _env = Env::new()
+            .set("HOME", home.display().to_string())
+            .set("XDG_CONFIG_HOME", xdg.display().to_string());
+        let installation = home.join("installation.config");
+        let system = home.join("system.config");
+
+        for (source, path) in [
+            (Source::GitInstallation, installation.clone()),
+            (Source::System, system.clone()),
+            (Source::Git, xdg.join("git/config")),
+            (Source::User, home.join(".gitconfig")),
+        ] {
+            let mut options = options_for(source)
+                .git_installation_config_path(&installation)
+                .system_config_path(&system);
+            options.permissions.env.home = Permission::Allow;
+            options.permissions.env.xdg_config_home = Permission::Allow;
+            let mut file = gix::config_mut(source, &options)?;
+            assert_eq!(
+                file.meta().path.as_deref(),
+                Some(path.as_path()),
+                "source resolves to its own file"
+            );
+            assert_eq!(file.meta().source, source, "new files retain their selected source");
+            file.set_raw_value("marker.value", "created")?;
+            assert_eq!(
+                file.section_by_key("marker")?.meta().source,
+                source,
+                "new sections inherit the source"
+            );
+            file.commit()?;
+            assert!(path.is_file(), "the selected missing file is created on commit");
+            assert_eq!(
+                gix::config(None, &options)?
+                    .string("marker.value")
+                    .expect("created marker"),
+                "created",
+                "reading uses the same source path"
+            );
+        }
+
+        let mut options = options_for(Source::Git);
+        options.permissions.env.home = Permission::Allow;
+        let file = gix::config_mut(Source::Git, &options)?;
+        assert_eq!(
+            file.meta().path.as_deref(),
+            Some(home.join(".config/git/config").as_path()),
+            "denying XDG environment access falls back to HOME"
+        );
+        drop(file);
+        options.permissions.env.home = Permission::Deny;
+        assert!(
+            matches!(
+                gix::config_mut(Source::Git, &options),
+                Err(Error::SourceUnavailable(Source::Git))
+            ),
+            "a source with no permitted path is unavailable"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn honors_environment_and_explicit_path_overrides() -> Result {
+        let temp = gix_testtools::tempfile::tempdir()?;
+        let global = temp.path().join("global.config");
+        let system = temp.path().join("system.config");
+        let explicit = temp.path().join("explicit.config");
+        let _env = Env::new()
+            .set("GIT_CONFIG_GLOBAL", global.display().to_string())
+            .set("GIT_CONFIG_SYSTEM", system.display().to_string())
+            .set("GIT_CONFIG_NOSYSTEM", "false");
+        for source in [Source::Git, Source::User, Source::System] {
+            let mut options = options_for(source);
+            options.permissions.env.git_prefix = Permission::Allow;
+            let file = gix::config_mut(source, &options)?;
+            let expected = if source == Source::System { &system } else { &global };
+            assert_eq!(
+                file.meta().path.as_deref(),
+                Some(expected.as_path()),
+                "Git environment overrides select the target"
+            );
+        }
+
+        for source in [Source::GitInstallation, Source::System] {
+            let mut options = options_for(source)
+                .git_installation_config_path(&explicit)
+                .system_config_path(&explicit);
+            options.permissions.env.git_prefix = Permission::Allow;
+            let file = gix::config_mut(source, &options)?;
+            assert_eq!(
+                file.meta().path.as_deref(),
+                Some(explicit.as_path()),
+                "explicit options take precedence over environment paths"
+            );
+            drop(file);
+            let _no_system = Env::new().set("GIT_CONFIG_NOSYSTEM", "true");
+            assert!(
+                matches!(gix::config_mut(source, &options), Err(Error::SourceUnavailable(actual)) if actual == source),
+                "GIT_CONFIG_NOSYSTEM suppresses explicit installation and system paths"
+            );
+            options.permissions.env.git_prefix = Permission::Deny;
+            assert!(
+                gix::config_mut(source, &options).is_ok(),
+                "denying environment access ignores GIT_CONFIG_NOSYSTEM, so the explicit path can be opened"
+            );
+        }
+
+        let mut options = options_for(Source::User).config_overrides(["core.configLockTimeout=0"]);
+        options.permissions.config.git = true;
+        options.permissions.env.git_prefix = Permission::Allow;
+        let _file = gix::config_mut(Source::User, &options)?;
+        assert!(
+            matches!(gix::config_mut(Source::Git, &options), Err(Error::AcquireLock(_))),
+            "sources overridden to the same file share its lock"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn rejects_unsupported_and_disabled_sources() -> Result {
+        let temp = gix_testtools::tempfile::tempdir()?;
+        let options = gix::open::Options::isolated()
+            .git_installation_config_path(temp.path().join("installation.config"))
+            .system_config_path(temp.path().join("system.config"));
+        for source in [Source::GitInstallation, Source::System, Source::Git, Source::User] {
+            assert!(
+                matches!(gix::config_mut(source, &options), Err(Error::SourceUnavailable(actual)) if actual == source),
+                "disabled sources cannot be opened for writing"
+            );
+        }
+        for source in [
+            Source::Local,
+            Source::Worktree,
+            Source::Env,
+            Source::Cli,
+            Source::Api,
+            Source::EnvOverride,
+        ] {
+            assert!(
+                matches!(gix::config_mut(source, &options), Err(Error::UnsupportedSource(actual)) if actual == source),
+                "repository and in-memory sources have no standalone transaction"
+            );
+        }
+        assert_eq!(
+            std::fs::read_dir(temp.path())?.count(),
+            0,
+            "rejected sources do not create files or locks"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn missing_files_require_existing_parent_directories() -> Result {
+        let temp = gix_testtools::tempfile::tempdir()?;
+        let path = temp.path().join("missing/global.config");
+        let options = options_for(Source::System).system_config_path(&path);
+        assert!(
+            matches!(gix::config_mut(Source::System, &options), Err(Error::AcquireLock(gix::lock::acquire::Error::Io(err))) if err.kind() == std::io::ErrorKind::NotFound),
+            "the parent directory must already exist"
+        );
+        assert!(
+            !path.parent().expect("config parent").exists(),
+            "opening does not create directories"
+        );
+        std::fs::create_dir(path.parent().expect("config parent"))?;
+        let mut file = gix::config_mut(Source::System, &options)?;
+        file.set_raw_value("marker.value", "discarded")?;
+        drop(file);
+        assert_eq!(
+            std::fs::read_dir(path.parent().expect("config parent"))?.count(),
+            0,
+            "dropping a new file leaves neither the file nor its lock"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn malformed_configuration_cannot_be_overwritten() -> Result {
+        let temp = gix_testtools::tempfile::tempdir()?;
+        let path = temp.path().join("global.config");
+        let options = options_for(Source::System).system_config_path(&path);
+        let malformed = "[unterminated";
+        std::fs::write(&path, malformed)?;
+        assert!(
+            matches!(gix::config_mut(Source::System, &options), Err(Error::Config(_))),
+            "malformed configuration cannot be overwritten through a transaction"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path)?,
+            malformed,
+            "failed opening preserves malformed input"
+        );
+        assert!(
+            !path.with_extension("config.lock").exists(),
+            "failed opening leaves no lock"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn lock_timeout_uses_global_configuration_and_option_precedence() -> Result {
+        use gix::lock::acquire::{Error as LockError, Fail};
+
+        let temp = gix_testtools::tempfile::tempdir()?;
+        let global_config_path = temp.path().join("global.config");
+        std::fs::write(
+            &global_config_path,
+            "[core]
+    configLockTimeout = 0
+",
+        )?;
+        std::fs::write(global_config_path.with_extension("config.lock"), "held")?;
+        let options = options_for(Source::System)
+            .system_config_path(&global_config_path)
+            .strict_config(true)
+            .cli_overrides(["core.configLockTimeout=invalid"])
+            .config_overrides(["core.configLockTimeout=0"]);
+        assert!(
+            matches!(
+                gix::config_mut(Source::System, &options),
+                Err(Error::AcquireLock(LockError::PermanentlyLocked {
+                    mode: Fail::Immediately,
+                    ..
+                }))
+            ),
+            "API overrides take precedence over CLI and disk values"
+        );
+        let options = options.filter_config_section(|meta| meta.source != Source::Api);
+        assert!(
+            matches!(gix::config_mut(Source::System, &options), Err(Error::LockTimeout(_))),
+            "section filtering exposes the invalid CLI timeout in strict mode"
+        );
+        let options = options.strict_config(false);
+        assert!(
+            matches!(gix::config_mut(Source::System, &options), Err(Error::AcquireLock(LockError::PermanentlyLocked { mode: Fail::AfterDurationWithBackoff(duration), .. })) if duration == std::time::Duration::from_millis(1000)),
+            "lenient invalid timeouts use the one-second default"
+        );
+
+        std::fs::write(
+            &global_config_path,
+            "[core]
+    configLockTimeout = invalid
+[include]
+    path = included.config
+",
+        )?;
+        std::fs::write(
+            global_config_path.with_file_name("included.config"),
+            "[core]
+    configLockTimeout = 0
+",
+        )?;
+        let mut options = options_for(Source::System)
+            .system_config_path(&global_config_path)
+            .strict_config(true);
+        options.permissions.config.includes = true;
+        assert!(
+            matches!(
+                gix::config_mut(Source::System, &options),
+                Err(Error::AcquireLock(LockError::PermanentlyLocked {
+                    mode: Fail::Immediately,
+                    ..
+                }))
+            ),
+            "expanded global includes can supply the lock timeout"
+        );
+        options.permissions.config.includes = false;
+        assert!(
+            matches!(gix::config_mut(Source::System, &options), Err(Error::LockTimeout(_))),
+            "disabling includes exposes the invalid physical timeout"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn relative_paths_remain_anchored_when_the_current_directory_changes() -> Result {
+        let temp = gix_testtools::tempfile::tempdir()?;
+        let _cwd = gix_testtools::set_current_dir(temp.path())?;
+        let root = std::env::current_dir()?;
+        let elsewhere = root.join("elsewhere");
+        std::fs::create_dir(&elsewhere)?;
+        let options = options_for(Source::System).system_config_path("global.config");
+        let mut file = gix::config_mut(Source::System, &options)?;
+        assert_eq!(
+            file.meta().path.as_deref(),
+            Some(root.join("global.config").as_path()),
+            "relative targets capture the opening directory"
+        );
+        file.set_raw_value("marker.value", "anchored")?;
+        let _elsewhere = gix_testtools::set_current_dir(&elsewhere)?;
+        file.commit()?;
+        assert!(root.join("global.config").is_file(), "commit uses the captured target");
+        assert!(
+            !elsewhere.join("global.config").exists(),
+            "the later working directory does not affect commit"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    #[serial]
+    fn global_permissions_honor_shared_repository_policy() -> Result {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = gix_testtools::tempfile::tempdir()?;
+        let path = temp.path().join("global.config");
+        let installation = temp.path().join("installation.config");
+        std::fs::write(
+            &installation,
+            "[core]
+    sharedRepository = 0664
+",
+        )?;
+        let mut options = options_for(Source::System)
+            .system_config_path(&path)
+            .git_installation_config_path(&installation)
+            .strict_config(true);
+        options.permissions.config.git_binary = true;
+        gix::config_mut(Source::System, &options)?.commit()?;
+        assert_eq!(
+            path.metadata()?.permissions().mode() & 0o777,
+            0o664,
+            "new global files honor the sharing policy from the resolved configuration"
+        );
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+        let mut file = gix::config_mut(Source::System, &options)?;
+        file.set_raw_value("marker.value", "written")?;
+        file.commit()?;
+        assert_eq!(
+            path.metadata()?.permissions().mode() & 0o777,
+            0o600,
+            "editing preserves existing permissions"
+        );
+        let options = options.config_overrides(["core.sharedRepository=invalid"]);
+        assert!(
+            matches!(
+                gix::config_mut(Source::System, &options),
+                Err(Error::InvalidSharedRepository(_))
+            ),
+            "invalid sharing policies in overrides are rejected even for existing files"
+        );
+        Ok(())
+    }
+
+    fn options_for(source: Source) -> gix::open::Options {
+        let mut options = gix::open::Options::isolated();
+        match source {
+            Source::GitInstallation => options.permissions.config.git_binary = true,
+            Source::System => options.permissions.config.system = true,
+            Source::Git => options.permissions.config.git = true,
+            Source::User => options.permissions.config.user = true,
+            _ => panic!("test options require a repository-independent file"),
+        }
+        options
+    }
 }
 
 mod with_overrides {

--- a/gix/tests/gix/repository/branch.rs
+++ b/gix/tests/gix/repository/branch.rs
@@ -56,7 +56,11 @@ fn deletes_a_batch_and_all_of_its_local_config_without_inspecting_commits() -> c
     repo.config_snapshot_mut()
         .append_config(["test.inMemory=retained"], gix_config::Source::Api)?;
 
-    repo.delete_local_branches([direct.clone(), symbolic.clone()])?;
+    assert_eq!(
+        repo.delete_local_branches([symbolic.clone(), direct.clone(), symbolic.clone()])?,
+        vec![direct.clone(), symbolic.clone()],
+        "loose and dangling symbolic branches are returned once, in name order"
+    );
 
     assert!(
         repo.try_find_reference(direct.as_ref())?.is_none(),
@@ -144,7 +148,15 @@ fn missing_branches_are_successful_and_their_config_is_removed() -> crate::Resul
         "all branch sections are loaded before deletion"
     );
 
-    repo.delete_local_branches([existing.clone(), missing.clone(), reserved_for_creation.clone()])?;
+    assert!(
+        !repo.common_dir().join("refs/heads/d1").exists(),
+        "the existing branch is stored only in packed refs"
+    );
+    assert_eq!(
+        repo.delete_local_branches([existing.clone(), missing.clone(), reserved_for_creation.clone()])?,
+        vec![existing.clone()],
+        "only the existing packed branch is reported as deleted"
+    );
 
     assert!(
         repo.try_find_reference(existing.as_ref())?.is_none(),
@@ -174,6 +186,15 @@ fn missing_branches_are_successful_and_their_config_is_removed() -> crate::Resul
     assert!(
         repo.branch_names().is_empty(),
         "configuration for existing, missing, and creation-reserved branch names is removed from memory"
+    );
+    assert!(
+        repo.delete_local_branches([existing, missing, reserved_for_creation])?
+            .is_empty(),
+        "repeating the deletion reports no branches"
+    );
+    assert!(
+        repo.delete_local_branches([])?.is_empty(),
+        "an empty batch reports no branches"
     );
     Ok(())
 }
@@ -227,7 +248,11 @@ fn linked_worktree_branches_are_protected_and_common_config_is_updated() -> crat
         linked_repo.branch_names().contains("delete-from-linked"),
         "the common branch configuration is loaded into the linked repository"
     );
-    linked_repo.delete_local_branches([deletable.clone()])?;
+    assert_eq!(
+        linked_repo.delete_local_branches([deletable.clone()])?,
+        vec![deletable.clone()],
+        "linked worktrees report branches deleted from the common store"
+    );
     assert!(linked_repo.try_find_reference(deletable.as_ref())?.is_none());
     assert!(
         !std::fs::read_to_string(main.common_dir().join("config"))?.contains("delete-from-linked"),


### PR DESCRIPTION
## Tasks

- [x] refackiew

----
Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- Skip null object-ID lookups when filtering worktree content for diffs and merges, avoiding guaranteed database misses and repeated pack-directory refreshes.
- Add `gix_object::find::Never::panic_on_access()` so tests can forbid object reads, existence checks, and writes through a shared implementation.
- Add `gix::config_mut(source, options)` to edit installation, system, XDG, or user configuration through `FileTransaction` without a repository.
- Return the sorted, deduplicated `Vec<FullName>` of branches actually deleted by `Repository::delete_local_branches()`.

## Context

Worktree resources naturally use null IDs when their content comes from file paths. Diff and merge filter callbacks now treat that sentinel as a missing index blob; real indexed blobs retain their line-ending behavior. The merge fix remains in its own commit.

Standalone configuration transactions share path resolution, permissions, and lock-timeout handling with existing configuration APIs. Edits preserve the physical file without persisting includes or runtime overrides. Missing files can be created when their parent directory exists.

Branch deletion determines which references existed from the committed edits observed under lock, removing the need for a separate, racy existence lookup. Missing branches still have stale local configuration removed. This is a breaking API change: the success value changes from `()` to `Vec<FullName>`, and `delete::Error::Cleanup` gains a `deleted` field so callers can recover the same result when configuration cleanup fails. The `gix-tix` callers are adapted in the same commit.

## Validation

- Diff tests: 93 passed; merge tests: 26 integration tests and 5 unit tests passed. The strengthened merge regression failed before the fix.
- Configuration tests: 140 passed, including eight new standalone transaction tests and a comparison with Git.
- Branch deletion: all four integration tests passed, covering loose, packed, symbolic, duplicate, missing, and linked-worktree branches.
- Formatting, targeted Clippy checks, the minimal SHA-1 build, and documentation with `blocking-network-client` passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p gix-object --no-deps --features sha1` passed after correcting the constructor links.
- Full CI results: [GitHub Actions checks](https://github.com/GitoxideLabs/gitoxide/pull/2971/checks).

## User Prompts

> $pr-from-session The session is the current branch and commit, just make sure it gets through CI. If the commit isn't there yet, wait until it's created.

> This extra check only matters when null-ids have special meaning or occur naturaly. Rename detection doesn't *seem* like that.

> Fix only Merge filtering in its own commit.

> Add a sibling to `gix::config()` named `gix::config_mut()` which ideally resuses `gix::config::FileTransaction` and provides access to global configuration paths, without needing a repository.

> This should be improved so `delete_local_branches()` returns the branches that were actually deleted, in a Vec.

> Follow CI and make it pass, ideally by amending to existing commits (tix show, tix travel, tix amend)
