### PR TITLE
Add single case inspection to slider report

### DIFF
--- a/gix-diff/tests/README.md
+++ b/gix-diff/tests/README.md
@@ -50,3 +50,20 @@ corpus, `--count 2024` produces 3,094 cases after duplicate blob pairs are remov
 
 The default report prints all mismatch categories without failing. Set `GIX_DIFF_SLIDER_STRICT=1` to require a
 non-empty external baseline and fail on any mismatch. The small built-in baseline always runs strictly.
+
+### Inspect one case
+
+Copy a primary baseline filename from the report and select it explicitly:
+
+```shell
+GIX_DIFF_SLIDER_CASE='<old>-<new>.myers.baseline' \
+  cargo test -p gix-diff --test diff blob::slider::baseline -- --exact --nocapture
+```
+
+The selector must match the complete filename, including the algorithm and `.baseline` suffix, not a path, substring,
+or `*.no-indent.baseline` filename. Inspection replaces the aggregate report with a `StrComparison` between the two
+unified diffs: gix with slider heuristics on the left and Git with the indent heuristic on the right. Matching output
+is reported explicitly. A mismatch doesn't fail inspection; an empty, missing, or ambiguous selection does.
+
+`GIX_DIFF_SLIDER_CASE` cannot be combined with `GIX_DIFF_SLIDER_STRICT`. Only the selected external case is loaded and
+diffed when `GIX_DIFF_SLIDER_CASE` is given.

--- a/gix-diff/tests/README.md
+++ b/gix-diff/tests/README.md
@@ -60,10 +60,11 @@ GIX_DIFF_SLIDER_CASE='<old>-<new>.myers.baseline' \
   cargo test -p gix-diff --test diff blob::slider::baseline -- --exact --nocapture
 ```
 
-The selector must match the complete filename, including the algorithm and `.baseline` suffix, not a path, substring,
-or `*.no-indent.baseline` filename. Inspection replaces the aggregate report with a `StrComparison` between the two
-unified diffs: gix with slider heuristics on the left and Git with the indent heuristic on the right. Matching output
-is reported explicitly. A mismatch doesn't fail inspection; an empty, missing, or ambiguous selection does.
+The selector must match the complete filename, including the algorithm and `.baseline` suffix.
+Inspection replaces the aggregate report with a `StrComparison` between the two
+unified diffs: Gitoxide with slider heuristics on the left and Git with the indent heuristic on the right.
+Matching output is reported explicitly. A mismatch doesn't fail inspection; an empty, missing,
+or ambiguous selection does.
 
 `GIX_DIFF_SLIDER_CASE` cannot be combined with `GIX_DIFF_SLIDER_STRICT`. Only the selected external case is loaded and
 diffed when `GIX_DIFF_SLIDER_CASE` is given.

--- a/gix-diff/tests/diff/blob/slider.rs
+++ b/gix-diff/tests/diff/blob/slider.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, hash::Hash, path::Path};
+use std::{
+    collections::BTreeMap,
+    hash::Hash,
+    path::{Path, PathBuf},
+};
 
 use gix_diff::blob::{self, Algorithm, InternedInput, diff_with_slider_heuristics};
 use gix_object::bstr::ByteSlice;
@@ -6,6 +10,29 @@ use pretty_assertions::StrComparison;
 
 #[test]
 fn baseline() -> gix_testtools::Result {
+    let selected_case = match std::env::var("GIX_DIFF_SLIDER_CASE") {
+        Ok(value) => Some(value),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(err) => return Err(err.into()),
+    };
+    let should_assert_strictly = std::env::var_os("GIX_DIFF_SLIDER_STRICT").is_some();
+    validate_selection(selected_case.as_deref(), should_assert_strictly)?;
+
+    if let Some(selected_file_name) = selected_case.as_deref() {
+        let case = case_from_fixture("make_diff_for_sliders_repo.sh", selected_file_name)?;
+        if let Some(case) = case {
+            eprintln!("{}", selected_case_report(&case)?);
+        } else {
+            return Err(format!(
+                "No primary slider baseline matched {selected_file_name:?}. \
+                 Use an exact '<old>-<new>.<algorithm>.baseline' filename \
+                 and ensure the external fixture has been generated."
+            )
+            .into());
+        }
+        return Ok(());
+    }
+
     let smoke_cases = cases_from_fixture("make_diff_for_sliders_smoke_repo.sh", false)?;
     assert!(
         !smoke_cases.is_empty(),
@@ -17,7 +44,6 @@ fn baseline() -> gix_testtools::Result {
         "the built-in slider baseline must be classified as exact"
     );
 
-    let should_assert_strictly = std::env::var_os("GIX_DIFF_SLIDER_STRICT").is_some();
     let cases = cases_from_fixture("make_diff_for_sliders_repo.sh", !should_assert_strictly)?;
 
     if cases.is_empty() {
@@ -34,6 +60,98 @@ fn baseline() -> gix_testtools::Result {
     Ok(())
 }
 
+fn validate_selection(selector: Option<&str>, should_assert_strictly: bool) -> gix_testtools::Result {
+    if let Some(selector) = selector {
+        if selector.is_empty() {
+            return Err("GIX_DIFF_SLIDER_CASE must not be empty".into());
+        }
+        if should_assert_strictly {
+            return Err("GIX_DIFF_SLIDER_CASE and GIX_DIFF_SLIDER_STRICT cannot be used together".into());
+        }
+    }
+    Ok(())
+}
+
+fn case_from_fixture(fixture: &str, selected_file_name: &str) -> gix_testtools::Result<Option<Case>> {
+    let worktree_path = crate::scripted_fixture_read_only(fixture)?;
+    let asset_dir = worktree_path.join("assets");
+
+    let dir = std::fs::read_dir(&worktree_path)?;
+
+    for entry in dir {
+        let entry = entry?;
+        if entry.file_name() == selected_file_name {
+            return read_fixture(&worktree_path, &asset_dir, entry, false);
+        }
+    }
+
+    Ok(None)
+}
+
+fn read_fixture(
+    worktree_path: &Path,
+    asset_dir: &Path,
+    entry: std::fs::DirEntry,
+    read_no_indent: bool,
+) -> gix_testtools::Result<Option<Case>> {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let project_root = crate_root
+        .parent()
+        .expect("gix-diff is directly inside the workspace root");
+    let entry_file_name = entry.file_name();
+    let Some(baseline::DirEntry {
+        file_name,
+        algorithm,
+        old_data,
+        new_data,
+    }) = baseline::parse_dir_entry(asset_dir, &entry_file_name)?
+    else {
+        return Ok(None);
+    };
+
+    let input = InternedInput::new(
+        old_data.to_str().expect("BUG: we don't have non-ascii here"),
+        new_data.to_str().expect("BUG: we don't have non-ascii here"),
+    );
+
+    let gix_no_postprocess = {
+        let diff = blob::Diff::compute(algorithm, &input);
+        render_unidiff(&diff, &input)?
+    };
+
+    let gix_postprocess_no_heuristic = {
+        let mut diff = blob::Diff::compute(algorithm, &input);
+        diff.postprocess_no_heuristic(&input);
+        render_unidiff(&diff, &input)?
+    };
+
+    let gix_postprocess_slider_heuristics = {
+        let diff = diff_with_slider_heuristics(algorithm, &input);
+        render_unidiff(&diff, &input)?
+    };
+
+    let baseline_path = worktree_path.join(&file_name);
+    let baseline = std::fs::read(&baseline_path)?;
+    let baseline = crate::blob::skip_header_and_fold_to_unidiff(&baseline);
+    let baseline_path = crate_root.join(&baseline_path).strip_prefix(project_root)?.to_owned();
+    let git_no_indent_heuristic = if read_no_indent {
+        read_no_indent_baseline(worktree_path, &file_name)?
+    } else {
+        None
+    };
+
+    Ok(Some(Case {
+        file_name,
+        baseline_path,
+        algorithm,
+        git_postprocess_indent_heuristic: baseline,
+        git_no_indent_heuristic,
+        gix_no_postprocess,
+        gix_postprocess_no_heuristic,
+        gix_postprocess_slider_heuristics,
+    }))
+}
+
 fn cases_from_fixture(fixture: &str, read_no_indent: bool) -> gix_testtools::Result<Vec<Case>> {
     let worktree_path = crate::scripted_fixture_read_only(fixture)?;
     let asset_dir = worktree_path.join("assets");
@@ -43,55 +161,9 @@ fn cases_from_fixture(fixture: &str, read_no_indent: bool) -> gix_testtools::Res
 
     for entry in dir {
         let entry = entry?;
-        let Some(baseline::DirEntry {
-            file_name,
-            algorithm,
-            old_data,
-            new_data,
-        }) = baseline::parse_dir_entry(&asset_dir, &entry.file_name())?
-        else {
-            continue;
-        };
-
-        let input = InternedInput::new(
-            old_data.to_str().expect("BUG: we don't have non-ascii here"),
-            new_data.to_str().expect("BUG: we don't have non-ascii here"),
-        );
-
-        let gix_no_postprocess = {
-            let diff = blob::Diff::compute(algorithm, &input);
-            render_unidiff(&diff, &input)?
-        };
-
-        let gix_postprocess_no_heuristic = {
-            let mut diff = blob::Diff::compute(algorithm, &input);
-            diff.postprocess_no_heuristic(&input);
-            render_unidiff(&diff, &input)?
-        };
-
-        let gix_postprocess_slider_heuristics = {
-            let diff = diff_with_slider_heuristics(algorithm, &input);
-            render_unidiff(&diff, &input)?
-        };
-
-        let baseline_path = worktree_path.join(&file_name);
-        let baseline = std::fs::read(baseline_path)?;
-        let baseline = crate::blob::skip_header_and_fold_to_unidiff(&baseline);
-        let git_no_indent_heuristic = if read_no_indent {
-            read_no_indent_baseline(&worktree_path, &file_name)?
-        } else {
-            None
-        };
-
-        cases.push(Case {
-            file_name,
-            algorithm,
-            git_postprocess_indent_heuristic: baseline,
-            git_no_indent_heuristic,
-            gix_no_postprocess,
-            gix_postprocess_no_heuristic,
-            gix_postprocess_slider_heuristics,
-        });
+        if let Some(case) = read_fixture(&worktree_path, &asset_dir, entry, read_no_indent)? {
+            cases.push(case);
+        }
     }
 
     Ok(cases)
@@ -99,6 +171,8 @@ fn cases_from_fixture(fixture: &str, read_no_indent: bool) -> gix_testtools::Res
 
 struct Case {
     file_name: String,
+    /// Location of the generated baseline, relative to the workspace root.
+    baseline_path: PathBuf,
     algorithm: Algorithm,
     /// The primary Git baseline, generated with `--indent-heuristic` and used for the pass/fail comparison.
     git_postprocess_indent_heuristic: String,
@@ -198,6 +272,28 @@ fn render_unidiff<T: AsRef<[u8]> + Hash + Eq>(diff: &blob::Diff, input: &Interne
         blob::unified_diff::ContextSize::symmetrical(3),
     )
     .consume()
+}
+
+/// Format one explicitly selected case without treating a diff mismatch as a test failure.
+fn selected_case_report(case: &Case) -> gix_testtools::Result<String> {
+    let mut report = format!(
+        "Selected baseline: {}\nAlgorithm: {:?}\n\
+         Left: gix with slider heuristics\nRight: Git with indent heuristic\n\n",
+        case.baseline_path.display(),
+        case.algorithm,
+    );
+    if case.gix_postprocess_slider_heuristics == case.git_postprocess_indent_heuristic {
+        report.push_str("Outputs match.");
+    } else {
+        report.push_str(
+            &StrComparison::new(
+                &case.gix_postprocess_slider_heuristics,
+                &case.git_postprocess_indent_heuristic,
+            )
+            .to_string(),
+        );
+    }
+    Ok(report)
 }
 
 fn read_no_indent_baseline(worktree_path: &Path, primary_file_name: &str) -> std::io::Result<Option<String>> {
@@ -552,6 +648,7 @@ mod baseline {
         fn classify(gix: &str, git: &str) -> Classification {
             Case {
                 file_name: "synthetic.myers.baseline".into(),
+                baseline_path: "synthetic.myers.baseline".into(),
                 algorithm: Algorithm::Myers,
                 git_postprocess_indent_heuristic: git.into(),
                 git_no_indent_heuristic: None,

--- a/gix-diff/tests/diff/blob/slider.rs
+++ b/gix-diff/tests/diff/blob/slider.rs
@@ -10,26 +10,9 @@ use pretty_assertions::StrComparison;
 
 #[test]
 fn baseline() -> gix_testtools::Result {
-    let selected_case = match std::env::var("GIX_DIFF_SLIDER_CASE") {
-        Ok(value) => Some(value),
-        Err(std::env::VarError::NotPresent) => None,
-        Err(err) => return Err(err.into()),
-    };
     let should_assert_strictly = std::env::var_os("GIX_DIFF_SLIDER_STRICT").is_some();
-    validate_selection(selected_case.as_deref(), should_assert_strictly)?;
-
-    if let Some(selected_file_name) = selected_case.as_deref() {
-        let case = case_from_fixture("make_diff_for_sliders_repo.sh", selected_file_name)?;
-        if let Some(case) = case {
-            eprintln!("{}", selected_case_report(&case)?);
-        } else {
-            return Err(format!(
-                "No primary slider baseline matched {selected_file_name:?}. \
-                 Use an exact '<old>-<new>.<algorithm>.baseline' filename \
-                 and ensure the external fixture has been generated."
-            )
-            .into());
-        }
+    if let Some(case) = try_single_case(should_assert_strictly)? {
+        eprintln!("{}", selected_case_report(&case)?);
         return Ok(());
     }
 
@@ -60,32 +43,44 @@ fn baseline() -> gix_testtools::Result {
     Ok(())
 }
 
-fn validate_selection(selector: Option<&str>, should_assert_strictly: bool) -> gix_testtools::Result {
-    if let Some(selector) = selector {
-        if selector.is_empty() {
-            return Err("GIX_DIFF_SLIDER_CASE must not be empty".into());
+fn try_single_case(should_assert_strictly: bool) -> gix_testtools::Result<Option<Case>> {
+    fn case_from_fixture(fixture: &str, selected_file_name: &str) -> gix_testtools::Result<Option<Case>> {
+        let worktree_path = crate::scripted_fixture_read_only(fixture)?;
+        let asset_dir = worktree_path.join("assets");
+
+        let dir = std::fs::read_dir(&worktree_path)?;
+
+        for entry in dir {
+            let entry = entry?;
+            if entry.file_name() == selected_file_name {
+                return read_fixture(&worktree_path, &asset_dir, entry, false);
+            }
         }
-        if should_assert_strictly {
-            return Err("GIX_DIFF_SLIDER_CASE and GIX_DIFF_SLIDER_STRICT cannot be used together".into());
-        }
+
+        Ok(None)
     }
-    Ok(())
-}
-
-fn case_from_fixture(fixture: &str, selected_file_name: &str) -> gix_testtools::Result<Option<Case>> {
-    let worktree_path = crate::scripted_fixture_read_only(fixture)?;
-    let asset_dir = worktree_path.join("assets");
-
-    let dir = std::fs::read_dir(&worktree_path)?;
-
-    for entry in dir {
-        let entry = entry?;
-        if entry.file_name() == selected_file_name {
-            return read_fixture(&worktree_path, &asset_dir, entry, false);
-        }
+    let selected_file_name = match std::env::var("GIX_DIFF_SLIDER_CASE") {
+        Ok(value) => value,
+        Err(std::env::VarError::NotPresent) => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    if selected_file_name.is_empty() {
+        return Err("GIX_DIFF_SLIDER_CASE must not be empty".into());
+    }
+    if should_assert_strictly {
+        return Err("GIX_DIFF_SLIDER_CASE and GIX_DIFF_SLIDER_STRICT cannot be used together".into());
     }
 
-    Ok(None)
+    let case = case_from_fixture("make_diff_for_sliders_repo.sh", &selected_file_name)?;
+    if case.is_none() {
+        return Err(format!(
+            "No primary slider baseline matched {selected_file_name:?}. \
+             Use an exact '<old>-<new>.<algorithm>.baseline' filename \
+             and ensure the external fixture has been generated."
+        )
+        .into());
+    }
+    Ok(case)
 }
 
 fn read_fixture(
@@ -277,8 +272,12 @@ fn render_unidiff<T: AsRef<[u8]> + Hash + Eq>(diff: &blob::Diff, input: &Interne
 /// Format one explicitly selected case without treating a diff mismatch as a test failure.
 fn selected_case_report(case: &Case) -> gix_testtools::Result<String> {
     let mut report = format!(
-        "Selected baseline: {}\nAlgorithm: {:?}\n\
-         Left: gix with slider heuristics\nRight: Git with indent heuristic\n\n",
+        "Selected baseline: {}
+Algorithm: {:?}
+Left: gix with slider heuristics
+Right: Git with indent heuristic
+
+",
         case.baseline_path.display(),
         case.algorithm,
     );


### PR DESCRIPTION
This PR is a follow-up to #2931.

In 7192d9a8e00f6b4e0836610f90dcbb990618cc7c and 169ae964f47b82237f33b616fd0c94fd3ea7d344, we added support for printing a detailed aggregate report of the differences between Git and `gix` for a corpus of diff slider cases. This PR adds a report for a single individual case, so we can dig deeper and inspect where Git and `gix` differ at the file level. The main work is done by `pretty_assertions::StrComparison` which is used to print a diff between the Git diff and the `gix` diff.

Example output that can be run if you followed `gix-diff/tests/README.md` for setting up the slider corpus and creating `make_diff_for_sliders_repo.sh` (in a terminal, there would also be colors):

```
❯ env GIX_DIFF_SLIDER_CASE='1333f781cf1f7ec617c7ebed21dbf067048c8140-d6bab352bb9271bde213e73626bd91cc9348be22.myers.baseline' cargo test -p gix-diff --test diff blob::slider::baseline -- --exact --nocapture
   Compiling gix-diff v0.67.1 (/home/christoph/worktrees/gitoxide/branch-8/gix-diff)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.39s
     Running tests/diff/main.rs (/home/christoph/worktrees/gitoxide/branch-8/target/debug/deps/diff-4cb879f80474636c)

running 1 test
Selected baseline: gix-diff/tests/fixtures/generated-do-not-edit/make_diff_for_sliders_repo/sha1/696894535-unix/1333f781cf1f7ec617c7ebed21dbf067048c8140-d6bab352bb9271bde213e73626bd91cc9348be22.myers.baseline
Algorithm: Myers
Left: gix with slider heuristics
Right: Git with indent heuristic

Diff < left / right > :
 @@ -1,7 +1,6 @@
 +use crate::{bstr::ByteSlice, config};
  use std::{collections::BTreeSet, ffi::OsString};

 -use crate::{bstr::ByteSlice, config, config::tree::Core};
 -
  /// General Configuration
  impl crate::Repository {
      /// Return the compression level used when writing loose objects.
 @@ -25,26 +24,68 @@
          config::Snapshot { repo: self }
      }

 -    /// Return the editor program selected by Git's precedence rules.
 +    /// Return the editor selected by Git's precedence rules.
      ///
      /// `GIT_EDITOR` takes precedence over `core.editor`. If the terminal isn't dumb, `VISUAL` is considered next,
 -    /// followed by `EDITOR`. If none are set, `vi` is returned unless `TERM` is unset or `dumb`, in which case there
 -    /// is no usable editor.
 +    /// followed by `EDITOR`. If none are set, a bundled `vi` (or its `vim` implementation) is returned when available
 +    /// unless `TERM` is unset or `dumb`, in which case there is no usable editor.
 +    ///
 +    /// Use [`editor_command()`](Self::editor_command) to obtain a command prepared for execution.
      pub fn editor(&self) -> Option<OsString> {
 -        if let Some(editor) = self.config_snapshot().trusted_program(Core::EDITOR) {
 -            return Some(editor);
 -        }
 +        use crate::config::tree::{Core, Gitoxide};
<+
>
>-        let terminal_is_dumb = std::env::var_os("TERM").is_none_or(|terminal| terminal == "dumb");
>-        if !terminal_is_dumb {
>-            if let Some(editor) = std::env::var_os("VISUAL") {
>-                return Some(editor);
>-            }
>-        }
>-        if let Some(editor) = std::env::var_os("EDITOR") {
>-            return Some(editor);
 +        let config = self.config_snapshot();
 +        let terminal_is_dumb = config.string(Gitoxide::TERM).is_none_or(|terminal| terminal == "dumb");
 +        config
 +            .trusted_program(Core::EDITOR)
 +            .or_else(|| {
 +                (!terminal_is_dumb)
 +                    .then(|| config.trusted_program(Gitoxide::VISUAL))
 +                    .flatten()
 +            })
 +            .or_else(|| config.trusted_program(Gitoxide::EDITOR))
 +            .or_else(|| {
 +                (!terminal_is_dumb).then(|| {
 +                    gix_path::env::installation_program("vi")
 +                        // Current Git for Windows versions provide `vi` as a shell script that delegates to `vim.exe`.
 +                        // Select the directly executable implementation when no `vi.exe` is installed.
 +                        .or_else(|| {
 +                            cfg!(windows)
 +                                .then(|| gix_path::env::installation_program("vim"))
 +                                .flatten()
 +                        })
 +                        .unwrap_or_else(|| "vi".into())
 +                        .into_os_string()
 +                })
 +            })
 +            .filter(|editor| !editor.is_empty())
 +    }
<
<-        let terminal_is_dumb = std::env::var_os("TERM").is_none_or(|terminal| terminal == "dumb");
<-        if !terminal_is_dumb {
<-            if let Some(editor) = std::env::var_os("VISUAL") {
<-                return Some(editor);
<-            }
<-        }
<-        if let Some(editor) = std::env::var_os("EDITOR") {
<-            return Some(editor);
>+
 +    /// Return the prepared [`editor`](Self::editor) command.
 +    ///
 +    /// The returned command has repository context and inherited standard streams. Add the paths to edit as arguments
 +    /// before spawning it.
 +    #[cfg(feature = "command")]
 +    pub fn editor_command(&self) -> Result<Option<gix_command::Prepare>, config::command_context::Error> {
 +        use std::{path::Path, process::Stdio};
 +
 +        let Some(editor) = self.editor() else {
 +            return Ok(None);
 +        };
 +
 +        let mut command = gix_command::prepare(&editor);
 +        if editor.to_string_lossy().trim_ascii() == ":" {
 +            command = command.with_shell();
 +        } else if !Path::new(&editor).is_file() {
 +            command = command.command_may_be_shell_script();
          }
 -        (!terminal_is_dumb).then(|| "vi".into())
 +        Ok(Some(
 +            command
 +                .with_context(self.command_context()?)
 +                .stdin(Stdio::inherit())
 +                .stdout(Stdio::inherit())
 +                .stderr(Stdio::inherit()),
 +        ))
      }

      /// Resolve all Git configuration needed to sign a commit with [`gix_object::Commit::sign()`].
 @@ -157,7 +198,7 @@

      /// Return the context to be passed to any spawned program that is supposed to interact with the repository, like
      /// hooks or filters.
 -    #[cfg(feature = "attributes")]
 +    #[cfg(feature = "command")]
      pub fn command_context(&self) -> Result<gix_command::Context, config::command_context::Error> {
          use crate::config::{cache::util::ApplyLeniency, tree::gitoxide};



test blob::slider::baseline ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 92 filtered out; finished in 0.03s
```