### PR TITLE
fix(gix-config-value): accept git's 12-bit hex color shorthand

### DIFF
--- a/gix-config-value/src/color.rs
+++ b/gix-config-value/src/color.rs
@@ -115,9 +115,10 @@ impl TryFrom<BString> for Color {
 /// Discriminating enum for names of [`Color`] values.
 ///
 /// `git-config` supports the eight standard colors, their bright variants, an
-/// ANSI color code, or a 24-bit hex value prefixed with an octothorpe/hash.
-/// Color names and the `bright` prefix are matched case-insensitively, and
-/// `bright` may only precede one of the eight standard colors.
+/// ANSI color code, or a hex value prefixed with an octothorpe/hash. The hex value
+/// is either 24-bit, like `#ff11bb`, or the 12-bit shorthand `#f1b`, which stands
+/// for the same color. Color names and the `bright` prefix are matched
+/// case-insensitively, and `bright` may only precede one of the eight standard colors.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum Name {
     /// The `normal` color name.
@@ -209,6 +210,25 @@ impl serde::Serialize for Name {
     }
 }
 
+/// Parse the digits behind a `#` the way `git` does, which is either a 24-bit value
+/// like `ff11bb`, or its 12-bit shorthand `f1b`, where each digit stands for a doubled
+/// pair. Any other length is rejected, as is a digit that isn't hexadecimal.
+fn parse_hex(hex: &[u8]) -> Option<(u8, u8, u8)> {
+    fn nibble(b: u8) -> Option<u8> {
+        char::from(b).to_digit(16).map(|d| d as u8)
+    }
+
+    match *hex {
+        [r, g, b] => Some((nibble(r)? * 0x11, nibble(g)? * 0x11, nibble(b)? * 0x11)),
+        [r1, r0, g1, g0, b1, b0] => Some((
+            nibble(r1)? << 4 | nibble(r0)?,
+            nibble(g1)? << 4 | nibble(g0)?,
+            nibble(b1)? << 4 | nibble(b0)?,
+        )),
+        _ => None,
+    }
+}
+
 impl FromStr for Name {
     type Err = Error;
 
@@ -255,21 +275,10 @@ impl FromStr for Name {
             return Ok(Self::Ansi(v));
         }
 
-        if let Some(s) = s.strip_prefix('#')
-            && s.len() == 6
-            && s.is_char_boundary(2)
-            && s.is_char_boundary(4)
-            && s.is_char_boundary(6)
+        if let Some(hex) = s.strip_prefix('#')
+            && let Some((r, g, b)) = parse_hex(hex.as_bytes())
         {
-            let rgb = (
-                u8::from_str_radix(&s[..2], 16),
-                u8::from_str_radix(&s[2..4], 16),
-                u8::from_str_radix(&s[4..], 16),
-            );
-
-            if let (Ok(r), Ok(g), Ok(b)) = rgb {
-                return Ok(Self::Rgb(r, g, b));
-            }
+            return Ok(Self::Rgb(r, g, b));
         }
 
         Err(color_err(s))

--- a/gix-config-value/tests/value/color.rs
+++ b/gix-config-value/tests/value/color.rs
@@ -81,6 +81,52 @@ mod name {
         assert_eq!(Name::from_str("#ff0010"), Ok(Name::Rgb(255, 0, 16)));
         assert_eq!(Name::from_str("#ffffff"), Ok(Name::Rgb(255, 255, 255)));
         assert_eq!(Name::from_str("#000000"), Ok(Name::Rgb(0, 0, 0)));
+        assert_eq!(Name::from_str("#FF0010"), Ok(Name::Rgb(255, 0, 16)));
+    }
+
+    #[test]
+    fn hex_shorthand_doubles_each_digit() {
+        // Values recorded from `git -c foo.bar=<input> config --type=color foo.bar` on
+        // git 2.50.1, which emits `\x1b[38;2;<r>;<g>;<b>m`. `git-config(1)` states it as
+        // "12-bit RGB values like #f1b, which is equivalent to the 24-bit color #ff11bb".
+        assert_eq!(
+            Name::from_str("#f1b"),
+            Ok(Name::Rgb(0xff, 0x11, 0xbb)),
+            "each digit of a 12-bit value is doubled to make the byte, as in git's own example"
+        );
+        assert_eq!(
+            Name::from_str("#abc"),
+            Ok(Name::Rgb(170, 187, 204)),
+            "`git` reports #abc as 170;187;204"
+        );
+        assert_eq!(
+            Name::from_str("#000"),
+            Ok(Name::Rgb(0, 0, 0)),
+            "doubling stays in range at the bottom of it"
+        );
+        assert_eq!(
+            Name::from_str("#fff"),
+            Ok(Name::Rgb(255, 255, 255)),
+            "doubling stays in range at the top of it"
+        );
+        assert_eq!(
+            Name::from_str("#aBc"),
+            Ok(Name::Rgb(170, 187, 204)),
+            "hex digits are matched case-insensitively, like the six-digit form"
+        );
+
+        assert_eq!(
+            Name::from_str("#f1b"),
+            Name::from_str("#ff11bb"),
+            "the shorthand and the long form it stands for are the same color"
+        );
+        assert_eq!(
+            Name::from_str("#f1b")
+                .expect("the shorthand parses, as asserted above")
+                .to_string(),
+            "#ff11bb",
+            "a shorthand renders back as the long form, since `Name::Rgb` keeps no record of which spelling it came from"
+        );
     }
 
     #[test]
@@ -92,9 +138,25 @@ mod name {
         assert!(Name::from_str("bright").is_err());
         assert!(Name::from_str("256").is_err());
         assert!(Name::from_str("#").is_err());
-        assert!(Name::from_str("#fff").is_err());
         assert!(Name::from_str("#gggggg").is_err());
         assert!(Name::from_str("#=»©=").is_err());
+
+        // `git` takes three or six digits and nothing in between or beyond, each
+        // checked against `git config --type=color` on git 2.50.1.
+        for input in ["#ab", "#abcd", "#abcde", "#abcdefa", "#aabbccddeeff"] {
+            assert!(
+                Name::from_str(input).is_err(),
+                "{input} has neither three nor six digits, and `git` rejects it too"
+            );
+        }
+        assert!(
+            Name::from_str("#ggg").is_err(),
+            "a three-digit value still has to be hexadecimal"
+        );
+        assert!(
+            Name::from_str("#-12").is_err(),
+            "a sign is not a hex digit, so it cannot fill one of the three slots"
+        );
     }
 }
 

--- a/gix-config-value/tests/value/color.rs
+++ b/gix-config-value/tests/value/color.rs
@@ -87,46 +87,27 @@ mod name {
     #[test]
     fn hex_shorthand_doubles_each_digit() {
         // Values recorded from `git -c foo.bar=<input> config --type=color foo.bar` on
-        // git 2.50.1, which emits `\x1b[38;2;<r>;<g>;<b>m`. `git-config(1)` states it as
-        // "12-bit RGB values like #f1b, which is equivalent to the 24-bit color #ff11bb".
-        assert_eq!(
-            Name::from_str("#f1b"),
-            Ok(Name::Rgb(0xff, 0x11, 0xbb)),
-            "each digit of a 12-bit value is doubled to make the byte, as in git's own example"
-        );
-        assert_eq!(
-            Name::from_str("#abc"),
-            Ok(Name::Rgb(170, 187, 204)),
-            "`git` reports #abc as 170;187;204"
-        );
-        assert_eq!(
-            Name::from_str("#000"),
-            Ok(Name::Rgb(0, 0, 0)),
-            "doubling stays in range at the bottom of it"
-        );
-        assert_eq!(
-            Name::from_str("#fff"),
-            Ok(Name::Rgb(255, 255, 255)),
-            "doubling stays in range at the top of it"
-        );
-        assert_eq!(
-            Name::from_str("#aBc"),
-            Ok(Name::Rgb(170, 187, 204)),
-            "hex digits are matched case-insensitively, like the six-digit form"
-        );
-
-        assert_eq!(
-            Name::from_str("#f1b"),
-            Name::from_str("#ff11bb"),
-            "the shorthand and the long form it stands for are the same color"
-        );
-        assert_eq!(
-            Name::from_str("#f1b")
-                .expect("the shorthand parses, as asserted above")
-                .to_string(),
-            "#ff11bb",
-            "a shorthand renders back as the long form, since `Name::Rgb` keeps no record of which spelling it came from"
-        );
+        // git 2.50.1, which emits `\x1b[38;2;<r>;<g>;<b>m`.
+        for (input, expected, long_form) in [
+            ("#f1b", Name::Rgb(0xff, 0x11, 0xbb), "#ff11bb"),
+            ("#abc", Name::Rgb(0xaa, 0xbb, 0xcc), "#aabbcc"),
+            ("#000", Name::Rgb(0x00, 0x00, 0x00), "#000000"),
+            ("#fff", Name::Rgb(0xff, 0xff, 0xff), "#ffffff"),
+            ("#aBc", Name::Rgb(0xaa, 0xbb, 0xcc), "#aabbcc"),
+        ] {
+            let actual = Name::from_str(input);
+            assert_eq!(actual, Ok(expected), "{input:?}");
+            assert_eq!(
+                actual,
+                Name::from_str(long_form),
+                "{input:?}: the shorthand and the long form it stands for are the same color"
+            );
+            assert_eq!(
+                actual.expect("the shorthand parses, as asserted above").to_string(),
+                long_form,
+                "{input:?}: a shorthand renders back as the long form, since `Name::Rgb` keeps no record of which spelling it came from"
+            );
+        }
     }
 
     #[test]
@@ -141,8 +122,6 @@ mod name {
         assert!(Name::from_str("#gggggg").is_err());
         assert!(Name::from_str("#=»©=").is_err());
 
-        // `git` takes three or six digits and nothing in between or beyond, each
-        // checked against `git config --type=color` on git 2.50.1.
         for input in ["#ab", "#abcd", "#abcde", "#abcdefa", "#aabbccddeeff"] {
             assert!(
                 Name::from_str(input).is_err(),


### PR DESCRIPTION
Written by Claude Opus 5 in Claude Code, through Roshan's account, per the identification rule in CONTRIBUTING.md. He has not read the diff line by line yet.

`git-config(1)` documents two hex forms: "24-bit RGB values as hex, like #ff0ab3, or 12-bit RGB values like #f1b, which is equivalent to the 24-bit color #ff11bb". Only the 24-bit form parsed, because the hex branch required exactly six digits, so `git` accepted `#f1b` and `gix` rejected it. Same parity gap as #2967, one type over.

Both lengths are handled now, doubling each shorthand digit. `Name::Rgb` is unchanged, so a shorthand parses to the long form and renders back as six digits: `#f1b` displays as `#ff11bb`. Git calls the two equivalent, but it is a normalisation, so say the word if you would rather keep the input spelling.

One existing assertion changed: `name::invalid` asserted `Name::from_str("#fff").is_err()`, which pinned the old behaviour. It is replaced by the lengths `git` really rejects.

Found by parsing ~110 colour specs with both `git` and `Color::try_from` and diffing the verdicts; `#RGB` was the only disagreement. Expected values recorded from `git config --type=color` on git 2.50.1. `cargo test -p gix-config-value` passes 56; reverting only `src/color.rs` fails exactly the one new test. `cargo clippy` reports only the pre-existing removed-lint warning that every crate in the workspace emits.
