### PR TITLE
Add `gix::config_path()` for standalone configuration

### DIFF
--- a/gix/src/config/file_mut.rs
+++ b/gix/src/config/file_mut.rs
@@ -7,7 +7,7 @@ use std::{
 
 use super::FileTransaction;
 
-/// The error produced when opening or committing a [`FileTransaction`].
+/// The error produced by [`crate::config_path()`] or when opening or committing a [`FileTransaction`].
 #[derive(Debug, thiserror::Error)]
 #[expect(missing_docs)]
 pub enum Error {

--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -456,13 +456,47 @@ pub fn config(git_dir: Option<&std::path::Path>, options: &open::Options) -> Res
     )
 }
 
-/// Lock and open one configuration file available without a repository, selected by its source.
+/// Return the path at which a configuration file is expected without a repository, selected by its source.
 ///
 /// Supported sources are [`GitInstallation`](config::Source::GitInstallation), [`System`](config::Source::System),
 /// [`Git`](config::Source::Git) (the XDG Git configuration), and [`User`](config::Source::User).
 /// Path selection honors the configuration permissions, environment permissions and explicit paths in `options`,
 /// just like [`config()`]. Disabled sources and sources without an available path return an error.
-/// Relative paths are resolved against the current directory when called.
+/// Relative paths are joined to the current directory when called.
+///
+/// Use this to inspect, prepare or load the file before calling [`config_mut()`]. The file and its parent directories
+/// do not have to exist. No configuration transaction is opened, no lock is acquired, and no directories are created.
+/// Discovering the Git installation path, or the system path on Windows, may invoke Git.
+pub fn config_path(
+    source: config::Source,
+    options: &open::Options,
+) -> Result<std::path::PathBuf, config::file_mut::Error> {
+    use config::file_mut::Error;
+
+    if !matches!(
+        source,
+        config::Source::GitInstallation | config::Source::System | config::Source::Git | config::Source::User
+    ) {
+        return Err(Error::UnsupportedSource(source));
+    }
+    let path = config::cache::source_path(
+        source,
+        options.git_installation_config_path.as_deref(),
+        options.system_config_path.as_deref(),
+        options.permissions.config,
+        &mut config::Cache::make_source_env(options.permissions.env),
+    )
+    .ok_or(Error::SourceUnavailable(source))?;
+    Ok(if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir().map_err(Error::CurrentDir)?.join(path)
+    })
+}
+
+/// Lock and open one configuration file available without a repository, selected by its source.
+///
+/// The path is selected by [`config_path()`], which can be used to inspect or prepare the file before opening it.
 ///
 /// The lock timeout comes from `core.configLockTimeout` in [`config(None, options)`](config()), honoring section filtering
 /// and leniency, and defaults to one second. Includes and runtime overrides can affect the timeout, but the returned file
@@ -485,27 +519,7 @@ pub fn config_mut(
     source: config::Source,
     options: &open::Options,
 ) -> Result<config::FileTransaction, config::file_mut::Error> {
-    use config::file_mut::Error;
-
-    if !matches!(
-        source,
-        config::Source::GitInstallation | config::Source::System | config::Source::Git | config::Source::User
-    ) {
-        return Err(Error::UnsupportedSource(source));
-    }
-    let path = config::cache::source_path(
-        source,
-        options.git_installation_config_path.as_deref(),
-        options.system_config_path.as_deref(),
-        options.permissions.config,
-        &mut config::Cache::make_source_env(options.permissions.env),
-    )
-    .ok_or(Error::SourceUnavailable(source))?;
-    let path = if path.is_absolute() {
-        path
-    } else {
-        std::env::current_dir().map_err(Error::CurrentDir)?.join(path)
-    };
+    let path = config_path(source, options)?;
     let resolved = config(None, options)?;
     let filter = options.filter_config_section.unwrap_or(config::section::is_trusted);
     let lock_mode = config::cache::access::config_lock_timeout(&resolved, options.lenient_config, filter)?;

--- a/gix/tests/gix-init.rs
+++ b/gix/tests/gix-init.rs
@@ -133,6 +133,50 @@ mod config_mut {
 
     #[test]
     #[serial]
+    fn path_lookup_does_not_open_configuration() -> Result {
+        let temp = gix_testtools::tempfile::tempdir()?;
+        let _cwd = gix_testtools::set_current_dir(temp.path())?;
+        let path = std::env::current_dir()?.join("missing/global.config");
+        let options = options_for(Source::System)
+            .system_config_path("missing/global.config")
+            .strict_config(true)
+            .config_overrides(["core.configLockTimeout=invalid", "core.sharedRepository=invalid"]);
+
+        assert_eq!(
+            gix::config_path(Source::System, &options)?,
+            path,
+            "relative paths are anchored without requiring a file or its parent directory"
+        );
+        assert_eq!(
+            std::fs::read_dir(temp.path())?.count(),
+            0,
+            "path lookup creates neither directories nor files"
+        );
+
+        std::fs::create_dir(path.parent().expect("config parent"))?;
+        std::fs::write(&path, "[unterminated")?;
+        let lock_path = path.with_extension("config.lock");
+        std::fs::write(&lock_path, "held")?;
+        assert_eq!(
+            gix::config_path(Source::System, &options)?,
+            path,
+            "malformed configuration, invalid overrides and existing locks do not affect path lookup"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path)?,
+            "[unterminated",
+            "the file is untouched"
+        );
+        assert_eq!(
+            std::fs::read_to_string(lock_path)?,
+            "held",
+            "the existing lock is untouched"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
     fn edits_one_physical_file_losslessly_without_a_repository() -> Result {
         let temp = gix_testtools::tempfile::tempdir()?;
         let _cwd = gix_testtools::set_current_dir(temp.path())?;
@@ -239,6 +283,11 @@ mod config_mut {
                 .system_config_path(&system);
             options.permissions.env.home = Permission::Allow;
             options.permissions.env.xdg_config_home = Permission::Allow;
+            assert_eq!(
+                gix::config_path(source, &options)?,
+                path,
+                "path lookup predicts the transaction target before the file exists"
+            );
             let mut file = gix::config_mut(source, &options)?;
             assert_eq!(
                 file.meta().path.as_deref(),
@@ -304,6 +353,11 @@ mod config_mut {
                 Some(expected.as_path()),
                 "Git environment overrides select the target"
             );
+            assert_eq!(
+                gix::config_path(source, &options)?,
+                *expected,
+                "path lookup honors environment overrides even while the target is locked"
+            );
         }
 
         for source in [Source::GitInstallation, Source::System] {
@@ -316,6 +370,11 @@ mod config_mut {
                 file.meta().path.as_deref(),
                 Some(explicit.as_path()),
                 "explicit options take precedence over environment paths"
+            );
+            assert_eq!(
+                gix::config_path(source, &options)?,
+                explicit,
+                "path lookup honors explicit options even while the target is locked"
             );
             drop(file);
             let _no_system = Env::new().set("GIT_CONFIG_NOSYSTEM", "true");


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-6`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Callers can now use `gix::config_path(source, options)` to locate a standalone configuration file before inspecting it, preparing its parent directory, or loading it themselves. It shares path selection with `config_mut()`, including source permissions, environment permissions, and explicit overrides.

Path lookup works with missing parent directories, malformed configuration, invalid transaction settings, and an existing lock. It reuses `config::file_mut::Error`; Git installation discovery retains its existing behavior and may invoke Git.

## Reported issue

Let's add `gix::config_path(source, options)` which merely yields the path at which the configuration file is expected. This allows callers of `confg_mut()` to pre-check or prepare configuration as needed, or to load it themselves.

## Validation

The new regression initially failed because `config_path()` did not exist. After implementation:

- Initialization tests: 20 passed.
- Configuration and repository configuration tests: 110 passed.
- Standalone configuration tests with default features disabled: 10 passed.
- Minimal `sha1` library check, Clippy for all `gix` targets, formatting, and whitespace checks passed.
- Documentation passed with `RUSTDOCFLAGS='-D warnings'` and `blocking-network-client` enabled.
- Codex review of `da20f241d1` found no actionable issues and independently passed all 20 initialization tests.
- The documentation follow-up `8128aaf13c` also passed its single Codex review and formatting checks.

Clippy reports an existing removed lint. A documentation build without networking features hits the existing `Self::with_fetch_options` link error in `gix/src/clone/access.rs:73`.

Git reference: `v2.55.0-782-g1630431f32`, `git_system_config()` and `git_global_config_paths()` in `config.c`, plus the global/system override tests in `t/t1300-config.sh`.
