### PR TITLE
feat(gix): add Repository::config_path()

### DIFF
--- a/gix/src/lib.rs
+++ b/gix/src/lib.rs
@@ -464,6 +464,8 @@ pub fn config(git_dir: Option<&std::path::Path>, options: &open::Options) -> Res
 /// just like [`config()`]. Disabled sources and sources without an available path return an error.
 /// Relative paths are joined to the current directory when called.
 ///
+/// With a repository, use [`Repository::config_path()`] to also resolve local and worktree configuration paths.
+///
 /// Use this to inspect, prepare or load the file before calling [`config_mut()`]. The file and its parent directories
 /// do not have to exist. No configuration transaction is opened, no lock is acquired, and no directories are created.
 /// Discovering the Git installation path, or the system path on Windows, may invoke Git.

--- a/gix/src/repository/config/mod.rs
+++ b/gix/src/repository/config/mod.rs
@@ -24,6 +24,40 @@ impl crate::Repository {
         config::Snapshot { repo: self }
     }
 
+    /// Return the path at which a configuration file is expected, selected by its source.
+    ///
+    /// [`Local`](config::Source::Local) selects `config` in the [`common_dir()`](Self::common_dir), and
+    /// [`Worktree`](config::Source::Worktree) selects `config.worktree` in the [`git_dir()`](Self::git_dir),
+    /// even if `extensions.worktreeConfig` is disabled. Other sources use the same path selection as [`crate::config_path()`]
+    /// with this repository's [`open_options()`](Self::open_options), including their permissions and explicit paths.
+    /// Relative paths are resolved against the current directory captured when this repository was opened.
+    /// Sources without a physical file or a permitted path return an error.
+    ///
+    /// The file and its parent directories do not have to exist. No [configuration transaction](config::FileTransaction)
+    /// is opened, no lock is acquired, and no directories are created. Pass the path to
+    /// [`config_file_mut()`](Self::config_file_mut) to edit it.
+    pub fn config_path(&self, source: config::Source) -> Result<std::path::PathBuf, config::file_mut::Error> {
+        use config::{Source, file_mut::Error};
+
+        let path = match source {
+            Source::Local => self.common_dir().join("config"),
+            Source::Worktree => self.git_dir().join("config.worktree"),
+            Source::GitInstallation | Source::System | Source::Git | Source::User => {
+                let options = self.open_options();
+                config::cache::source_path(
+                    source,
+                    options.git_installation_config_path.as_deref(),
+                    options.system_config_path.as_deref(),
+                    options.permissions.config,
+                    &mut config::Cache::make_source_env(options.permissions.env),
+                )
+                .ok_or(Error::SourceUnavailable(source))?
+            }
+            _ => return Err(Error::UnsupportedSource(source)),
+        };
+        Ok(self.current_dir().join(path))
+    }
+
     /// Lock and open `path` as one physical configuration file without expanding its includes.
     ///
     /// Relative paths are resolved against the current directory captured when this repository was opened. Dropping the

--- a/gix/tests/gix/repository/config/mod.rs
+++ b/gix/tests/gix/repository/config/mod.rs
@@ -5,6 +5,35 @@ mod identity;
 mod remote;
 
 #[test]
+fn config_path_for_repository_sources_matches_git() -> crate::Result {
+    use gix::config::Source;
+
+    let fixture = gix_testtools::scripted_fixture_read_only("make_worktree_repo.sh")?;
+    for name in ["repo", "wt-a", "natively-bare-repo", "worktree-of-natively-bare-repo"] {
+        let repo = gix::open_opts(fixture.join(name), gix::open::Options::isolated())?;
+        for (source, filename) in [(Source::Local, "config"), (Source::Worktree, "config.worktree")] {
+            let baseline = gix_testtools::git(
+                repo.git_dir(),
+                &format!("rev-parse --path-format=absolute --git-path {filename}"),
+            )?;
+            let path = repo.config_path(source)?;
+            assert_eq!(
+                gix::path::realpath(&path)?,
+                gix::path::realpath(baseline.trim())?,
+                "{name}: local configuration is shared, while worktree configuration belongs to each Git directory"
+            );
+            if source == Source::Worktree {
+                assert!(
+                    !path.exists(),
+                    "the worktree path is available without creating a file or enabling extensions.worktreeConfig"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
 fn big_file_threshold() -> crate::Result {
     let repo = repo("with-hasconfig");
     assert_eq!(

--- a/gix/tests/repository.rs
+++ b/gix/tests/repository.rs
@@ -6,6 +6,98 @@ use serial_test::serial;
 
 #[test]
 #[serial]
+fn config_path_uses_repository_options_for_global_sources() -> gix_testtools::Result {
+    use gix::config::{Source, file_mut::Error};
+
+    let fixture = gix::path::realpath(gix_testtools::scripted_fixture_read_only("make_config_repos.sh")?)?;
+    let git_dir = fixture.join("bare-repo");
+    let missing = fixture.join("missing");
+    let installation = missing.join("installation.config");
+    let system = missing.join("system.config");
+    let global = missing.join("global.config");
+    let _env = Env::new()
+        .set("GIT_CONFIG_GLOBAL", global.to_string_lossy())
+        .set("GIT_CONFIG_SYSTEM", "ignored.config")
+        .set("GIT_CONFIG_NOSYSTEM", "0");
+    let mut options = gix::open::Options::isolated()
+        .git_installation_config_path(&installation)
+        .system_config_path(&system);
+    options.permissions.config.git_binary = true;
+    options.permissions.config.system = true;
+    options.permissions.config.git = true;
+    options.permissions.config.user = true;
+    options.permissions.env.git_prefix = gix::sec::Permission::Allow;
+    let repo = gix::open_opts(&git_dir, options)?;
+    for (source, expected) in [
+        (Source::GitInstallation, installation),
+        (Source::System, system),
+        (Source::Git, global.clone()),
+        (Source::User, global),
+    ] {
+        assert_eq!(
+            repo.config_path(source)?,
+            expected,
+            "{source:?} honors the repository's explicit paths and environment permissions"
+        );
+    }
+    assert!(!missing.exists(), "path lookup does not create files or directories");
+
+    let repo = gix::open_opts(&git_dir, gix::open::Options::isolated())?;
+    for source in [Source::GitInstallation, Source::System, Source::Git, Source::User] {
+        assert!(
+            matches!(repo.config_path(source), Err(Error::SourceUnavailable(actual)) if actual == source),
+            "{source:?} remains unavailable when disabled by the repository's permissions"
+        );
+    }
+    for source in [Source::Env, Source::Cli, Source::Api, Source::EnvOverride] {
+        assert!(
+            matches!(repo.config_path(source), Err(Error::UnsupportedSource(actual)) if actual == source),
+            "{source:?} has no physical configuration file even with a repository"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn config_paths_use_the_opening_cwd() -> gix_testtools::Result {
+    use gix::config::Source;
+
+    let fixture = gix::path::realpath(gix_testtools::scripted_fixture_read_only("make_config_repos.sh")?)?;
+    let _cwd = gix_testtools::set_current_dir(&fixture)?;
+    let _env = Env::new()
+        .set("GIT_CONFIG_GLOBAL", "missing/global.config")
+        .set("GIT_CONFIG_NOSYSTEM", "0");
+    let mut options = gix::open::Options::isolated()
+        .git_installation_config_path("missing/installation.config")
+        .system_config_path("missing/system.config");
+    options.permissions.config.git_binary = true;
+    options.permissions.config.system = true;
+    options.permissions.config.git = true;
+    options.permissions.config.user = true;
+    options.permissions.env.git_prefix = gix::sec::Permission::Allow;
+    let repo = gix::open_opts("bare-repo", options)?;
+    std::env::set_current_dir(fixture.join("bare-repo"))?;
+
+    for (source, path) in [
+        (Source::Local, "bare-repo/config"),
+        (Source::Worktree, "bare-repo/config.worktree"),
+        (Source::GitInstallation, "missing/installation.config"),
+        (Source::System, "missing/system.config"),
+        (Source::Git, "missing/global.config"),
+        (Source::User, "missing/global.config"),
+    ] {
+        assert_eq!(
+            repo.config_path(source)?,
+            repo.current_dir().join(path),
+            "{source:?} resolves relative paths against the opening CWD whether or not the file exists"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+#[serial]
 fn config_file_paths_use_the_cwd_captured_while_opening() -> gix_testtools::Result {
     let fixture = gix_testtools::scripted_fixture_writable("make_config_repo.sh")?;
     let elsewhere = gix_testtools::tempfile::tempdir()?;


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Callers with a repository can now use `repo.config_path(source)?` to locate a physical configuration file. `Local` selects the common directory's `config`, `Worktree` selects the Git directory's `config.worktree`, and global sources use the existing resolver with the repository's open options. Worktree paths remain available when `extensions.worktreeConfig` is disabled; missing files are not created.

## Validation

- Added regression tests first; they failed with `E0599` before implementation.
- 31 tests passed: `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix --test repository --test gix-init`.
- Formatting, Clippy for all `gix` targets, and `cargo check -p gix --no-default-features --features sha1` passed.
- Documentation passed with `RUSTDOCFLAGS='-D warnings' cargo doc -p gix --no-deps --features blocking-network-client`. A default-features-only docs build encounters an existing link to the networking-gated `PrepareFetch::with_fetch_options` method.
- Repository-source paths are compared with `git rev-parse --git-path` for normal, bare, and linked repositories. Global-source tests cover options, permissions, environment overrides, missing files, and unsupported sources.

Git reference: `builtin/config.c` and `Documentation/git-config.adoc` in the local Git checkout at `1630431f326e15fcde608827b5ff38422528eb59`; executable baseline: Git 2.50.1 (Apple Git-155).

## Reported issue

Let's have a `Repository::config_path()` method that resolves the configuration path, to fully replace code like this:

    match source {
        gix::config::Source::Local | gix::config::Source::Worktree => {
            let repo = repo.with_context(|| {
                format!("determining the {source:?} git config location requires a repository")
            })?;
            Ok(if source == gix::config::Source::Local {
                repo.common_dir().join("config")
            } else {
                repo.git_dir().join("config.worktree")
            })
        }
        _ => gix::config_path(source, &gix::open::Options::default())
            .with_context(|| format!("failed to determine {source:?} git config location")),
    }

Of course, that only applies if a repo instance exists.
