### PR TITLE
fix: allow merge-base with an absent `objects/info` directory

### DIFF
--- a/gix-commitgraph/src/init.rs
+++ b/gix-commitgraph/src/init.rs
@@ -8,6 +8,8 @@ use std::{
 /// Instantiate a `Graph` from various sources.
 impl Graph {
     /// Instantiate a commit graph from `path` which may be a directory containing graph files or the graph file itself.
+    ///
+    /// Filesystem errors retain their [`std::io::Error`] source, including when `path` does not exist.
     pub fn at(path: &Path) -> Result<Self, Exn<Message>> {
         Self::try_from(path)
     }
@@ -85,11 +87,14 @@ impl TryFrom<&Path> for Graph {
     type Error = Exn<Message>;
 
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
-        if path.is_file() {
+        let metadata = path
+            .metadata()
+            .or_raise(|| message!("Could not access commit-graph path at '{}'", path.display()))?;
+        if metadata.is_file() {
             // Assume we are looking at `.git/objects/info/commit-graph` or
             // `.git/objects/info/commit-graphs/graph-*.graph`.
             Self::from_file(path)
-        } else if path.is_dir() {
+        } else if metadata.is_dir() {
             if path.join("commit-graph-chain").is_file() {
                 Self::from_commit_graphs_dir(path)
             } else {

--- a/gix-commitgraph/tests/commitgraph.rs
+++ b/gix-commitgraph/tests/commitgraph.rs
@@ -11,6 +11,22 @@ use gix_testtools::scripted_fixture_read_only;
 
 mod access;
 
+#[test]
+fn missing_path_keeps_io_error() -> gix_testtools::Result {
+    let dir = gix_testtools::tempfile::tempdir()?;
+    let err = gix_commitgraph::at(dir.path().join("missing"))
+        .err()
+        .expect("a missing path cannot contain a commit-graph");
+    assert_eq!(
+        err.downcast_any_ref::<std::io::Error>()
+            .expect("the filesystem error is preserved")
+            .kind(),
+        std::io::ErrorKind::NotFound,
+        "callers can distinguish a missing optional cache from other failures"
+    );
+    Ok(())
+}
+
 pub fn check_common(cg: &Graph, expected: &HashMap<String, RefInfo, impl BuildHasher>) {
     cg.verify_integrity(|_| Ok::<_, gix_error::Message>(()))
         .expect("graph is valid");

--- a/gix/tests/gix/repository/mod.rs
+++ b/gix/tests/gix/repository/mod.rs
@@ -33,6 +33,36 @@ mod worktree;
 #[cfg(feature = "revision")]
 mod revision {
     #[test]
+    fn missing_objects_info_does_not_prevent_merge_base() -> crate::Result {
+        let (repo, _tmp) = crate::util::basic_rw_repo()?;
+        let info_dir = repo.objects.store_ref().path().join("info");
+        std::fs::create_dir_all(&info_dir)?;
+        assert!(
+            repo.commit_graph_if_enabled()?.is_none(),
+            "an empty objects/info directory has no optional commit-graph"
+        );
+        std::fs::remove_dir(&info_dir)?;
+        assert!(
+            repo.commit_graph_if_enabled()?.is_none(),
+            "an absent objects/info directory also has no optional commit-graph"
+        );
+
+        let head_commit_id = repo.head_id()?;
+        assert_eq!(
+            repo.merge_base(head_commit_id, head_commit_id)?,
+            head_commit_id,
+            "a commit is its own merge-base without a commit-graph"
+        );
+        let parent_commit_id = repo.rev_parse_single("HEAD^")?;
+        assert_eq!(
+            repo.merge_base(head_commit_id, parent_commit_id)?,
+            parent_commit_id,
+            "merge-base can traverse history without a commit-graph"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn date() -> crate::Result {
         let repo = crate::named_repo("make_rev_parse_repo.sh")?;
         let actual = repo


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-6`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #2978.

`Repository::merge_base()` now succeeds when the optional `.git/objects/info` directory is absent. The shared `gix-commitgraph` loader reads path metadata once and preserves its filesystem error, allowing the existing optional-cache fallback to recognize `NotFound`. Other metadata failures retain their underlying cause.

Regression tests cover the missing-path error source, empty and absent `objects/info` directories, and merge-base lookup for both identical commits and a commit with its parent.

## Validation

- Both new regressions failed before the fix and pass afterward. The repository regression also passes with `--no-default-features --features sha1,revision`.
- `cargo nextest run --locked -p gix -p gix-commitgraph --no-fail-fast`, with `GIX_TEST_IGNORE_ARCHIVES=1` and separate SHA-1/SHA-256 fixture runs: 457 tests passed in each run.
- `cargo clippy --locked -p gix -p gix-commitgraph --all-targets -- -D warnings -A unknown-lints --no-deps`
- `cargo fmt --all -- --check`
- One post-commit Codex review of `c9508418eb` completed with no findings.

Git 2.50.1 (Apple Git-155) returns the expected merge bases for `HEAD HEAD` and `HEAD HEAD^` with either an empty or absent `objects/info`. Git's `commit-graph.c` at `1630431f326e15fcde608827b5ff38422528eb59` likewise falls back when no commit-graph can be opened.
