### PR TITLE
change(gix-blame)!: make invalid BlameRanges unrepresentable

### DIFF
--- a/gix-blame/src/file/function.rs
+++ b/gix-blame/src/file/function.rs
@@ -926,17 +926,18 @@ fn initial_state(
                 commit_id: suspect,
             })?;
             let blamed_file_blob = odb.find_blob(&blamed_file_entry_id, buf)?.data.to_vec();
-            let num_lines_in_blamed = tokens_for_diffing(&blamed_file_blob).tokenize().count() as u32;
 
             // Binary or otherwise empty?
-            if num_lines_in_blamed == 0 {
+            let Some(num_lines_in_blamed) =
+                NonZeroU32::new(tokens_for_diffing(&blamed_file_blob).tokenize().count() as u32)
+            else {
                 return Ok(InitialState {
                     blamed_file_blob,
                     hunks_to_blame: Vec::new(),
                     out: Vec::new(),
                     first_suspect: None,
                 });
-            }
+            };
 
             let ranges_to_blame = options.ranges.to_zero_based_exclusive_ranges(num_lines_in_blamed);
             let hunks_to_blame = ranges_to_blame
@@ -957,16 +958,18 @@ fn initial_state(
         } => {
             let null_id = first_suspect.kind().null();
             let blamed_file_blob = contents.into_owned();
-            let num_lines_in_blamed = tokens_for_diffing(&blamed_file_blob).tokenize().count() as u32;
 
-            if num_lines_in_blamed == 0 {
+            // Binary or otherwise empty?
+            let Some(num_lines_in_blamed) =
+                NonZeroU32::new(tokens_for_diffing(&blamed_file_blob).tokenize().count() as u32)
+            else {
                 return Ok(InitialState {
                     blamed_file_blob,
                     hunks_to_blame: Vec::new(),
                     out: Vec::new(),
                     first_suspect: None,
                 });
-            }
+            };
 
             let ranges_to_blame = options.ranges.to_zero_based_exclusive_ranges(num_lines_in_blamed);
             let mut hunks_to_blame = ranges_to_blame

--- a/gix-blame/src/file/tests.rs
+++ b/gix-blame/src/file/tests.rs
@@ -996,6 +996,44 @@ mod blame_ranges {
     }
 
     #[test]
+    #[expect(clippy::reversed_empty_ranges)]
+    fn constructors_reject_reversed_ranges() {
+        assert!(
+            matches!(
+                BlameRanges::from_one_based_inclusive_range(2..=1),
+                Err(Error::InvalidOneBasedLineRange)
+            ),
+            "a reversed range cannot be turned into a non-empty 0-based range, so it must be rejected"
+        );
+        assert!(
+            matches!(
+                BlameRanges::from_one_based_inclusive_ranges(vec![1..=2, 4..=3]),
+                Err(Error::InvalidOneBasedLineRange)
+            ),
+            "a single reversed range invalidates the whole set, even if other ranges are fine"
+        );
+    }
+
+    #[test]
+    #[expect(clippy::reversed_empty_ranges)]
+    fn adding_a_reversed_range_is_rejected_and_leaves_the_selection_untouched() {
+        let mut ranges = BlameRanges::from_one_based_inclusive_range(1..=3).expect("valid range");
+
+        assert!(
+            matches!(
+                ranges.add_one_based_inclusive_range(5..=4),
+                Err(Error::InvalidOneBasedLineRange)
+            ),
+            "adding a reversed range fails just like constructing from one"
+        );
+        assert_eq!(
+            ranges.to_zero_based_exclusive_ranges(100),
+            vec![0..3],
+            "a rejected range must not be merged into the existing selection"
+        );
+    }
+
+    #[test]
     fn create_from_single_range() {
         let ranges = BlameRanges::from_one_based_inclusive_range(20..=40).unwrap();
 

--- a/gix-blame/src/file/tests.rs
+++ b/gix-blame/src/file/tests.rs
@@ -1103,7 +1103,7 @@ mod blame_ranges {
 
     #[test]
     fn convert_full_file_to_zero_based() {
-        let ranges = BlameRanges::WholeFile;
+        let ranges = BlameRanges::default();
 
         assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![0..100]);
     }
@@ -1145,6 +1145,40 @@ mod blame_ranges {
     fn default_is_full_file() {
         let ranges = BlameRanges::default();
 
-        assert!(matches!(ranges, BlameRanges::WholeFile));
+        assert!(
+            ranges.is_whole_file(),
+            "not selecting anything in particular blames the whole file"
+        );
+        assert_eq!(
+            ranges.selected_ranges(),
+            None,
+            "there are no individual ranges to inspect when the whole file is selected"
+        );
+    }
+
+    #[test]
+    fn selected_ranges_are_non_empty_sorted_and_disjoint() {
+        let ranges = BlameRanges::from_one_based_inclusive_ranges(vec![10..=15, 1..=5, 3..=4, 6..=7])
+            .expect("all ranges are valid");
+
+        assert!(
+            !ranges.is_whole_file(),
+            "selecting individual ranges is not the same as selecting the whole file"
+        );
+        assert_eq!(
+            ranges.selected_ranges(),
+            Some([0..7, 9..15].as_slice()),
+            "overlapping and adjacent ranges are merged, and the result is sorted, so no line is blamed twice"
+        );
+    }
+
+    #[test]
+    fn an_empty_set_of_ranges_is_the_whole_file() {
+        let ranges = BlameRanges::from_one_based_inclusive_ranges(vec![]).expect("an empty selection is valid");
+
+        assert!(
+            ranges.is_whole_file(),
+            "selecting no ranges at all cannot be distinguished from selecting everything"
+        );
     }
 }

--- a/gix-blame/src/file/tests.rs
+++ b/gix-blame/src/file/tests.rs
@@ -986,7 +986,16 @@ mod process_changes {
 }
 
 mod blame_ranges {
+    use std::num::NonZeroU32;
+
     use crate::{BlameRanges, Error};
+
+    /// A file of `n` lines, for resolving a selection against.
+    ///
+    /// A file without lines cannot be expressed, which is the point: it has nothing to blame.
+    fn num_lines(n: u32) -> NonZeroU32 {
+        NonZeroU32::new(n).expect("these tests never describe a file without lines")
+    }
 
     #[test]
     fn create_with_invalid_range() {
@@ -1027,7 +1036,7 @@ mod blame_ranges {
             "adding a reversed range fails just like constructing from one"
         );
         assert_eq!(
-            ranges.to_zero_based_exclusive_ranges(100),
+            ranges.to_zero_based_exclusive_ranges(num_lines(100)),
             vec![0..3],
             "a rejected range must not be merged into the existing selection"
         );
@@ -1037,21 +1046,21 @@ mod blame_ranges {
     fn create_from_single_range() {
         let ranges = BlameRanges::from_one_based_inclusive_range(20..=40).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![19..40]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(100)), vec![19..40]);
     }
 
     #[test]
     fn create_from_multiple_ranges() {
         let ranges = BlameRanges::from_one_based_inclusive_ranges(vec![1..=4, 10..=14]).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![0..4, 9..14]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(100)), vec![0..4, 9..14]);
     }
 
     #[test]
     fn create_with_empty_ranges() {
         let ranges = BlameRanges::from_one_based_inclusive_ranges(vec![]).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![0..100]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(100)), vec![0..100]);
     }
 
     #[test]
@@ -1059,7 +1068,7 @@ mod blame_ranges {
         let mut ranges = BlameRanges::from_one_based_inclusive_range(1..=5).unwrap();
         ranges.add_one_based_inclusive_range(3..=7).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![0..7]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(100)), vec![0..7]);
     }
 
     #[test]
@@ -1068,7 +1077,7 @@ mod blame_ranges {
         ranges.add_one_based_inclusive_range(5..=7).unwrap();
         ranges.add_one_based_inclusive_range(2..=6).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![0..7]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(100)), vec![0..7]);
     }
 
     #[test]
@@ -1076,7 +1085,7 @@ mod blame_ranges {
         let mut ranges = BlameRanges::from_one_based_inclusive_range(5..=7).unwrap();
         ranges.add_one_based_inclusive_range(1..=3).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![0..3, 4..7]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(100)), vec![0..3, 4..7]);
     }
 
     #[test]
@@ -1084,28 +1093,39 @@ mod blame_ranges {
         let mut ranges = BlameRanges::from_one_based_inclusive_range(1..=5).unwrap();
         ranges.add_one_based_inclusive_range(6..=10).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![0..10]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(100)), vec![0..10]);
     }
 
     #[test]
     fn non_sorted_ranges() {
         let ranges = BlameRanges::from_one_based_inclusive_ranges(vec![10..=15, 1..=5]).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![0..5, 9..15]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(100)), vec![0..5, 9..15]);
     }
 
     #[test]
     fn convert_to_zero_based_exclusive() {
         let ranges = BlameRanges::from_one_based_inclusive_ranges(vec![1..=5, 10..=15]).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![0..5, 9..15]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(100)), vec![0..5, 9..15]);
     }
 
     #[test]
     fn convert_full_file_to_zero_based() {
         let ranges = BlameRanges::default();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![0..100]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(100)), vec![0..100]);
+    }
+
+    #[test]
+    fn the_whole_file_always_resolves_to_exactly_one_non_empty_range() {
+        for n in [1, 2, 100] {
+            assert_eq!(
+                BlameRanges::default().to_zero_based_exclusive_ranges(num_lines(n)),
+                vec![0..n],
+                "selecting the whole file always yields exactly one range covering all {n} lines"
+            );
+        }
     }
 
     #[test]
@@ -1114,7 +1134,7 @@ mod blame_ranges {
 
         ranges.add_one_based_inclusive_range(1..=10).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(100), vec![0..10]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(100)), vec![0..10]);
     }
 
     #[test]
@@ -1122,7 +1142,7 @@ mod blame_ranges {
         let mut ranges = BlameRanges::from_one_based_inclusive_range(1..=5).unwrap();
         ranges.add_one_based_inclusive_range(16..=20).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(7), vec![0..5]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(7)), vec![0..5]);
     }
 
     #[test]
@@ -1130,7 +1150,7 @@ mod blame_ranges {
         let mut ranges = BlameRanges::from_one_based_inclusive_range(1..=5).unwrap();
         ranges.add_one_based_inclusive_range(6..=10).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(7), vec![0..7]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(7)), vec![0..7]);
     }
 
     #[test]
@@ -1138,7 +1158,7 @@ mod blame_ranges {
         let mut ranges = BlameRanges::from_one_based_inclusive_range(1..=4).unwrap();
         ranges.add_one_based_inclusive_range(6..=10).unwrap();
 
-        assert_eq!(ranges.to_zero_based_exclusive_ranges(7), vec![0..4, 5..7]);
+        assert_eq!(ranges.to_zero_based_exclusive_ranges(num_lines(7)), vec![0..4, 5..7]);
     }
 
     #[test]

--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -185,10 +185,23 @@ impl BlameRanges {
         }
     }
 
-    /// Gets zero-based exclusive ranges.
-    pub(crate) fn to_zero_based_exclusive_ranges(&self, max_lines: u32) -> Vec<Range<u32>> {
-        match &self.0 {
+    /// Resolves the selection into 0-based exclusive ranges while taking into account `max_lines` -
+    /// the number of lines in the content that will be blamed.
+    ///
+    /// Ranges that reach past `max_lines` are clamped to it, and ranges that start past `max_lines`
+    /// are dropped. Consequently the result can be empty, if every selected range starts past
+    /// `max_lines`, but every range it does contain is guaranteed to be non-empty.
+    /// [`file()`](crate::file()) relies on that guarantee, as a hunk without lines cannot be turned
+    /// into a [`BlameEntry`].
+    ///
+    /// Note that a file without lines cannot be expressed here, as `max_lines` is a [`NonZeroU32`].
+    /// Such a file has nothing to attribute, and [`file()`](crate::file()) recognizes it before
+    /// any range is resolved.
+    pub(crate) fn to_zero_based_exclusive_ranges(&self, max_lines: NonZeroU32) -> Vec<Range<u32>> {
+        let max_lines = max_lines.get();
+        let ranges = match &self.0 {
             Selection::WholeFile => {
+                // Kept as a binding to avoid `clippy::single_range_in_vec_init`.
                 let full_range = 0..max_lines;
                 vec![full_range]
             }
@@ -206,7 +219,12 @@ impl BlameRanges {
                     }
                 })
                 .collect(),
-        }
+        };
+        debug_assert!(
+            ranges.iter().all(|range| !range.is_empty()),
+            "BUG: resolved ranges must never be empty, or creating a `BlameEntry` from them will panic"
+        );
+        ranges
     }
 }
 

--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -24,11 +24,10 @@ use crate::file::function::tokens_for_diffing;
 /// let range = BlameRanges::from_one_based_inclusive_range(20..=40);
 ///
 /// // Blame multiple ranges
-/// let mut ranges = BlameRanges::from_one_based_inclusive_ranges(vec![
-///     1..=4, // Lines 1-4
+/// let ranges = BlameRanges::from_one_based_inclusive_ranges(vec![
+///     1..=4,  // Lines 1-4
 ///    10..=14, // Lines 10-14
-/// ]
-/// );
+/// ]);
 /// ```
 ///
 /// # Line Number Representation
@@ -37,8 +36,18 @@ use crate::file::function::tokens_for_diffing;
 /// - A range of `20..=40` represents 21 lines, spanning from line 20 up to and including line 40
 /// - This will be converted to `19..40` internally as the algorithm uses 0-based ranges that are exclusive at the end
 ///
-/// # Empty Ranges
-/// You can blame the entire file by calling `BlameRanges::default()`, or by passing an empty vector to `from_one_based_inclusive_ranges`.
+/// Ranges are always non-empty, so `<start>` may never exceed `<end>`. This mirrors the `gix blame -L <start>,<end>`
+/// command-line interface, but differs from `git blame -L <start>,<end>` which silently swaps reversed ranges.
+/// That swapping is [explicitly documented as undocumented behaviour][swap] in `git`'s own test suite, so we
+/// prefer to reject what we cannot unambiguously interpret.
+///
+/// # Blaming the Whole File
+///
+/// You can blame the entire file by calling [`BlameRanges::default()`], or by passing an empty vector to
+/// [`BlameRanges::from_one_based_inclusive_ranges()`]. Note that this is about an empty collection of ranges;
+/// an individual range may never be empty.
+///
+/// [swap]: https://github.com/git/git/blob/3cb9185f65410273787f74333cc027d2ea5daada/t/annotate-tests.sh#L271-L273
 #[derive(Debug, Clone, Default)]
 pub enum BlameRanges {
     /// Blame the entire file.
@@ -50,21 +59,31 @@ pub enum BlameRanges {
 
 /// Lifecycle
 impl BlameRanges {
-    /// Create from a single 0-based range.
+    /// Create from a single 1-based inclusive range.
     ///
     /// Note that the input range is 1-based inclusive, as used by git, and
-    /// the output is a zero-based `BlameRanges` instance.
+    /// the output is a 0-based exclusive `BlameRanges` instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidOneBasedLineRange`] if `range` starts at `0`, or if it is reversed,
+    /// i.e. if its start exceeds its end.
     pub fn from_one_based_inclusive_range(range: RangeInclusive<u32>) -> Result<Self, Error> {
         let zero_based_range = Self::inclusive_to_zero_based_exclusive(range)?;
         Ok(Self::PartialFile(vec![zero_based_range]))
     }
 
-    /// Create from multiple 0-based ranges.
+    /// Create from multiple 1-based inclusive ranges.
     ///
     /// Note that the input ranges are 1-based inclusive, as used by git, and
-    /// the output is a zero-based `BlameRanges` instance.
+    /// the output is a 0-based exclusive `BlameRanges` instance.
     ///
     /// If the input vector is empty, the result will be `WholeFile`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidOneBasedLineRange`] if any range starts at `0`, or if any range is
+    /// reversed, i.e. if its start exceeds its end.
     pub fn from_one_based_inclusive_ranges(ranges: Vec<RangeInclusive<u32>>) -> Result<Self, Error> {
         if ranges.is_empty() {
             return Ok(Self::WholeFile);
@@ -82,13 +101,16 @@ impl BlameRanges {
     }
 
     /// Convert a 1-based inclusive range to a 0-based exclusive range.
+    ///
+    /// Reversed ranges are rejected rather than turned into empty 0-based ranges, as the blame
+    /// algorithm cannot represent a hunk without lines.
     fn inclusive_to_zero_based_exclusive(range: RangeInclusive<u32>) -> Result<Range<u32>, Error> {
-        if range.start() == &0 {
+        let (start, end) = (*range.start(), *range.end());
+        // Not `RangeInclusive::is_empty()`, which is also `true` for a range iterated to exhaustion.
+        if start == 0 || start > end {
             return Err(Error::InvalidOneBasedLineRange);
         }
-        let start = range.start() - 1;
-        let end = *range.end();
-        Ok(start..end)
+        Ok(start - 1..end)
     }
 }
 
@@ -96,6 +118,12 @@ impl BlameRanges {
     /// Add a single range to blame.
     ///
     /// The new range will be merged with any overlapping existing ranges.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidOneBasedLineRange`] if `new_range` starts at `0`, or if it is
+    /// reversed, i.e. if its start exceeds its end. The existing selection is left untouched in
+    /// that case.
     pub fn add_one_based_inclusive_range(&mut self, new_range: RangeInclusive<u32>) -> Result<(), Error> {
         let zero_based_range = Self::inclusive_to_zero_based_exclusive(new_range)?;
         self.merge_zero_based_exclusive_range(zero_based_range);

--- a/gix-blame/src/types.rs
+++ b/gix-blame/src/types.rs
@@ -15,6 +15,10 @@ use crate::file::function::tokens_for_diffing;
 /// It handles the conversion between git's 1-based inclusive ranges and the internal
 /// 0-based exclusive ranges used by the blame algorithm.
 ///
+/// Values of this type are always valid: they either select the whole file, or a non-empty set of
+/// non-empty, sorted and pairwise disjoint ranges. Construction therefore goes through the
+/// constructors below, which validate and normalize their input.
+///
 /// # Examples
 ///
 /// ```rust
@@ -47,13 +51,26 @@ use crate::file::function::tokens_for_diffing;
 /// [`BlameRanges::from_one_based_inclusive_ranges()`]. Note that this is about an empty collection of ranges;
 /// an individual range may never be empty.
 ///
+/// If you already hold 0-based exclusive ranges, convert each `start..end` to the 1-based inclusive
+/// `(start + 1)..=end` before passing it in. That conversion is exact for every non-empty range.
+///
 /// [swap]: https://github.com/git/git/blob/3cb9185f65410273787f74333cc027d2ea5daada/t/annotate-tests.sh#L271-L273
 #[derive(Debug, Clone, Default)]
-pub enum BlameRanges {
+pub struct BlameRanges(Selection);
+
+#[derive(Debug, Clone, Default)]
+enum Selection {
     /// Blame the entire file.
     #[default]
     WholeFile,
-    /// Blame ranges in 0-based exclusive format.
+    /// Blame the given ranges, in 0-based exclusive format.
+    ///
+    /// Upheld invariants, all established by [`BlameRanges::merge_zero_based_exclusive_range()`]:
+    ///
+    /// * the `Vec` is never empty - that state is spelled [`Selection::WholeFile`],
+    /// * every range is non-empty, so it can become a [`BlameEntry`] with a [`NonZeroU32`] length,
+    /// * the ranges are sorted by `start` and pairwise disjoint and non-adjacent, so no line is
+    ///   ever attributed twice.
     PartialFile(Vec<Range<u32>>),
 }
 
@@ -69,8 +86,9 @@ impl BlameRanges {
     /// Returns [`Error::InvalidOneBasedLineRange`] if `range` starts at `0`, or if it is reversed,
     /// i.e. if its start exceeds its end.
     pub fn from_one_based_inclusive_range(range: RangeInclusive<u32>) -> Result<Self, Error> {
-        let zero_based_range = Self::inclusive_to_zero_based_exclusive(range)?;
-        Ok(Self::PartialFile(vec![zero_based_range]))
+        let mut result = Self::default();
+        result.merge_zero_based_exclusive_range(Self::inclusive_to_zero_based_exclusive(range)?);
+        Ok(result)
     }
 
     /// Create from multiple 1-based inclusive ranges.
@@ -78,24 +96,16 @@ impl BlameRanges {
     /// Note that the input ranges are 1-based inclusive, as used by git, and
     /// the output is a 0-based exclusive `BlameRanges` instance.
     ///
-    /// If the input vector is empty, the result will be `WholeFile`.
+    /// If the input vector is empty, the result selects the whole file.
     ///
     /// # Errors
     ///
     /// Returns [`Error::InvalidOneBasedLineRange`] if any range starts at `0`, or if any range is
     /// reversed, i.e. if its start exceeds its end.
     pub fn from_one_based_inclusive_ranges(ranges: Vec<RangeInclusive<u32>>) -> Result<Self, Error> {
-        if ranges.is_empty() {
-            return Ok(Self::WholeFile);
-        }
-
-        let zero_based_ranges = ranges
-            .into_iter()
-            .map(Self::inclusive_to_zero_based_exclusive)
-            .collect::<Vec<_>>();
-        let mut result = Self::PartialFile(vec![]);
-        for range in zero_based_ranges {
-            result.merge_zero_based_exclusive_range(range?);
+        let mut result = Self::default();
+        for range in ranges {
+            result.merge_zero_based_exclusive_range(Self::inclusive_to_zero_based_exclusive(range)?);
         }
         Ok(result)
     }
@@ -111,6 +121,24 @@ impl BlameRanges {
             return Err(Error::InvalidOneBasedLineRange);
         }
         Ok(start - 1..end)
+    }
+}
+
+/// Access
+impl BlameRanges {
+    /// Return `true` if the entire file is selected, which is the default.
+    pub fn is_whole_file(&self) -> bool {
+        matches!(self.0, Selection::WholeFile)
+    }
+
+    /// Return the selected 0-based exclusive ranges, or `None` if the whole file is selected.
+    ///
+    /// The ranges are non-empty, sorted and pairwise disjoint.
+    pub fn selected_ranges(&self) -> Option<&[Range<u32>]> {
+        match &self.0 {
+            Selection::WholeFile => None,
+            Selection::PartialFile(ranges) => Some(ranges),
+        }
     }
 }
 
@@ -131,10 +159,14 @@ impl BlameRanges {
         Ok(())
     }
 
-    /// Adds a new ranges, merging it with any existing overlapping ranges.
+    /// Add `new_range`, merging it with any existing overlapping or adjacent ranges.
+    ///
+    /// This is the only place that creates [`Selection::PartialFile`], and is what upholds its
+    /// invariants. `new_range` must be non-empty.
     fn merge_zero_based_exclusive_range(&mut self, new_range: Range<u32>) {
-        match self {
-            Self::PartialFile(ranges) => {
+        debug_assert!(!new_range.is_empty(), "BUG: an empty range must never be selected");
+        match &mut self.0 {
+            Selection::PartialFile(ranges) => {
                 // Partition ranges into those that don't overlap and those that do.
                 let (mut non_overlapping, overlapping): (Vec<_>, Vec<_>) = ranges
                     .drain(..)
@@ -149,18 +181,18 @@ impl BlameRanges {
                 *ranges = non_overlapping;
                 ranges.sort_by_key(|a| a.start);
             }
-            Self::WholeFile => *self = Self::PartialFile(vec![new_range]),
+            Selection::WholeFile => self.0 = Selection::PartialFile(vec![new_range]),
         }
     }
 
     /// Gets zero-based exclusive ranges.
-    pub fn to_zero_based_exclusive_ranges(&self, max_lines: u32) -> Vec<Range<u32>> {
-        match self {
-            Self::WholeFile => {
+    pub(crate) fn to_zero_based_exclusive_ranges(&self, max_lines: u32) -> Vec<Range<u32>> {
+        match &self.0 {
+            Selection::WholeFile => {
                 let full_range = 0..max_lines;
                 vec![full_range]
             }
-            Self::PartialFile(ranges) => ranges
+            Selection::PartialFile(ranges) => ranges
                 .iter()
                 .filter_map(|range| {
                     if range.end < max_lines {

--- a/gix-blame/tests/blame.rs
+++ b/gix-blame/tests/blame.rs
@@ -683,6 +683,37 @@ mod untracked_changes {
         Ok(())
     }
 
+    // An empty buffer is the only way to express content without lines: a lone newline tokenizes to
+    // one line, as does newline-free binary content. Blaming it as untracked changes is what lets us
+    // exercise a line count of zero, which the internal range resolution no longer accepts.
+    #[test]
+    fn a_file_without_lines_has_nothing_to_blame() -> gix_testtools::Result {
+        let worktree_path = gix_testtools::scripted_fixture_read_only("make_blame_repo.sh")?;
+
+        let mut fixture = Fixture::for_worktree_path(worktree_path.to_path_buf())?;
+        let lines_blamed = fixture
+            .blame_untracked_changes(
+                "untracked-lines.txt".into(),
+                Vec::new(),
+                gix_blame::Options {
+                    diff_algorithm: gix_diff::blob::Algorithm::Histogram,
+                    ranges: BlameRanges::default(),
+                    since: None,
+                    rewrites: Some(gix_diff::Rewrites::default()),
+                    debug_track_path: false,
+                },
+            )?
+            .entries;
+
+        assert!(
+            lines_blamed.is_empty(),
+            "content without lines cannot be attributed, so blame stops before a line count is ever \
+             needed to resolve `BlameRanges` into ranges to blame"
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn untracked_file() -> gix_testtools::Result {
         let worktree_path = gix_testtools::scripted_fixture_read_only("make_blame_repo.sh")?;


### PR DESCRIPTION
Hello! :wave: This is my first PR to this project, so I'm going to do a brief introduction: my name is Ivan, and ~2 years ago I built [a small TUI app for exploring Git blames](https://github.com/izuzak/blame) (nothing popular, just a personal project). The app is written in Rust and uses command-line Git for all Git information extraction/querying. I'd like to try replacing that direct Git usage with gitoxide, specifically gix-blame. And as a part of that, I'm hoping to contribute a bit to the gitoxide project. 

-------

Okay, now about this PR. _Note: I did write most of the code and PR description myself (my issues/PRs are often detailed+long -- sorry! 🙈), but also used an AI agent for a final review and edit -- it caught a few small problems both in my changes and in pre-existing code, and also added a few notes to the commit messages and code comments._

### TL;DR version since the full explanation is a bit long

Currently, it's possible to construct `BlameRanges::PartialFile` values with empty internal ranges (e.g. a reversed range `2..1`). The `gix_blame::file()` function takes a `BlameRanges` value as input and eventually attempts to create a `BlameEntry`. Attempting to create a `BlameEntry` from an empty range violates a pre-existing internal invariant and causes a panic. Directly constructed overlapping or duplicate ranges can also silently produce duplicate blame entries.

With the changes in this PR, the constructors and the `add_one_based_inclusive_range()` method reject reversed one-based ranges (which were previously converted into empty internal ranges) and return the existing `InvalidOneBasedLineRange` error. `BlameRanges` also becomes an opaque struct, so callers can no longer bypass those methods to create or mutate invalid selections directly. It either selects the whole file or holds a non-empty collection of non-empty, sorted and disjoint ranges.

This is a breaking change: the public `BlameRanges` enum variants were removed, and `to_zero_based_exclusive_ranges()` is now crate-private to reduce public API surface. The existing constructors remain, and two new read-only accessors (`is_whole_file()` and `selected_ranges()`) allow callers to inspect the internal `BlameRanges` selections.

And here's the longer version below. 📚 

### The problem I observed

I noticed that the `gix blame` command line wrapper (correctly) rejects reversed ranges (e.g. `-L 2,1` instead of `-L 1,2`):

```
> gix blame -L 2,1 gix-blame/tests/blame.rs

error: invalid value '2,1' for '-L <RANGES>': error: invalid value for one of the arguments

> gix blame -L 1,2 gix-blame/tests/blame.rs

d2e98f3c 1 gix-blame/tests/blame.rs 1 use std::{collections::BTreeMap, path::PathBuf};
26bfd2d7 2 gix-blame/tests/blame.rs 2
```

However, there's no such validation for reversed ranges in the API and trying to use such ranges leads to panics. Specifically:
* The private [`BlameRanges::inclusive_to_zero_based_exclusive`](https://github.com/GitoxideLabs/gitoxide/blob/4a870be7db38a3fde68db3774fa7d7f2000c3d68/gix-blame/src/types.rs#L85-L92) method only checks that the start of the range is greater than 0. This method is called from the public `BlameRanges::from_one_based_inclusive_range`, `BlameRanges::from_one_based_inclusive_ranges` and `BlameRanges::add_one_based_inclusive_range` methods used for creating and modifying `BlameRanges::PartialFile` values. So, a `BlameRanges::PartialFile` value with an empty internal range can be created here, e.g. `BlameRanges::from_one_based_inclusive_range(2..=1)` results in a `1..1` range.
* On top of that, a `BlameRanges::PartialFile` value with a reversed/empty range can also be created directly since the enum and variants are public, e.g. `PartialFile(vec![2..1])`.

In both cases, a `BlameRanges` value is passed to `gix_blame::file()` as input, and `gix_blame::file()` doesn't validate the included ranges. Things eventually lead to [a `BlameEntry` being created](https://github.com/GitoxideLabs/gitoxide/blob/4a870be7db38a3fde68db3774fa7d7f2000c3d68/gix-blame/src/file/mod.rs#L445-L451) and as a part of that creation -- [`force_non_zero()` is called with the range's length](https://github.com/GitoxideLabs/gitoxide/blob/4a870be7db38a3fde68db3774fa7d7f2000c3d68/gix-blame/src/file/mod.rs#L448) which then calls `NonZeroU32::new(n).expect(...)`. For an empty range, the range's length `n` is 0, [causing `NonZeroU32::new(n)` to return `None`](https://doc.rust-lang.org/std/num/type.NonZeroU32.html#method.new) and thus the `expect()` call panics with `BUG: hunks are never empty`.

While looking at direct creation of `BlameRanges::PartialFile` values, I also found a few other problems:
* `PartialFile(vec![0..3, 1..4])` succeeds, but blames lines 2 and 3 twice.
* `PartialFile(vec![0..2, 0..2])` succeeds, but duplicates every entry.
* `PartialFile(vec![])` succeeds and blames nothing, while `from_one_based_inclusive_ranges(vec![])` blames everything.

The `BlameRanges` constructors already merge overlapping and adjacent ranges and sort the result, but direct construction bypasses all of that.

I tried searching prior issues and PRs for reports of this reversed-range panic, but couldn't find any. I did find #1766 which added `gix blame -L start,end` and [the `start <= end` validation](https://github.com/GitoxideLabs/gitoxide/pull/1766/files#diff-c11e72174294250d95d68429cbb5e9ec58c16ac64087d428736be92bd22cd688R426-R428) for the CLI call. I also found #1976 where [the `range.start() == 0` check was suggested](https://github.com/GitoxideLabs/gitoxide/pull/1976#discussion_r2104788585) (and finally implemented in the follow-up #2204), but it doesn't seem there were discussions about the `start > end` or `RangeInclusive::is_empty()` cases. 

### The solution in this PR

Initially, I thought "I'll just add a bit of validation in a few places", and even [implemented that approach](https://github.com/izuzak/gitoxide/commit/f042ed1448c0a8a0895ac814694dea1dd1196476). But as I was writing up the PR for that change -- it occurred to me that preventing invalid `BlameRanges` from being constructed in the first place (the old ["parse, don't validate" idea](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)) might be a more robust and durable approach, even though it would be a breaking change. 

So, that "make invalid `BlameRanges` unrepresentable" approach is what's in this PR and I split the changes into three commits:

1. 9390c8abed102bed3d6ca8bfb02f2c84cdee7860 - Reject reversed one-based ranges in `BlameRanges::inclusive_to_zero_based_exclusive()`, returning the existing `Error::InvalidOneBasedLineRange`. This covers both constructors and `add_one_based_inclusive_range()`.
2. fd1aad388c44bd36b116e285061c4ca9eed4b3fc - Replace the public `BlameRanges` enum with an opaque struct over a private `Selection` enum. All construction and modification of selected ranges go through validation and the existing `merge_zero_based_exclusive_range()` logic. The result is either the whole file or a non-empty collection of non-empty, sorted, disjoint and non-adjacent ranges. Also, add read-only accessors (`is_whole_file()` and `selected_ranges()`) and make `to_zero_based_exclusive_ranges()` crate-private (a few notes about this change are in a separate section below).
3. 3dac5d63d46688a2f18e4fe4c9898f669ca72a0f - Change the now-private `to_zero_based_exclusive_ranges()` method's `max_lines` parameter from `u32` to `NonZeroU32`. Previously, resolving a whole-file selection with `0` produced `vec![0..0]`, another empty range. `gix_blame::file()` already returned early for content without lines, so it didn't hit this case. But the new parameter type makes handling `0` a requirement for calling the resolver (which should be more robust).

Regression tests cover reversed-range rejection (including unchanged state on error), normalized range inspection, and non-empty whole-file resolution. An integration test also checks that blaming empty untracked content returns no entries.

The `expect()` in `force_non_zero()` stays since a `BlameEntry` without lines is still a bug. This PR prevents such ranges from being created and passed to `gix_blame::file()`.

If the breaking changes feel too disruptive or you don't like that approach in general, I'm happy to go back to the validation approach or something else based on your feedback. (That said, in my first attempt -- the validation approach also introduced a small breaking change due to a new variant in an exhaustive `Error` enum.)

Also, one trade-off is that callers who previously constructed `BlameRanges::PartialFile` manually from already-normalized ranges must now go through the `merge_zero_based_exclusive_range()` normalization too. This will obviously have worse performance, so if this is a concern -- optimizing bulk construction could be something to discuss.

### Breaking changes and migration paths

One breaking change is that the `BlameRanges::WholeFile` and `BlameRanges::PartialFile` enum variants are no longer public.
* To select the whole file, use `BlameRanges::default()`.
* To select ranges, use the existing `from_one_based_inclusive_range()`, `from_one_based_inclusive_ranges()` and `add_one_based_inclusive_range()` methods.
* To inspect a selection, use `is_whole_file()` or `selected_ranges()`. The latter returns `Option<&[Range<u32>]>`: `None` for the whole file, or a borrowed slice of normalized 0-based exclusive ranges. 
* To select ranges based on non-empty 0-based exclusive ranges, convert each `start..end` to the 1-based inclusive `(start + 1)..=end` before passing it to a constructor. If this feels like a common use-case, we might offer new constructors for that as well?

The other breaking change is that `to_zero_based_exclusive_ranges()` is no longer `pub` but rather `pub(crate)`. 
* To inspect a selection, use `selected_ranges()` and `is_whole_file()` instead.
* To blame it, pass the selection through `Options::ranges` to `gix_blame::file()`, which resolves it internally. 
* There is no public replacement for obtaining file-clamped ranges without running blame -- callers would need to do it themselves. See more notes below.

### Why make the `to_zero_based_exclusive_ranges()` range resolution internal?

TLDR: changing the `to_zero_based_exclusive_ranges()` method from `pub` to `pub(crate)` reduces the public API surface since it felt like it didn't need to be public. If this doesn't feel helpful, I can remove that change. 

`to_zero_based_exclusive_ranges()` does more than expose the stored ranges: it resolves a selection against the line count of a particular file, clamping ranges that reach past its end and dropping those that start past it. That behavior is unchanged. (Also note: for ordered positive ranges, Git also clamps ends past EOF, but errors on starts past EOF rather than dropping those ranges.)

`gix_blame::file()` already [obtains the actual content and counts its lines](https://github.com/GitoxideLabs/gitoxide/blob/4a870be7db38a3fde68db3774fa7d7f2000c3d68/gix-blame/src/file/function.rs#L923-L929). Callers could compute that count themselves, but would need the same content and [line-counting rules](https://github.com/GitoxideLabs/gitoxide/blob/4a870be7db38a3fde68db3774fa7d7f2000c3d68/gix-blame/src/file/function.rs#L892-L896) -- it isn't something known from the selection alone. The new accessors let callers inspect a selection without a line count. 

Also, the PR which introduced this method removed the previous version of it called `to_zero_based_exclusive()` which was also `pub`. But that method was [documented as "used internally by the blame algorithm"](https://github.com/GitoxideLabs/gitoxide/pull/2204/files#diff-493a4b2009b6d72674ce039f421f7c5b9c60a30e887f5aaf4de10637b0732876L103-L118) implying that this method is primarily there for internal use and perhaps could have been `pub(crate)` from the start. And as far as I could tell, [there's no external usage of this method in public repositories](https://github.com/search?q=to_zero_based_exclusive_ranges&type=code). Of course, there could be some usage in private repositories.

### What does Git do for reversed ranges?

While I was working on this, I checked what command-line `git blame` does and -- it actually behaves differently! Instead of rejecting reversed ranges, it swaps them for you:

```
> git blame -L 1,2 gix-blame/tests/blame.rs
d2e98f3cf4 (Christoph Rüßler 2025-05-22 16:00:49 +0200 1) use std::{collections::BTreeMap, path::PathBuf};
26bfd2d733 (Byron            2024-12-23 17:29:28 +0100 2)

> git blame -L 2,1 gix-blame/tests/blame.rs
d2e98f3cf4 (Christoph Rüßler 2025-05-22 16:00:49 +0200 1) use std::{collections::BTreeMap, path::PathBuf};
26bfd2d733 (Byron            2024-12-23 17:29:28 +0100 2)
```

The behavior comes from [here](https://github.com/git/git/blob/3cb9185f65410273787f74333cc027d2ea5daada/line-range.c#L277-L279) and there's even [a regression test for it](https://github.com/git/git/blob/3cb9185f65410273787f74333cc027d2ea5daada/t/annotate-tests.sh#L271-L273), but that regression test explicitly classifies this as undocumented behavior. Also, [the `git blame` docs](https://git-scm.com/docs/git-blame) only say that the two numbers should be 1-based and don't mention the swapping:

> ```
> -L <start>,<end>
>   ...
>   If <start> or <end> is a number, it specifies an absolute line number (lines count from 1).
> ```

So, technically, `gix_blame::file()` is not matching Git's behavior with respect to reversed ranges, but on the other hand -- Git's swapping behavior is explicitly marked as undocumented and the `gix blame` CLI command already rejects reversed ranges. So, I think rejecting them in the API also makes more sense than silently swapping them.

Thanks for reading my novel! :bow: