### PR TITLE
feat(gix-url): add path access without query or fragment

### DIFF
--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -31,7 +31,7 @@ document-features = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-gix-testtools = { path = "../tests/tools" }
+gix-testtools = { path = "../tests/tools", features = ["sha1"] }
 serde_json = "1.0.150"
 
 [package.metadata.docs.rs]

--- a/gix-url/fuzz/fuzz_targets/parse.rs
+++ b/gix-url/fuzz/fuzz_targets/parse.rs
@@ -15,6 +15,7 @@ fn fuzz(data: &[u8]) -> Result<()> {
         assert!(!safe_host.starts_with("ssh://-"));
     }
     _ = black_box(url.path_argument_safe());
+    _ = black_box(url.path_query_fragment());
     _ = black_box(url.path_is_root());
     _ = black_box(url.port_or_default());
     _ = black_box(url.canonicalized(Path::new("/cwd")));

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -26,7 +26,7 @@
 
 use std::{borrow::Cow, path::PathBuf};
 
-use bstr::{BStr, BString};
+use bstr::{BStr, BString, ByteSlice};
 use gix_utils::AsBStr;
 
 const HTTP_PATH_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
@@ -118,6 +118,24 @@ pub enum ArgumentSafety<'a> {
     Dangerous(&'a str),
 }
 
+/// Decoded components returned by [`Url::path_query_fragment()`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathComponents<'a> {
+    /// The repository path, with `/` used for an empty HTTP path.
+    pub path: &'a BStr,
+    /// HTTP query name/value pairs in input order, including duplicate names.
+    ///
+    /// Names and values use form decoding: literal `+` becomes a space, while `%2B` becomes `+`.
+    /// Empty `&`-separated fields are skipped; names without `=` have an empty value.
+    /// `None` means no query delimiter was present, while `Some(Vec::new())` represents an empty query.
+    /// Decoded bytes are borrowed except when replacing literal plus signs requires an owned value.
+    pub query: Option<Vec<(Cow<'a, BStr>, Cow<'a, BStr>)>>,
+    /// The decoded HTTP fragment without its leading `#`, preserving literal plus signs.
+    ///
+    /// `None` means no fragment delimiter was present, while `Some("")` represents an empty fragment.
+    pub fragment: Option<&'a BStr>,
+}
+
 /// A URL with support for specialized git related capabilities.
 ///
 /// Additionally, there is support for [deserialization](Url::from_bytes()) and [serialization](Url::to_bstring()).
@@ -195,6 +213,7 @@ pub struct Url {
     ///
     /// This type has no separate query or fragment fields. For HTTP and HTTPS, `?`, `#`, and everything after them are
     /// stored in this field. For other URL schemes, Git treats `?` and `#` before the first slash as authority text.
+    /// Use [`Self::path_query_fragment()`] to access the decoded path, query pairs, and fragment separately.
     ///
     /// For locations in the `<helper>::<address>` form of
     /// [`gitremote-helpers`](https://git-scm.com/docs/gitremote-helpers), this holds the address verbatim,
@@ -468,9 +487,142 @@ impl Url {
             .then_some(encoded.as_ref())
     }
 
-    /// Return the original percent-escaped path if [Self::path] wasn't changed in the meantime, or [`Self::path`] otherwise.
+    /// Return the original percent-escaped spelling of [`Self::path`] when it still matches the current path.
+    ///
+    /// Parsing decodes percent escapes into [`Self::path`], so `/my%20repo` becomes `/my repo`. This method
+    /// preserves the encoded spelling as long as decoding it produces the current path bytes. This compares
+    /// values, not mutation history: restoring the decoded path also restores access to its original spelling.
+    ///
+    /// If no encoded spelling was retained, or the current path differs, return [`Self::path`] as-is. This method
+    /// does not percent-encode a modified path; use [`Self::to_bstring()`] to serialize the complete URL.
+    /// Query and fragment components stored in the path are included; use
+    /// [`Self::path_query_fragment()`] to obtain the decoded path, query pairs, and fragment separately.
+    ///
+    /// ```
+    /// let mut url = gix_url::parse("https://host/my%20repo")?;
+    /// assert_eq!(url.path, "/my repo", "the public path contains decoded bytes");
+    /// assert_eq!(url.original_path(), "/my%20repo", "the original spelling is retained");
+    ///
+    /// url.path = "/other repo".into();
+    /// assert_eq!(url.original_path(), "/other repo", "a changed path is returned as-is");
+    /// assert_eq!(url.to_bstring(), "https://host/other%20repo", "HTTP serialization encodes spaces");
+    ///
+    /// url.path = "/my repo".into();
+    /// assert_eq!(url.original_path(), "/my%20repo", "restoring the path reuses the original spelling");
+    /// # Ok::<(), gix_url::parse::Error>(())
+    /// ```
     pub fn original_path(&self) -> &BStr {
         self.path_with_percent_escapes().unwrap_or(self.path.as_ref())
+    }
+
+    /// Return the decoded path, query name/value pairs, and fragment for HTTP and HTTPS.
+    ///
+    /// Component boundaries, query `&` separators, and the first `=` in each query pair are recognized before
+    /// percent-decoding. Encoded delimiters remain data: `?x=a%26b` yields one pair, `("x", "a&b")`.
+    /// Percent escapes are decoded exactly once, so `%2523` remains `%23`. Query names and values also use form
+    /// decoding, turning literal `+` into spaces; `%2B` remains `+`. Path and fragment plus signs remain literal.
+    ///
+    /// Paths supplied through [`Self::from_parts()`] or changed through [`Self::path`] are already decoded data:
+    /// percent escapes remain literal text, while literal delimiters and query plus signs retain their syntactic roles.
+    /// This agrees with parsing the serialized URL. An original escaped spelling is reused only while it still decodes
+    /// to the current path.
+    /// Empty HTTP paths return `/`, including when the URL only specifies a query or fragment after the host.
+    ///
+    /// Other schemes return [`Self::path`] unchanged with no query or fragment. In particular, SSH paths retain
+    /// literal `?` and `#`, URL-form SSH paths are already decoded, and SCP-style paths retain literal percent escapes.
+    /// Repository names and any `.git` suffix are preserved for the caller to interpret. Serialization is unchanged.
+    ///
+    /// ```
+    /// let url = gix_url::parse("https://host/repo%23one?x=a%26b#fragment%23one")?;
+    /// let parts = url.path_query_fragment();
+    /// assert_eq!(parts.path, "/repo#one");
+    /// let query = parts.query.expect("the URL has a query");
+    /// assert_eq!(query.len(), 1);
+    /// assert_eq!(query[0].0.as_ref(), "x");
+    /// assert_eq!(query[0].1.as_ref(), "a&b");
+    /// assert_eq!(parts.fragment, Some("fragment#one".into()));
+    /// assert_eq!(url.path, "/repo#one?x=a&b#fragment#one");
+    /// # Ok::<(), gix_url::parse::Error>(())
+    /// ```
+    pub fn path_query_fragment(&self) -> PathComponents<'_> {
+        fn decoded_len(original: &[u8], is_encoded: bool) -> usize {
+            if is_encoded {
+                percent_encoding::percent_decode(original).count()
+            } else {
+                original.len()
+            }
+        }
+
+        /// Advance over an original component while borrowing its already-decoded bytes.
+        fn take_decoded<'a>(original: &[u8], decoded: &mut &'a [u8], is_encoded: bool) -> &'a BStr {
+            let (part, rest) = decoded.split_at(decoded_len(original, is_encoded));
+            *decoded = rest;
+            BStr::new(part)
+        }
+
+        fn decode_query_component<'a>(original: &[u8], decoded: &'a BStr, is_encoded: bool) -> Cow<'a, BStr> {
+            if !original.contains(&b'+') {
+                return Cow::Borrowed(decoded);
+            }
+            let mut out = decoded.to_owned();
+            let mut offset = 0;
+            for part in original.split_inclusive(|byte| *byte == b'+') {
+                offset += decoded_len(part, is_encoded);
+                if part.ends_with(b"+") {
+                    out[offset - 1] = b' ';
+                }
+            }
+            Cow::Owned(out)
+        }
+
+        let mut parts = PathComponents {
+            path: self.path.as_ref(),
+            query: None,
+            fragment: None,
+        };
+        if !matches!(self.scheme, Scheme::Http | Scheme::Https) {
+            return parts;
+        }
+        let original = self.path_with_percent_escapes();
+        let is_encoded = original.is_some();
+        let mut original: &[u8] = original.unwrap_or(self.path.as_ref());
+        let mut decoded: &[u8] = self.path.as_ref();
+        let path_end = original.find_byteset(b"?#").unwrap_or(original.len());
+        parts.path = take_decoded(&original[..path_end], &mut decoded, is_encoded);
+        if parts.path.is_empty() {
+            parts.path = "/".into();
+        }
+        original = &original[path_end..];
+
+        if let Some(query_and_fragment) = original.strip_prefix(b"?") {
+            decoded = &decoded[1..];
+            let query_end = query_and_fragment.find_byte(b'#').unwrap_or(query_and_fragment.len());
+            original = &query_and_fragment[query_end..];
+            let mut pairs = Vec::new();
+            for (index, pair) in query_and_fragment[..query_end].split(|byte| *byte == b'&').enumerate() {
+                if index != 0 {
+                    decoded = &decoded[1..];
+                }
+                let mut decoded_pair: &[u8] = take_decoded(pair, &mut decoded, is_encoded);
+                if pair.is_empty() {
+                    continue;
+                }
+                let (name, value) = pair.split_at(pair.find_byte(b'=').unwrap_or(pair.len()));
+                let decoded_name = take_decoded(name, &mut decoded_pair, is_encoded);
+                let (value, decoded_value) = if value.is_empty() {
+                    (value, decoded_pair)
+                } else {
+                    (&value[1..], &decoded_pair[1..])
+                };
+                pairs.push((
+                    decode_query_component(name, decoded_name, is_encoded),
+                    decode_query_component(value, BStr::new(decoded_value), is_encoded),
+                ));
+            }
+            parts.query = Some(pairs);
+        }
+        parts.fragment = original.starts_with(b"#").then(|| BStr::new(&decoded[1..]));
+        parts
     }
 
     /// Return a slash-prefixed path if the bytes after the slash can't be mistaken for a command-line argument.

--- a/gix-url/tests/url/access.rs
+++ b/gix-url/tests/url/access.rs
@@ -34,6 +34,344 @@ mod canonicalized {
 
 use gix_url::ArgumentSafety;
 
+mod path_query_fragment {
+    use std::borrow::Cow;
+
+    use bstr::BStr;
+    use gix_url::{Scheme, Url};
+
+    fn borrowed_pairs<'a>(pairs: &'a [(Cow<'_, BStr>, Cow<'_, BStr>)]) -> Vec<(&'a BStr, &'a BStr)> {
+        pairs
+            .iter()
+            .map(|(name, value)| (name.as_ref(), value.as_ref()))
+            .collect()
+    }
+
+    fn str_pairs<'a>(pairs: &[(&'a str, &'a str)]) -> Vec<(&'a BStr, &'a BStr)> {
+        pairs
+            .iter()
+            .map(|&(name, value)| (BStr::new(name), BStr::new(value)))
+            .collect()
+    }
+
+    #[test]
+    fn http_delimiters_are_recognized_before_decoding() -> crate::Result {
+        for scheme in ["http", "https"] {
+            for (suffix, expected) in [
+                ("/repo%23one?query=value#fragment", "/repo#one"),
+                ("/repo%3Fone?query=value", "/repo?one"),
+                ("/repo%2523one", "/repo%23one"),
+                ("/repo%2523one?query=value", "/repo%23one"),
+                ("/repo%3fone#fragment?query=value", "/repo?one"),
+                ("/repo?query=%23value", "/repo"),
+                ("/repo#fragment", "/repo"),
+                ("/caf%C3%A9/%E2%98%83%23one?query=value", "/café/☃#one"),
+                ("/repo%2Fone+two?query=value", "/repo/one+two"),
+                ("/owner/example.github.io.git", "/owner/example.github.io.git"),
+                ("", "/"),
+                ("/", "/"),
+                ("?query=value#fragment", "/"),
+                ("#fragment?query=value", "/"),
+                ("?query=%23value", "/"),
+            ] {
+                let input = format!("{scheme}://host{suffix}");
+                let url = gix_url::parse(&input)?;
+                assert_eq!(
+                    url.path_query_fragment().path,
+                    expected,
+                    "only literal HTTP delimiters end the path, which is decoded once: {input}"
+                );
+                let serialized = if suffix.is_empty() {
+                    format!("{input}/")
+                } else {
+                    input.clone()
+                };
+                assert_eq!(
+                    url.to_bstring(),
+                    serialized,
+                    "serialization keeps the full URL: {input}"
+                );
+                assert_eq!(
+                    url.original_path(),
+                    if suffix.is_empty() { "/" } else { suffix },
+                    "the original path still includes query and fragment text: {input}"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn other_schemes_keep_their_stored_paths() -> crate::Result {
+        for (input, expected) in [
+            ("git@host:repo#one?two%23three", "repo#one?two%23three"),
+            ("ssh://git@host/repo%23one?two", "/repo#one?two"),
+            ("ssh://git@host/repo%2523one?two#three", "/repo%23one?two#three"),
+            ("ssh://git@host/~repo%23one?two", "~repo#one?two"),
+            ("git://host/repo%23one?two", "/repo#one?two"),
+            ("file:///repo#one?two%23three", "/repo#one?two%23three"),
+            ("./repo#one?two%23three", "./repo#one?two%23three"),
+            ("http::repo#one?two%23three", "repo#one?two%23three"),
+        ] {
+            let url = gix_url::parse(input)?;
+            let parts = url.path_query_fragment();
+            assert_eq!(
+                parts.path, expected,
+                "non-HTTP paths retain literal delimiters and their existing decoding rules: {input}"
+            );
+            assert!(parts.query.is_none(), "non-HTTP paths have no query: {input}");
+            assert!(parts.fragment.is_none(), "non-HTTP paths have no fragment: {input}");
+            assert_eq!(url.path, expected, "the public path is unchanged: {input}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn constructed_and_mutated_http_paths_are_already_decoded() -> crate::Result {
+        for scheme in [Scheme::Http, Scheme::Https] {
+            for (path, expected) in [
+                ("/repo%23one?query=value#fragment", "/repo%23one"),
+                ("/repo%3Fone#fragment", "/repo%3Fone"),
+                ("/repo%2523one", "/repo%2523one"),
+                ("/repo#one?new=query", "/repo"),
+                ("/café%23one?query=value", "/café%23one"),
+                ("", "/"),
+                ("?query=value", "/"),
+                ("#fragment", "/"),
+            ] {
+                let constructed = Url::from_parts(
+                    scheme.clone(),
+                    None,
+                    None,
+                    Some("host".into()),
+                    None,
+                    path.into(),
+                    false,
+                )?;
+                let mut mutated = gix_url::parse(format!("{scheme}://host/repo%23one?old=query"))?;
+                mutated.path = path.into();
+                for url in [constructed, mutated] {
+                    assert_eq!(
+                        url.path_query_fragment().path,
+                        expected,
+                        "caller-supplied paths keep literal percent escapes and ignore stale cached spelling: {path}"
+                    );
+                    assert_eq!(
+                        gix_url::parse(url.to_bstring())?.path_query_fragment(),
+                        url.path_query_fragment(),
+                        "decoded components agree with serialization: {path}"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn mutation_keeps_paths_byte_oriented_and_uses_the_current_scheme() -> crate::Result {
+        let mut url = gix_url::parse("https://host/repo%23one?query=value#fragment")?;
+        url.scheme = Scheme::Ssh;
+        assert_eq!(
+            url.path_query_fragment().path,
+            "/repo#one?query=value#fragment",
+            "changing to SSH makes all delimiters path data"
+        );
+        url.scheme = Scheme::Https;
+        assert_eq!(
+            url.path_query_fragment().path,
+            "/repo#one",
+            "unchanged parsed paths retain encoded delimiters when changing back to HTTP"
+        );
+        url.path = b"/repo\xff%23?na\xfe+me=va\xfd%26+lue#frag\xfc+%23".into();
+        let parts = url.path_query_fragment();
+        assert_eq!(
+            parts.path,
+            b"/repo\xff%23".as_slice(),
+            "mutated paths need neither UTF-8 conversion nor another percent-decoding pass"
+        );
+        let query = parts.query.expect("the query delimiter is present");
+        assert_eq!(query.len(), 1, "the query contains one name/value pair");
+        assert_eq!(
+            query[0].0.as_ref(),
+            b"na\xfe me".as_slice(),
+            "query names remain byte-oriented"
+        );
+        assert_eq!(
+            query[0].1.as_ref(),
+            b"va\xfd%26 lue".as_slice(),
+            "form decoding preserves arbitrary bytes and literal percent text"
+        );
+        assert_eq!(
+            parts.fragment,
+            Some(BStr::new(b"frag\xfc+%23")),
+            "fragments keep arbitrary bytes, plus signs, and caller-supplied percent text"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn query_pairs_and_fragments_are_split_before_decoding() -> crate::Result {
+        for scheme in ["http", "https"] {
+            for (suffix, path, query, fragment) in [
+                (
+                    "/repo%23one?x=a%26b&x=c%3Dd#frag%23one%3Ftwo",
+                    "/repo#one",
+                    &[("x", "a&b"), ("x", "c=d")][..],
+                    Some("frag#one?two"),
+                ),
+                (
+                    "/repo?key%26name%3Dpart=value%3Fone%23two&flag&empty=&=value#frag%2523",
+                    "/repo",
+                    &[
+                        ("key&name=part", "value?one#two"),
+                        ("flag", ""),
+                        ("empty", ""),
+                        ("", "value"),
+                    ][..],
+                    Some("frag%23"),
+                ),
+                (
+                    "/repo?x=%2526%253D%2523&x=a=b=c#%2523",
+                    "/repo",
+                    &[("x", "%26%3D%23"), ("x", "a=b=c")][..],
+                    Some("%23"),
+                ),
+                (
+                    "/repo+one?first+name=a+b&literal=%2B&mixed=+%2B%252B#fragment+%2B",
+                    "/repo+one",
+                    &[("first name", "a b"), ("literal", "+"), ("mixed", " +%2B")][..],
+                    Some("fragment++"),
+                ),
+                (
+                    "/caf%C3%A9?caf%C3%A9=%E2%98%83%26%3D#%F0%9F%A6%80",
+                    "/café",
+                    &[("café", "☃&=")][..],
+                    Some("🦀"),
+                ),
+                (
+                    "/repo?caf%C3%A9+%2B=%E2%98%83+%2B+#frag+%23",
+                    "/repo",
+                    &[("café +", "☃ + ")][..],
+                    Some("frag+#"),
+                ),
+                ("/repo?&&x=a&&x=b&", "/repo", &[("x", "a"), ("x", "b")][..], None),
+                (
+                    "/repo?x=?one?two#fragment?x=y#rest",
+                    "/repo",
+                    &[("x", "?one?two")][..],
+                    Some("fragment?x=y#rest"),
+                ),
+                ("?x=a%26b#frag", "/", &[("x", "a&b")][..], Some("frag")),
+                ("/repo?x=a;b=two", "/repo", &[("x", "a;b=two")][..], None),
+            ] {
+                let input = format!("{scheme}://host{suffix}");
+                let url = gix_url::parse(&input)?;
+                let gix_url::PathComponents {
+                    path: actual_path,
+                    query: pairs,
+                    fragment: actual_fragment,
+                } = url.path_query_fragment();
+                assert_eq!(actual_path, path, "query decoding does not change the path: {input}");
+                let pairs = pairs.expect("each input contains a query delimiter");
+                let actual = borrowed_pairs(&pairs);
+                let expected = str_pairs(query);
+                assert_eq!(
+                    actual, expected,
+                    "encoded separators remain data and duplicates retain their order: {input}"
+                );
+                assert_eq!(
+                    actual_fragment,
+                    fragment.map(BStr::new),
+                    "fragments are decoded once without form decoding: {input}"
+                );
+                assert_eq!(url.to_bstring(), input, "splitting preserves serialization: {input}");
+                assert_eq!(
+                    url.original_path(),
+                    suffix,
+                    "the original spelling remains available: {input}"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn empty_and_absent_components_remain_distinct() -> crate::Result {
+        for (suffix, has_query, fragment) in [
+            ("", false, None),
+            ("/repo", false, None),
+            ("/repo?", true, None),
+            ("/repo#", false, Some("")),
+            ("/repo?#", true, Some("")),
+            ("?&&", true, None),
+            ("#fragment?x=y", false, Some("fragment?x=y")),
+        ] {
+            let url = gix_url::parse(format!("https://host{suffix}"))?;
+            let parts = url.path_query_fragment();
+            assert_eq!(
+                parts.query.as_ref().map(Vec::len),
+                has_query.then_some(0),
+                "an explicit empty query is distinct from an absent query: {suffix}"
+            );
+            assert_eq!(
+                parts.fragment,
+                fragment.map(BStr::new),
+                "a question mark after the fragment delimiter does not start a query: {suffix}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn constructed_and_mutated_components_keep_literal_percent_escapes() -> crate::Result {
+        let path = "/repo%23one?x=a%26b&space=+%2B#frag%23+";
+        let constructed = Url::from_parts(Scheme::Https, None, None, Some("host".into()), None, path.into(), false)?;
+        let mut mutated = gix_url::parse("https://host/old%23repo?x=%26#old%23fragment")?;
+        mutated.path = path.into();
+        for url in [constructed, mutated] {
+            let parts = url.path_query_fragment();
+            assert_eq!(parts.path, "/repo%23one", "caller-supplied path escapes are literal");
+            let pairs = parts.query.as_ref().expect("the query delimiter is present");
+            let actual = borrowed_pairs(pairs);
+            assert_eq!(
+                actual,
+                str_pairs(&[("x", "a%26b"), ("space", " %2B")]),
+                "form decoding replaces literal plus signs without interpreting caller-supplied percent escapes"
+            );
+            assert_eq!(
+                parts.fragment,
+                Some(BStr::new("frag%23+")),
+                "fragment escapes remain literal"
+            );
+            assert_eq!(
+                gix_url::parse(url.to_bstring())?.path_query_fragment(),
+                parts,
+                "all components agree with serialization"
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_preserves_component_boundaries() -> crate::Result {
+        let mut mutated = gix_url::parse("https://host/old%23repo?x=%26#old%23fragment")?;
+        mutated.path = "/repo%23one?x=a%26b&space=+%2B#frag%23+".into();
+        for url in [
+            gix_url::parse("https://host/repo%23one?x=a%26b&space=+%2B#frag%23+")?,
+            mutated,
+        ] {
+            let restored: Url = serde_json::from_slice(&serde_json::to_vec(&url)?)?;
+            assert_eq!(
+                restored.path_query_fragment(),
+                url.path_query_fragment(),
+                "deserialization preserves valid cached boundaries and ignores stale cached spelling"
+            );
+        }
+        Ok(())
+    }
+}
+
 #[test]
 fn user() -> crate::Result {
     let mut url = gix_url::parse("https://user:password@host/path")?;


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-6`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

GitButler needs a repository path without HTTP query or fragment text, while preserving encoded path characters. Add `Url::path_without_query_and_fragment() -> &BStr`: `https://host/repo%23one?query=value#fragment` now exposes `/repo#one` through this accessor.

The method locates literal HTTP/HTTPS delimiters in the validated original spelling and borrows the corresponding decoded bytes from `Url::path`. Nested escapes are decoded once, empty HTTP paths return `/`, and constructed or mutated paths follow the existing serialization rules without decoding literal percent text again. Other schemes retain their stored path, including SSH delimiters and SCP-style percent escapes. The addition preserves `Url::path`, `original_path()`, serialization, and the Serde representation.

## GitButler example

In [`RemoteUrl::parse()`](https://github.com/gitbutlerapp/gitbutler/pull/15739), the scheme-dependent split-and-decode block can become:

```rust
let path = std::str::from_utf8(parsed.path_without_query_and_fragment()).ok()?;
let path = path.trim_matches('/');
let path = path.strip_suffix(".git").unwrap_or(path).to_owned();
```

Forge-specific owner/repository extraction and terminal `.git` stripping stay with GitButler; `example.github.io.git` remains intact in the accessor.

## Validation

Regressions were written first and reproduced the unwanted suffixes before the implementation. They cover both HTTP schemes, encoded delimiters, nested and multibyte escapes, empty paths, construction, stale cached spelling, scheme changes, arbitrary path bytes, SSH/SCP, and repository names containing `.git`.

- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix-url --features gix-testtools/sha1 --test url access::path_without_query_and_fragment` — 4 passed.
- `GIX_TEST_IGNORE_ARCHIVES=1 cargo test -p gix-url --features serde,gix-testtools/sha1` — 20 unit tests, 147 integration tests, and 2 doctests passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- `cargo clippy -p gix-url --all-targets --features serde,gix-testtools/sha1 -- -D warnings -A unknown-lints --no-deps` — passed; Rust 1.98.1 reports the workspace's existing removed-lint configuration warning.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p gix-url --features serde --no-deps` — passed.
- One `codex review --commit a90497beedd8f849c03ae9448ae7ad8ada81cfce` — no actionable defects.

## Git reference

Inspected `connect.c::parse_connect_url()` in `/Users/byron/dev/github.com/git/git` at `1630431f326e15fcde608827b5ff38422528eb59`. Its existing binary identifies as `2.55.0.windows.4.17.g15c6308cf7.dirty`; `fetch-pack --diag-url` confirms `/repo#one?two` for the SSH URL and `repo#one?two%23three` for SCP syntax, with nested escapes also decoded once. The standalone `url-parse -c path` returns `/repo` for these delimiter examples, so it was not used as the SSH transport oracle.

## Reported issue

<details>
<summary>User-provided report (verbatim)</summary>

```text
$issue-full-auto Improve gix-url’s path-access API for consumers identifying repositories from Git remote URLs.

Target repository: GitoxideLabs/gitoxide.
Downstream motivation: https://github.com/gitbutlerapp/gitbutler/pull/15739

GitButler’s RemoteUrl::parse() works around gix-url storing HTTP query and fragment text inside the decoded Url::path. It reads original_path(), splits off literal '?' and '#' delimiters, then percent-decodes the remaining path. This ordering preserves encoded path characters such as %23 and %3F. SSH paths require different handling because '?' and '#' are literal path characters.

Investigate the current implementation and add the smallest coherent public API for obtaining the decoded path without HTTP/HTTPS query or fragment components. Choose an appropriate name and document its scheme-specific behavior.

Prefer a non-breaking addition that preserves Url::path, original_path(), and serialization semantics. Breaking changes are acceptable if necessary to fix an underlying architectural issue; explain why and update affected callers together.

Requirements:
- Recognize HTTP query/fragment boundaries before percent-decoding.
- Decode exactly once, preserving nested escapes such as %2523 as literal %23.
- Preserve literal '?' and '#' in SSH paths, and literal percent escapes in SCP-style paths.
- Handle constructed and mutated URLs correctly. original_path() can fall back to already-decoded data, so blindly decoding its result is insufficient.
- Keep paths byte-oriented and reuse existing helpers and dependencies.
- Leave forge-specific owner/repository extraction and terminal '.git' stripping with consumers. gix-url already preserves '.git' within repository names.

Write regression tests before implementation, including:
- https://host/repo%23one?query=value#fragment → /repo#one
- https://host/repo%3Fone?query=value → /repo?one
- https://host/repo%2523one → /repo%23one
- git@host:repo#one?two%23three → repo#one?two%23three
- ssh://git@host/repo%23one?two → /repo#one?two
- https://host/owner/example.github.io.git → /owner/example.github.io.git

Also cover HTTP URLs without an explicit path, multibyte escapes, and construction/mutation behavior.

Inspect /Users/byron/dev/github.com/git/git as the Git reference. Distinguish SSH transport behavior in connect.c from the standalone git url-parse command; its output alone is insufficient for these delimiter cases.

Run focused tests and proportional repository checks. Follow issue-full-auto through commits, review, PR creation, and CI follow-up. Give every commit a substantive body explaining motivation, behavior, design choices, and actual validation. Include a short example in the PR showing how GitButler could replace its manual split-and-decode logic.
```

</details>

