### PR TITLE
fix(gix-config-value)!: expand `~` and `~user` like `git` does

### DIFF
--- a/gix-config-value/src/path.rs
+++ b/gix-config-value/src/path.rs
@@ -147,10 +147,10 @@ impl From<&str> for Path {
 impl Path {
     /// Interpolates this path into a path usable on the file system.
     ///
-    /// If this path starts with `~/` or `~user/` or `%(prefix)/`
-    ///  - `~/` is expanded to the value of `home_dir`. The caller can use the [dirs](https://crates.io/crates/dirs) crate to obtain it.
+    /// If this path starts with `~/` or `~` or `~user` or `%(prefix)/`
+    ///  - `~` or `~/` is expanded to the value of `home_dir`. The caller can use the [dirs](https://crates.io/crates/dirs) crate to obtain it.
     ///    If it is required but not set, an error is produced.
-    ///  - `~user/` to the specified user’s home directory, e.g `~alice` might get expanded to `/home/alice` on linux, but requires
+    ///  - `~user` or `~user/` to the specified user’s home directory, e.g `~alice` might get expanded to `/home/alice` on linux, but requires
     ///    the `home_for_user` function to be provided.
     ///    The interpolation uses `getpwnam` sys call and is therefore not available on windows.
     ///  - `%(prefix)/` is expanded to the location where `gitoxide` is installed.
@@ -186,15 +186,19 @@ impl Path {
                     }
                 })?;
             Ok(git_install_dir.join(path_without_trailing_slash))
-        } else if self.starts_with(USER_HOME) {
+        } else if self.as_bstr() == "~" || self.starts_with(USER_HOME) {
             let home_path = home_dir.ok_or(interpolate::Error::Missing { what: "home dir" })?;
-            let (_prefix, val) = self.split_at(USER_HOME.len());
-            let val = gix_path::try_from_byte_slice(val).map_err(|err| interpolate::Error::Utf8Conversion {
-                what: "path past ~/",
-                err,
-            })?;
-            Ok(home_path.join(val))
-        } else if self.starts_with(b"~") && self.contains(&b'/') {
+            if self.as_bstr() == "~" {
+                Ok(home_path.to_path_buf())
+            } else {
+                let (_prefix, val) = self.split_at(USER_HOME.len());
+                let val = gix_path::try_from_byte_slice(val).map_err(|err| interpolate::Error::Utf8Conversion {
+                    what: "path past ~/",
+                    err,
+                })?;
+                Ok(home_path.join(val))
+            }
+        } else if self.starts_with(b"~") {
             self.interpolate_user(home_for_user.ok_or(interpolate::Error::Missing {
                 what: "home for user lookup",
             })?)
@@ -210,21 +214,27 @@ impl Path {
 
     #[cfg(not(any(target_os = "windows", target_os = "android")))]
     fn interpolate_user(self, home_for_user: fn(&str) -> Option<PathBuf>) -> Result<PathBuf, interpolate::Error> {
-        let (_prefix, val) = self.split_at("/".len());
-        let i = val
-            .iter()
-            .position(|&e| e == b'/')
-            .ok_or(interpolate::Error::Missing { what: "/" })?;
-        let (username, path_with_leading_slash) = val.split_at(i);
+        let (_prefix, val) = self.split_at(1);
+        let (username, path_past_user) = match val.iter().position(|&e| e == b'/') {
+            Some(i) => {
+                let (username, path_with_slash) = val.split_at(i);
+                (username, Some(&path_with_slash[1..]))
+            }
+            None => (val, None),
+        };
         let username = std::str::from_utf8(username)?;
         let home = home_for_user(username).ok_or(interpolate::Error::Missing { what: "pwd user info" })?;
-        let path_past_user_prefix =
-            gix_path::try_from_byte_slice(&path_with_leading_slash["/".len()..]).map_err(|err| {
-                interpolate::Error::Utf8Conversion {
-                    what: "path past ~user/",
-                    err,
-                }
-            })?;
-        Ok(home.join(path_past_user_prefix))
+        match path_past_user {
+            Some(path_past_user) => {
+                let path_past_user_prefix = gix_path::try_from_byte_slice(path_past_user).map_err(|err| {
+                    interpolate::Error::Utf8Conversion {
+                        what: "path past ~user/",
+                        err,
+                    }
+                })?;
+                Ok(home.join(path_past_user_prefix))
+            }
+            None => Ok(home),
+        }
     }
 }

--- a/gix-config-value/src/path.rs
+++ b/gix-config-value/src/path.rs
@@ -15,7 +15,8 @@ pub mod interpolate {
         pub git_install_dir: Option<&'a std::path::Path>,
         /// The home directory of the current user. If `None`, `~/` in paths will cause an error.
         pub home_dir: Option<&'a std::path::Path>,
-        /// A function returning the home directory of a given user. If `None`, `~name/` in paths will cause an error.
+        /// A function returning the home directory of a given user.
+        /// If `None`, `~name` or `~name/` in paths will cause an error.
         pub home_for_user: Option<fn(&str) -> Option<PathBuf>>,
     }
 
@@ -43,13 +44,12 @@ pub mod interpolate {
         },
         #[error("Ill-formed UTF-8 in username")]
         UsernameConversion(#[from] std::str::Utf8Error),
-        #[error("User interpolation is not available on this platform")]
-        UserInterpolationUnsupported,
     }
 
     /// Obtain the home directory for the given user `name` or return `None` if the user wasn't found
     /// or any other error occurred.
     /// It can be used as `home_for_user` parameter in [`Path::interpolate()`][crate::Path::interpolate()].
+    /// Returns `None` on Windows, Android, and WebAssembly targets other than Emscripten.
     #[cfg_attr(windows, allow(unused_variables))]
     #[cfg_attr(all(target_family = "wasm", not(target_os = "emscripten")), allow(unused_variables))]
     pub fn home_for_user(name: &str) -> Option<PathBuf> {
@@ -152,7 +152,7 @@ impl Path {
     ///    If it is required but not set, an error is produced.
     ///  - `~user` or `~user/` to the specified user’s home directory, e.g `~alice` might get expanded to `/home/alice` on linux, but requires
     ///    the `home_for_user` function to be provided.
-    ///    The interpolation uses `getpwnam` sys call and is therefore not available on windows.
+    ///    The default lookup uses `getpwnam` where available.
     ///  - `%(prefix)/` is expanded to the location where `gitoxide` is installed.
     ///    This location is not known at compile time and therefore need to be
     ///    optionally provided by the caller through `git_install_dir`.
@@ -172,7 +172,6 @@ impl Path {
         }
 
         const PREFIX: &[u8] = b"%(prefix)/";
-        const USER_HOME: &[u8] = b"~/";
         if self.starts_with(PREFIX) {
             let git_install_dir = git_install_dir.ok_or(interpolate::Error::Missing {
                 what: "git install dir",
@@ -186,55 +185,46 @@ impl Path {
                     }
                 })?;
             Ok(git_install_dir.join(path_without_trailing_slash))
-        } else if self.as_bstr() == "~" || self.starts_with(USER_HOME) {
-            let home_path = home_dir.ok_or(interpolate::Error::Missing { what: "home dir" })?;
-            if self.as_bstr() == "~" {
-                Ok(home_path.to_path_buf())
+        } else if let Some(val) = self.strip_prefix(b"~") {
+            let (username, path) = match val.split_once_str(b"/") {
+                Some((username, path)) => (username, Some(path)),
+                None => (val, None),
+            };
+            let (mut home, what) = if username.is_empty() {
+                (
+                    home_dir
+                        .ok_or(interpolate::Error::Missing { what: "home dir" })?
+                        .to_path_buf(),
+                    "path past ~/",
+                )
             } else {
-                let (_prefix, val) = self.split_at(USER_HOME.len());
-                let val = gix_path::try_from_byte_slice(val).map_err(|err| interpolate::Error::Utf8Conversion {
-                    what: "path past ~/",
-                    err,
-                })?;
-                Ok(home_path.join(val))
+                (
+                    Self::home_for_username(
+                        username,
+                        home_for_user.ok_or(interpolate::Error::Missing {
+                            what: "home for user lookup",
+                        })?,
+                    )?,
+                    "path past ~user/",
+                )
+            };
+            if let Some(path) = path {
+                home.push(
+                    gix_path::try_from_byte_slice(path)
+                        .map_err(|err| interpolate::Error::Utf8Conversion { what, err })?,
+                );
             }
-        } else if self.starts_with(b"~") {
-            self.interpolate_user(home_for_user.ok_or(interpolate::Error::Missing {
-                what: "home for user lookup",
-            })?)
+            Ok(home)
         } else {
             Ok(gix_path::from_bstr(self.value.as_bstr()).into_owned())
         }
     }
 
-    #[cfg(any(target_os = "windows", target_os = "android"))]
-    fn interpolate_user(self, _home_for_user: fn(&str) -> Option<PathBuf>) -> Result<PathBuf, interpolate::Error> {
-        Err(interpolate::Error::UserInterpolationUnsupported)
-    }
-
-    #[cfg(not(any(target_os = "windows", target_os = "android")))]
-    fn interpolate_user(self, home_for_user: fn(&str) -> Option<PathBuf>) -> Result<PathBuf, interpolate::Error> {
-        let (_prefix, val) = self.split_at(1);
-        let (username, path_past_user) = match val.iter().position(|&e| e == b'/') {
-            Some(i) => {
-                let (username, path_with_slash) = val.split_at(i);
-                (username, Some(&path_with_slash[1..]))
-            }
-            None => (val, None),
-        };
+    fn home_for_username(
+        username: &[u8],
+        home_for_user: fn(&str) -> Option<PathBuf>,
+    ) -> Result<PathBuf, interpolate::Error> {
         let username = std::str::from_utf8(username)?;
-        let home = home_for_user(username).ok_or(interpolate::Error::Missing { what: "pwd user info" })?;
-        match path_past_user {
-            Some(path_past_user) => {
-                let path_past_user_prefix = gix_path::try_from_byte_slice(path_past_user).map_err(|err| {
-                    interpolate::Error::Utf8Conversion {
-                        what: "path past ~user/",
-                        err,
-                    }
-                })?;
-                Ok(home.join(path_past_user_prefix))
-            }
-            None => Ok(home),
-        }
+        home_for_user(username).ok_or(interpolate::Error::Missing { what: "pwd user info" })
     }
 }

--- a/gix-config-value/tests/value/path.rs
+++ b/gix-config-value/tests/value/path.rs
@@ -76,45 +76,37 @@ mod interpolate {
 
     #[test]
     fn tilde_slash_substitutes_current_user() -> crate::Result {
-        let path = "~/user/bar";
         let home = std::env::current_dir()?;
-        let expected = home.join("user").join("bar");
-        assert_eq!(
-            gix_config_value::Path::from(path)
-                .interpolate(path::interpolate::Context {
+        for suffix in ["", "user/bar", r"user\bar", "/user/bar"] {
+            let actual = gix_config_value::Path::from(format!("~/{suffix}").as_str()).interpolate(
+                path::interpolate::Context {
                     home_dir: Some(&home),
                     home_for_user: Some(home_for_user),
                     ..Default::default()
-                })
-                .unwrap(),
-            expected
-        );
+                },
+            )?;
+            assert_eq!(
+                actual.as_os_str(),
+                home.join(suffix).as_os_str(),
+                "tilde expansion preserves the suffix, including empty or leading-slash suffixes"
+            );
+        }
         Ok(())
     }
 
-    #[cfg(any(target_os = "windows", target_os = "android"))]
-    #[test]
-    fn tilde_with_given_user_is_unsupported_on_windows_and_android() {
-        assert!(matches!(
-            interpolate_without_context("~baz/foo/bar"),
-            Err(gix_config_value::path::interpolate::Error::UserInterpolationUnsupported)
-        ));
-        assert!(matches!(
-            interpolate_without_context("~baz"),
-            Err(gix_config_value::path::interpolate::Error::UserInterpolationUnsupported)
-        ));
-    }
-
-    #[cfg(not(any(target_os = "windows", target_os = "android")))]
     #[test]
     fn tilde_with_given_user() -> crate::Result {
         let home = std::env::current_dir()?;
 
         for path_suffix in &["foo/bar", r"foo\bar", ""] {
-            let path = format!("~user{}{}", std::path::MAIN_SEPARATOR, path_suffix);
+            let path = format!("~user/{path_suffix}");
             let expected = home.join("user").join(path_suffix);
 
-            assert_eq!(interpolate_without_context(path)?, expected);
+            assert_eq!(
+                interpolate_without_context(path)?.as_os_str(),
+                expected.as_os_str(),
+                "named-user expansion preserves the suffix, including a trailing slash"
+            );
         }
 
         assert_eq!(

--- a/gix-config-value/tests/value/path.rs
+++ b/gix-config-value/tests/value/path.rs
@@ -56,8 +56,21 @@ mod interpolate {
     }
 
     #[test]
-    fn tilde_alone_does_not_interpolate() -> crate::Result {
-        assert_eq!(interpolate_without_context("~")?, Path::new("~"));
+    fn tilde_alone_substitutes_current_user() -> crate::Result {
+        let home = std::env::current_dir()?;
+        assert_eq!(
+            gix_config_value::Path::from("~")
+                .interpolate(path::interpolate::Context {
+                    home_dir: Some(&home),
+                    ..Default::default()
+                })
+                .unwrap(),
+            home
+        );
+        assert!(matches!(
+            interpolate_without_context("~"),
+            Err(path::interpolate::Error::Missing { what: "home dir" })
+        ));
         Ok(())
     }
 
@@ -86,6 +99,10 @@ mod interpolate {
             interpolate_without_context("~baz/foo/bar"),
             Err(gix_config_value::path::interpolate::Error::UserInterpolationUnsupported)
         ));
+        assert!(matches!(
+            interpolate_without_context("~baz"),
+            Err(gix_config_value::path::interpolate::Error::UserInterpolationUnsupported)
+        ));
     }
 
     #[cfg(not(any(target_os = "windows", target_os = "android")))]
@@ -99,6 +116,20 @@ mod interpolate {
 
             assert_eq!(interpolate_without_context(path)?, expected);
         }
+
+        assert_eq!(
+            interpolate_without_context("~user")?,
+            home.join("user"),
+            "~user without trailing slash is expanded like git does"
+        );
+        assert!(matches!(
+            interpolate_without_context("~nonexistent"),
+            Err(path::interpolate::Error::Missing { what: "pwd user info" })
+        ));
+        assert!(matches!(
+            interpolate_without_context("~nonexistent/foo"),
+            Err(path::interpolate::Error::Missing { what: "pwd user info" })
+        ));
         Ok(())
     }
 
@@ -112,6 +143,9 @@ mod interpolate {
     }
 
     fn home_for_user(name: &str) -> Option<PathBuf> {
+        if name == "nonexistent" {
+            return None;
+        }
         std::env::current_dir().unwrap().join(name).into()
     }
 }

--- a/gix-config/src/file/includes/mod.rs
+++ b/gix-config/src/file/includes/mod.rs
@@ -312,9 +312,7 @@ fn check_interpolation_result(
     match res {
         Ok(good) => Ok(Some(good.into())),
         Err(err) => match err {
-            path::interpolate::Error::Missing { .. } | path::interpolate::Error::UserInterpolationUnsupported => {
-                Ok(None)
-            }
+            path::interpolate::Error::Missing { .. } => Ok(None),
             path::interpolate::Error::UsernameConversion(_) | path::interpolate::Error::Utf8Conversion { .. } => {
                 Err(err)
             }

--- a/gix-config/src/file/includes/mod.rs
+++ b/gix-config/src/file/includes/mod.rs
@@ -247,15 +247,13 @@ fn gitdir_matches(
     }
     let git_dir = gix_path::to_unix_separators_on_windows(gix_path::into_bstr(git_dir.ok_or(Error::MissingGitDir)?));
 
-    let mut pattern_path: BString = {
-        let path = match check_interpolation_result(
-            err_on_interpolation_failure,
-            crate::Path::from(condition_path.to_owned()).interpolate(context),
-        )? {
-            Some(p) => p,
-            None => return Ok(false),
-        };
-        gix_path::into_bstr(path).into_owned()
+    let mut pattern_path = match check_interpolation_result(
+        err_on_interpolation_failure,
+        crate::Path::from(condition_path.to_owned()).interpolate(context),
+    )? {
+        Some(path) => gix_path::into_bstr(path).into_owned(),
+        // Git keeps the original condition pattern when interpolation fails.
+        None => condition_path.to_owned(),
     };
     // NOTE: yes, only if we do path interpolation will the slashes be forced to unix separators on windows
     if pattern_path != condition_path {

--- a/gix-config/src/file/includes/types.rs
+++ b/gix-config/src/file/includes/types.rs
@@ -39,7 +39,8 @@ pub struct Options<'a> {
     pub err_on_max_depth_exceeded: bool,
     /// If true, default false, failing to interpolate paths will result in an error.
     ///
-    /// Interpolation also happens if paths in conditional includes can't be interpolated.
+    /// This also applies to paths in conditional include patterns. If false, patterns with missing
+    /// interpolation context or unknown users are matched unchanged, while such include paths are skipped.
     pub err_on_interpolation_failure: bool,
     /// If true, default true, configuration not originating from a path will cause errors when trying to resolve
     /// relative include paths (which would require the including configuration's path).

--- a/gix-config/tests/config/file/init/from_paths/includes/conditional/gitdir/mod.rs
+++ b/gix-config/tests/config/file/init/from_paths/includes/conditional/gitdir/mod.rs
@@ -31,6 +31,61 @@ fn tilde_slash_expands_the_current_user_home() -> crate::Result {
 }
 
 #[test]
+fn failed_user_expansion_matches_the_literal_pattern() -> crate::Result {
+    let temp = gix_testtools::tempfile::tempdir()?;
+    let name = format!(
+        "~gix-config-{}",
+        temp.path()
+            .file_name()
+            .expect("temporary directory has a name")
+            .to_string_lossy()
+    );
+    let git_dir = temp.path().join(&name);
+    super::git_init(&git_dir, true)?;
+    std::fs::write(git_dir.join("included.config"), "[section]\nvalue = included\n")?;
+    for condition in ["gitdir", "gitdir/i"] {
+        std::fs::write(
+            git_dir.join("config"),
+            format!(
+                r#"[core]
+bare = true
+[includeIf "{condition}:{name}"]
+path = included.config
+"#
+            ),
+        )?;
+        assert_eq!(
+            gix_testtools::git(&git_dir, "config --get section.value")?.trim_end(),
+            "included",
+            "Git matches the literal directory name when user expansion fails"
+        );
+        for strict in [false, true] {
+            let mut options = super::options_with_git_dir(&git_dir);
+            options.includes.interpolate.home_for_user = Some(|_| None);
+            options.includes.err_on_interpolation_failure = strict;
+            let result = gix_config::File::from_paths_metadata(
+                Some(gix_config::file::Metadata::try_from_path(
+                    git_dir.join("config"),
+                    gix_config::Source::Local,
+                )?),
+                options,
+            );
+            if strict {
+                assert!(result.is_err(), "strict mode still reports the failed lookup");
+            } else {
+                let config = result?.expect("the repository config exists");
+                assert_eq!(
+                    config.string("section.value"),
+                    Some(crate::file::bstring("included")),
+                    "{condition} preserves the original pattern when the user is unknown"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
 fn tilde_alone_does_not_match_even_if_home_is_git_directory() -> crate::Result {
     let env = GitEnv::repo_in_home()?;
     assert_section_value(Condition::new("gitdir:~").expect_original_value(), env)

--- a/gix/src/open/repository.rs
+++ b/gix/src/open/repository.rs
@@ -274,20 +274,22 @@ impl ThreadSafeRepository {
                 is_eligible_worktree_config_section(section, &git_dir, current_dir, &mut filter_config_section)
             })
             .ok()
-            .map(|(value, section)| (gix_config::Path::from(value), section.meta().source));
+            .map(|(value, section)| (value, section.meta().source));
         let worktree_from_environment = configured_worktree
             .as_ref()
             .is_some_and(|(_, source)| *source == gix_config::Source::EnvOverride);
         let may_use_configured_worktree = config.is_bare == Some(false) || worktree_from_environment;
 
         if let Some((worktree, source)) = configured_worktree.filter(|_| may_use_configured_worktree) {
-            let original = worktree.clone();
-            let worktree = worktree
-                .interpolate(interpolate_context(git_install_dir.as_deref(), home.as_deref()))
-                .map_err(|err| config::Error::PathInterpolation {
-                    path: original.value,
-                    source: err,
-                })?;
+            if worktree.is_empty() {
+                return Err(config::Error::PathInterpolation {
+                    path: worktree,
+                    source: gix_config::path::interpolate::Error::Missing { what: "path" },
+                }
+                .into());
+            }
+            // Git treats core.worktree as a literal path, without tilde or prefix interpolation.
+            let worktree = gix_path::from_bstr(worktree.as_bstr()).into_owned();
             let worktree = match source {
                 gix_config::Source::Env
                 | gix_config::Source::Cli

--- a/gix/tests/fixtures/generated-archives/.gitignore
+++ b/gix/tests/fixtures/generated-archives/.gitignore
@@ -32,6 +32,9 @@
 # clones to test relative-vs-absolute worktree resolution.
 /make_core_worktree_repo.tar
 /make_core_worktree_repo_sha256.tar
+# Generate these small worktree fixtures instead of storing their archives.
+/make_literal_worktree_paths.tar
+/make_literal_worktree_paths_sha256.tar
 # Writes `global.config`/`system.config` files whose absolute paths the test
 # injects via `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`; the path layout must
 # match the host running the test.

--- a/gix/tests/fixtures/make_literal_worktree_paths.sh
+++ b/gix/tests/fixtures/make_literal_worktree_paths.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# core.worktree is literal even when its value resembles a path interpolation.
+# Keep Git's baseline relative to each repository so the fixture can be relocated.
+i=0
+for path in '~' '~someone' '~/nested' '~someone/nested' '%(prefix)/nested'; do
+  i=$((i + 1))
+  repo="repo-$i"
+  git init -q "$repo"
+  mkdir -p "$repo/.git/$path"
+  git -C "$repo" config core.worktree "$path"
+  worktree=$(git -C "$repo" rev-parse --path-format=relative --show-toplevel)
+  printf '%s\t%s\n' "$repo" "$worktree" >>worktrees.baseline
+done

--- a/gix/tests/gix/repository/open.rs
+++ b/gix/tests/gix/repository/open.rs
@@ -40,6 +40,31 @@ fn discover_with_git_dir_environment_override_uses_it_and_sets_trust() -> crate:
 }
 
 #[test]
+fn core_worktree_paths_are_literal() -> crate::Result {
+    let fixture = gix_testtools::scripted_fixture_read_only("make_literal_worktree_paths.sh")?;
+    let baseline = std::fs::read_to_string(fixture.join("worktrees.baseline"))?;
+    for line in baseline.lines() {
+        let (repo, path) = line
+            .split_once('\t')
+            .expect("baseline contains repository and worktree paths");
+        let repo_path = fixture.join(repo);
+        // Canonicalize Windows short names as well as symlinks before comparing paths.
+        let expected = repo_path.join(path).canonicalize()?;
+        for home_permission in [gix_sec::Permission::Deny, gix_sec::Permission::Allow] {
+            let mut options = gix::open::Options::isolated();
+            options.permissions.env.home = home_permission;
+            let repo = gix::open_opts(&repo_path, options)?;
+            assert_eq!(
+                repo.workdir().expect("core.worktree is configured").canonicalize()?,
+                expected,
+                "{path} matches Git's literal worktree path regardless of home-directory access"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
 fn core_worktree_cli_override_does_not_override_bare() -> crate::Result {
     let fixture = gix_testtools::scripted_fixture_read_only("make_config_repos.sh")?;
     let worktree = gix_testtools::tempfile::TempDir::new()?;

--- a/tests/tools/src/lib.rs
+++ b/tests/tools/src/lib.rs
@@ -710,6 +710,7 @@ pub fn fixture_bytes(path: impl AsRef<Path>) -> Vec<u8> {
 /// the path is returned.
 ///
 /// Note that it persists and the script at `script_name` will only be executed once if it ran without error.
+/// Inherited `GIT_TEMPLATE_DIR` is cleared; Git's installed templates remain available.
 ///
 /// ### Automatic Archive Creation
 ///
@@ -1988,6 +1989,7 @@ fn configure_command<'a, I: IntoIterator<Item = S>, S: AsRef<OsStr>>(
         .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_TEMPLATE_DIR")
         .env_remove("GIT_ASKPASS")
         .env_remove("SSH_ASKPASS")
         .env("MSYS", msys_for_git_bash_on_windows)

--- a/tests/tools/src/tests.rs
+++ b/tests/tools/src/tests.rs
@@ -65,6 +65,25 @@ fn configure_command_clears_external_config() {
 }
 
 #[test]
+fn configure_command_clears_external_git_templates() -> Result {
+    let temp = tempfile::TempDir::new()?;
+    let template = temp.path().join("template");
+    std::fs::create_dir(&template)?;
+    std::fs::write(template.join("template-marker"), "external template")?;
+
+    let mut cmd = std::process::Command::new(gix_path::env::exe_invocation());
+    cmd.env("GIT_TEMPLATE_DIR", &template);
+    let output =
+        configure_command(&mut cmd, gix_hash::Kind::default(), ["init", "-q", "repo"], temp.path()).output()?;
+    assert!(output.status.success(), "git init succeeds: {output:?}");
+    assert!(
+        !temp.path().join("repo/.git/template-marker").exists(),
+        "external templates must not contribute files to fixture repositories"
+    );
+    Ok(())
+}
+
+#[test]
 fn an_absolute_selected_git_is_preferred_in_path() {
     let temp = tempfile::TempDir::new().expect("can create temp dir");
     let git = temp.path().join("bin").join("git");


### PR DESCRIPTION
Written with assistance from the Zed coding agent through @justonemorenight's account, per the identification rule in `CONTRIBUTING.md`.

Git expands `~` and `~user` paths via `interpolate_path()` in `path.c`. In `gix-config-value`, `Path::interpolate()` previously required a trailing slash for the current user (`~/`) and required a slash for named users (`self.starts_with(b"~") && self.contains(&b'/')`). Consequently:
- A standalone `~` was left unexpanded as a literal `"~"`.
- A standalone `~user` without a trailing slash was left unexpanded as a literal `"~user"`.
- A nonexistent user without a slash (`~nonexistent`) silently returned the literal instead of producing a user lookup error.

### Parity with Git

Recorded from `git -c t.k=<input> config --type=path t.k` on git 2.50.1:

| input | git | before | after |
|---|---|---|---|
| `~` | `/home/user` | `"~"` | `/home/user` |
| `~/` | `/home/user/` | `/home/user` | `/home/user` |
| `~/foo` | `/home/user/foo` | `/home/user/foo` | `/home/user/foo` |
| `~user` | `/home/user` | `"~user"` | `/home/user` |
| `~user/` | `/home/user/` | `/home/user` | `/home/user` |
| `~user/foo` | `/home/user/foo` | `/home/user/foo` | `/home/user/foo` |
| `~nonexistent` | error | `"~nonexistent"` | error |

### Changes
- Expand `~` to `home_dir` when standalone, matching `~/`.
- In `interpolate_user`, allow paths without `/` (e.g. `~user`) to expand directly to the user's home directory.
- Update `tests/value/path.rs`: replace `tilde_alone_does_not_interpolate` with `tilde_alone_substitutes_current_user`, and add tests for `~user` and missing user error cases.

Marked breaking (`!`): `~` and `~user` without trailing slashes now interpolate instead of returning literal strings.

### Verification
- `cargo test -p gix-config-value` (56 tests + 2 doctests pass)
- `cargo test -p gix-config` (366 tests pass)
- `cargo clippy -p gix-config-value` (clean)
- `cargo fmt --check` (clean)