### PR TITLE
fix(gix-config-value): expand ~user with no path after it

### DIFF
--- a/gix-config-value/src/path.rs
+++ b/gix-config-value/src/path.rs
@@ -194,7 +194,7 @@ impl Path {
                 err,
             })?;
             Ok(home_path.join(val))
-        } else if self.starts_with(b"~") && self.contains(&b'/') {
+        } else if self.starts_with(b"~") && self.len() > 1 {
             self.interpolate_user(home_for_user.ok_or(interpolate::Error::Missing {
                 what: "home for user lookup",
             })?)
@@ -210,14 +210,18 @@ impl Path {
 
     #[cfg(not(any(target_os = "windows", target_os = "android")))]
     fn interpolate_user(self, home_for_user: fn(&str) -> Option<PathBuf>) -> Result<PathBuf, interpolate::Error> {
-        let (_prefix, val) = self.split_at("/".len());
-        let i = val
-            .iter()
-            .position(|&e| e == b'/')
-            .ok_or(interpolate::Error::Missing { what: "/" })?;
-        let (username, path_with_leading_slash) = val.split_at(i);
+        let (_prefix, val) = self.split_at("~".len());
+        // `git` takes everything up to the first `/` as the user name, and the whole
+        // remainder when there is no `/` at all, so `~user` is that user's home.
+        let (username, path_with_leading_slash) = match val.iter().position(|&e| e == b'/') {
+            Some(i) => val.split_at(i),
+            None => (val, &[][..]),
+        };
         let username = std::str::from_utf8(username)?;
         let home = home_for_user(username).ok_or(interpolate::Error::Missing { what: "pwd user info" })?;
+        if path_with_leading_slash.is_empty() {
+            return Ok(home);
+        }
         let path_past_user_prefix =
             gix_path::try_from_byte_slice(&path_with_leading_slash["/".len()..]).map_err(|err| {
                 interpolate::Error::Utf8Conversion {

--- a/gix-config-value/tests/value/path.rs
+++ b/gix-config-value/tests/value/path.rs
@@ -102,6 +102,17 @@ mod interpolate {
         Ok(())
     }
 
+    #[cfg(not(any(target_os = "windows", target_os = "android")))]
+    #[test]
+    fn tilde_with_given_user_and_no_path() -> crate::Result {
+        // `git -c foo.bar='~root' config --type=path foo.bar` prints that user's home
+        // directory on git 2.50.1: everything past the `~` is the user name when there
+        // is no `/`, and no trailing slash is needed.
+        let home = std::env::current_dir()?;
+        assert_eq!(interpolate_without_context("~user")?, home.join("user"));
+        Ok(())
+    }
+
     fn interpolate_without_context(
         path: impl AsRef<str>,
     ) -> Result<PathBuf, gix_config_value::path::interpolate::Error> {


### PR DESCRIPTION
written by Claude Opus 5 in Claude Code, through Roshan's account, per the identification rule in CONTRIBUTING.md. he has not read the diff line by line yet.

third type in this crate after #2967 and #2980, same method: run the inputs through `git config --type=path` and diff.

on git 2.50.1, everything matched except the tilde with no `/` after it:

| input | git | before |
| --- | --- | --- |
| `~root` | that user's home | `~root`, unchanged |
| `~root/` | home, trailing slash kept | already right |
| `~root/x` | home joined with `x` | already right |
| `%(prefix)` | `%(prefix)`, unchanged | already right |
| `~nosuchuser/x` | error | already right |

`git` takes everything past the `~` as the user name when there is no `/`, so the fix is to stop requiring one. `interpolate_user` now takes the whole remainder as the name in that case and returns the home directory as-is.

one thing i deliberately did not change, because it looks like your decision rather than an oversight. `git` also expands a bare `~` to the home directory, and this crate returns it unchanged, which `tilde_alone_does_not_interpolate` asserts. that test goes through `interpolate_without_context`, so what it really pins is `~` with no `home_dir` in the `Context`, where returning the literal is a reasonable lenience and erroring would be the alternative. note `~/x` does error there, so the two are inconsistent today. happy to make `~` expand whenever `home_dir` is set and keep the literal when it is not, which would close the gap without touching that test, if that is the behaviour you want.

`cargo test -p gix-config-value` is 59 passing. reverting only `src/path.rs` fails exactly the new test. `cargo fmt` applied; clippy reports only the pre-existing removed-lint warning the workspace emits.
