### PR TITLE
Diff parity fixes

### DIFF
--- a/gix-imara-diff/src/myers/preprocess.rs
+++ b/gix-imara-diff/src/myers/preprocess.rs
@@ -218,8 +218,14 @@ mod tests {
             token_status[pos + 1..=pos + after].fill(Occurrences::None);
             should_prune_common_line(&token_status, pos)
         };
-        assert!(!run(3, 3));
-        assert!(run(3, 4));
+        assert!(
+            !run(3, 3),
+            "six unmatched lines must keep the candidate: counting it twice gives `6 > 3 * 2`, which is false"
+        );
+        assert!(
+            run(3, 4),
+            "seven unmatched lines must prune the candidate: counting it twice gives `7 > 3 * 2`, which is true"
+        );
     }
 
     #[test]
@@ -232,9 +238,15 @@ mod tests {
         token_status[pos..pos + 25].fill(Occurrences::Common);
         token_status[pos + 25..=pos + 100].fill(Occurrences::None);
 
-        assert!(should_prune_common_line(&token_status, pos));
+        assert!(
+            should_prune_common_line(&token_status, pos),
+            "the unmatched line 100 positions after the candidate must be counted to exceed the pruning threshold"
+        );
 
         token_status[pos + 100] = Occurrences::Some;
-        assert!(!should_prune_common_line(&token_status, pos));
+        assert!(
+            !should_prune_common_line(&token_status, pos),
+            "without the hundredth unmatched line, the candidate must stay at the threshold and be kept"
+        );
     }
 }

--- a/gix-imara-diff/src/myers/preprocess.rs
+++ b/gix-imara-diff/src/myers/preprocess.rs
@@ -133,8 +133,13 @@ fn prune_unmatched_tokens(
 fn should_prune_common_line(token_status: &[Occurrences], pos: usize) -> bool {
     const WINDOW_SIZE: usize = 100;
 
+    // Git's `xdl_clean_mmatch` starts both `rpdis0` and `rpdis1` at 1 and sums them,
+    // so the line under test is counted twice. Here, the backward scan stops just
+    // before the candidate so we initialize the count to 1 to account for it. In the
+    // forward scan we'll start from the candidate line and count it there, leaving a
+    // count of 2; matching `xdl_clean_mmatch`'s behavior.
     let mut unmatched_before = 0;
-    let mut common_before = 0;
+    let mut common_before = 1;
 
     let start = pos.saturating_sub(WINDOW_SIZE);
     for status in token_status[start..pos].iter().rev() {
@@ -153,7 +158,10 @@ fn should_prune_common_line(token_status: &[Occurrences], pos: usize) -> bool {
         return false;
     }
 
-    let end = token_status.len().min(pos + WINDOW_SIZE);
+    // The candidate line gets walked over and counted in this scan so the
+    // count starts at 0 here. We also make sure to walk a full `WINDOW_SIZE`
+    // lines after the candidate and not just walk `WINDOW_SIZE` in total.
+    let end = token_status.len().min(pos + WINDOW_SIZE + 1);
     let mut unmatched_after = 0;
     let mut common_after = 0;
     for status in token_status[pos..end].iter() {
@@ -195,5 +203,38 @@ mod tests {
             !should_prune_common_line(&token_status, 500),
             "only the last 100 items before the current line should contribute to the backward scan"
         );
+    }
+
+    #[test]
+    fn candidate_line_counts_exactly_twice() {
+        // `xdl_clean_mmatch` starts both frequent-line counters at 1 and sums them, so the
+        // line under test contributes 2 and six unmatched lines around it is the boundary:
+        // `6 > 3 * 2` is false and git keeps the line, seven discards it.
+        let run = |before: usize, after: usize| {
+            let mut token_status = vec![Occurrences::Some; 40];
+            let pos = 20;
+            token_status[pos - before..pos].fill(Occurrences::None);
+            token_status[pos] = Occurrences::Common;
+            token_status[pos + 1..=pos + after].fill(Occurrences::None);
+            should_prune_common_line(&token_status, pos)
+        };
+        assert!(!run(3, 3));
+        assert!(run(3, 4));
+    }
+
+    #[test]
+    fn forward_scan_reaches_a_hundred_lines_past_the_candidate() {
+        // git's forward scan runs while `(i + r) <= i + XDL_SIMSCAN_WINDOW`, covering the
+        // 100 lines after the candidate. Here the hundredth is what tips the ratio.
+        let pos = 120;
+        let mut token_status = vec![Occurrences::Some; 300];
+        token_status[pos - 3..pos].fill(Occurrences::None);
+        token_status[pos..pos + 25].fill(Occurrences::Common);
+        token_status[pos + 25..=pos + 100].fill(Occurrences::None);
+
+        assert!(should_prune_common_line(&token_status, pos));
+
+        token_status[pos + 100] = Occurrences::Some;
+        assert!(!should_prune_common_line(&token_status, pos));
     }
 }

--- a/gix-imara-diff/src/slider_heuristic.rs
+++ b/gix-imara-diff/src/slider_heuristic.rs
@@ -195,6 +195,8 @@ pub struct Indents {
     leading_blanks: u8,
     /// The number of blank lines after the line following the current position.
     trailing_blanks: u8,
+    /// Whether the split sits past the last line of the file.
+    at_eof: bool,
 }
 
 /// Maximum number of consecutive blank lines to consider when computing indentation context.
@@ -238,7 +240,7 @@ impl Indents {
                         }
                     }
                 })
-                .unwrap_or((token_idx, IndentLevel::BLANK))
+                .unwrap_or((tokens.len() - token_idx - 1, IndentLevel::BLANK))
         };
         let indent = tokens
             .get(token_idx)
@@ -249,6 +251,7 @@ impl Indents {
             next_indent: indent_next_line,
             leading_blanks: leading_blank_lines as u8,
             trailing_blanks: trailing_blank_lines as u8,
+            at_eof,
         }
     }
 
@@ -257,7 +260,7 @@ impl Indents {
         if self.prev_indent == IndentLevel::BLANK && self.leading_blanks == 0 {
             penalty += START_OF_FILE_PENALTY;
         }
-        if self.next_indent == IndentLevel::BLANK && self.trailing_blanks == 0 {
+        if self.at_eof {
             penalty += END_OF_FILE_PENALTY;
         }
 
@@ -375,7 +378,31 @@ impl Score {
 
 #[cfg(test)]
 mod tests {
-    use super::IndentLevel;
+    use super::{IndentLevel, Indents};
+    use crate::intern::Token;
+
+    #[test]
+    fn trailing_blanks_are_counted_not_positioned() {
+        // Everything after the split is blank so there are no indents to find. git's
+        // measure_split leaves `post_blank` set to the number of blank lines it walked
+        // over, which is 3 here. Reporting the split's position instead provides an
+        // incorrect score.
+        const BLANK: Token = Token(0);
+        const CODE: Token = Token(1);
+        let indent = |token: Token| {
+            if token == BLANK {
+                IndentLevel::BLANK
+            } else {
+                IndentLevel(0)
+            }
+        };
+
+        let mut tokens = vec![CODE; 300];
+        tokens.extend([BLANK; 3]);
+        let split = tokens.len() - 4;
+        let indents = Indents::at_token(&tokens, split, indent);
+        assert_eq!(indents.trailing_blanks, 3);
+    }
 
     #[test]
     fn ascii_indent_clamps_before_overflow() {

--- a/gix-imara-diff/src/tests.rs
+++ b/gix-imara-diff/src/tests.rs
@@ -68,49 +68,6 @@ fn myers_is_odd() {
     );
 }
 
-/// Check for parity with Git at frequent-line detection. Even though the line being checked is
-/// frequent, it is not discarded because it is bounded by unmatched runs that are short, which
-/// is offset by Git counting the line twice. Counting it only once would cause it to be discarded.
-#[test]
-fn a_frequent_line_between_short_unmatched_runs_is_kept() {
-    fn file(tag: &str) -> String {
-        // The first and last lines differ so that stripping the common prefix and postfix leaves
-        // the blank lines in the region, which is what makes an empty line frequent here. The
-        // unmatched runs are bounded by non-blank shared lines, so nothing else inside them is.
-        let mut out = format!("first line, {tag}\n");
-        for i in 0..8 {
-            out.push_str(&format!("shared line {i}\n\n"));
-        }
-        out.push_str("anchor above\n");
-        for i in 0..3 {
-            out.push_str(&format!("only in {tag} {i}\n"));
-        }
-        out.push('\n');
-        for i in 3..6 {
-            out.push_str(&format!("only in {tag} {i}\n"));
-        }
-        out.push_str("anchor below\n");
-        for i in 8..16 {
-            out.push_str(&format!("shared line {i}\n\n"));
-        }
-        out.push_str(&format!("last line, {tag}\n"));
-        out
-    }
-
-    let (before, after) = (file("old"), file("new"));
-    let input = InternedInput::new(before.as_str(), after.as_str());
-    let diff = Diff::compute(Algorithm::Myers, &input);
-    let changed = diff.hunks().fold((0, 0), |(removed, inserted), hunk| {
-        (removed + hunk.before.len(), inserted + hunk.after.len())
-    });
-    // `git diff --no-index --numstat` reports 8 and 8 for these two files.
-    assert_eq!(
-        changed,
-        (8, 8),
-        "the blank line between the two unmatched runs should still be matched"
-    );
-}
-
 /// The frequency limit above which a line becomes a candidate for discarding comes from git's
 /// `xdl_bogosqrt`, which rounds the halved bit count up. Rounding down halves the limit for every
 /// odd bit length, so lines git considers ordinary are treated as too frequent to match.

--- a/gix-imara-diff/src/tests.rs
+++ b/gix-imara-diff/src/tests.rs
@@ -66,3 +66,46 @@ fn myers_is_odd() {
             .to_string(),
     );
 }
+
+/// Check for parity with Git at frequent-line detection. Even though the line being checked is
+/// frequent, it is not discarded because it is bounded by unmatched runs that are short, which
+/// is offset by Git counting the line twice. Counting it only once would cause it to be discarded.
+#[test]
+fn a_frequent_line_between_short_unmatched_runs_is_kept() {
+    fn file(tag: &str) -> String {
+        // The first and last lines differ so that stripping the common prefix and postfix leaves
+        // the blank lines in the region, which is what makes an empty line frequent here. The
+        // unmatched runs are bounded by non-blank shared lines, so nothing else inside them is.
+        let mut out = format!("first line, {tag}\n");
+        for i in 0..8 {
+            out.push_str(&format!("shared line {i}\n\n"));
+        }
+        out.push_str("anchor above\n");
+        for i in 0..3 {
+            out.push_str(&format!("only in {tag} {i}\n"));
+        }
+        out.push('\n');
+        for i in 3..6 {
+            out.push_str(&format!("only in {tag} {i}\n"));
+        }
+        out.push_str("anchor below\n");
+        for i in 8..16 {
+            out.push_str(&format!("shared line {i}\n\n"));
+        }
+        out.push_str(&format!("last line, {tag}\n"));
+        out
+    }
+
+    let (before, after) = (file("old"), file("new"));
+    let input = InternedInput::new(before.as_str(), after.as_str());
+    let diff = Diff::compute(Algorithm::Myers, &input);
+    let changed = diff.hunks().fold((0, 0), |(removed, inserted), hunk| {
+        (removed + hunk.before.len(), inserted + hunk.after.len())
+    });
+    // `git diff --no-index --numstat` reports 8 and 8 for these two files.
+    assert_eq!(
+        changed,
+        (8, 8),
+        "the blank line between the two unmatched runs should still be matched"
+    );
+}

--- a/gix-imara-diff/src/tests.rs
+++ b/gix-imara-diff/src/tests.rs
@@ -1,3 +1,4 @@
+use crate::util::sqrt;
 use crate::{Algorithm, BasicLineDiffPrinter, Diff, InternedInput, UnifiedDiffConfig};
 use expect_test::expect;
 
@@ -108,4 +109,47 @@ fn a_frequent_line_between_short_unmatched_runs_is_kept() {
         (8, 8),
         "the blank line between the two unmatched runs should still be matched"
     );
+}
+
+/// The frequency limit above which a line becomes a candidate for discarding comes from git's
+/// `xdl_bogosqrt`, which rounds the halved bit count up. Rounding down halves the limit for every
+/// odd bit length, so lines git considers ordinary are treated as too frequent to match.
+#[test]
+fn the_frequency_limit_rounds_the_way_git_rounds() {
+    // `xdl_bogosqrt`: for (i = 1; n > 0; n >>= 2) i <<= 1;
+    fn bogosqrt(mut n: usize) -> u32 {
+        let mut i = 1u32;
+        while n > 0 {
+            n >>= 2;
+            i <<= 1;
+        }
+        i
+    }
+
+    // Test that sqrt matches git's bogosqrt for typical values
+    // and values near the top of the `usize` range
+    let mut inputs = vec![0, 1, 2, 3, 4, 16, 24, 69, 277, 345, 450, 1000, 4096, 65_535];
+    if usize::BITS >= 4 {
+        let hi = 1usize << (usize::BITS - 3);
+        inputs.extend([hi - 1, hi]);
+    }
+    for n in inputs {
+        assert_eq!(sqrt(n), bogosqrt(n), "at {n}");
+    }
+
+    // On 64-bit platforms we have to clamp to `u32::MAX`
+    // when the input is >= `1 << 62` to avoid overflow.
+    let edge_inputs = [usize::MAX, 1 << (usize::BITS - 1), 1 << (usize::BITS - 2)];
+    if usize::BITS >= 64 {
+        for n in edge_inputs {
+            assert_eq!(sqrt(n), u32::MAX, "at {n}");
+        }
+    }
+    // On platforms with smaller word sizes these values
+    // should still be at parity with bogosqrt.
+    else {
+        for n in edge_inputs {
+            assert_eq!(sqrt(n), bogosqrt(n), "at {n}");
+        }
+    }
 }

--- a/gix-imara-diff/src/util.rs
+++ b/gix-imara-diff/src/util.rs
@@ -52,9 +52,18 @@ pub fn strip_common_postfix(file1: &mut &[Token], file2: &mut &[Token]) -> u32 {
 }
 
 /// Computes an approximation of the square root using bit operations.
+/// This returns a u32 instead of a u64 like `xdl_bogosqrt` does, so
+/// when `val` has >=63 significant bits the result clamps to `u32::MAX`
+/// to avoid an overflow.
 pub fn sqrt(val: usize) -> u32 {
-    let nbits = (usize::BITS - val.leading_zeros()) / 2;
-    1 << nbits
+    // git's xdl_bogosqrt shifts `n` right by two per doubling and stops
+    // once it reaches zero, which rounds the halved bit count up:
+    //
+    //     for (i = 1; n > 0; n >>= 2) i <<= 1;
+    //
+    // Take the ceiling here to avoid the integer division rounding down.
+    let nbits = (usize::BITS - val.leading_zeros()).div_ceil(2);
+    1u32.checked_shl(nbits).unwrap_or(u32::MAX)
 }
 
 impl Hunk {

--- a/gix-imara-diff/tests/integration/main.rs
+++ b/gix-imara-diff/tests/integration/main.rs
@@ -667,3 +667,81 @@ fn postprocess() {
         .assert_eq(&diff);
     }
 }
+
+/// Check for parity with Git at frequent-line detection. Even though the line being checked is
+/// frequent, it is not discarded because it is bounded by unmatched runs that are short, which
+/// is offset by Git counting the line twice. Counting it only once would cause it to be discarded.
+#[test]
+fn a_frequent_line_between_short_unmatched_runs_is_kept() {
+    fn file(tag: &str) -> String {
+        // The first and last lines differ so that stripping the common prefix and postfix leaves
+        // the blank lines in the region, which is what makes an empty line frequent here. The
+        // unmatched runs are bounded by non-blank shared lines, so nothing else inside them is.
+        let mut out = format!("first line, {tag}\n");
+        for i in 0..8 {
+            out.push_str(&format!("shared line {i}\n\n"));
+        }
+        out.push_str("anchor above\n");
+        for i in 0..3 {
+            out.push_str(&format!("only in {tag} {i}\n"));
+        }
+        out.push('\n');
+        for i in 3..6 {
+            out.push_str(&format!("only in {tag} {i}\n"));
+        }
+        out.push_str("anchor below\n");
+        for i in 8..16 {
+            out.push_str(&format!("shared line {i}\n\n"));
+        }
+        out.push_str(&format!("last line, {tag}\n"));
+        out
+    }
+
+    let (before, after) = (file("old"), file("new"));
+    let input = InternedInput::new(before.as_str(), after.as_str());
+    let diff = Diff::compute(Algorithm::Myers, &input);
+    let changed = diff.hunks().fold((0, 0), |(removed, inserted), hunk| {
+        (removed + hunk.before.len(), inserted + hunk.after.len())
+    });
+    assert_eq!(
+        changed,
+        (8, 8),
+        "the blank line between the two unmatched runs should still be matched, just like `git diff --no-index --numstat`"
+    );
+}
+
+#[test]
+fn a_repeated_line_below_gits_frequency_limit_is_kept() {
+    // These 19 lines give Git's `xdl_bogosqrt` a frequency limit of 8; rounding
+    // down gives 4 and incorrectly treats the four blank lines as frequent.
+    // Eight unmatched lines surround the last blank, so it would then be pruned.
+    // Different first and last lines prevent common-edge stripping.
+    let before = "old start
+a
+
+b
+
+c
+
+anchor above
+old 0
+old 1
+old 2
+old 3
+
+old 4
+old 5
+old 6
+old 7
+anchor below
+old end
+";
+    let after = before.replace("old", "new");
+    let input = InternedInput::new(before, after.as_str());
+    let diff = Diff::compute(Algorithm::Myers, &input);
+    assert_eq!(
+        (diff.count_removals(), diff.count_additions()),
+        (10, 10),
+        "the blank line between the unmatched runs should still be matched, just like `git diff --no-index --numstat`"
+    );
+}


### PR DESCRIPTION
## Fix 3 parity issues between gitoxide and git diffs

I found three places where gitoxide's Myers implementation differs from Git's C implementation:

- `should_prune_common_line` undercounts candidate lines and scans one less following line.
- `sqrt` rounds bit-counts down while git's `xdl_bogosqrt` rounds them up.
  - Additionally, when an input's high bit is set on a 64-bit platform bogosqrt returns 2^32 but `sqrt` either panics (in debug) or returns 0 (in release).
- Inaccurate tracking of the end of file position and trailing blanks in `at_token`.

I've put them into a single PR assuming that would be easiest for review, but if you'd prefer them to be split just let me know.

## More complete explanations

(Samples taken from git commit `3cb9185f65`)

### 1. Candidate count and forward window in `should_prune_common_line`

From `xdiff/xprepare.c`:

```c
for (r = 1, rdis0 = 0, rpdis0 = 1; (i - r) >= s; r++) {
...
if (rdis0 == 0)
        return 0;
for (r = 1, rdis1 = 0, rpdis1 = 1; (i + r) <= e; r++) {
...
rdis1 += rdis0;
rpdis1 += rpdis0;
return rpdis1 * XDL_KPDIS_RUN < (rpdis1 + rdis1);
```

Both `rpdis` counters start at 1 and neither loop visits index `i`, so the candidate contributes exactly 2. The current gitoxide implementation only counts it in the forward scan, leading to a count of 1.

Git also caps `e` at `i + XDL_SIMSCAN_WINDOW`, then scans from `i + 1` while `i + r <= e`. That covers 100 lines after the candidate. The Rust scan starts at the candidate itself, but its exclusive end was `pos + WINDOW_SIZE`, so it only covered 99 lines after it. Extending the end by one makes the windows match.

---

### 2. The sqrt approximation rounds down instead of up as in `xdl_bogosqrt`

From `xdiff/xutils.c:24-34`:

```c
uint64_t xdl_bogosqrt(uint64_t n) {
  uint64_t i;
  /* Classical integer square root approximation using shifts. */
  for (i = 1; n > 0; n >>= 2)
    i <<= 1;
  return i;
}
```

`i` doubles once per iteration and the loop runs `ceil(bit_length(n) / 2)` times, so the result is `1 << ceil(bit_length(n)/2)`. `gix-imara-diff`'s `sqrt` function does a single integer division of `bit_length(n)` by 2, so its result is `1 << floor(bit_length(n) / 2)`.

---

### 2b. Overflow starting at 2^63 (2^62 with the `floor` -> `ceil` change from above)

This is unrealistic to hit in practice, but it doesn't cost much to improve. If it's not wanted and the other changes are I'd be happy to remove it. 

With a 64-bit input the result of `sqrt`/`bogosqrt` is `1 << 32`; a 33-bit integer that `bogosqrt` can safely represent because it returns `uint64_t`s. Currently `sqrt` overflows which panics in debug mode and returns 0 in release. There are no great options for handling this, but I think the one that's most pragmatic is to saturate to u32::MAX which avoids changing to a u64 return type, avoids panics in debug, and makes the difference because the two implementations 1 instead of (2^32)+1 in release.

---

### 3. Inaccurate tracking of the end of file position and trailing blanks in `at_token`

Two pieces of `xdiff/xdiffi.c`. `measure_split`:

```c
if (split >= (long)xdf->nrec) {
        m->end_of_file = 1;
        m->indent = -1;
} else {
        m->end_of_file = 0;
        m->indent = get_indent(&xdf->recs[split]);
}
...
m->post_blank = 0;
m->post_indent = -1;
for (i = split + 1; i < (long)xdf->nrec; i++) {
        m->post_indent = get_indent(&xdf->recs[i]);
        if (m->post_indent != -1)
                break;
        m->post_blank += 1;
        if (m->post_blank == MAX_BLANKS) {
                m->post_indent = 0;
                break;
        }
}
```

`end_of_file` is set from the position alone, and `post_blank` is only ever incremented when walking blank lines; it's never assigned the index. When the loop runs off the end, `post_blank` is `nrec - split - 1`.

And `score_add_split`:

```c
if (m->pre_indent == -1 && m->pre_blank == 0)
        s->penalty += START_OF_FILE_PENALTY;

if (m->end_of_file)
        s->penalty += END_OF_FILE_PENALTY;

post_blank = (m->indent == -1) ? 1 + m->post_blank : 0;
```

The flag is the only input to `END_OF_FILE_PENALTY` and nothing is inferred from indent content. `MAX_BLANKS` is 20 at line 404, matching the Rust constant. The `at_eof` path in Rust returns `(0, BLANK)`, which is what git's loop ends at when `split >= nrec`.
