### PR TITLE
fix(gix-object): omit the final newline from bodyless commit titles

### DIFF
--- a/gix-object/src/commit/message/decode.rs
+++ b/gix-object/src/commit/message/decode.rs
@@ -12,7 +12,11 @@ pub fn message_title_and_body(input: &[u8]) -> (&BStr, Option<&BStr>) {
         }
         pos += 1;
     }
-    (input.as_bstr(), None)
+    let title = input
+        .strip_suffix(b"\r\n")
+        .or_else(|| input.strip_suffix(b"\n"))
+        .unwrap_or(input);
+    (title.as_bstr(), None)
 }
 
 fn newline_len(input: &[u8]) -> Option<usize> {

--- a/gix-object/src/commit/mod.rs
+++ b/gix-object/src/commit/mod.rs
@@ -29,6 +29,7 @@ pub mod message;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MessageRef<'a> {
     /// The title of the commit, as separated from the body with two consecutive newlines. The newlines are not included.
+    /// Without a body separator, a final LF or CRLF is also excluded. All other whitespace is preserved.
     #[cfg_attr(feature = "serde", serde(borrow))]
     pub title: &'a BStr,
     /// All bytes not consumed by the title, excluding the separating newlines.

--- a/gix-object/tests/object/commit/message.rs
+++ b/gix-object/tests/object/commit/message.rs
@@ -41,29 +41,57 @@ fn title_and_body_inconsistent_newlines() {
 }
 
 #[test]
-fn only_title_trailing_newline_is_retained() {
+fn only_title_trailing_newline_is_removed() {
     let msg = MessageRef::from_bytes(b"hello there\n");
     assert_eq!(
         msg,
         MessageRef {
-            title: b"hello there\n".as_bstr(),
+            title: b"hello there".as_bstr(),
             body: None
-        }
+        },
+        "a bodyless title excludes its final LF"
     );
     assert_eq!(msg.summary().as_ref(), "hello there");
 }
 
 #[test]
-fn only_title_trailing_windows_newline_is_retained() {
+fn only_title_trailing_windows_newline_is_removed() {
     let msg = MessageRef::from_bytes(b"hello there\r\n");
     assert_eq!(
         msg,
         MessageRef {
-            title: b"hello there\r\n".as_bstr(),
+            title: b"hello there".as_bstr(),
             body: None
-        }
+        },
+        "a bodyless title excludes its final CRLF"
     );
     assert_eq!(msg.summary().as_ref(), "hello there");
+}
+
+#[test]
+fn only_title_preserves_bytes_other_than_the_final_newline() {
+    for (input, title) in [
+        (b"".as_slice(), b"".as_slice()),
+        (b"\n", b""),
+        (b"\r\n", b""),
+        (b"hello\nthere\n", b"hello\nthere"),
+        (b"hello\r\nthere\r\n", b"hello\r\nthere"),
+        (b" \thello \t\n", b" \thello \t"),
+        (b" \thello \t\r\n", b" \thello \t"),
+        (b"hello\r", b"hello\r"),
+        (b"hello\r\r\n", b"hello\r"),
+        (b"hello\xff\n", b"hello\xff"),
+    ] {
+        assert_eq!(
+            MessageRef::from_bytes(input),
+            MessageRef {
+                title: title.as_bstr(),
+                body: None,
+            },
+            "only the final LF or CRLF is removed from {:?}",
+            input.as_bstr()
+        );
+    }
 }
 
 #[test]

--- a/gix/src/repository/reference.rs
+++ b/gix/src/repository/reference.rs
@@ -302,7 +302,7 @@ impl crate::Repository {
     /// let mut reference = repo.find_reference("main")?;
     ///
     /// assert_eq!(reference, "refs/heads/main");
-    /// assert_eq!(reference.peel_to_commit()?.message()?.title, "c2\n");
+    /// assert_eq!(reference.peel_to_commit()?.message()?.title, "c2");
     /// # Ok(()) }
     /// ```
     pub fn find_reference<'a, Name, E>(&self, name: Name) -> Result<Reference<'_>, reference::find::existing::Error>


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-6`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #2991.

For a commit message such as `initial commit\n`, `MessageRef::title` now returns `initial commit`. The shared parser excludes a final LF or CRLF when there is no body separator, preserving other whitespace and raw bytes. The documentation and the public `gix` doctest reflect this behavior.

The regression tests failed before the fix and pass afterward. Coverage includes LF, CRLF, empty and multiline titles, other whitespace, lone CR, and non-UTF-8 bytes.

Validation:
- Full `gix-object` nextest suite with SHA-1 and SHA-256 fixtures: 169 tests passed in each run.
- Focused `gix` commit tests: 8 passed; reference doctests: 5 passed.
- `cargo fmt --all -- --check` and `gix-object` Clippy with all targets and features passed.
- One `codex review --commit` for `4c27f1f1290` completed with no findings.

Git reference: `pretty.c` (`is_blank_line()` / `format_subject()`) and `t/t6006-rev-list-format.sh` at Git commit `1630431f326e15fcde608827b5ff38422528eb59`. Confirmed with Git 2.50.1 that `%s` omits the trailing LF from a bodyless commit's raw message.
